### PR TITLE
Show bitcoin in the transaction sync panel and fix the progress cursor

### DIFF
--- a/frontend/app/src/modules/core/messaging/types/status-types.ts
+++ b/frontend/app/src/modules/core/messaging/types/status-types.ts
@@ -84,9 +84,14 @@ const EvmTransactionStatusData = z.object({
   subtype: z.literal('evm').or(z.literal('evmlike')),
 });
 
+/**
+ * Batched: one message covers every address of a chain. `period` is optional only because the
+ * backend does not send it yet; downstream is wired for it either way.
+ */
 const BitcoinTransactionStatusData = z.object({
   addresses: z.array(z.string()),
   chain: z.string(),
+  period: z.tuple([z.number(), z.number()]).optional(),
   status: z.enum(TransactionsQueryStatus),
   subtype: z.literal('bitcoin'),
 });

--- a/frontend/app/src/modules/dashboard/progress/use-history-query-progress.spec.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-history-query-progress.spec.ts
@@ -71,9 +71,9 @@ describe('useHistoryQueryProgress', () => {
     expect(value?.percentage).toBe(0);
   });
 
-  it('should treat bitcoin as finished only at DECODING_TRANSACTIONS_FINISHED', () => {
+  it('should treat bitcoin as active while it is decoding', () => {
     setTxStatuses({
-      a: bitcoinTx(TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
+      a: bitcoinTx(TransactionsQueryStatus.DECODING_TRANSACTIONS_STARTED),
       b: bitcoinTx(TransactionsQueryStatus.DECODING_TRANSACTIONS_FINISHED, 'bc2'),
     });
 
@@ -84,6 +84,23 @@ describe('useHistoryQueryProgress', () => {
     expect(value?.currentStep).toBe(1);
     expect(value?.totalSteps).toBe(2);
     expect(value?.percentage).toBe(50);
+  });
+
+  // The backend skips the decode messages when the query came back empty, so requiring them kept
+  // this indicator spinning over addresses the sync panel already showed as complete.
+  it('should treat bitcoin as finished at QUERYING_TRANSACTIONS_FINISHED', () => {
+    setTxStatuses({
+      a: bitcoinTx(TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
+      b: bitcoinTx(TransactionsQueryStatus.DECODING_TRANSACTIONS_FINISHED, 'bc2'),
+    });
+
+    const { progress } = useHistoryQueryProgress();
+    const value = get(progress);
+
+    expect(value?.currentOperation).toBeNull();
+    expect(value?.currentStep).toBe(2);
+    expect(value?.totalSteps).toBe(2);
+    expect(value?.percentage).toBe(100);
   });
 
   it('should treat non-bitcoin as finished at QUERYING_TRANSACTIONS_FINISHED', () => {

--- a/frontend/app/src/modules/dashboard/progress/use-history-query-progress.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-history-query-progress.ts
@@ -7,7 +7,7 @@ import {
   TransactionsQueryStatus,
 } from '@/modules/core/messaging/types';
 import { useEventsQueryStatusStore } from '@/modules/history/use-events-query-status-store';
-import { type TxQueryStatusData, useTxQueryStatusStore } from '@/modules/history/use-tx-query-status-store';
+import { isTxQueryStatusFinished, type TxQueryStatusData, useTxQueryStatusStore } from '@/modules/history/use-tx-query-status-store';
 
 interface HistoryQueryProgressOperationData {
   type: HistoryQueryProgressType;
@@ -72,20 +72,7 @@ function isTransactionActive(status: TxQueryStatusData): boolean {
   if (isTerminal(status))
     return false;
 
-  if (status.subtype === 'bitcoin') {
-    return status.status !== TransactionsQueryStatus.DECODING_TRANSACTIONS_FINISHED;
-  }
-  return status.status !== TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED;
-}
-
-function isTransactionFinished(status: TxQueryStatusData): boolean {
-  if (isTerminal(status))
-    return true;
-
-  if (status.subtype === 'bitcoin') {
-    return status.status === TransactionsQueryStatus.DECODING_TRANSACTIONS_FINISHED;
-  }
-  return status.status === TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED;
+  return !isTxQueryStatusFinished(status);
 }
 
 function createTransactionProgress(
@@ -133,7 +120,7 @@ function calculateProgressMetrics(
   txStatuses: TxQueryStatusData[],
   eventStatuses: HistoryEventsQueryData[],
 ): { completedSteps: number; totalItems: number; percentage: number } {
-  const finishedTxItems = txStatuses.filter(isTransactionFinished).length;
+  const finishedTxItems = txStatuses.filter(isTxQueryStatusFinished).length;
   const finishedEventItems = eventStatuses.filter(isEventFinished).length;
 
   const completedSteps = finishedTxItems + finishedEventItems;

--- a/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.spec.ts
@@ -6,10 +6,18 @@ import { ActivityKind } from '@/modules/task-center/core/types';
 import { useHistoryTransactionDecoding } from './use-history-transaction-decoding';
 
 const mockNotifyError = vi.fn();
+
+interface UndecodedStatus {
+  chain: string;
+  processed: number;
+  total: number;
+}
+
 const mocks = vi.hoisted(() => ({
   markDecodingCancelled: vi.fn(),
   runTaskResult: vi.fn(),
   submitTask: vi.fn(),
+  undecodedStatus: new Array<{ chain: string; processed: number; total: number }>(),
 }));
 
 vi.mock('@/modules/core/notifications/use-notifications', () => ({
@@ -21,6 +29,7 @@ vi.mock('@/modules/task-center/use-native-task', () => ({
     cancelByType: vi.fn(() => vi.fn()),
     reportProgress: vi.fn(),
     runTaskResult: mocks.runTaskResult,
+    statusOf: vi.fn(() => ({ active: false, everCompleted: false, pending: false, running: false })),
     submitTask: mocks.submitTask,
   })),
 }));
@@ -44,7 +53,7 @@ vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
 
 vi.mock('@/modules/history/use-decoding-status-store', () => ({
   useDecodingStatusStore: vi.fn(() => ({
-    getUndecodedTransactionStatus: vi.fn(() => []),
+    getUndecodedTransactionStatus: vi.fn(() => mocks.undecodedStatus),
     markDecodingCancelled: mocks.markDecodingCancelled,
     resetUndecodedTransactionsStatus: vi.fn(),
     updateUndecodedTransactionsStatus: vi.fn(),
@@ -56,6 +65,7 @@ vi.mock('@/modules/core/common/use-supported-chains', () => ({
     decodableTxChainsInfo: ref<{ id: string }[]>([]),
     getChain: vi.fn((chain: string) => chain),
     getChainName: vi.fn((chain: string) => chain),
+    isBtcChains: vi.fn((chain: string) => ['btc', 'bch'].includes(chain)),
     isEvmLikeChains: vi.fn(() => false),
     isSolanaChains: vi.fn(() => false),
   })),
@@ -65,7 +75,33 @@ describe('useHistoryTransactionDecoding', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    mocks.undecodedStatus = [];
     mocks.submitTask.mockResolvedValue(ok(undefined));
+  });
+
+  describe('checkMissingEventsAndRedecode', () => {
+    /**
+     * Bitcoin decodes through its own backend path, never the EVM decode endpoint. It only reaches
+     * this store once bitcoin reports decoding progress over the websocket, so the sweep's
+     * "everything that is not evmlike is EVM" split silently starts claiming it.
+     */
+    it('should not sweep a bitcoin chain into the EVM decode', async () => {
+      const seeded: UndecodedStatus[] = [
+        { chain: 'eth', processed: 0, total: 5 },
+        { chain: 'btc', processed: 0, total: 3 },
+      ];
+      mocks.undecodedStatus = seeded;
+
+      const { checkMissingEventsAndRedecode } = useHistoryTransactionDecoding();
+      await checkMissingEventsAndRedecode();
+
+      const decoded = mocks.submitTask.mock.calls
+        .filter(call => call[0].kind === ActivityKind.TX_DECODING)
+        .map(call => call[0].id);
+
+      expect(decoded).toContain(decodeActivityId('eth'));
+      expect(decoded).not.toContain(decodeActivityId('btc'));
+    });
   });
 
   describe('redecodeTransactions', () => {

--- a/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.ts
@@ -43,7 +43,7 @@ export const useHistoryTransactionDecoding = createSharedComposable(() => {
   const { decodeTransactions } = useHistoryEventsApi();
   const { cancelByKind, submitTask } = useNativeTask();
   const { getUndecodedTransactionStatus, markDecodingCancelled, resetUndecodedTransactionsStatus } = useDecodingStatusStore();
-  const { decodableTxChainsInfo, getChain, getChainName, isEvmLikeChains } = useSupportedChains();
+  const { decodableTxChainsInfo, getChainName, isBtcChains, isEvmLikeChains } = useSupportedChains();
   const { fetchUndecodedTransactionsBreakdown } = useUndecodedTransactionsStatus();
 
   const decodeTransactionsTask = async (
@@ -98,13 +98,16 @@ export const useHistoryTransactionDecoding = createSharedComposable(() => {
 
   const checkMissingEventsAndRedecodeHandler = async (type: TransactionChainType): Promise<void> => {
     const isEvmType = type === TransactionChainType.EVM;
+    // The store already keys on the canonical chain id, so no resolution is needed here.
+    //
+    // ⚠️ The evmlike test alone splits the world in two, so anything that is not evmlike counts as
+    // EVM. Bitcoin decodes through its own backend path and must not be handed to the EVM decode
+    // endpoint — it reaches this store as soon as it reports decoding progress over the websocket.
     const chains = getUndecodedTransactionStatus()
-      .filter(({ chain, processed, total }) => {
-        const blockchain = getChain(chain);
-        const isEvmLike = isEvmLikeChains(blockchain);
-        return processed < total && isEvmType === !isEvmLike;
-      })
-      .map(({ chain }) => getChain(chain));
+      .filter(({ chain, processed, total }) =>
+        processed < total && !isBtcChains(chain) && isEvmType === !isEvmLikeChains(chain),
+      )
+      .map(({ chain }) => chain);
     // No wrapper: each of these submits onto DECODE_LANE, which is what bounds how many chains
     // decode at once. Wrapping them in a second limiter only hid that.
     await Promise.all(chains.map(async chain => decodeTransactionsTask(chain)));

--- a/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.ts
@@ -101,8 +101,10 @@ export const useHistoryTransactionDecoding = createSharedComposable(() => {
     // The store already keys on the canonical chain id, so no resolution is needed here.
     //
     // ⚠️ The evmlike test alone splits the world in two, so anything that is not evmlike counts as
-    // EVM. Bitcoin decodes through its own backend path and must not be handed to the EVM decode
-    // endpoint — it reaches this store as soon as it reports decoding progress over the websocket.
+    // EVM. Bitcoin has no redecode endpoint at all: it decodes only as a phase inside its own
+    // `query_transactions`, and the backend's `CHAINS_WITH_TX_DECODING` covers EVM, evmlike and
+    // Solana only, so the schema rejects it. Without this guard it would be posted there anyway,
+    // since it reaches this store as soon as it reports decoding progress over the websocket.
     const chains = getUndecodedTransactionStatus()
       .filter(({ chain, processed, total }) =>
         processed < total && !isBtcChains(chain) && isEvmType === !isEvmLikeChains(chain),

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.spec.ts
@@ -1,10 +1,11 @@
 import type { RefreshTransactionsParams } from './types';
 import type { Exchange } from '@/modules/balances/types/exchanges';
-import type { ChainAddress } from '@/modules/history/events/event-payloads';
+import type { SeededAccount } from '@/modules/history/use-tx-query-status-store';
 import flushPromises from 'flush-promises';
 import { err, ok, type Result } from 'plainfp/result';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Cancelled, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { type ChainAddress, TransactionChainType } from '@/modules/history/events/event-payloads';
 import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
 import { ActivityKind, makeActivityId, type WorkStatus } from '@/modules/task-center/core/types';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
@@ -36,7 +37,7 @@ const mockExchanges: Exchange[] = [
 
 // Mock stores and composables
 const mockTxQueryStatusStore = {
-  initializeQueryStatus: vi.fn<(accounts: ChainAddress[], options?: { extend?: boolean }) => void>(),
+  initializeQueryStatus: vi.fn<(accounts: SeededAccount[], options?: { extend?: boolean }) => void>(),
   resetQueryStatus: vi.fn(),
   stopSyncing: vi.fn(),
 };
@@ -50,6 +51,9 @@ const mockEventsQueryStatusStore = {
 const mockHistoryTransactionAccounts = {
   filterDisabledChainAccounts: vi.fn((accounts: ChainAddress[]) => accounts),
   getAllAccounts: vi.fn(() => [...mockEvmAccounts, ...mockBitcoinAccounts]),
+  getTransactionTypeFromChain: vi.fn((chain: string): TransactionChainType =>
+    chain === 'btc' ? TransactionChainType.BITCOIN : TransactionChainType.EVM,
+  ),
 };
 
 // Novelty now comes from the completion ledger, so the spec states which per-account work has been
@@ -467,8 +471,14 @@ describe('useRefreshTransactions', () => {
       // address the first wave had already finished, so the bar's denominator fell mid-sync
       // (the reported 6/7 -> 3/3) with nothing to signal that a second wave had begun.
       const [initial, drained] = mockTxQueryStatusStore.initializeQueryStatus.mock.calls;
-      expect(initial).toEqual([mockEvmAccounts, { extend: false }]);
-      expect(drained).toEqual([[addedMidRefresh], { extend: true }]);
+      expect(initial).toEqual([
+        [
+          ...mockEvmAccounts.map(account => ({ ...account, subtype: 'evm' })),
+          ...mockBitcoinAccounts.map(account => ({ ...account, subtype: 'bitcoin' })),
+        ],
+        { extend: false },
+      ]);
+      expect(drained).toEqual([[{ ...addedMidRefresh, subtype: 'evm' }], { extend: true }]);
 
       // One reset for the sync as a whole, not one per wave.
       expect(mockTxQueryStatusStore.resetQueryStatus).toHaveBeenCalledTimes(1);
@@ -752,12 +762,20 @@ describe('useRefreshTransactions', () => {
   });
 
   describe('query status management', () => {
-    it('should initialize query status for EVM accounts', async () => {
+    // Seeded from the same set that gets synced, subtype included. Seeding only the decodable
+    // accounts kept bitcoin out of the sync panel entirely while its addresses were being queried.
+    it('should initialize query status for every synced account, bitcoin included', async () => {
       const { refreshTransactions } = scope.run(() => useRefreshTransactions())!;
 
       await refreshTransactions();
 
-      expect(mockTxQueryStatusStore.initializeQueryStatus).toHaveBeenCalledWith(mockEvmAccounts, { extend: false });
+      expect(mockTxQueryStatusStore.initializeQueryStatus).toHaveBeenCalledWith(
+        [
+          ...mockEvmAccounts.map(account => ({ ...account, subtype: 'evm' })),
+          ...mockBitcoinAccounts.map(account => ({ ...account, subtype: 'bitcoin' })),
+        ],
+        { extend: false },
+      );
     });
 
     it('should reset query status when no accounts to refresh', async () => {

--- a/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-transactions.ts
@@ -40,7 +40,7 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
 
   const { initializeQueryStatus, resetQueryStatus, stopSyncing: stopTxSyncing } = useTxQueryStatusStore();
   const { initializeQueryStatus: initializeExchangeEventsQueryStatus, resetQueryStatus: resetExchangesQueryStatus, stopSyncing: stopEventsSyncing } = useEventsQueryStatusStore();
-  const { filterDisabledChainAccounts } = useHistoryTransactionAccounts();
+  const { filterDisabledChainAccounts, getTransactionTypeFromChain } = useHistoryTransactionAccounts();
   const { statusOf, submitTask } = useNativeTask();
   const { fetchUndecodedTransactionsBreakdown } = useUndecodedTransactionsStatus();
   const { resetDecodingSyncProgress, resetUndecodedTransactionsStatus, resumeDecodingSyncProgress, stopDecodingSyncProgress } = useDecodingStatusStore();
@@ -82,7 +82,13 @@ export function useRefreshTransactions(): UseRefreshTransactionsReturn {
       return;
     }
 
-    initializeQueryStatus(targets.decodableAccounts, { extend: continuation });
+    // ⚠️ Seeded from `accounts`, the same set `syncTransactionsByChains` queries — not from
+    // `decodableAccounts`, which drops bitcoin by definition and so kept every bitcoin chain out of
+    // the sync panel while its addresses were being queried.
+    initializeQueryStatus(
+      targets.accounts.map(account => ({ ...account, subtype: getTransactionTypeFromChain(account.chain) })),
+      { extend: continuation },
+    );
 
     if (continuation) {
       // ⚠️ Re-arm, do not reset. The decode section is gated by a single flag that the previous

--- a/frontend/app/src/modules/history/tx-query-status-period.ts
+++ b/frontend/app/src/modules/history/tx-query-status-period.ts
@@ -1,0 +1,111 @@
+import {
+  TransactionsQueryStatus,
+  type UnifiedTransactionStatusData,
+} from '@/modules/core/messaging/types';
+
+/**
+ * The queried range and the boundaries progress is measured against.
+ *
+ * Kept beside the pure functions that derive it rather than in the store, which only wires them to
+ * incoming messages. `existing` is typed structurally here so this module stays independent of the
+ * store's own entry union.
+ */
+export interface PeriodTracking {
+  period: [number, number];
+  originalPeriodEnd?: number;
+  originalPeriodStart?: number;
+}
+
+/**
+ * Determines the original period end value for progress tracking.
+ * For STARTED status, captures the period[1] as the end boundary.
+ * For subsequent updates, preserves the existing value.
+ */
+export function determineOriginalPeriodEnd(
+  status: TransactionsQueryStatus,
+  period: [number, number],
+  existing?: Partial<PeriodTracking>,
+): number | undefined {
+  if (status === TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED) {
+    return period[1];
+  }
+  if (existing && 'originalPeriodEnd' in existing) {
+    return existing.originalPeriodEnd;
+  }
+  return undefined;
+}
+
+/**
+ * Determines the original period start value for progress tracking.
+ * - If period[0] > 0, uses that as the actual start
+ * - If period[0] is 0 (beginning of time), captures the first non-zero period[1] as the effective start
+ * - Preserves existing originalPeriodStart for subsequent updates
+ * - Does not capture from STARTED status (where period[1] is the end boundary, not progress)
+ */
+export function determineOriginalPeriodStart(
+  status: TransactionsQueryStatus,
+  period: [number, number],
+  existing?: Partial<PeriodTracking>,
+): number | undefined {
+  const [periodStart, periodCurrent] = period;
+
+  if (periodStart > 0) {
+    return periodStart;
+  }
+  if (existing && 'originalPeriodStart' in existing && existing.originalPeriodStart !== undefined) {
+    return existing.originalPeriodStart;
+  }
+  if (periodCurrent > 0 && status !== TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED) {
+    return periodCurrent;
+  }
+  return undefined;
+}
+
+/**
+ * The stored period, with `period[1]` normalised to mean the query's current cursor.
+ *
+ * ⚠️ The backend overloads that slot: it is the range's target end on STARTED, and the cursor
+ * reached so far on every later message. Stored raw, STARTED reads as "already at the end" — it is
+ * captured as `originalPeriodEnd` and compared against itself, so the bar renders 100% and the range
+ * renders `to → to` before anything has been queried. Nothing has progressed yet, so the cursor
+ * belongs at the start of the range.
+ *
+ * EVM hides this: its cursor advances within milliseconds, so the wrong value is never seen. Bitcoin
+ * sends one cursor update per block-height batch, after that batch has already been queried, and
+ * none at all when a batch comes back empty, so it shows the wrong value for the whole query.
+ *
+ * ⚠️ Callers must still pass the *raw* period to `determineOriginalPeriodEnd`, which is what makes
+ * STARTED the message that establishes the target.
+ */
+export function periodWithCursorAtStart(
+  status: TransactionsQueryStatus,
+  period: [number, number],
+): [number, number] {
+  return status === TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED ? [period[0], period[0]] : period;
+}
+
+/**
+ * Period tracking for a bitcoin message, which is the one subtype whose `period` is optional.
+ *
+ * ⚠️ Carries `existing`'s values when the message has none: the entry is rebuilt from scratch per
+ * message, so a period-less update would otherwise erase what an earlier one established and make
+ * the progress bar vanish mid-query.
+ */
+export function bitcoinPeriodFields(
+  data: Extract<UnifiedTransactionStatusData, { subtype: 'bitcoin' }>,
+  existing?: Partial<PeriodTracking>,
+): Partial<PeriodTracking> {
+  if (data.period === undefined) {
+    return {
+      originalPeriodEnd: existing?.originalPeriodEnd,
+      originalPeriodStart: existing?.originalPeriodStart,
+      period: existing?.period,
+    };
+  }
+
+  return {
+    originalPeriodEnd: determineOriginalPeriodEnd(data.status, data.period, existing),
+    originalPeriodStart: determineOriginalPeriodStart(data.status, data.period, existing),
+    period: periodWithCursorAtStart(data.status, data.period),
+  };
+}

--- a/frontend/app/src/modules/history/use-decoding-status-store.spec.ts
+++ b/frontend/app/src/modules/history/use-decoding-status-store.spec.ts
@@ -1,6 +1,21 @@
 import type { EvmUnDecodedTransactionsData } from '@/modules/core/messaging/types';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDecodingStatusStore } from './use-decoding-status-store';
+
+// Stands in for the real resolver, which indexes every chain under its id, its name and its
+// evmChainName. Without it `matchChain` finds nothing and the store's lowercase fallback would
+// carry these tests, proving none of the canonicalisation.
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn().mockReturnValue({
+    matchChain: (location: string): string | undefined => ({
+      bitcoin: 'btc',
+      btc: 'btc',
+      eth: 'eth',
+      ethereum: 'eth',
+      optimism: 'optimism',
+    })[location.toLowerCase()],
+  }),
+}));
 
 describe('useDecodingStatusStore', () => {
   beforeEach(() => {
@@ -11,6 +26,70 @@ describe('useDecodingStatusStore', () => {
     chain,
     processed,
     total,
+  });
+
+  describe('canonical chain keys', () => {
+    it('should key an uppercase SupportedBlockchain value under the canonical chain id', () => {
+      const store = useDecodingStatusStore();
+      // The shape bitcoin decoding progress arrives in: `chain` is the enum value, not the id.
+      store.setUndecodedTransactionsStatus(createStatus('BTC', 1, 1));
+
+      expect(get(store.undecodedTransactionsStatus)).toEqual({
+        btc: { chain: 'btc', processed: 1, total: 1 },
+      });
+    });
+
+    it('should key the EVM decoder chain name under the canonical chain id', () => {
+      const store = useDecodingStatusStore();
+      // The EVM decoder reports ChainID.to_name(), which is not the frontend's chain id.
+      store.setUndecodedTransactionsStatus(createStatus('ethereum', 100, 50));
+
+      expect(Object.keys(get(store.undecodedTransactionsStatus))).toEqual(['eth']);
+    });
+
+    it('should collapse different spellings of one chain into a single entry', () => {
+      const store = useDecodingStatusStore();
+      store.setUndecodedTransactionsStatus(createStatus('ethereum', 100, 50));
+      store.setUndecodedTransactionsStatus(createStatus('eth', 100, 80));
+
+      // Two entries would mean two rows in the sync panel and double weight in the progress bar.
+      const status = get(store.undecodedTransactionsStatus);
+      expect(Object.keys(status)).toHaveLength(1);
+      expect(status.eth.processed).toBe(80);
+    });
+
+    it('should cancel a decode addressed by the canonical id after progress arrived under another spelling', () => {
+      const store = useDecodingStatusStore();
+      store.resetDecodingSyncProgress();
+      store.setUndecodedTransactionsStatus(createStatus('ethereum', 100, 50));
+
+      // `markDecodingCancelled` is called with the frontend's own chain id. Keyed raw, it looked up
+      // 'eth' against an entry stored as 'ethereum' and the cancellation was silently dropped.
+      store.markDecodingCancelled('eth');
+
+      expect(get(store.decodingSyncProgress).eth.cancelled).toBe(true);
+    });
+
+    it('should not file an unrecognised chain under ethereum', () => {
+      const store = useDecodingStatusStore();
+      // `getChain` defaults to ETH for anything it cannot match, which would misattribute the row.
+      store.setUndecodedTransactionsStatus(createStatus('Unknownchain', 10, 5));
+
+      expect(Object.keys(get(store.undecodedTransactionsStatus))).toEqual(['unknownchain']);
+    });
+
+    it('should canonicalise the keys of a bulk breakdown update', () => {
+      const store = useDecodingStatusStore();
+      store.updateUndecodedTransactionsStatus({
+        BTC: createStatus('BTC', 4, 1),
+        ethereum: createStatus('ethereum', 100, 50),
+      });
+
+      const status = get(store.undecodedTransactionsStatus);
+      expect(Object.keys(status).sort()).toEqual(['btc', 'eth']);
+      expect(status.btc.chain).toBe('btc');
+      expect(status.eth.chain).toBe('eth');
+    });
   });
 
   describe('setUndecodedTransactionsStatus', () => {

--- a/frontend/app/src/modules/history/use-decoding-status-store.ts
+++ b/frontend/app/src/modules/history/use-decoding-status-store.ts
@@ -1,10 +1,33 @@
 import type { EvmUnDecodedTransactionsData } from '@/modules/core/messaging/types';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 
 export interface DecodingStatusEntry extends EvmUnDecodedTransactionsData {
   cancelled?: boolean;
 }
 
 export const useDecodingStatusStore = defineStore('history/decoding-status', () => {
+  const { matchChain } = useSupportedChains();
+
+  /**
+   * Resolve a chain identifier to the canonical id everything else in the app uses.
+   *
+   * ⚠️ Producers disagree on spelling: the EVM decoder reports `ChainID.to_name()` (`ethereum`),
+   * a chain reporting through `SupportedBlockchain` sends the enum value (`BTC`), and the frontend
+   * itself uses the chain id (`eth`, `btc`). Keyed raw, one chain occupies several entries — a row
+   * each in the sync panel and multiplied weight in the progress bar — and `markDecodingCancelled`,
+   * called with the frontend's own id, misses the entry it means to cancel.
+   *
+   * ⚠️ `matchChain`, not `getChain`: the latter answers `Blockchain.ETH` for anything it does not
+   * recognise, which would file that chain's progress under Ethereum and send Ethereum's id to the
+   * decode endpoint. Not hypothetical — `chainTokenLookup` skips any chain absent from the
+   * frontend's `Blockchain` enum, so a chain the backend ships first is always unmatched. Such a
+   * chain keeps a stable lowercase key of its own instead, which is also what the backend calls it.
+   *
+   * The lookup is built from the supported-chain list, which `use-session-ready.ts` awaits before
+   * navigating, so it is populated well before any decode can report progress.
+   */
+  const canonicalChain = (chain: string): string => matchChain(chain) ?? chain.toLowerCase();
+
   const undecodedTransactionsStatus = shallowRef<Record<string, EvmUnDecodedTransactionsData>>({});
   const decodingSyncProgress = shallowRef<Record<string, DecodingStatusEntry>>({});
   const decodingSyncing = shallowRef<boolean>(false);
@@ -18,28 +41,38 @@ export const useDecodingStatusStore = defineStore('history/decoding-status', () 
   );
 
   const setUndecodedTransactionsStatus = (data: EvmUnDecodedTransactionsData): void => {
+    const key = canonicalChain(data.chain);
+    const entry: EvmUnDecodedTransactionsData = { ...data, chain: key };
+
     set(undecodedTransactionsStatus, {
       ...get(undecodedTransactionsStatus),
-      [data.chain]: data,
+      [key]: entry,
     });
 
     if (!get(decodingSyncing))
       return;
 
     const currentSync = get(decodingSyncProgress);
-    if (currentSync[data.chain]?.cancelled)
+    if (currentSync[key]?.cancelled)
       return;
 
     set(decodingSyncProgress, {
       ...currentSync,
-      [data.chain]: data,
+      [key]: entry,
     });
   };
 
   const updateUndecodedTransactionsStatus = (data: Record<string, EvmUnDecodedTransactionsData>): void => {
+    const canonical = Object.fromEntries(
+      Object.entries(data).map(([chain, status]) => {
+        const key = canonicalChain(chain);
+        return [key, { ...status, chain: key }];
+      }),
+    );
+
     set(undecodedTransactionsStatus, {
       ...get(undecodedTransactionsStatus),
-      ...data,
+      ...canonical,
     });
 
     if (!get(decodingSyncing))
@@ -49,7 +82,7 @@ export const useDecodingStatusStore = defineStore('history/decoding-status', () 
     const updatedSyncProgress = { ...currentSyncProgress };
     let hasChanges = false;
 
-    for (const [chain, status] of Object.entries(data)) {
+    for (const [chain, status] of Object.entries(canonical)) {
       const existing = currentSyncProgress[chain];
       if (existing?.cancelled)
         continue;
@@ -65,12 +98,13 @@ export const useDecodingStatusStore = defineStore('history/decoding-status', () 
   };
 
   const markDecodingCancelled = (chain: string): void => {
+    const key = canonicalChain(chain);
     const current = get(decodingSyncProgress);
-    const existing = current[chain];
+    const existing = current[key];
     if (existing) {
       set(decodingSyncProgress, {
         ...current,
-        [chain]: { ...existing, cancelled: true },
+        [key]: { ...existing, cancelled: true },
       });
     }
   };

--- a/frontend/app/src/modules/history/use-tx-query-status-store.spec.ts
+++ b/frontend/app/src/modules/history/use-tx-query-status-store.spec.ts
@@ -129,6 +129,51 @@ describe('store/history/query-status/tx-query-status', () => {
       expect(Object.keys(get(store.queryStatus))).toHaveLength(0);
     });
 
+    // `period[1]` is the range's target end on STARTED and the cursor on every later message. Stored
+    // raw, STARTED compares against itself and reports a full bar before anything has been queried.
+    it('should park the cursor at the start of the range on STARTED', () => {
+      const store = useTxQueryStatusStore();
+      store.syncing = true;
+
+      store.setUnifiedTxQueryStatus({
+        address: '0x123',
+        chain: 'ETH',
+        period: [100, 1000],
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED,
+        subtype: 'evm',
+      });
+
+      // The target end is still captured, so the denominator is intact; only the cursor moves back.
+      expect(get(store.queryStatus)['0x123eth']).toMatchObject({
+        originalPeriodEnd: 1000,
+        period: [100, 100],
+      });
+    });
+
+    // The EVM cursor must keep advancing through the range: this is the behaviour that the STARTED
+    // normalisation above must not disturb.
+    it('should advance the evm cursor across the message sequence', () => {
+      const store = useTxQueryStatusStore();
+      store.syncing = true;
+      const base = { address: '0x123', chain: 'ETH', subtype: 'evm' } as const;
+
+      store.setUnifiedTxQueryStatus({ ...base, period: [0, 1000], status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED });
+      expect(get(store.queryStatus)['0x123eth'].period).toEqual([0, 0]);
+
+      store.setUnifiedTxQueryStatus({ ...base, period: [0, 400], status: TransactionsQueryStatus.QUERYING_TRANSACTIONS });
+      expect(get(store.queryStatus)['0x123eth'].period).toEqual([0, 400]);
+
+      store.setUnifiedTxQueryStatus({ ...base, period: [0, 750], status: TransactionsQueryStatus.QUERYING_TRANSACTIONS });
+      expect(get(store.queryStatus)['0x123eth'].period).toEqual([0, 750]);
+
+      // FINISHED carries the target end again, which is now the truth: the range is fully covered.
+      store.setUnifiedTxQueryStatus({ ...base, period: [0, 1000], status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED });
+      expect(get(store.queryStatus)['0x123eth']).toMatchObject({
+        originalPeriodEnd: 1000,
+        period: [0, 1000],
+      });
+    });
+
     it('should ignore ACCOUNT_CHANGE status', () => {
       const store = useTxQueryStatusStore();
       store.syncing = true;
@@ -218,9 +263,11 @@ describe('store/history/query-status/tx-query-status', () => {
         subtype: 'bitcoin',
       });
 
+      // The target end survives as `originalPeriodEnd`, while the cursor stays where STARTED left
+      // it: at the beginning, because nothing has been queried yet.
       expect(get(store.queryStatus).bc1abcbtc).toMatchObject({
         originalPeriodEnd: 1000,
-        period: [0, 1000],
+        period: [0, 0],
         status: TransactionsQueryStatus.QUERYING_TRANSACTIONS,
       });
     });

--- a/frontend/app/src/modules/history/use-tx-query-status-store.spec.ts
+++ b/frontend/app/src/modules/history/use-tx-query-status-store.spec.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TransactionsQueryStatus } from '@/modules/core/messaging/types';
 import { type TxQueryStatusData, useTxQueryStatusStore } from './use-tx-query-status-store';
 
@@ -34,8 +34,8 @@ describe('store/history/query-status/tx-query-status', () => {
     it('should initialize status for multiple accounts', () => {
       const store = useTxQueryStatusStore();
       const accounts = [
-        { address: '0x123', chain: 'eth' },
-        { address: '0x456', chain: 'optimism' },
+        { address: '0x123', chain: 'eth', subtype: 'evm' as const },
+        { address: '0x456', chain: 'optimism', subtype: 'evm' as const },
       ];
 
       store.initializeQueryStatus(accounts);
@@ -53,10 +53,10 @@ describe('store/history/query-status/tx-query-status', () => {
     it('should reset existing status before initializing', () => {
       const store = useTxQueryStatusStore();
 
-      store.initializeQueryStatus([{ address: '0x123', chain: 'eth' }]);
+      store.initializeQueryStatus([{ address: '0x123', chain: 'eth', subtype: 'evm' }]);
       expect(Object.keys(get(store.queryStatus))).toHaveLength(1);
 
-      store.initializeQueryStatus([{ address: '0x456', chain: 'optimism' }]);
+      store.initializeQueryStatus([{ address: '0x456', chain: 'optimism', subtype: 'evm' }]);
       expect(Object.keys(get(store.queryStatus))).toHaveLength(1);
       expect(get(store.queryStatus)['0x123eth']).toBeUndefined();
     });
@@ -64,8 +64,8 @@ describe('store/history/query-status/tx-query-status', () => {
     it('should keep the earlier entries when extending', () => {
       const store = useTxQueryStatusStore();
 
-      store.initializeQueryStatus([{ address: '0x123', chain: 'eth' }]);
-      store.initializeQueryStatus([{ address: '0x456', chain: 'optimism' }], { extend: true });
+      store.initializeQueryStatus([{ address: '0x123', chain: 'eth', subtype: 'evm' }]);
+      store.initializeQueryStatus([{ address: '0x456', chain: 'optimism', subtype: 'evm' }], { extend: true });
 
       const status = get(store.queryStatus);
       expect(Object.keys(status)).toHaveLength(2);
@@ -75,7 +75,7 @@ describe('store/history/query-status/tx-query-status', () => {
 
     it('should not walk a finished address back to ACCOUNT_CHANGE when extending', () => {
       const store = useTxQueryStatusStore();
-      const account = { address: '0x123', chain: 'eth' };
+      const account = { address: '0x123', chain: 'eth', subtype: 'evm' as const };
 
       store.initializeQueryStatus([account]);
       store.setUnifiedTxQueryStatus({
@@ -91,13 +91,24 @@ describe('store/history/query-status/tx-query-status', () => {
       expect(get(store.queryStatus)['0x123eth'].status).toBe(TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED);
     });
 
+    it('should seed a bitcoin account without a synthetic period', () => {
+      const store = useTxQueryStatusStore();
+
+      store.initializeQueryStatus([{ address: 'bc1abc', chain: 'btc', subtype: 'bitcoin' }]);
+
+      const entry = get(store.queryStatus).bc1abcbtc;
+      expect(entry).toMatchObject({ address: 'bc1abc', chain: 'btc', subtype: 'bitcoin' });
+      // A seeded period would render a progress bar over a range nobody queried.
+      expect(entry).not.toHaveProperty('period');
+    });
+
     it('should resume syncing when extending', () => {
       const store = useTxQueryStatusStore();
 
-      store.initializeQueryStatus([{ address: '0x123', chain: 'eth' }]);
+      store.initializeQueryStatus([{ address: '0x123', chain: 'eth', subtype: 'evm' }]);
       store.stopSyncing();
 
-      store.initializeQueryStatus([{ address: '0x456', chain: 'optimism' }], { extend: true });
+      store.initializeQueryStatus([{ address: '0x456', chain: 'optimism', subtype: 'evm' }], { extend: true });
 
       expect(get(store.syncing)).toBe(true);
     });
@@ -156,6 +167,79 @@ describe('store/history/query-status/tx-query-status', () => {
         chain: 'btc',
         subtype: 'bitcoin',
       });
+    });
+
+    it('should track a bitcoin period the same way as every other subtype', () => {
+      const store = useTxQueryStatusStore();
+      store.syncing = true;
+
+      store.setUnifiedTxQueryStatus({
+        addresses: ['bc1abc'],
+        chain: 'BTC',
+        period: [0, 1000],
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED,
+        subtype: 'bitcoin',
+      });
+
+      store.setUnifiedTxQueryStatus({
+        addresses: ['bc1abc'],
+        chain: 'BTC',
+        period: [0, 600],
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS,
+        subtype: 'bitcoin',
+      });
+
+      expect(get(store.queryStatus).bc1abcbtc).toMatchObject({
+        originalPeriodEnd: 1000,
+        originalPeriodStart: 600,
+        period: [0, 600],
+        subtype: 'bitcoin',
+      });
+    });
+
+    it('should keep a bitcoin period when a later message omits it', () => {
+      const store = useTxQueryStatusStore();
+      store.syncing = true;
+
+      store.setUnifiedTxQueryStatus({
+        addresses: ['bc1abc'],
+        chain: 'BTC',
+        period: [0, 1000],
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED,
+        subtype: 'bitcoin',
+      });
+
+      // `period` is optional on this subtype alone, so a message without one must not erase what an
+      // earlier message established, or the progress bar appears and then vanishes mid-query.
+      store.setUnifiedTxQueryStatus({
+        addresses: ['bc1abc'],
+        chain: 'BTC',
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS,
+        subtype: 'bitcoin',
+      });
+
+      expect(get(store.queryStatus).bc1abcbtc).toMatchObject({
+        originalPeriodEnd: 1000,
+        period: [0, 1000],
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS,
+      });
+    });
+
+    it('should leave a bitcoin entry period-less when the message carries none', () => {
+      const store = useTxQueryStatusStore();
+      store.syncing = true;
+
+      store.setUnifiedTxQueryStatus({
+        addresses: ['bc1abc'],
+        chain: 'BTC',
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED,
+        subtype: 'bitcoin',
+      });
+
+      const entry = get(store.queryStatus).bc1abcbtc;
+      assert(entry.subtype === 'bitcoin');
+      expect(entry.period).toBeUndefined();
+      expect(entry.originalPeriodEnd).toBeUndefined();
     });
 
     it('should set originalPeriodEnd from period[1] on STARTED status', () => {
@@ -576,8 +660,8 @@ describe('store/history/query-status/tx-query-status', () => {
       const store = useTxQueryStatusStore();
 
       store.initializeQueryStatus([
-        { address: '0x123', chain: 'eth' },
-        { address: '0x456', chain: 'optimism' },
+        { address: '0x123', chain: 'eth', subtype: 'evm' },
+        { address: '0x456', chain: 'optimism', subtype: 'evm' },
       ]);
 
       store.removeQueryStatus({ address: '0x123', chain: 'eth' });
@@ -635,24 +719,39 @@ describe('store/history/query-status/tx-query-status', () => {
       expect(get(store.isAllFinished)).toBe(false);
     });
 
-    it('should use DECODING_FINISHED for bitcoin status', () => {
+    it('should settle bitcoin on DECODING_FINISHED', () => {
       const store = useTxQueryStatusStore();
       store.syncing = true;
 
       store.setUnifiedTxQueryStatus({
         addresses: ['bc1abc'],
         chain: 'BTC',
-        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED,
+        status: TransactionsQueryStatus.DECODING_TRANSACTIONS_STARTED,
         subtype: 'bitcoin',
       });
 
-      // Bitcoin uses DECODING_TRANSACTIONS_FINISHED as the finished status
       expect(get(store.isAllFinished)).toBe(false);
 
       store.setUnifiedTxQueryStatus({
         addresses: ['bc1abc'],
         chain: 'BTC',
         status: TransactionsQueryStatus.DECODING_TRANSACTIONS_FINISHED,
+        subtype: 'bitcoin',
+      });
+
+      expect(get(store.isAllFinished)).toBe(true);
+    });
+
+    it('should settle bitcoin on QUERYING_FINISHED when no decode follows', () => {
+      const store = useTxQueryStatusStore();
+      store.syncing = true;
+
+      // The empty-result path: the backend stops at QUERYING_TRANSACTIONS_FINISHED and never sends
+      // the decode pair, so requiring the decode left the address querying forever.
+      store.setUnifiedTxQueryStatus({
+        addresses: ['bc1abc'],
+        chain: 'BTC',
+        status: TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED,
         subtype: 'bitcoin',
       });
 
@@ -682,8 +781,8 @@ describe('store/history/query-status/tx-query-status', () => {
       const store = useTxQueryStatusStore();
 
       store.initializeQueryStatus([
-        { address: '0x123', chain: 'eth' },
-        { address: '0x456', chain: 'optimism' },
+        { address: '0x123', chain: 'eth', subtype: 'evm' },
+        { address: '0x456', chain: 'optimism', subtype: 'evm' },
       ]);
 
       expect(Object.keys(get(store.queryStatus))).toHaveLength(2);

--- a/frontend/app/src/modules/history/use-tx-query-status-store.ts
+++ b/frontend/app/src/modules/history/use-tx-query-status-store.ts
@@ -21,32 +21,36 @@ interface BaseTxQueryStatusData {
   status: TransactionsQueryStatus;
 }
 
-interface EvmTxQueryStatusData extends BaseTxQueryStatusData {
+/** The queried range and the boundaries progress is measured against. */
+interface PeriodTracking {
+  period: [number, number];
+  originalPeriodEnd?: number;
+  originalPeriodStart?: number;
+}
+
+interface EvmTxQueryStatusData extends BaseTxQueryStatusData, PeriodTracking {
   subtype: 'evm';
-  period: [number, number];
-  originalPeriodEnd?: number;
-  originalPeriodStart?: number;
 }
 
-interface EvmlikeTxQueryStatusData extends BaseTxQueryStatusData {
+interface EvmlikeTxQueryStatusData extends BaseTxQueryStatusData, PeriodTracking {
   subtype: 'evmlike';
-  period: [number, number];
-  originalPeriodEnd?: number;
-  originalPeriodStart?: number;
 }
 
-interface BitcoinTxQueryStatusData extends BaseTxQueryStatusData {
+/** `PeriodTracking` is partial only because the backend does not send bitcoin a period yet. */
+interface BitcoinTxQueryStatusData extends BaseTxQueryStatusData, Partial<PeriodTracking> {
   subtype: 'bitcoin';
 }
 
-interface SolanaTxQueryStatusData extends BaseTxQueryStatusData {
+interface SolanaTxQueryStatusData extends BaseTxQueryStatusData, PeriodTracking {
   subtype: 'solana';
-  period: [number, number];
-  originalPeriodEnd?: number;
-  originalPeriodStart?: number;
 }
 
 export type TxQueryStatusData = EvmTxQueryStatusData | EvmlikeTxQueryStatusData | BitcoinTxQueryStatusData | SolanaTxQueryStatusData;
+
+/** An account plus the subtype its chain queries under, which decides the shape of its entry. */
+export interface SeededAccount extends ChainAddress {
+  subtype: TxQueryStatusData['subtype'];
+}
 
 function isBitcoinTxQueryStatusData(data: TxQueryStatusData): data is BitcoinTxQueryStatusData {
   return data.subtype === 'bitcoin';
@@ -97,20 +101,63 @@ function determineOriginalPeriodStart(
   return undefined;
 }
 
+/**
+ * Whether an address will report no further progress.
+ *
+ * ⚠️ The single source of truth: the sync panel and the dashboard indicator both read this. Separate
+ * copies of the rule are how the panel came to call a bitcoin address complete while the indicator
+ * still counted it as querying.
+ *
+ * Bitcoin decodes inline rather than through the separate decoding section, so it can end on either
+ * finish message: the backend sends `QUERYING_TRANSACTIONS_FINISHED` on both the empty and the
+ * decoding path, and only reaches `DECODING_TRANSACTIONS_FINISHED` on the latter. Accepting both
+ * settles the empty path, at the cost of a bitcoin address reading complete for the moment between
+ * the two on the decoding path.
+ */
+export function isTxQueryStatusFinished(item: TxQueryStatusData): boolean {
+  // Failed and cancelled are both terminal: no further progress is coming for that address, so a
+  // run holding one must still be able to settle.
+  if (item.status === TransactionsQueryStatus.CANCELLED || item.status === TransactionsQueryStatus.FAILED)
+    return true;
+
+  if (isBitcoinTxQueryStatusData(item)) {
+    return item.status === TransactionsQueryStatus.DECODING_TRANSACTIONS_FINISHED
+      || item.status === TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED;
+  }
+
+  return item.status === TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED;
+}
+
+/**
+ * Period tracking for a bitcoin message, which is the one subtype whose `period` is optional.
+ *
+ * ⚠️ Carries `existing`'s values when the message has none: the entry is rebuilt from scratch per
+ * message, so a period-less update would otherwise erase what an earlier one established and make
+ * the progress bar vanish mid-query.
+ */
+function bitcoinPeriodFields(
+  data: Extract<UnifiedTransactionStatusData, { subtype: 'bitcoin' }>,
+  existing?: TxQueryStatusData,
+): Partial<PeriodTracking> {
+  if (data.period === undefined) {
+    return {
+      originalPeriodEnd: existing?.originalPeriodEnd,
+      originalPeriodStart: existing?.originalPeriodStart,
+      period: existing?.period,
+    };
+  }
+
+  return {
+    originalPeriodEnd: determineOriginalPeriodEnd(data.status, data.period, existing),
+    originalPeriodStart: determineOriginalPeriodStart(data.status, data.period, existing),
+    period: data.period,
+  };
+}
+
 export const useTxQueryStatusStore = defineStore('history/transaction-query-status', () => {
   const createKey = ({ address, chain }: ChainAddress): string => address + chain.toLowerCase();
 
-  const isStatusFinished = (item: TxQueryStatusData): boolean => {
-    // Failed and cancelled are both terminal: no further progress is coming for that address, so a
-    // run holding one must still be able to settle.
-    if (item.status === TransactionsQueryStatus.CANCELLED || item.status === TransactionsQueryStatus.FAILED)
-      return true;
-
-    if (isBitcoinTxQueryStatusData(item)) {
-      return item.status === TransactionsQueryStatus.DECODING_TRANSACTIONS_FINISHED;
-    }
-    return item.status === TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED;
-  };
+  const isStatusFinished = isTxQueryStatusFinished;
 
   const {
     isAllFinished,
@@ -134,7 +181,7 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
    * ⚠️ An address already present is left alone. Re-seeding it as `ACCOUNT_CHANGE` would walk a
    * finished chain's progress backwards, which is the same lie in the other direction.
    */
-  const initializeQueryStatus = (data: ChainAddress[], { extend = false }: { extend?: boolean } = {}): void => {
+  const initializeQueryStatus = (data: SeededAccount[], { extend = false }: { extend?: boolean } = {}): void => {
     if (!extend)
       resetQueryStatus();
 
@@ -147,14 +194,17 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
       if (extend && status[key])
         continue;
 
-      status[key] = {
+      const base = {
         address: item.address,
         chain: item.chain,
-        originalPeriodEnd: now,
-        period: [0, now],
         status: TransactionsQueryStatus.ACCOUNT_CHANGE,
-        subtype: 'evm' as const,
       };
+
+      // ⚠️ The subtype comes from the caller rather than being assumed. Seeding everything as `evm`
+      // gave bitcoin rows a synthetic period, hence a progress bar for a range nobody queried.
+      status[key] = item.subtype === 'bitcoin'
+        ? { ...base, subtype: item.subtype }
+        : { ...base, originalPeriodEnd: now, period: [0, now], subtype: item.subtype };
     }
     set(queryStatus, status);
   };
@@ -175,11 +225,12 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
     const chain = data.chain.toLowerCase();
 
     if (data.subtype === 'bitcoin') {
-      // Convert bitcoin transactions (with addresses array) to individual entries
+      // One batched message covers every address, so it fans out into an entry each.
       for (const address of data.addresses) {
         const key = createKey({ address, chain });
+        const existing = statuses[key];
         // Guard: don't overwrite cancelled entries
-        if (statuses[key]?.status === TransactionsQueryStatus.CANCELLED)
+        if (existing?.status === TransactionsQueryStatus.CANCELLED)
           continue;
 
         statuses[key] = {
@@ -187,6 +238,7 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
           chain,
           status: data.status,
           subtype: 'bitcoin' as const,
+          ...bitcoinPeriodFields(data, existing),
         };
       }
     }

--- a/frontend/app/src/modules/history/use-tx-query-status-store.ts
+++ b/frontend/app/src/modules/history/use-tx-query-status-store.ts
@@ -6,6 +6,13 @@ import {
   type UnifiedTransactionStatusData,
 } from '@/modules/core/messaging/types';
 import { createQueryStatusState } from '@/modules/history/create-query-status-state';
+import {
+  bitcoinPeriodFields,
+  determineOriginalPeriodEnd,
+  determineOriginalPeriodStart,
+  type PeriodTracking,
+  periodWithCursorAtStart,
+} from '@/modules/history/tx-query-status-period';
 
 type EvmlikeStatusStep = 'started' | 'finished';
 
@@ -19,13 +26,6 @@ interface BaseTxQueryStatusData {
   address: string;
   chain: string;
   status: TransactionsQueryStatus;
-}
-
-/** The queried range and the boundaries progress is measured against. */
-interface PeriodTracking {
-  period: [number, number];
-  originalPeriodEnd?: number;
-  originalPeriodStart?: number;
 }
 
 interface EvmTxQueryStatusData extends BaseTxQueryStatusData, PeriodTracking {
@@ -57,51 +57,6 @@ function isBitcoinTxQueryStatusData(data: TxQueryStatusData): data is BitcoinTxQ
 }
 
 /**
- * Determines the original period end value for progress tracking.
- * For STARTED status, captures the period[1] as the end boundary.
- * For subsequent updates, preserves the existing value.
- */
-function determineOriginalPeriodEnd(
-  status: TransactionsQueryStatus,
-  period: [number, number],
-  existing?: TxQueryStatusData,
-): number | undefined {
-  if (status === TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED) {
-    return period[1];
-  }
-  if (existing && 'originalPeriodEnd' in existing) {
-    return existing.originalPeriodEnd;
-  }
-  return undefined;
-}
-
-/**
- * Determines the original period start value for progress tracking.
- * - If period[0] > 0, uses that as the actual start
- * - If period[0] is 0 (beginning of time), captures the first non-zero period[1] as the effective start
- * - Preserves existing originalPeriodStart for subsequent updates
- * - Does not capture from STARTED status (where period[1] is the end boundary, not progress)
- */
-function determineOriginalPeriodStart(
-  status: TransactionsQueryStatus,
-  period: [number, number],
-  existing?: TxQueryStatusData,
-): number | undefined {
-  const [periodStart, periodCurrent] = period;
-
-  if (periodStart > 0) {
-    return periodStart;
-  }
-  if (existing && 'originalPeriodStart' in existing && existing.originalPeriodStart !== undefined) {
-    return existing.originalPeriodStart;
-  }
-  if (periodCurrent > 0 && status !== TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED) {
-    return periodCurrent;
-  }
-  return undefined;
-}
-
-/**
  * Whether an address will report no further progress.
  *
  * ⚠️ The single source of truth: the sync panel and the dashboard indicator both read this. Separate
@@ -126,32 +81,6 @@ export function isTxQueryStatusFinished(item: TxQueryStatusData): boolean {
   }
 
   return item.status === TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED;
-}
-
-/**
- * Period tracking for a bitcoin message, which is the one subtype whose `period` is optional.
- *
- * ⚠️ Carries `existing`'s values when the message has none: the entry is rebuilt from scratch per
- * message, so a period-less update would otherwise erase what an earlier one established and make
- * the progress bar vanish mid-query.
- */
-function bitcoinPeriodFields(
-  data: Extract<UnifiedTransactionStatusData, { subtype: 'bitcoin' }>,
-  existing?: TxQueryStatusData,
-): Partial<PeriodTracking> {
-  if (data.period === undefined) {
-    return {
-      originalPeriodEnd: existing?.originalPeriodEnd,
-      originalPeriodStart: existing?.originalPeriodStart,
-      period: existing?.period,
-    };
-  }
-
-  return {
-    originalPeriodEnd: determineOriginalPeriodEnd(data.status, data.period, existing),
-    originalPeriodStart: determineOriginalPeriodStart(data.status, data.period, existing),
-    period: data.period,
-  };
 }
 
 export const useTxQueryStatusStore = defineStore('history/transaction-query-status', () => {
@@ -257,7 +186,7 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
         chain,
         originalPeriodEnd: determineOriginalPeriodEnd(data.status, data.period, existing),
         originalPeriodStart: determineOriginalPeriodStart(data.status, data.period, existing),
-        period: data.period,
+        period: periodWithCursorAtStart(data.status, data.period),
         status: data.status,
         subtype: data.subtype,
       };

--- a/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.spec.ts
@@ -172,6 +172,34 @@ describe('modules/sync-progress/components/AddressProgressItem', () => {
       expect(wrapper.find('[data-testid="progress"]').exists()).toBe(false);
     });
 
+    // What the STARTED message looks like once the store parks the cursor at the range start. Read
+    // raw it would be `[from, to]`, rendering the target end on both sides of the arrow as though
+    // the whole range had already been covered.
+    it('should render the range as "Beginning" while the cursor sits at the start', () => {
+      const address = createAddress(AddressStatus.QUERYING, {
+        period: [100, 100],
+        originalPeriodEnd: 1000,
+        periodProgress: 0,
+      });
+      wrapper = createWrapper(address);
+
+      expect(wrapper.text()).toContain('sync_progress.period.beginning');
+      // One date remains: the target end on the right of the arrow.
+      expect(wrapper.findAllComponents({ name: 'DateDisplay' })).toHaveLength(1);
+    });
+
+    it('should render the cursor date once the query has advanced', () => {
+      const address = createAddress(AddressStatus.QUERYING, {
+        period: [100, 600],
+        originalPeriodEnd: 1000,
+        periodProgress: 55,
+      });
+      wrapper = createWrapper(address);
+
+      expect(wrapper.text()).not.toContain('sync_progress.period.beginning');
+      expect(wrapper.findAllComponents({ name: 'DateDisplay' })).toHaveLength(2);
+    });
+
     it('should not show progress bar in compact mode', () => {
       const address = createAddress(AddressStatus.QUERYING, {
         period: [0, 500],

--- a/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.spec.ts
@@ -164,7 +164,18 @@ describe('modules/sync-progress/components/AddressProgressItem', () => {
       expect(progress.attributes('data-value')).toBe('50');
     });
 
-    it('should not show progress bar for bitcoin addresses', () => {
+    it('should not show progress bar for an address with no period', () => {
+      const address = createAddress(AddressStatus.QUERYING, {
+        subtype: AddressSubtype.BITCOIN,
+      });
+      wrapper = createWrapper(address);
+
+      expect(wrapper.find('[data-testid="progress"]').exists()).toBe(false);
+    });
+
+    // Gated on the period, not the subtype: bitcoin carries none today, and gets the same bar as
+    // every other chain once the backend starts sending one.
+    it('should show progress bar for a bitcoin address that has period progress', () => {
       const address = createAddress(AddressStatus.QUERYING, {
         period: [0, 500],
         periodProgress: 50,
@@ -172,7 +183,7 @@ describe('modules/sync-progress/components/AddressProgressItem', () => {
       });
       wrapper = createWrapper(address);
 
-      expect(wrapper.find('[data-testid="progress"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="progress"]').exists()).toBe(true);
     });
 
     it('should not show progress bar in compact mode', () => {

--- a/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.spec.ts
@@ -1,7 +1,7 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type AddressProgress, AddressStatus, AddressStep, AddressSubtype } from '../types';
+import { type AddressProgress, AddressStatus, AddressStep } from '../types';
 import AddressProgressItem from './AddressProgressItem.vue';
 
 vi.mock('@/modules/assets/api/use-asset-icon-api', () => ({
@@ -22,7 +22,6 @@ describe('modules/sync-progress/components/AddressProgressItem', () => {
     return {
       address: '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c',
       status,
-      subtype: AddressSubtype.EVM,
       ...options,
     };
   }
@@ -151,6 +150,8 @@ describe('modules/sync-progress/components/AddressProgressItem', () => {
   });
 
   describe('period progress', () => {
+    // Gated on the period alone, so any chain that sends one gets a bar without the component
+    // having to know which chain it is. Bitcoin reaches this path too.
     it('should show progress bar when address has period progress', () => {
       const address = createAddress(AddressStatus.QUERYING, {
         period: [0, 500],
@@ -165,25 +166,10 @@ describe('modules/sync-progress/components/AddressProgressItem', () => {
     });
 
     it('should not show progress bar for an address with no period', () => {
-      const address = createAddress(AddressStatus.QUERYING, {
-        subtype: AddressSubtype.BITCOIN,
-      });
+      const address = createAddress(AddressStatus.QUERYING);
       wrapper = createWrapper(address);
 
       expect(wrapper.find('[data-testid="progress"]').exists()).toBe(false);
-    });
-
-    // Gated on the period, not the subtype: bitcoin carries none today, and gets the same bar as
-    // every other chain once the backend starts sending one.
-    it('should show progress bar for a bitcoin address that has period progress', () => {
-      const address = createAddress(AddressStatus.QUERYING, {
-        period: [0, 500],
-        periodProgress: 50,
-        subtype: AddressSubtype.BITCOIN,
-      });
-      wrapper = createWrapper(address);
-
-      expect(wrapper.find('[data-testid="progress"]').exists()).toBe(true);
     });
 
     it('should not show progress bar in compact mode', () => {

--- a/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
-import { type AddressProgress, AddressStatus, AddressStep, AddressSubtype } from '../types';
+import { type AddressProgress, AddressStatus, AddressStep } from '../types';
 
 const { address } = defineProps<{
   address: AddressProgress;
@@ -70,9 +70,9 @@ const statusText = computed<string>(() => {
   return t('sync_progress.status.pending');
 });
 
-const hasPeriod = computed<boolean>(() =>
-  get(isQuerying) && !!address.period && address.subtype !== AddressSubtype.BITCOIN,
-);
+// Keyed on the period itself rather than the subtype: bitcoin carries none today, and renders the
+// same range as everything else once the backend sends one.
+const hasPeriod = computed<boolean>(() => get(isQuerying) && !!address.period);
 
 // Current position is period[1], show "Beginning" if current is 0 or equals start (hasn't progressed)
 const showBeginning = computed<boolean>(() => {
@@ -83,7 +83,7 @@ const showBeginning = computed<boolean>(() => {
 });
 
 const hasPeriodProgress = computed<boolean>(() =>
-  get(isQuerying) && address.periodProgress !== undefined && address.subtype !== AddressSubtype.BITCOIN,
+  get(isQuerying) && address.periodProgress !== undefined,
 );
 </script>
 

--- a/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/AddressProgressItem.vue
@@ -70,8 +70,8 @@ const statusText = computed<string>(() => {
   return t('sync_progress.status.pending');
 });
 
-// Keyed on the period itself rather than the subtype: bitcoin carries none today, and renders the
-// same range as everything else once the backend sends one.
+// Keyed on the period itself rather than the subtype, so a chain renders a range as soon as it
+// sends one and nothing has to be taught which subtypes carry periods. Bitcoin now does.
 const hasPeriod = computed<boolean>(() => get(isQuerying) && !!address.period);
 
 // Current position is period[1], show "Beginning" if current is 0 or equals start (hasn't progressed)

--- a/frontend/app/src/modules/shell/sync-progress/components/ChainProgressItem.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/ChainProgressItem.spec.ts
@@ -1,7 +1,7 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { AddressStatus, AddressSubtype, type ChainProgress } from '../types';
+import { AddressStatus, type ChainProgress } from '../types';
 import ChainProgressItem from './ChainProgressItem.vue';
 
 vi.mock('@/modules/assets/api/use-asset-icon-api', () => ({
@@ -40,7 +40,6 @@ describe('modules/sync-progress/components/ChainProgressItem', () => {
       addresses.push({
         address: `0x${i.toString().padStart(40, '0')}`,
         status,
-        subtype: AddressSubtype.EVM,
       });
     }
 

--- a/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.spec.ts
@@ -1,7 +1,7 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { AddressStatus, AddressSubtype, type ChainProgress } from '../types';
+import { AddressStatus, type ChainProgress } from '../types';
 import ChainProgressList from './ChainProgressList.vue';
 
 vi.mock('@/modules/assets/api/use-asset-icon-api', () => ({
@@ -24,7 +24,6 @@ describe('modules/sync-progress/components/ChainProgressList', () => {
       addresses: Array.from({ length: total }, (_, i) => ({
         address: `0x${chain}${i.toString().padStart(38, '0')}`,
         status: i < completed ? AddressStatus.COMPLETE : AddressStatus.PENDING,
-        subtype: AddressSubtype.EVM,
       })),
       cancelled: 0,
       chain,
@@ -43,7 +42,6 @@ describe('modules/sync-progress/components/ChainProgressList', () => {
       addresses: Array.from({ length: total }, (_, i) => ({
         address: `0x${chain}${i.toString().padStart(38, '0')}`,
         status: AddressStatus.FAILED,
-        subtype: AddressSubtype.EVM,
       })),
       cancelled: 0,
       chain,

--- a/frontend/app/src/modules/shell/sync-progress/components/SyncProgressDetails.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/SyncProgressDetails.spec.ts
@@ -1,7 +1,7 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { AddressStatus, AddressSubtype, type ChainProgress, type DecodingProgress, type LocationProgress, LocationStatus, type ProtocolCacheProgress } from '../types';
+import { AddressStatus, type ChainProgress, type DecodingProgress, type LocationProgress, LocationStatus, type ProtocolCacheProgress } from '../types';
 import SyncProgressDetails from './SyncProgressDetails.vue';
 
 vi.mock('@/modules/assets/api/use-asset-icon-api', () => ({
@@ -62,7 +62,6 @@ describe('modules/sync-progress/components/SyncProgressDetails', () => {
       addresses: Array.from({ length: total }, (_, i) => ({
         address: `0x${i.toString().padStart(40, '0')}`,
         status: i < completed ? AddressStatus.COMPLETE : AddressStatus.PENDING,
-        subtype: AddressSubtype.EVM,
       })),
       cancelled: 0,
       chain,

--- a/frontend/app/src/modules/shell/sync-progress/types.ts
+++ b/frontend/app/src/modules/shell/sync-progress/types.ts
@@ -9,15 +9,6 @@ export const AddressStatus = {
 
 export type AddressStatus = (typeof AddressStatus)[keyof typeof AddressStatus];
 
-export const AddressSubtype = {
-  BITCOIN: 'bitcoin',
-  EVM: 'evm',
-  EVMLIKE: 'evmlike',
-  SOLANA: 'solana',
-} as const;
-
-export type AddressSubtype = (typeof AddressSubtype)[keyof typeof AddressSubtype];
-
 export const AddressStep = {
   INTERNAL: 'internal',
   TOKENS: 'tokens',
@@ -34,7 +25,6 @@ export interface AddressProgress {
   originalPeriodEnd?: number;
   originalPeriodStart?: number;
   periodProgress?: number;
-  subtype: AddressSubtype;
 }
 
 export interface ChainProgress {

--- a/frontend/app/src/modules/shell/sync-progress/use-chain-progress.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-chain-progress.spec.ts
@@ -408,6 +408,26 @@ describe('useChainProgress', () => {
   });
 
   describe('period handling', () => {
+    // The store parks the cursor at the range start on STARTED, so the bar must read 0 there and
+    // climb from the later cursors. Read raw, STARTED compares the target end against itself and
+    // reports 100 before anything has been queried.
+    it('should report evm progress from the cursor, starting at zero', () => {
+      const cases: [period: [number, number], expected: number][] = [
+        [[0, 0], 0],
+        [[0, 250], 25],
+        [[0, 500], 50],
+        [[0, 1000], 100],
+      ];
+
+      for (const [period, expected] of cases) {
+        const queryStatus = ref<Record<string, TxQueryStatusData>>({
+          key1: createEvmStatusData('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS, period, 1000),
+        });
+
+        expect(get(useChainProgress(queryStatus))[0].addresses[0].periodProgress).toBe(expected);
+      }
+    });
+
     // The progress bar is driven by the period alone, so an entry that carries none must produce
     // neither a period nor a progress value rather than defaulting to one.
     it('should leave period and progress unset for an entry without a period', () => {

--- a/frontend/app/src/modules/shell/sync-progress/use-chain-progress.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-chain-progress.spec.ts
@@ -407,8 +407,10 @@ describe('useChainProgress', () => {
     });
   });
 
-  describe('subtype handling', () => {
-    it('should handle bitcoin subtype correctly', () => {
+  describe('period handling', () => {
+    // The progress bar is driven by the period alone, so an entry that carries none must produce
+    // neither a period nor a progress value rather than defaulting to one.
+    it('should leave period and progress unset for an entry without a period', () => {
       const queryStatus = ref<Record<string, TxQueryStatusData>>({
         key1: createBitcoinStatusData('bc1q...', 'btc', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
       });
@@ -416,20 +418,8 @@ describe('useChainProgress', () => {
       const result = useChainProgress(queryStatus);
       const chains = get(result);
 
-      expect(chains[0].addresses[0].subtype).toBe('bitcoin');
       expect(chains[0].addresses[0].period).toBeUndefined();
       expect(chains[0].addresses[0].periodProgress).toBeUndefined();
-    });
-
-    it('should handle evm subtype correctly', () => {
-      const queryStatus = ref<Record<string, TxQueryStatusData>>({
-        key1: createEvmStatusData('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
-      });
-
-      const result = useChainProgress(queryStatus);
-      const chains = get(result);
-
-      expect(chains[0].addresses[0].subtype).toBe('evm');
     });
   });
 

--- a/frontend/app/src/modules/shell/sync-progress/use-chain-progress.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-chain-progress.ts
@@ -61,9 +61,7 @@ function calculatePeriodProgress(period?: [number, number], originalPeriodEnd?: 
 }
 
 function toAddressProgress(data: TxQueryStatusData): AddressProgress {
-  const period = 'period' in data ? data.period : undefined;
-  const originalPeriodEnd = 'originalPeriodEnd' in data ? data.originalPeriodEnd : undefined;
-  const originalPeriodStart = 'originalPeriodStart' in data ? data.originalPeriodStart : undefined;
+  const { originalPeriodEnd, originalPeriodStart, period } = data;
 
   return {
     address: data.address,

--- a/frontend/app/src/modules/shell/sync-progress/use-chain-progress.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-chain-progress.ts
@@ -71,7 +71,6 @@ function toAddressProgress(data: TxQueryStatusData): AddressProgress {
     periodProgress: data.status === TransactionsQueryStatus.CANCELLED ? undefined : calculatePeriodProgress(period, originalPeriodEnd, originalPeriodStart),
     status: mapStatus(data.status),
     step: mapStep(data.status),
-    subtype: data.subtype,
   };
 }
 

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-progress.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-progress.spec.ts
@@ -72,7 +72,7 @@ describe('useSyncProgress', () => {
     // First initialize with addresses
     const addresses = statuses
       .filter((s): s is UnifiedTransactionStatusData & { address: string } => 'address' in s)
-      .map(s => ({ address: s.address, chain: s.chain }));
+      .map(s => ({ address: s.address, chain: s.chain, subtype: s.subtype }));
     txStore.initializeQueryStatus(addresses);
     // Then update each status
     for (const status of statuses) {


### PR DESCRIPTION
## Problem

Bitcoin never appeared in the transaction sync panel, and every chain's progress bar read 100% before anything had been queried.

**Bitcoin missing from the panel.** `use-refresh-transactions` seeded the panel from `targets.decodableAccounts` while the sync itself ran over `targets.accounts`. `decodableAccounts` is built from `isDecodableChains`, which excludes bitcoin by construction, so every bitcoin address was absent from the panel for the whole query.

**Decoding progress keyed on inconsistent chain ids.** The producers of the decoding-progress messages disagree on spelling: the EVM decoder reports `ChainID.to_name()` (`ethereum`), the bitcoin manager reports `SupportedBlockchain.value` (`BTC`, uppercase), and the frontend uses the chain id (`eth`, `btc`). Keyed raw, one chain occupies several entries, giving it a row each in the panel and multiplied weight in the progress bar. It also broke cancelling: an EVM decode is stored under `ethereum` while `markDecodingCancelled` looks up `eth`, so cancelling silently did nothing.

**The progress bar read 100% immediately.** `period[1]` means two different things: the range's target end on `QUERYING_TRANSACTIONS_STARTED`, and the cursor reached so far on every later message. The store read it as the cursor either way, and captured that same value as `originalPeriodEnd`, so on STARTED the cursor was compared against itself.

## Changes

- Seed the panel from `accounts`, carrying each account's subtype from `getTransactionTypeFromChain`. `initializeQueryStatus` takes `SeededAccount[]` rather than inventing a subtype per account.
- Resolve decoding-progress chains through `matchChain(chain) ?? chain.toLowerCase()`. Not `getChain`, which answers `Blockchain.ETH` for anything unmatched and would file an unknown chain's progress under Ethereum.
- Exclude bitcoin from the EVM redecode sweep. Bitcoin decodes only as a phase inside its own `query_transactions` and has no redecode endpoint: `CHAINS_WITH_TX_DECODING` covers EVM, evmlike and Solana only, so the schema rejects it.
- Park the cursor at the start of the range on STARTED. `originalPeriodEnd` still comes from the raw period, so STARTED remains the message that establishes the target and only the cursor moves.
- Drop `AddressSubtype`, which was set on every `AddressProgress` and read nowhere in production once the progress bar started keying on the period's presence.

## Verification

Run against a real profile with the websocket instrumented, so the message stream could be measured rather than inferred.

EVM, a fresh account tracking vitalik.eth on Ethereum: 4165 `querying_transactions` frames, cursor strictly increasing from Oct 2015 to Aug 2026 (4131 up, 33 repeated, 0 decreasing), plus 924 more in the internal-transactions phase. The bar climbs smoothly from 0.

Bitcoin: appears in the panel with its own icon, decodes as a single row (4053 transactions on the address tested), and the sync completes 12/12 without hanging on the empty path, where the backend skips the decode messages entirely.

Unit tests cover both halves. `should advance the evm cursor across the message sequence` walks STARTED to FINISHED and asserts the cursor advances and lands on the target; reverting the cursor change fails it.

## Known limitation, not addressed here

Bitcoin sends exactly one cursor message per address, and it arrives after the query has finished (`bitcoin/manager.py:282-286` runs after `_query` returns). Measured on a 304 second query, the only cursor frame landed at t=303.8s. So bitcoin's bar is now correct but still cannot animate. That needs a backend change and is being raised separately.