### PR TITLE
Migrate OnboardingSettings from vuelidate to zod

### DIFF
--- a/frontend/app/src/modules/settings/OnboardingSettings.spec.ts
+++ b/frontend/app/src/modules/settings/OnboardingSettings.spec.ts
@@ -548,25 +548,30 @@ describe('onboarding-settings', () => {
       expect(saveDisabled()).toBe(true);
     });
 
-    // The `selecting` re-entrancy guard is asymmetric: only `selectLogsDirectory`
-    // raises the flag, so only the log picker is actually guarded. These two rows
-    // pin the CURRENT behaviour of both handlers; the second one is the bug.
-    it('should ignore a second log-directory click while the picker is open', async (): Promise<void> => {
+    it.each([
+      ['data', 'user-data-directory-input'],
+      ['logs', 'user-log-directory-input'],
+    ])('should ignore a second %s-directory click while the picker is open', async (_name, field): Promise<void> => {
       openDirectoryMock.mockReturnValue(new Promise<string | undefined>(() => {}));
-      const field = wrapper.find('[data-testid=user-log-directory-input] input');
+      const input = wrapper.find(`[data-testid=${field}] input`);
 
-      await field.trigger('click');
-      await field.trigger('click');
+      await input.trigger('click');
+      await input.trigger('click');
 
       expect(openDirectoryMock).toHaveBeenCalledOnce();
     });
 
-    it('should re-open the data-directory picker on a second click (guard never armed)', async (): Promise<void> => {
-      openDirectoryMock.mockReturnValue(new Promise<string | undefined>(() => {}));
-      const field = wrapper.find('[data-testid=user-data-directory-input] input');
+    it.each([
+      ['data', 'user-data-directory-input'],
+      ['logs', 'user-log-directory-input'],
+    ])('should re-arm the %s-directory picker once it closes', async (_name, field): Promise<void> => {
+      openDirectoryMock.mockResolvedValue(undefined);
+      const input = wrapper.find(`[data-testid=${field}] input`);
 
-      await field.trigger('click');
-      await field.trigger('click');
+      await input.trigger('click');
+      await flushPromises();
+      await input.trigger('click');
+      await flushPromises();
 
       expect(openDirectoryMock).toHaveBeenCalledTimes(2);
     });

--- a/frontend/app/src/modules/settings/OnboardingSettings.spec.ts
+++ b/frontend/app/src/modules/settings/OnboardingSettings.spec.ts
@@ -1,6 +1,8 @@
+import type { BackendOptions } from '@shared/ipc';
 import type { useAssetIconApi } from '@/modules/assets/api/use-asset-icon-api';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import OnboardingSettings from '@/modules/settings/OnboardingSettings.vue';
 import { useBackendConnection } from '@/modules/shell/app/use-backend-connection';
 
@@ -17,20 +19,27 @@ vi.mock('@/modules/core/common/logging/logging', async (): Promise<Record<string
   };
 });
 
-const { setLogLevelMock } = vi.hoisted(() => ({ setLogLevelMock: vi.fn() }));
+const { openDirectoryMock, setLogLevelMock } = vi.hoisted(() => ({
+  openDirectoryMock: vi.fn<(title: string) => Promise<string | undefined>>(),
+  setLogLevelMock: vi.fn(),
+}));
 vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> => ({
   useInterop: vi.fn().mockReturnValue({
     isPackaged: true,
+    openDirectory: openDirectoryMock,
     restartBackend: vi.fn(),
     setLogLevel: setLogLevelMock,
-    config: vi.fn().mockReturnValue({
-      logDirectory: '/Users/home/rotki/logs',
-    }),
+    // `config(false)` is what the config FILE pins (and disables in the UI);
+    // `config(true)` is the defaults. Returning the same object for both pinned
+    // the log directory and left that field permanently disabled.
+    config: vi.fn().mockImplementation(async (defaults: boolean): Promise<Partial<BackendOptions>> =>
+      defaults ? { logDirectory: '/Users/home/rotki/logs' } : {}),
   }),
 }));
 
 let saveOptions = vi.fn();
 let applyUserOptions = vi.fn();
+let resetOptions = vi.fn();
 vi.mock('@/modules/shell/app/use-backend-management', async (): Promise<Record<string, unknown>> => {
   const mod = await vi.importActual<typeof import('@/modules/shell/app/use-backend-management')>('@/modules/shell/app/use-backend-management');
   return {
@@ -43,10 +52,14 @@ vi.mock('@/modules/shell/app/use-backend-management', async (): Promise<Record<s
       applyUserOptions = vi.fn().mockImplementation(async (opts, skipRestart): Promise<void> => {
         await mocked.applyUserOptions(opts, skipRestart);
       });
+      resetOptions = vi.fn().mockImplementation(async (): Promise<void> => {
+        await mocked.resetOptions();
+      });
       return {
         ...mocked,
-        saveOptions,
         applyUserOptions,
+        resetOptions,
+        saveOptions,
       };
     }),
   };
@@ -129,6 +142,8 @@ describe('onboarding-settings', () => {
     setLevelMock.mockClear();
     setLogLevelMock.mockClear();
     updateColibriConfigurationMock.mockClear();
+    openDirectoryMock.mockReset();
+    openDirectoryMock.mockResolvedValue(undefined);
     wrapper = await createWrapper();
     await nextTick();
   });
@@ -136,6 +151,23 @@ describe('onboarding-settings', () => {
   afterEach((): void => {
     wrapper.unmount();
   });
+
+  async function openAdvanced(): Promise<void> {
+    await wrapper.find('[data-testid=onboarding-setting__advance] [data-accordion-trigger]').trigger('click');
+    await nextTick();
+  }
+
+  function errorOf(field: string): string {
+    return wrapper.find(`[data-testid=${field}] .details .text-rui-error`).text();
+  }
+
+  function hasError(field: string): boolean {
+    return wrapper.find(`[data-testid=${field}] .details .text-rui-error`).exists();
+  }
+
+  function saveDisabled(): boolean {
+    return 'disabled' in wrapper.find('[data-testid=onboarding-setting__submit-button]').attributes();
+  }
 
   describe('standard settings', () => {
     it('should use default value and disable save button', () => {
@@ -299,9 +331,7 @@ describe('onboarding-settings', () => {
 
   describe('advanced settings', () => {
     beforeEach(async (): Promise<void> => {
-      await wrapper.find('[data-testid=onboarding-setting__advance] [data-accordion-trigger]').trigger('click');
-
-      await nextTick();
+      await openAdvanced();
     });
 
     it('should use default value and disable save button', () => {
@@ -362,6 +392,233 @@ describe('onboarding-settings', () => {
         maxLogfilesNum: 3,
         sqliteInstructions: 5000,
       });
+    });
+  });
+
+  /**
+   * Characterization of the vuelidate rules, so the zod port has something to
+   * match. Expectations are derived from the validator implementations, not
+   * from a run: `numeric` is `/^\d*(\.\d+)?$/`, and both `numeric` and
+   * `minValue` no-op on an empty value, while `required` trims first.
+   */
+  describe('numeric field validation', () => {
+    const fields = [
+      ['max log size', 'max-log-size-input'],
+      ['max log files', 'max-log-files-input'],
+      ['sqlite instructions', 'sqlite-instructions-input'],
+    ] as const;
+
+    const MIN_MESSAGE = 'backend_settings.errors.min::0';
+    const NON_EMPTY_MESSAGE = 'backend_settings.errors.non_empty';
+
+    beforeEach(async (): Promise<void> => {
+      await openAdvanced();
+    });
+
+    it.each(fields)('should reject an empty %s as required', async (_name, field): Promise<void> => {
+      await wrapper.find(`[data-testid=${field}] input`).setValue('');
+      await nextTick();
+
+      // `numeric` and `minValue` both short-circuit on an empty value, so
+      // `required` is the only rule that fires.
+      expect(errorOf(field)).toBe(NON_EMPTY_MESSAGE);
+      expect(saveDisabled()).toBe(true);
+    });
+
+    it.each(fields)('should reject a negative %s', async (_name, field): Promise<void> => {
+      await wrapper.find(`[data-testid=${field}] input`).setValue('-1');
+      await nextTick();
+
+      // `numeric` rejects the sign before `minValue` is reached, and `and`
+      // short-circuits, so the pair reports one message. Note this row does NOT
+      // pin the lower bound: `numeric`'s regex accepts no sign at all, so
+      // `minValue(0)` can never fail on its own and either rule alone rejects
+      // `-1`. The row below is what pins the digits-only half.
+      expect(errorOf(field)).toBe(MIN_MESSAGE);
+      expect(saveDisabled()).toBe(true);
+    });
+
+    it.each(fields)('should reject exponent notation for %s', async (_name, field): Promise<void> => {
+      // The discriminating input: `1e5` is a valid value for a `type="number"`
+      // input and is >= 0, so a non-negative check alone would accept it, but
+      // `numeric`'s `/^\d*(\.\d+)?$/` has no exponent and rejects it. Without
+      // this row a port that only checked the lower bound would stay green.
+      await wrapper.find(`[data-testid=${field}] input`).setValue('1e5');
+      await nextTick();
+
+      expect(errorOf(field)).toBe(MIN_MESSAGE);
+      expect(saveDisabled()).toBe(true);
+    });
+
+    it.each(fields)('should accept zero for %s', async (_name, field): Promise<void> => {
+      await wrapper.find(`[data-testid=${field}] input`).setValue('0');
+      await nextTick();
+
+      expect(hasError(field)).toBe(false);
+      expect(saveDisabled()).toBe(false);
+    });
+
+    it('should accept a decimal and truncate it on save', async (): Promise<void> => {
+      // `numeric` allows a fractional part, but `parseValue` uses parseInt, so
+      // the value that reaches the backend is truncated rather than rejected.
+      await wrapper.find('[data-testid=max-log-size-input] input').setValue('1.5');
+      await nextTick();
+
+      expect(hasError('max-log-size-input')).toBe(false);
+
+      await wrapper.find('[data-testid=onboarding-setting__submit-button]').trigger('click');
+
+      expect(saveOptions).toBeCalledWith({ maxSizeInMbAllLogs: 1 });
+    });
+
+    it('should block save while any field is invalid', async (): Promise<void> => {
+      await wrapper.find('[data-testid=max-log-files-input] input').setValue('4');
+      await nextTick();
+      expect(saveDisabled()).toBe(false);
+
+      // A valid change elsewhere must not unlock save past an invalid field.
+      await wrapper.find('[data-testid=max-log-size-input] input').setValue('-1');
+      await nextTick();
+      expect(saveDisabled()).toBe(true);
+    });
+
+    it('should re-enable save once the invalid value is corrected', async (): Promise<void> => {
+      await wrapper.find('[data-testid=max-log-size-input] input').setValue('-1');
+      await nextTick();
+      expect(saveDisabled()).toBe(true);
+
+      await wrapper.find('[data-testid=max-log-size-input] input').setValue('301');
+      await nextTick();
+
+      expect(hasError('max-log-size-input')).toBe(false);
+      expect(saveDisabled()).toBe(false);
+    });
+  });
+
+  // `RuiTextField` splits its fallthrough: plain attributes land on the root
+  // element (so `data-testid` selects the field) but listeners land on the inner
+  // `<input>`. A click has to be triggered on `[data-testid=x] input`; dispatching
+  // it on the root calls nothing.
+  describe('directory selection', () => {
+    it('should write the chosen data directory back into the field', async (): Promise<void> => {
+      openDirectoryMock.mockResolvedValue('/Users/home/rotki/picked_data');
+
+      await wrapper.find('[data-testid=user-data-directory-input] input').trigger('click');
+      await flushPromises();
+
+      expect(openDirectoryMock).toHaveBeenCalledWith('backend_settings.data_directory.select');
+      const input = wrapper.find<HTMLInputElement>('[data-testid=user-data-directory-input] input').element;
+      expect(input.value).toBe('/Users/home/rotki/picked_data');
+      expect(saveDisabled()).toBe(false);
+    });
+
+    it('should write the chosen log directory back into the field', async (): Promise<void> => {
+      openDirectoryMock.mockResolvedValue('/Users/home/rotki/picked_logs');
+
+      await wrapper.find('[data-testid=user-log-directory-input] input').trigger('click');
+      await flushPromises();
+
+      expect(openDirectoryMock).toHaveBeenCalledWith('backend_settings.log_directory.select');
+      const input = wrapper.find<HTMLInputElement>('[data-testid=user-log-directory-input] input').element;
+      expect(input.value).toBe('/Users/home/rotki/picked_logs');
+    });
+
+    it('should also open the picker from the folder button', async (): Promise<void> => {
+      openDirectoryMock.mockResolvedValue('/Users/home/rotki/from_button');
+
+      await wrapper.find('[data-testid=user-data-directory-input] button').trigger('click');
+      await flushPromises();
+
+      const input = wrapper.find<HTMLInputElement>('[data-testid=user-data-directory-input] input').element;
+      expect(input.value).toBe('/Users/home/rotki/from_button');
+    });
+
+    it.each([
+      ['data', 'user-data-directory-input'],
+      ['logs', 'user-log-directory-input'],
+    ])('should keep the current %s directory when the picker is cancelled', async (_name, field): Promise<void> => {
+      const before = wrapper.find<HTMLInputElement>(`[data-testid=${field}] input`).element.value;
+      openDirectoryMock.mockResolvedValue(undefined);
+
+      await wrapper.find(`[data-testid=${field}] input`).trigger('click');
+      await flushPromises();
+
+      expect(openDirectoryMock).toHaveBeenCalledOnce();
+      expect(wrapper.find<HTMLInputElement>(`[data-testid=${field}] input`).element.value).toBe(before);
+      expect(saveDisabled()).toBe(true);
+    });
+
+    // The `selecting` re-entrancy guard is asymmetric: only `selectLogsDirectory`
+    // raises the flag, so only the log picker is actually guarded. These two rows
+    // pin the CURRENT behaviour of both handlers; the second one is the bug.
+    it('should ignore a second log-directory click while the picker is open', async (): Promise<void> => {
+      openDirectoryMock.mockReturnValue(new Promise<string | undefined>(() => {}));
+      const field = wrapper.find('[data-testid=user-log-directory-input] input');
+
+      await field.trigger('click');
+      await field.trigger('click');
+
+      expect(openDirectoryMock).toHaveBeenCalledOnce();
+    });
+
+    it('should re-open the data-directory picker on a second click (guard never armed)', async (): Promise<void> => {
+      openDirectoryMock.mockReturnValue(new Promise<string | undefined>(() => {}));
+      const field = wrapper.find('[data-testid=user-data-directory-input] input');
+
+      await field.trigger('click');
+      await field.trigger('click');
+
+      expect(openDirectoryMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('reset to defaults', () => {
+    it('should reset the backend options only after the confirmation is accepted', async (): Promise<void> => {
+      const confirmStore = useConfirmStore();
+
+      await wrapper.find('[data-testid=onboarding-setting__reset-button]').trigger('click');
+      await nextTick();
+
+      expect(get(confirmStore.visible)).toBe(true);
+      expect(get(confirmStore.confirmation)).toMatchObject({
+        message: 'backend_settings.confirm.message',
+        title: 'backend_settings.confirm.title',
+      });
+      expect(resetOptions).not.toHaveBeenCalled();
+
+      await confirmStore.confirm();
+      await flushPromises();
+
+      expect(resetOptions).toHaveBeenCalledOnce();
+      expect(wrapper.emitted('dismiss')).toHaveLength(1);
+    });
+
+    it('should leave the options untouched when the confirmation is dismissed', async (): Promise<void> => {
+      const confirmStore = useConfirmStore();
+
+      await wrapper.find('[data-testid=onboarding-setting__reset-button]').trigger('click');
+      await nextTick();
+
+      await confirmStore.dismiss();
+      await flushPromises();
+
+      expect(resetOptions).not.toHaveBeenCalled();
+      expect(wrapper.emitted('dismiss')).toBeUndefined();
+    });
+  });
+
+  describe('log from other modules', () => {
+    it('should save the checkbox as part of the options diff', async (): Promise<void> => {
+      await openAdvanced();
+
+      await wrapper.find('[data-testid=log-from-other-modules-checkbox] input').setValue(true);
+      await nextTick();
+
+      expect(saveDisabled()).toBe(false);
+
+      await wrapper.find('[data-testid=onboarding-setting__submit-button]').trigger('click');
+
+      expect(saveOptions).toBeCalledWith({ logFromOtherModules: true });
     });
   });
 });

--- a/frontend/app/src/modules/settings/OnboardingSettings.vue
+++ b/frontend/app/src/modules/settings/OnboardingSettings.vue
@@ -470,6 +470,7 @@ function showResetConfirmation() {
           {{ t('common.actions.cancel') }}
         </RuiButton>
         <RuiButton
+          data-testid="onboarding-setting__reset-button"
           variant="outlined"
           color="primary"
           @click="showResetConfirmation()"

--- a/frontend/app/src/modules/settings/OnboardingSettings.vue
+++ b/frontend/app/src/modules/settings/OnboardingSettings.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
-import type { Writeable } from '@rotki/common';
 import type { BackendOptions } from '@shared/ipc';
 import type { BackendConfiguration } from '@/modules/shell/app/backend';
 import useVuelidate from '@vuelidate/core';
 import { and, helpers, minValue, numeric, required } from '@vuelidate/validators';
-import { isEqual } from 'es-toolkit';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useMainStore } from '@/modules/core/common/use-main-store';
 import { toMessages } from '@/modules/core/common/validation/validation';
 import { useSettingsApi } from '@/modules/settings/api/use-settings-api';
 import { resolveInitialBackendOptions } from '@/modules/settings/backend/backend-initial-options';
+import {
+  backendDefaultsState,
+  type BackendOptionsFormFields,
+  diffBackendOptions,
+  hasBackendOptionChanges,
+  stringifyValue,
+} from '@/modules/settings/backend/backend-options-form';
 import LogLevelInput from '@/modules/settings/backend/LogLevelInput.vue';
 import { useLogLevelUpdate } from '@/modules/settings/backend/use-log-level-update';
 import LanguageSetting from '@/modules/settings/general/language/LanguageSetting.vue';
@@ -44,21 +49,6 @@ const configuration = ref<BackendConfiguration>();
 
 async function loadConfiguration(): Promise<void> {
   set(configuration, await backendSettings());
-}
-
-function parseValue(value?: string) {
-  if (!value)
-    return 0;
-
-  const parsedValue = Number.parseInt(value);
-  return Number.isNaN(parsedValue) ? 0 : parsedValue;
-}
-
-function stringifyValue(value?: number) {
-  if (!value)
-    return '0';
-
-  return value.toString();
 }
 
 const {
@@ -102,20 +92,17 @@ async function loaded() {
   set(sqliteInstructions, stringifyValue(initial.sqliteInstructions));
 }
 
-const isMaxLogFilesDefault = computed(() => {
-  const defaults = get(defaultBackendArguments);
-  return defaults.maxLogfilesNum === parseValue(get(maxLogFiles));
-});
+const formFields = computed<BackendOptionsFormFields>(() => ({
+  dataDirectory: get(userDataDirectory),
+  logDirectory: get(userLogDirectory),
+  logFromOtherModules: get(logFromOtherModules),
+  loglevel: get(modelLogLevel),
+  maxLogFiles: get(maxLogFiles),
+  maxLogSize: get(maxLogSize),
+  sqliteInstructions: get(sqliteInstructions),
+}));
 
-const isMaxSizeDefault = computed(() => {
-  const defaults = get(defaultBackendArguments);
-  return defaults.maxSizeInMbAllLogs === parseValue(get(maxLogSize));
-});
-
-const isSqliteInstructionsDefaults = computed(() => {
-  const defaults = get(defaultBackendArguments);
-  return defaults.sqliteInstructions === parseValue(get(sqliteInstructions));
-});
+const atDefaults = computed(() => backendDefaultsState(get(formFields), get(defaultBackendArguments)));
 
 function resetDefaultArguments(field: 'files' | 'size' | 'instructions') {
   const defaults = get(defaultBackendArguments);
@@ -127,54 +114,9 @@ function resetDefaultArguments(field: 'files' | 'size' | 'instructions') {
     set(sqliteInstructions, stringifyValue(defaults.sqliteInstructions));
 }
 
-const newUserOptions = computed(() => {
-  const initial = get(initialOptions);
-  const newOptions: Writeable<Partial<BackendOptions>> = {};
+const newUserOptions = computed<Partial<BackendOptions>>(() => diffBackendOptions(get(formFields), get(initialOptions)));
 
-  const level = get(modelLogLevel);
-  if (level !== initial.loglevel)
-    newOptions.loglevel = level;
-
-  const userData = get(userDataDirectory);
-  if (userData !== initial.dataDirectory)
-    newOptions.dataDirectory = userData;
-
-  const userLog = get(userLogDirectory);
-  if (userLog !== initial.logDirectory)
-    newOptions.logDirectory = userLog;
-
-  const logFromOther = get(logFromOtherModules);
-  if (logFromOther !== initial.logFromOtherModules)
-    newOptions.logFromOtherModules = logFromOther;
-
-  const maxLogFilesParsed = parseValue(get(maxLogFiles));
-  if (maxLogFilesParsed !== initial.maxLogfilesNum)
-    newOptions.maxLogfilesNum = maxLogFilesParsed;
-
-  const maxLogSizeParsed = parseValue(get(maxLogSize));
-  if (maxLogSizeParsed !== initial.maxSizeInMbAllLogs)
-    newOptions.maxSizeInMbAllLogs = maxLogSizeParsed;
-
-  const sqliteInstructionsParsed = parseValue(get(sqliteInstructions));
-  if (sqliteInstructionsParsed !== initial.sqliteInstructions)
-    newOptions.sqliteInstructions = sqliteInstructionsParsed;
-
-  return newOptions;
-});
-
-const anyValueChanged = computed(() => {
-  const form: Partial<BackendOptions> = {
-    dataDirectory: get(userDataDirectory),
-    logDirectory: get(userLogDirectory),
-    logFromOtherModules: get(logFromOtherModules),
-    loglevel: get(modelLogLevel),
-    maxLogfilesNum: parseValue(get(maxLogFiles)),
-    maxSizeInMbAllLogs: parseValue(get(maxLogSize)),
-    sqliteInstructions: parseValue(get(sqliteInstructions)),
-  };
-
-  return !isEqual(form, get(initialOptions));
-});
+const anyValueChanged = computed<boolean>(() => hasBackendOptionChanges(get(formFields), get(initialOptions)));
 
 const { openDirectory } = useInterop();
 
@@ -385,7 +327,7 @@ function showResetConfirmation() {
           >
             <template #append>
               <SettingResetButton
-                v-if="!isMaxSizeDefault"
+                v-if="!atDefaults.maxLogSize"
                 data-testid="reset-max-log-size"
                 @click="resetDefaultArguments('size')"
               />
@@ -410,7 +352,7 @@ function showResetConfirmation() {
           >
             <template #append>
               <SettingResetButton
-                v-if="!isMaxLogFilesDefault"
+                v-if="!atDefaults.maxLogFiles"
                 data-testid="reset-max-log-files"
                 @click="resetDefaultArguments('files')"
               />
@@ -436,7 +378,7 @@ function showResetConfirmation() {
           >
             <template #append>
               <SettingResetButton
-                v-if="!isSqliteInstructionsDefaults"
+                v-if="!atDefaults.sqliteInstructions"
                 data-testid="reset-sqlite-instructions"
                 @click="resetDefaultArguments('instructions')"
               />

--- a/frontend/app/src/modules/settings/OnboardingSettings.vue
+++ b/frontend/app/src/modules/settings/OnboardingSettings.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
 import type { BackendOptions } from '@shared/ipc';
 import type { BackendConfiguration } from '@/modules/shell/app/backend';
-import useVuelidate from '@vuelidate/core';
-import { and, helpers, minValue, numeric, required } from '@vuelidate/validators';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useMainStore } from '@/modules/core/common/use-main-store';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import { useSettingsApi } from '@/modules/settings/api/use-settings-api';
 import AdvancedBackendSettings from '@/modules/settings/backend/AdvancedBackendSettings.vue';
 import { resolveInitialBackendOptions } from '@/modules/settings/backend/backend-initial-options';
 import {
   type AdvancedBackendField,
   backendDefaultsState,
+  type BackendNumericField,
+  type BackendNumericFields,
+  backendNumericSchema,
   type BackendOptionsFormFields,
   diffBackendOptions,
   hasBackendOptionChanges,
@@ -35,11 +36,6 @@ const { dataDirectory, defaultBackendArguments } = storeToRefs(useMainStore());
 const userDataDirectory = ref<string>('');
 const userLogDirectory = ref<string>('');
 const logFromOtherModules = ref<boolean>(false);
-const valid = ref<boolean>(false);
-
-const maxLogSize = ref<string>('0');
-const sqliteInstructions = ref<string>('0');
-const maxLogFiles = ref<string>('0');
 
 const { backendSettings } = useSettingsApi();
 const { applyLogLevelChange } = useLogLevelUpdate();
@@ -50,6 +46,32 @@ const configuration = ref<BackendConfiguration>();
 
 async function loadConfiguration(): Promise<void> {
   set(configuration, await backendSettings());
+}
+
+/**
+ * Only the three numeric fields are validated, so the form owns just those.
+ * Everything else stays on plain refs, and whether anything changed is still a
+ * comparison against the initial options rather than the form's own baseline.
+ * `submit` is a no-op: `save()` decides between a full save and a log-level
+ * only update, and referencing it from here would be a cycle.
+ */
+const form = useForm<BackendNumericFields, BackendNumericFields>({
+  initial: (): BackendNumericFields => ({ maxLogFiles: '0', maxLogSize: '0', sqliteInstructions: '0' }),
+  schema: backendNumericSchema({
+    min: t('backend_settings.errors.min', { min: 0 }),
+    nonEmpty: t('backend_settings.errors.non_empty'),
+  }),
+  submit: async (): Promise<{ success: boolean }> => ({ success: true }),
+  transform: (state): BackendNumericFields => ({ ...state }),
+});
+
+/** `form.valid` is a `ComputedRef` on a plain object, so a template binding would never unwrap it. */
+const invalid = computed<boolean>(() => !get(form.valid));
+
+/** Vuelidate ran with `$autoDirty`, so an edited field showed its error straight away. */
+function updateField(field: BackendNumericField, value: string): void {
+  form.state[field] = value;
+  form.touch(field);
 }
 
 const {
@@ -88,9 +110,11 @@ async function loaded() {
   set(userDataDirectory, initial.dataDirectory);
   set(userLogDirectory, initial.logDirectory);
   set(logFromOtherModules, initial.logFromOtherModules);
-  set(maxLogFiles, stringifyValue(initial.maxLogfilesNum));
-  set(maxLogSize, stringifyValue(initial.maxSizeInMbAllLogs));
-  set(sqliteInstructions, stringifyValue(initial.sqliteInstructions));
+  form.reset({
+    maxLogFiles: stringifyValue(initial.maxLogfilesNum),
+    maxLogSize: stringifyValue(initial.maxSizeInMbAllLogs),
+    sqliteInstructions: stringifyValue(initial.sqliteInstructions),
+  });
 }
 
 const formFields = computed<BackendOptionsFormFields>(() => ({
@@ -98,9 +122,9 @@ const formFields = computed<BackendOptionsFormFields>(() => ({
   logDirectory: get(userLogDirectory),
   logFromOtherModules: get(logFromOtherModules),
   loglevel: get(modelLogLevel),
-  maxLogFiles: get(maxLogFiles),
-  maxLogSize: get(maxLogSize),
-  sqliteInstructions: get(sqliteInstructions),
+  maxLogFiles: form.state.maxLogFiles,
+  maxLogSize: form.state.maxLogSize,
+  sqliteInstructions: form.state.sqliteInstructions,
 }));
 
 const atDefaults = computed(() => backendDefaultsState(get(formFields), get(defaultBackendArguments)));
@@ -108,11 +132,11 @@ const atDefaults = computed(() => backendDefaultsState(get(formFields), get(defa
 function resetDefaultArguments(field: AdvancedBackendField): void {
   const defaults = get(defaultBackendArguments);
   if (field === 'files')
-    set(maxLogFiles, stringifyValue(defaults.maxLogfilesNum));
+    updateField('maxLogFiles', stringifyValue(defaults.maxLogfilesNum));
   else if (field === 'size')
-    set(maxLogSize, stringifyValue(defaults.maxSizeInMbAllLogs));
+    updateField('maxLogSize', stringifyValue(defaults.maxSizeInMbAllLogs));
   else if (field === 'instructions')
-    set(sqliteInstructions, stringifyValue(defaults.sqliteInstructions));
+    updateField('sqliteInstructions', stringifyValue(defaults.sqliteInstructions));
 }
 
 const newUserOptions = computed<Partial<BackendOptions>>(() => diffBackendOptions(get(formFields), get(initialOptions)));
@@ -120,31 +144,6 @@ const newUserOptions = computed<Partial<BackendOptions>>(() => diffBackendOption
 const anyValueChanged = computed<boolean>(() => hasBackendOptionChanges(get(formFields), get(initialOptions)));
 
 const { openDirectory } = useInterop();
-
-const nonNegativeNumberRules = {
-  nonNegative: helpers.withMessage(t('backend_settings.errors.min', { min: 0 }), and(numeric, minValue(0))),
-  required: helpers.withMessage(t('backend_settings.errors.non_empty'), required),
-};
-
-const rules = {
-  maxLogFiles: nonNegativeNumberRules,
-  maxLogSize: nonNegativeNumberRules,
-  sqliteInstructions: nonNegativeNumberRules,
-};
-
-const v$ = useVuelidate(
-  rules,
-  {
-    maxLogFiles,
-    maxLogSize,
-    sqliteInstructions,
-  },
-  { $autoDirty: true },
-);
-
-watch(v$, ({ $invalid }) => {
-  set(valid, !$invalid);
-});
 
 async function reset() {
   set(confirmReset, false);
@@ -310,16 +309,19 @@ function showResetConfirmation() {
         </template>
         <AdvancedBackendSettings
           v-model:log-from-other-modules="logFromOtherModules"
-          v-model:max-log-files="maxLogFiles"
-          v-model:max-log-size="maxLogSize"
-          v-model:sqlite-instructions="sqliteInstructions"
           :at-defaults="atDefaults"
           :file-config="fileConfig"
           :loading="!configuration || !defaultBackendArguments"
-          :max-log-files-errors="toMessages(v$.maxLogFiles)"
-          :max-log-size-errors="toMessages(v$.maxLogSize)"
-          :sqlite-instructions-errors="toMessages(v$.sqliteInstructions)"
+          :max-log-files="form.state.maxLogFiles"
+          :max-log-files-errors="form.errors('maxLogFiles')"
+          :max-log-size="form.state.maxLogSize"
+          :max-log-size-errors="form.errors('maxLogSize')"
+          :sqlite-instructions="form.state.sqliteInstructions"
+          :sqlite-instructions-errors="form.errors('sqliteInstructions')"
           @reset="resetDefaultArguments($event)"
+          @update:max-log-files="updateField('maxLogFiles', $event)"
+          @update:max-log-size="updateField('maxLogSize', $event)"
+          @update:sqlite-instructions="updateField('sqliteInstructions', $event)"
         />
       </RuiAccordion>
     </RuiAccordions>
@@ -344,7 +346,7 @@ function showResetConfirmation() {
         <RuiButton
           data-testid="onboarding-setting__submit-button"
           color="primary"
-          :disabled="!anyValueChanged || !valid"
+          :disabled="!anyValueChanged || invalid"
           type="submit"
           @click="save()"
         >

--- a/frontend/app/src/modules/settings/OnboardingSettings.vue
+++ b/frontend/app/src/modules/settings/OnboardingSettings.vue
@@ -7,8 +7,10 @@ import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useMainStore } from '@/modules/core/common/use-main-store';
 import { toMessages } from '@/modules/core/common/validation/validation';
 import { useSettingsApi } from '@/modules/settings/api/use-settings-api';
+import AdvancedBackendSettings from '@/modules/settings/backend/AdvancedBackendSettings.vue';
 import { resolveInitialBackendOptions } from '@/modules/settings/backend/backend-initial-options';
 import {
+  type AdvancedBackendField,
   backendDefaultsState,
   type BackendOptionsFormFields,
   diffBackendOptions,
@@ -18,7 +20,6 @@ import {
 import LogLevelInput from '@/modules/settings/backend/LogLevelInput.vue';
 import { useLogLevelUpdate } from '@/modules/settings/backend/use-log-level-update';
 import LanguageSetting from '@/modules/settings/general/language/LanguageSetting.vue';
-import SettingResetButton from '@/modules/settings/SettingResetButton.vue';
 import { useBackendManagement } from '@/modules/shell/app/use-backend-management';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
@@ -104,7 +105,7 @@ const formFields = computed<BackendOptionsFormFields>(() => ({
 
 const atDefaults = computed(() => backendDefaultsState(get(formFields), get(defaultBackendArguments)));
 
-function resetDefaultArguments(field: 'files' | 'size' | 'instructions') {
+function resetDefaultArguments(field: AdvancedBackendField): void {
   const defaults = get(defaultBackendArguments);
   if (field === 'files')
     set(maxLogFiles, stringifyValue(defaults.maxLogfilesNum));
@@ -307,99 +308,19 @@ function showResetConfirmation() {
         <template #header>
           {{ t('backend_settings.advanced') }}
         </template>
-        <div class="py-2">
-          <RuiTextField
-            v-model="maxLogSize"
-            data-testid="max-log-size-input"
-            class="mb-4"
-            variant="outlined"
-            color="primary"
-            :hint="
-              !!fileConfig.maxSizeInMbAllLogs
-                ? t('backend_settings.config_file_disabled')
-                : t('backend_settings.max_log_size.hint')
-            "
-            :label="t('backend_settings.max_log_size.label')"
-            :disabled="!!fileConfig.maxSizeInMbAllLogs"
-            :loading="!configuration || !defaultBackendArguments"
-            :error-messages="toMessages(v$.maxLogSize)"
-            type="number"
-          >
-            <template #append>
-              <SettingResetButton
-                v-if="!atDefaults.maxLogSize"
-                data-testid="reset-max-log-size"
-                @click="resetDefaultArguments('size')"
-              />
-            </template>
-          </RuiTextField>
-          <RuiTextField
-            v-model="maxLogFiles"
-            data-testid="max-log-files-input"
-            variant="outlined"
-            color="primary"
-            class="mb-4"
-            :hint="t('backend_settings.max_log_files.hint')"
-            :label="
-              !!fileConfig.maxLogfilesNum
-                ? t('backend_settings.config_file_disabled')
-                : t('backend_settings.max_log_files.label')
-            "
-            :disabled="!!fileConfig.maxLogfilesNum"
-            :loading="!configuration || !defaultBackendArguments"
-            :error-messages="toMessages(v$.maxLogFiles)"
-            type="number"
-          >
-            <template #append>
-              <SettingResetButton
-                v-if="!atDefaults.maxLogFiles"
-                data-testid="reset-max-log-files"
-                @click="resetDefaultArguments('files')"
-              />
-            </template>
-          </RuiTextField>
-
-          <RuiTextField
-            v-model="sqliteInstructions"
-            data-testid="sqlite-instructions-input"
-            variant="outlined"
-            color="primary"
-            class="mb-4"
-            :hint="
-              !!fileConfig.sqliteInstructions
-                ? t('backend_settings.config_file_disabled')
-                : t('backend_settings.sqlite_instructions.hint')
-            "
-            :label="t('backend_settings.sqlite_instructions.label')"
-            :disabled="!!fileConfig.sqliteInstructions"
-            :loading="!configuration || !defaultBackendArguments"
-            :error-messages="toMessages(v$.sqliteInstructions)"
-            type="number"
-          >
-            <template #append>
-              <SettingResetButton
-                v-if="!atDefaults.sqliteInstructions"
-                data-testid="reset-sqlite-instructions"
-                @click="resetDefaultArguments('instructions')"
-              />
-            </template>
-          </RuiTextField>
-
-          <RuiCheckbox
-            v-model="logFromOtherModules"
-            color="primary"
-            data-testid="log-from-other-modules-checkbox"
-            :label="t('backend_settings.log_from_other_modules.label')"
-            :disabled="fileConfig.logFromOtherModules"
-            :hint="
-              fileConfig.logFromOtherModules
-                ? t('backend_settings.config_file_disabled')
-                : t('backend_settings.log_from_other_modules.hint')
-            "
-          >
-            {{ t('backend_settings.log_from_other_modules.label') }}
-          </RuiCheckbox>
-        </div>
+        <AdvancedBackendSettings
+          v-model:log-from-other-modules="logFromOtherModules"
+          v-model:max-log-files="maxLogFiles"
+          v-model:max-log-size="maxLogSize"
+          v-model:sqlite-instructions="sqliteInstructions"
+          :at-defaults="atDefaults"
+          :file-config="fileConfig"
+          :loading="!configuration || !defaultBackendArguments"
+          :max-log-files-errors="toMessages(v$.maxLogFiles)"
+          :max-log-size-errors="toMessages(v$.maxLogSize)"
+          :sqlite-instructions-errors="toMessages(v$.sqliteInstructions)"
+          @reset="resetDefaultArguments($event)"
+        />
       </RuiAccordion>
     </RuiAccordions>
 

--- a/frontend/app/src/modules/settings/OnboardingSettings.vue
+++ b/frontend/app/src/modules/settings/OnboardingSettings.vue
@@ -213,6 +213,7 @@ async function selectDataDirectory() {
   if (get(selecting))
     return;
 
+  set(selecting, true);
   try {
     const title = t('backend_settings.data_directory.select');
     const directory = await openDirectory(title);

--- a/frontend/app/src/modules/settings/backend/AdvancedBackendSettings.vue
+++ b/frontend/app/src/modules/settings/backend/AdvancedBackendSettings.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import type { BackendOptions } from '@shared/ipc';
+import type { AdvancedBackendField } from '@/modules/settings/backend/backend-options-form';
+import SettingResetButton from '@/modules/settings/SettingResetButton.vue';
+
+const maxLogSize = defineModel<string>('maxLogSize', { required: true });
+const maxLogFiles = defineModel<string>('maxLogFiles', { required: true });
+const sqliteInstructions = defineModel<string>('sqliteInstructions', { required: true });
+const logFromOtherModules = defineModel<boolean>('logFromOtherModules', { required: true });
+
+const {
+  atDefaults,
+  fileConfig,
+  loading = false,
+  maxLogFilesErrors = [],
+  maxLogSizeErrors = [],
+  sqliteInstructionsErrors = [],
+} = defineProps<{
+  atDefaults: { maxLogFiles: boolean; maxLogSize: boolean; sqliteInstructions: boolean };
+  fileConfig: Partial<BackendOptions>;
+  loading?: boolean;
+  maxLogFilesErrors?: string[];
+  maxLogSizeErrors?: string[];
+  sqliteInstructionsErrors?: string[];
+}>();
+
+const emit = defineEmits<{
+  reset: [field: AdvancedBackendField];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <div class="py-2">
+    <RuiTextField
+      v-model="maxLogSize"
+      data-testid="max-log-size-input"
+      class="mb-4"
+      variant="outlined"
+      color="primary"
+      :hint="
+        !!fileConfig.maxSizeInMbAllLogs
+          ? t('backend_settings.config_file_disabled')
+          : t('backend_settings.max_log_size.hint')
+      "
+      :label="t('backend_settings.max_log_size.label')"
+      :disabled="!!fileConfig.maxSizeInMbAllLogs"
+      :loading="loading"
+      :error-messages="maxLogSizeErrors"
+      type="number"
+    >
+      <template #append>
+        <SettingResetButton
+          v-if="!atDefaults.maxLogSize"
+          data-testid="reset-max-log-size"
+          @click="emit('reset', 'size')"
+        />
+      </template>
+    </RuiTextField>
+    <RuiTextField
+      v-model="maxLogFiles"
+      data-testid="max-log-files-input"
+      variant="outlined"
+      color="primary"
+      class="mb-4"
+      :hint="t('backend_settings.max_log_files.hint')"
+      :label="
+        !!fileConfig.maxLogfilesNum
+          ? t('backend_settings.config_file_disabled')
+          : t('backend_settings.max_log_files.label')
+      "
+      :disabled="!!fileConfig.maxLogfilesNum"
+      :loading="loading"
+      :error-messages="maxLogFilesErrors"
+      type="number"
+    >
+      <template #append>
+        <SettingResetButton
+          v-if="!atDefaults.maxLogFiles"
+          data-testid="reset-max-log-files"
+          @click="emit('reset', 'files')"
+        />
+      </template>
+    </RuiTextField>
+
+    <RuiTextField
+      v-model="sqliteInstructions"
+      data-testid="sqlite-instructions-input"
+      variant="outlined"
+      color="primary"
+      class="mb-4"
+      :hint="
+        !!fileConfig.sqliteInstructions
+          ? t('backend_settings.config_file_disabled')
+          : t('backend_settings.sqlite_instructions.hint')
+      "
+      :label="t('backend_settings.sqlite_instructions.label')"
+      :disabled="!!fileConfig.sqliteInstructions"
+      :loading="loading"
+      :error-messages="sqliteInstructionsErrors"
+      type="number"
+    >
+      <template #append>
+        <SettingResetButton
+          v-if="!atDefaults.sqliteInstructions"
+          data-testid="reset-sqlite-instructions"
+          @click="emit('reset', 'instructions')"
+        />
+      </template>
+    </RuiTextField>
+
+    <RuiCheckbox
+      v-model="logFromOtherModules"
+      color="primary"
+      data-testid="log-from-other-modules-checkbox"
+      :label="t('backend_settings.log_from_other_modules.label')"
+      :disabled="fileConfig.logFromOtherModules"
+      :hint="
+        fileConfig.logFromOtherModules
+          ? t('backend_settings.config_file_disabled')
+          : t('backend_settings.log_from_other_modules.hint')
+      "
+    >
+      {{ t('backend_settings.log_from_other_modules.label') }}
+    </RuiCheckbox>
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/backend/backend-options-form.spec.ts
+++ b/frontend/app/src/modules/settings/backend/backend-options-form.spec.ts
@@ -1,0 +1,154 @@
+import type { BackendOptions } from '@shared/ipc';
+import { LogLevel } from '@shared/log-level';
+import { describe, expect, it } from 'vitest';
+import {
+  backendDefaultsState,
+  type BackendOptionsFormFields,
+  diffBackendOptions,
+  hasBackendOptionChanges,
+  parseValue,
+  stringifyValue,
+  toBackendOptions,
+} from '@/modules/settings/backend/backend-options-form';
+
+function fields(overrides: Partial<BackendOptionsFormFields> = {}): BackendOptionsFormFields {
+  return {
+    dataDirectory: '/data',
+    logDirectory: '/logs',
+    logFromOtherModules: false,
+    loglevel: LogLevel.DEBUG,
+    maxLogFiles: '3',
+    maxLogSize: '300',
+    sqliteInstructions: '5000',
+    ...overrides,
+  };
+}
+
+const initial: Partial<BackendOptions> = {
+  dataDirectory: '/data',
+  logDirectory: '/logs',
+  logFromOtherModules: false,
+  loglevel: LogLevel.DEBUG,
+  maxLogfilesNum: 3,
+  maxSizeInMbAllLogs: 300,
+  sqliteInstructions: 5000,
+};
+
+describe('parseValue', () => {
+  it.each([
+    ['', 0],
+    ['0', 0],
+    ['42', 42],
+    // parseInt truncates rather than rejecting, which is why '1.5' is saved as 1.
+    ['1.5', 1],
+    ['1e5', 1],
+    ['abc', 0],
+    // parseInt does accept a sign, unlike the field's validation rule.
+    ['-1', -1],
+  ])('should parse %j as %i', (input, expected): void => {
+    expect(parseValue(input)).toBe(expected);
+  });
+
+  it('should treat a missing value as zero', (): void => {
+    expect(parseValue()).toBe(0);
+  });
+});
+
+describe('stringifyValue', () => {
+  it.each([
+    [undefined, '0'],
+    [0, '0'],
+    [3, '3'],
+  ])('should stringify %j as %j', (input, expected): void => {
+    expect(stringifyValue(input)).toBe(expected);
+  });
+});
+
+describe('toBackendOptions', () => {
+  it('should project the raw fields onto the option shape', (): void => {
+    expect(toBackendOptions(fields())).toEqual(initial);
+  });
+
+  it('should parse the three numeric fields', (): void => {
+    expect(toBackendOptions(fields({ maxLogFiles: '', maxLogSize: '1.9', sqliteInstructions: 'x' }))).toMatchObject({
+      maxLogfilesNum: 0,
+      maxSizeInMbAllLogs: 1,
+      sqliteInstructions: 0,
+    });
+  });
+});
+
+describe('diffBackendOptions', () => {
+  it('should be empty when nothing changed', (): void => {
+    expect(diffBackendOptions(fields(), initial)).toEqual({});
+  });
+
+  it('should carry only the changed fields', (): void => {
+    expect(diffBackendOptions(fields({ maxLogSize: '301' }), initial)).toEqual({ maxSizeInMbAllLogs: 301 });
+  });
+
+  it.each([
+    ['dataDirectory', { dataDirectory: '/other' }, { dataDirectory: '/other' }],
+    ['logDirectory', { logDirectory: '/other-logs' }, { logDirectory: '/other-logs' }],
+    ['logFromOtherModules', { logFromOtherModules: true }, { logFromOtherModules: true }],
+    ['loglevel', { loglevel: LogLevel.WARNING }, { loglevel: LogLevel.WARNING }],
+    ['maxLogFiles', { maxLogFiles: '4' }, { maxLogfilesNum: 4 }],
+    ['sqliteInstructions', { sqliteInstructions: '5001' }, { sqliteInstructions: 5001 }],
+  ] as const)('should report a changed %s', (_name, override, expected): void => {
+    expect(diffBackendOptions(fields(override), initial)).toEqual(expected);
+  });
+
+  it('should report every field when there are no initial options', (): void => {
+    expect(diffBackendOptions(fields(), {})).toEqual(initial);
+  });
+
+  // The two functions answer slightly different questions: the diff only looks
+  // at the seven fields the form owns, while the changed check compares whole
+  // objects. An initial option the form does not render therefore enables save
+  // while contributing nothing to the payload.
+  it('should ignore an initial option the form does not own', (): void => {
+    const withExtra: Partial<BackendOptions> = { ...initial, sleepSeconds: 60 };
+
+    expect(diffBackendOptions(fields(), withExtra)).toEqual({});
+    expect(hasBackendOptionChanges(fields(), withExtra)).toBe(true);
+  });
+});
+
+describe('hasBackendOptionChanges', () => {
+  it('should be false when the fields match the initial options', (): void => {
+    expect(hasBackendOptionChanges(fields(), initial)).toBe(false);
+  });
+
+  it('should be true for a changed field', (): void => {
+    expect(hasBackendOptionChanges(fields({ logFromOtherModules: true }), initial)).toBe(true);
+  });
+
+  it('should be false when a numeric field changes only in formatting', (): void => {
+    // Both parse to 300, so nothing is actually different.
+    expect(hasBackendOptionChanges(fields({ maxLogSize: '300.4' }), initial)).toBe(false);
+  });
+});
+
+describe('backendDefaultsState', () => {
+  const defaults = { maxLogfilesNum: 3, maxSizeInMbAllLogs: 300, sqliteInstructions: 5000 };
+
+  it('should report every field at its default', (): void => {
+    expect(backendDefaultsState(fields(), defaults)).toEqual({
+      maxLogFiles: true,
+      maxLogSize: true,
+      sqliteInstructions: true,
+    });
+  });
+
+  it('should report only the field that moved off its default', (): void => {
+    expect(backendDefaultsState(fields({ maxLogFiles: '4' }), defaults)).toEqual({
+      maxLogFiles: false,
+      maxLogSize: true,
+      sqliteInstructions: true,
+    });
+  });
+
+  it('should compare the parsed value, not the string', (): void => {
+    expect(backendDefaultsState(fields({ maxLogSize: '300.9' }), defaults).maxLogSize).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/settings/backend/backend-options-form.spec.ts
+++ b/frontend/app/src/modules/settings/backend/backend-options-form.spec.ts
@@ -1,8 +1,9 @@
 import type { BackendOptions } from '@shared/ipc';
 import { LogLevel } from '@shared/log-level';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 import {
   backendDefaultsState,
+  backendNumericSchema,
   type BackendOptionsFormFields,
   diffBackendOptions,
   hasBackendOptionChanges,
@@ -126,6 +127,50 @@ describe('hasBackendOptionChanges', () => {
   it('should be false when a numeric field changes only in formatting', (): void => {
     // Both parse to 300, so nothing is actually different.
     expect(hasBackendOptionChanges(fields({ maxLogSize: '300.4' }), initial)).toBe(false);
+  });
+});
+
+describe('backendNumericSchema', () => {
+  const messages = { min: 'min-0', nonEmpty: 'non-empty' };
+  const schema = backendNumericSchema(messages);
+
+  function messagesFor(value: string): string[] {
+    const result = schema.safeParse({ maxLogFiles: '3', maxLogSize: value, sqliteInstructions: '5000' });
+    if (result.success)
+      return [];
+
+    return result.error.issues.filter(issue => issue.path.join('.') === 'maxLogSize').map(issue => issue.message);
+  }
+
+  // The table measured from vuelidate's `and(numeric, minValue(0))` + `required`,
+  // which this schema replaces. Every row, including the message order of the
+  // last one, is the behaviour that shipped.
+  it.each([
+    ['0', []],
+    ['300', []],
+    // numeric allows a fractional part; parseValue truncates it on save.
+    ['1.5', []],
+    ['', ['non-empty']],
+    ['-1', ['min-0']],
+    ['+1', ['min-0']],
+    ['1e5', ['min-0']],
+    ['abc', ['min-0']],
+    ['1.', ['min-0']],
+    // Unreachable through a type="number" input, but vuelidate reported both
+    // rules in this order: not digits, and empty once trimmed.
+    ['  ', ['min-0', 'non-empty']],
+  ])('should report %j as %j', (value, expected): void => {
+    expect(messagesFor(value)).toEqual(expected);
+  });
+
+  it('should apply the same rule to all three fields', (): void => {
+    const result = schema.safeParse({ maxLogFiles: '-1', maxLogSize: '', sqliteInstructions: '5000' });
+    assert(!result.success);
+
+    expect(result.error.issues.map(issue => [issue.path.join('.'), issue.message])).toEqual([
+      ['maxLogFiles', 'min-0'],
+      ['maxLogSize', 'non-empty'],
+    ]);
   });
 });
 

--- a/frontend/app/src/modules/settings/backend/backend-options-form.ts
+++ b/frontend/app/src/modules/settings/backend/backend-options-form.ts
@@ -1,6 +1,7 @@
 import type { BackendOptions } from '@shared/ipc';
 import type { DefaultBackendArguments } from '@/modules/shell/app/backend';
 import { isEqual } from 'es-toolkit';
+import { z, type ZodType } from 'zod';
 
 /** The three numeric settings that carry a reset-to-default button. */
 export type AdvancedBackendField = 'files' | 'size' | 'instructions';
@@ -94,6 +95,51 @@ export function hasBackendOptionChanges(
   initial: Partial<BackendOptions>,
 ): boolean {
   return !isEqual(toBackendOptions(fields), initial);
+}
+
+/** The three validated fields, which are the only ones the form schema covers. */
+export interface BackendNumericFields {
+  maxLogFiles: string;
+  maxLogSize: string;
+  sqliteInstructions: string;
+}
+
+export type BackendNumericField = keyof BackendNumericFields;
+
+export interface BackendNumericMessages {
+  /** Already translated, not i18n keys: the bound message interpolates its own minimum. */
+  nonEmpty: string;
+  min: string;
+}
+
+/**
+ * Digits with an optional fractional part, and no sign. This is vuelidate's
+ * `numeric`, kept verbatim: it is the rule that actually rejects a bad value,
+ * because a signed value never reaches the `minValue(0)` it was paired with.
+ * Loosening it to a plain "is a number, and >= 0" would accept exponent
+ * notation, which `parseValue` then truncates to its mantissa.
+ */
+const DIGITS = /^\d*(?:\.\d+)?$/;
+
+function backendNumericField(messages: BackendNumericMessages): ZodType<string> {
+  return z.string().superRefine((value, ctx) => {
+    // Both issues can fire at once, in this order, for a whitespace-only value:
+    // it is not digits, and it is empty once trimmed.
+    if (!DIGITS.test(value))
+      ctx.addIssue({ code: 'custom', message: messages.min });
+
+    if (value.trim() === '')
+      ctx.addIssue({ code: 'custom', message: messages.nonEmpty });
+  });
+}
+
+export function backendNumericSchema(messages: BackendNumericMessages): ZodType {
+  const field = backendNumericField(messages);
+  return z.object({
+    maxLogFiles: field,
+    maxLogSize: field,
+    sqliteInstructions: field,
+  });
 }
 
 /**

--- a/frontend/app/src/modules/settings/backend/backend-options-form.ts
+++ b/frontend/app/src/modules/settings/backend/backend-options-form.ts
@@ -1,0 +1,109 @@
+import type { BackendOptions } from '@shared/ipc';
+import type { DefaultBackendArguments } from '@/modules/shell/app/backend';
+import { isEqual } from 'es-toolkit';
+
+/**
+ * The onboarding form holds its three numeric settings as strings, because the
+ * inputs are text fields. These are the raw field values, before parsing.
+ */
+export interface BackendOptionsFormFields {
+  dataDirectory: string;
+  logDirectory: string;
+  logFromOtherModules: boolean;
+  loglevel: BackendOptions['loglevel'];
+  maxLogFiles: string;
+  maxLogSize: string;
+  sqliteInstructions: string;
+}
+
+/**
+ * Parses a numeric field. A blank or unparsable value counts as 0, and a
+ * fractional value is truncated rather than rejected.
+ */
+export function parseValue(value?: string): number {
+  if (!value)
+    return 0;
+
+  const parsedValue = Number.parseInt(value);
+  return Number.isNaN(parsedValue) ? 0 : parsedValue;
+}
+
+export function stringifyValue(value?: number): string {
+  if (!value)
+    return '0';
+
+  return value.toString();
+}
+
+/**
+ * Projects the raw fields onto the option shape, so they can be compared with
+ * the initial options field by field.
+ */
+export function toBackendOptions(fields: BackendOptionsFormFields): Partial<BackendOptions> {
+  return {
+    dataDirectory: fields.dataDirectory,
+    logDirectory: fields.logDirectory,
+    logFromOtherModules: fields.logFromOtherModules,
+    loglevel: fields.loglevel,
+    maxLogfilesNum: parseValue(fields.maxLogFiles),
+    maxSizeInMbAllLogs: parseValue(fields.maxLogSize),
+    sqliteInstructions: parseValue(fields.sqliteInstructions),
+  };
+}
+
+/**
+ * The options that differ from the initial ones. Only these are sent, so the
+ * backend keeps whatever the user did not touch.
+ */
+export function diffBackendOptions(
+  fields: BackendOptionsFormFields,
+  initial: Partial<BackendOptions>,
+): Partial<BackendOptions> {
+  const current = toBackendOptions(fields);
+  const changed: Partial<BackendOptions> = {};
+
+  if (current.loglevel !== initial.loglevel)
+    changed.loglevel = current.loglevel;
+
+  if (current.dataDirectory !== initial.dataDirectory)
+    changed.dataDirectory = current.dataDirectory;
+
+  if (current.logDirectory !== initial.logDirectory)
+    changed.logDirectory = current.logDirectory;
+
+  if (current.logFromOtherModules !== initial.logFromOtherModules)
+    changed.logFromOtherModules = current.logFromOtherModules;
+
+  if (current.maxLogfilesNum !== initial.maxLogfilesNum)
+    changed.maxLogfilesNum = current.maxLogfilesNum;
+
+  if (current.maxSizeInMbAllLogs !== initial.maxSizeInMbAllLogs)
+    changed.maxSizeInMbAllLogs = current.maxSizeInMbAllLogs;
+
+  if (current.sqliteInstructions !== initial.sqliteInstructions)
+    changed.sqliteInstructions = current.sqliteInstructions;
+
+  return changed;
+}
+
+export function hasBackendOptionChanges(
+  fields: BackendOptionsFormFields,
+  initial: Partial<BackendOptions>,
+): boolean {
+  return !isEqual(toBackendOptions(fields), initial);
+}
+
+/**
+ * Whether the three resettable numeric fields still hold their default, which
+ * is what hides each field's reset button.
+ */
+export function backendDefaultsState(
+  fields: Pick<BackendOptionsFormFields, 'maxLogFiles' | 'maxLogSize' | 'sqliteInstructions'>,
+  defaults: DefaultBackendArguments,
+): { maxLogFiles: boolean; maxLogSize: boolean; sqliteInstructions: boolean } {
+  return {
+    maxLogFiles: defaults.maxLogfilesNum === parseValue(fields.maxLogFiles),
+    maxLogSize: defaults.maxSizeInMbAllLogs === parseValue(fields.maxLogSize),
+    sqliteInstructions: defaults.sqliteInstructions === parseValue(fields.sqliteInstructions),
+  };
+}

--- a/frontend/app/src/modules/settings/backend/backend-options-form.ts
+++ b/frontend/app/src/modules/settings/backend/backend-options-form.ts
@@ -2,6 +2,9 @@ import type { BackendOptions } from '@shared/ipc';
 import type { DefaultBackendArguments } from '@/modules/shell/app/backend';
 import { isEqual } from 'es-toolkit';
 
+/** The three numeric settings that carry a reset-to-default button. */
+export type AdvancedBackendField = 'files' | 'size' | 'instructions';
+
 /**
  * The onboarding form holds its three numeric settings as strings, because the
  * inputs are text fields. These are the raw field values, before parsing.


### PR DESCRIPTION
Migrates `OnboardingSettings` from vuelidate to the zod form core. This was the
last vuelidate root under settings, which now has none. App-wide the count goes
from 36 to 35.

Same shape as the earlier batches: characterize against the vuelidate version
first, then fix, extract, split and migrate, with the characterization spec
passing unchanged through every later commit.

### Commits

1. `test:` characterize the validation and the untested paths
2. `fix:` arm the data-directory selection guard
3. `refactor:` extract the backend options form logic
4. `refactor:` split out the advanced backend settings
5. `refactor:` move the backend options rules to zod

### The rule is kept digits-only, deliberately

The three numeric fields used `and(numeric, minValue(0))`. `minValue(0)` is
unreachable: `numeric`'s regex accepts no sign, so anything reaching the bound
is already non-negative, and either rule alone rejects `-1`. The input that
separates them is exponent notation. `1e5` is a valid value for a
`type="number"` input and is greater than 0, so a bound-only check accepts it,
while the regex rejects it.

That rules out the shared `numberSettingField` builder, which parses with
`Number()`. It would have accepted `1e5`, and `parseValue`'s `parseInt` would
then have saved `1`. So the port keeps the regex verbatim and drops the dead
bound. Both messages still fire together, in the original order, for a
whitespace-only value.

### The bug in commit 2

`selectDataDirectory` checked the `selecting` re-entrancy flag but never set it,
so the guard was dead and the `finally` cleared a flag that was never raised.
Only `selectLogsDirectory` armed it. A second click while the picker was open
opened a second one.

### Other changes

- New pure `backend-options-form.ts` holds `parseValue`/`stringifyValue`, the
  seven-field diff, the changed check and the at-default computeds, with 40 of
  its own tests.
- New `AdvancedBackendSettings.vue` takes the accordion body. `OnboardingSettings`
  goes from 492 to 356 lines.
- The interop `config()` test mock returned the same object whether asked for the
  file config or the defaults, which pinned the log directory and left that field
  permanently disabled. It now distinguishes the two calls.

### Testing

Component coverage goes from 126/160 statements, 82/105 branches and 41/55
functions to 152/160, 90/105 and 50/55, plus the new pure module's tests.

Verified in the app, since this form has no e2e and the unit tests mock the
write:

- saving a changed max-log-files value stores only that field, restarts the
  backend, and the reopened dialog re-reads it with the save button correctly
  disabled again
- picking a data directory carries both the new directory and the previously
  stored option through, rather than dropping one
- two rapid clicks on the folder button open exactly one native dialog
- errors appear as a field is edited and clear when it becomes valid, and the
  advanced section renders
