### PR TITLE
Fail the activity when a task result 404s

### DIFF
--- a/frontend/app/src/modules/core/tasks/use-task-handler.spec.ts
+++ b/frontend/app/src/modules/core/tasks/use-task-handler.spec.ts
@@ -4,10 +4,14 @@ import { hasTag } from 'plainfp/tagged';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCancelAsyncTask = vi.fn();
+const mockQueryTasks = vi.fn();
+const mockQueryTaskResult = vi.fn();
 
 vi.mock('@/modules/core/tasks/use-task-api', () => ({
   useTaskApi: vi.fn().mockReturnValue({
     cancelAsyncTask: (...args: unknown[]): unknown => mockCancelAsyncTask(...args),
+    queryTaskResult: (...args: unknown[]): unknown => mockQueryTaskResult(...args),
+    queryTasks: (...args: unknown[]): unknown => mockQueryTasks(...args),
   }),
 }));
 
@@ -144,6 +148,38 @@ describe('useTaskHandler', () => {
       assert(isErr(outcome));
       assert(hasTag(outcome.error, 'TaskFailed'));
       expect(outcome.error.message).toBe('something went wrong');
+    });
+
+    /**
+     * The monitor and the handler are only wrong *together*, so this drives the real pair rather
+     * than a mocked `handleResult`: the monitor's 404 payload once carried `result: {}`, which is
+     * not `null`, so the handler took its success branch and resolved the producer `ok({})` for a
+     * task the backend had forgotten — silently, since the message was dropped with it.
+     *
+     * `useTaskHandler` and `useTaskMonitor` are both `createSharedComposable`, so importing the
+     * monitor here (no `resetModules` since `beforeEach`) hands it the same handler instance.
+     */
+    it('should resolve TaskFailed when the backend no longer knows the task', async () => {
+      const { TaskNotFoundError } = await import('@/modules/core/tasks/types');
+      const { useTaskMonitor } = await import('@/modules/core/tasks/use-task-monitor');
+      const monitor = useTaskMonitor();
+      const taskFn = vi.fn().mockResolvedValue({ taskId: 30 });
+
+      const promise = handler.runTask<string>(taskFn, 'Forgotten task');
+      await nextTick();
+
+      mockQueryTasks.mockResolvedValue({ completed: [30], pending: [] });
+      mockQueryTaskResult.mockRejectedValue(new TaskNotFoundError('Task 30 not found'));
+
+      await monitor.monitor();
+
+      const outcome = await promise;
+
+      assert(isErr(outcome));
+      assert(hasTag(outcome.error, 'TaskFailed'));
+      // Carries the reason rather than dropping it: `terminalStatus` maps TaskFailed to FAILED.
+      expect(outcome.error.message).toContain('Task 30 not found');
+      expect(get(store.taskById)[30]).toBeUndefined();
     });
 
     it('should resolve each concurrent task from its own handler', async () => {

--- a/frontend/app/src/modules/core/tasks/use-task-monitor.spec.ts
+++ b/frontend/app/src/modules/core/tasks/use-task-monitor.spec.ts
@@ -79,8 +79,14 @@ describe('useTaskMonitor', () => {
     await monitor.monitor();
 
     expect(get(store.taskById)[2]).toBeUndefined();
+    // 🔴 `result` is asserted, not just `message`: `objectContaining` ignores the field, and
+    // anything but `null` sends the handler down its success branch — see the end-to-end case in
+    // `use-task-handler.spec.ts`.
     expect(mockHandleResult).toHaveBeenCalledWith(
-      expect.objectContaining({ message: expect.stringContaining('Task 2 not found') }),
+      {
+        message: expect.stringContaining('Task 2 not found'),
+        result: null,
+      },
       2,
     );
   });

--- a/frontend/app/src/modules/core/tasks/use-task-monitor.ts
+++ b/frontend/app/src/modules/core/tasks/use-task-monitor.ts
@@ -14,6 +14,15 @@ const MAX_BACKOFF_MS = 8000;
 
 type ErrorHandler = (task: Task, message?: string) => ActionResult<unknown>;
 
+/**
+ * The payload for a task the backend no longer knows about.
+ *
+ * 🔴 `result` must stay `null`. `use-task-handler` branches on `result !== null` *before* it looks
+ * at `message`, so an empty object here resolved the producer's promise as `ok({})` — a task the
+ * backend has forgotten was reported as a success carrying nothing, and the message below (the
+ * only thing saying anything went wrong) was discarded. `null` reaches the `message` branch, which
+ * yields `TaskFailed` and settles the activity FAILED.
+ */
 function useError(): { error: ErrorHandler } {
   const { t } = useI18n({ useScope: 'global' });
   const error: ErrorHandler = (task, error) => ({
@@ -22,7 +31,7 @@ function useError(): { error: ErrorHandler } {
       taskId: task.id,
       title: task.label,
     }),
-    result: {},
+    result: null,
   });
   return { error };
 }


### PR DESCRIPTION
A task the backend no longer knows about resolved its producer as a **success carrying an empty
object**, silently.

`use-task-monitor.ts` catches `TaskNotFoundError` (HTTP 404 on the task result) and builds a payload
via `useError()`, which set `result: {}`. `use-task-handler.ts` branches in this order:

```ts
if (error)                            -> err(TaskFailed)
else if (result !== null)             -> ok(result)      // <- taken
else if (message === USER_CANCELLED)  -> err(Cancelled)
else if (message)                     -> err(TaskFailed)
```

There is no `error` field and `{} !== null`, so it took the success branch and resolved `ok({})`.
The `task_manager.error` message built one line earlier, the only thing saying anything went wrong,
was discarded with it. Nothing notified, nothing retried.

## The fix

`useError()` returns `result: null`, so the payload reaches the `message` branch and yields
`TaskFailed`. `terminalStatus` (`lifecycle.ts:50-62`) maps that to `FAILED`, so the activity now
settles failed with the reason intact.

This needs no producer changes: the standard shape is
`run: async ({ runTask }) => mapResult(await runTask(...), transform)`, and `mapResult` is plainfp's
`map`, which passes `err` straight through. The few sites using `getOr` or an early `ok` do so
outside the run body, after the activity has already settled.

The sibling branch ten lines down already passed `result: null` and produced `TaskFailed` correctly;
the two paths differed only in that field.

## Not a regression from the task-centre work

`git log -S "result: {},"` puts this at `520da1b4b5` (2021-12-10, the pinia migration of the task
store). The pre-refactor code had the same `result: {}` with the branch order inverted
(`result === null` on the error side), so it resolved the old promise successfully in exactly the
same way. Three refactors moved the code without re-reading that branch.

## Side effect worth noting

Blockchain balances already went red, but by accident: `BlockchainBalances` requires `perAccount`
and `totals` with no defaults, so `parse({})` threw, escaped `handleRefresh`'s `try`/`finally` (no
catch), and `runActivity` caught it as `TaskFailed({ message: 'Unexpected error' })`. Because the
throw happened while evaluating `settleChain`'s argument, **`settleChain` never ran** and the
per-chain bookkeeping was skipped. With the `err` flowing through `mapResult` normally, it runs
again. Producers with lenient schemas were the ones silently completing.

## Tests

- **End-to-end** (`use-task-handler.spec.ts`): drives the real monitor and handler together rather
  than a mocked `handleResult`, since the two are only wrong in combination. Both are
  `createSharedComposable`, so importing the monitor shares the instance. Asserts the producer's
  resolved `Result` is `TaskFailed` carrying the 404's message.
- **Boundary** (`use-task-monitor.spec.ts`): the existing test asserted only `message` through
  `expect.objectContaining`, which ignores `result` entirely, which is why it passed for four years.
  It now asserts the full payload.
- **Negative control**: reverting to `result: {}` fails exactly those two tests and nothing else.

Full unit suite green (787 files / 7586 tests), typecheck and lint clean.

## Left out on purpose

The message still does not reach the UI. `orchestrator.ts:214` passes only the status to
`settleTerminal`, and `ActivityRecord` has no message field, so a FAILED row renders the generic
"Failed" chip. Carrying the reason onto the record is a larger change and affects the `Skipped`
reasons the same way, so it belongs in its own PR.
