### PR TITLE
Stop a date in an event note from breaking the events table

### DIFF
--- a/frontend/app/src/modules/history/events/note-processors.spec.ts
+++ b/frontend/app/src/modules/history/events/note-processors.spec.ts
@@ -1,0 +1,79 @@
+import { bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { WORD_PROCESSORS, type WordProcessorContext } from './note-processors';
+
+function createContext(word: string, overrides: Partial<WordProcessorContext> = {}): WordProcessorContext {
+  return {
+    amountArr: [bigNumberify(100)],
+    getAssetSymbol: (id: string): string => id,
+    getCleanWord: (value: string): string => value,
+    index: 0,
+    processedWords: [word],
+    shouldFormatAllAmount: false,
+    validatorIndices: [],
+    word,
+    ...overrides,
+  };
+}
+
+describe('note word processors', () => {
+  // Notes are arbitrary text, and a processor throwing here is not contained: it escapes the
+  // `formatNotes` computed mid-render and takes the surrounding patch down with it. `processWord`
+  // catches as a safety net, which is exactly why this asserts on the processors directly, where
+  // nothing hides a throw.
+  //
+  // `09/09/2026` is the real case, from an ENS registration note. `parseFloat` reports 9 for it
+  // because it stops at the first slash, so a guard built on `parseFloat` waves the whole string
+  // through to BigNumber, which since v11 throws rather than yielding NaN.
+  it.each([
+    '09/09/2026',
+    '1/2/2027',
+    '2026-09-09',
+    '15:04:56',
+    '12:30',
+    '0x1234zz',
+    '1.2.3',
+    '-',
+    '.',
+  ])('should not throw on the non-numeric word "%s"', (word) => {
+    for (const processor of WORD_PROCESSORS)
+      expect(() => processor(createContext(word))).not.toThrow();
+  });
+
+  // Dates and times sit next to amounts in real notes ("Lock expires at 09/09/2026 15:04:56 CEST").
+  // A numeric-prefix test reads 9 and 15 out of those, so they must be rejected on shape, not just
+  // survive the parse.
+  it.each([
+    '09/09/2026',
+    '1/2/2027',
+    '2026-09-09',
+    '15:04:56',
+    '12:30',
+  ])('should not treat the date or time "%s" as an amount', (word) => {
+    const results = WORD_PROCESSORS
+      .map(processor => processor(createContext(word, { amountArr: [bigNumberify(9), bigNumberify(15)] })))
+      .filter(Boolean);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not throw on a non-numeric word when every amount is formatted', () => {
+    for (const processor of WORD_PROCESSORS)
+      expect(() => processor(createContext('09/09/2026', { shouldFormatAllAmount: true }))).not.toThrow();
+  });
+
+  it('should still recognise a genuine amount', () => {
+    const results = WORD_PROCESSORS.map(processor => processor(createContext('100'))).filter(Boolean);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.format).toMatchObject({ amount: bigNumberify(100) });
+  });
+
+  it('should still recognise an amount written with thousand separators', () => {
+    const ctx = createContext('15,123.233', { amountArr: [bigNumberify(15123.233)] });
+    const results = WORD_PROCESSORS.map(processor => processor(ctx)).filter(Boolean);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.format).toMatchObject({ amount: bigNumberify(15123.233) });
+  });
+});

--- a/frontend/app/src/modules/history/events/note-processors.ts
+++ b/frontend/app/src/modules/history/events/note-processors.ts
@@ -11,6 +11,18 @@ import {
 } from '@rotki/common';
 import { type NoteFormat, NoteType } from './use-history-event-note';
 
+/** Sentinel for "this word is not a number", so `bigNumberify` returns instead of throwing. */
+const NOT_A_NUMBER = bigNumberify(Number.NaN);
+
+/**
+ * A word is a candidate amount only if it is numeric end to end.
+ *
+ * ⚠️ Anchored on purpose. Notes routinely carry dates and times next to amounts (`Lock expires at
+ * 09/09/2026 15:04:56 CEST`), and any test that accepts a numeric *prefix* takes those for amounts:
+ * `parseFloat('09/09/2026')` is 9 and `parseFloat('15:04:56')` is 15.
+ */
+const NUMERIC_WORD = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
+
 // Word processor types
 export interface WordProcessorContext {
   word: string;
@@ -102,12 +114,22 @@ const processAmount: WordProcessor = ({
   getCleanWord,
 }) => {
   const wordUsed = word.replace(/(\d),(?=\d{3}(?!\d))/g, '$1');
-  const isAmount = (amountArr.length > 0 || shouldFormatAllAmount) && !isNaN(parseFloat(wordUsed));
 
-  if (!isAmount)
+  if (amountArr.length === 0 && !shouldFormatAllAmount)
     return undefined;
 
-  const bigNumber = bigNumberify(wordUsed);
+  if (!NUMERIC_WORD.test(wordUsed))
+    return undefined;
+
+  // ⚠️ The fallback stays even with the shape already checked: since bignumber.js 11 an input
+  // BigNumber rejects throws rather than yielding NaN, and a throw here does not stay local. It
+  // escapes the `formatNotes` computed mid-render, Vue abandons the patch with vnodes left
+  // unmounted, and every later patch dies on them, which is what made a history group render its
+  // header with none of its events. Nothing about a note's text is worth that.
+  const bigNumber = bigNumberify(wordUsed, NOT_A_NUMBER);
+
+  if (bigNumber.isNaN())
+    return undefined;
   const isIncluded = amountArr.some(item => item.eq(bigNumber)) || shouldFormatAllAmount;
 
   if (!isIncluded || !bigNumber.gt(0))

--- a/frontend/app/src/modules/history/events/use-history-event-note.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-note.spec.ts
@@ -70,6 +70,55 @@ describe('useHistoryEventNotes', () => {
     expect(formatted).toMatchObject(expected);
   });
 
+  // An ENS registration note carries a date, and `parseFloat` reports 9 for `09/09/2026` because
+  // it stops at the first slash. Since bignumber.js 11 handing that whole string to BigNumber
+  // throws, and the throw escaped this computed mid-render: Vue abandoned the patch with vnodes
+  // left unmounted, every later patch died on them, and a history group rendered its header with
+  // none of its events.
+  it('should leave a date-like word as plain text when an amount is present', () => {
+    const notes = 'Register yabir.eth until 09/09/2026';
+
+    const formatted = get(formatNotes({ notes, amount: bigNumberify(100), assetId: 'ETH' }));
+
+    expect(formatted).toMatchObject([
+      { type: NoteType.WORD, word: 'Register yabir.eth until 09/09/2026' },
+    ]);
+  });
+
+  // The real note this was found on. It carries two words BigNumber rejects, the standalone `.`
+  // and the date, both of them *after* the amount. The throw discarded the whole computed result,
+  // so the GRT amount was parsed and then thrown away with everything else, which read as "the
+  // amount is not detected".
+  it('should format the amount in a note that also contains a date and a bare period', () => {
+    const notes = 'Undelegate 153.912179766381639129 GRT from indexer 0x089f78D8cF0a5ae1b7A581B1910a73F8CB3e4774 . Lock expires at 09/09/2026 15:04:56 CEST';
+
+    const formatted = get(formatNotes({
+      notes,
+      amount: bigNumberify('153.912179766381639129'),
+      assetId: 'GRT',
+    }));
+
+    expect(formatted).toContainEqual(expect.objectContaining({
+      amount: bigNumberify('153.912179766381639129'),
+      type: NoteType.AMOUNT,
+    }));
+    expect(formatted.map(item => item.word).join(' ')).toContain('09/09/2026');
+  });
+
+  // Defence in depth for the same failure: whatever a processor throws on, it must cost that one
+  // word and not the surrounding render.
+  it('should keep formatting the rest of a note when one word cannot be parsed', () => {
+    const notes = 'Receive 100 ETH before 01/02/2027';
+
+    const formatted = get(formatNotes({ notes, amount: bigNumberify(100), assetId: 'ETH' }));
+
+    expect(formatted).toMatchObject([
+      { type: NoteType.WORD, word: 'Receive' },
+      { type: NoteType.AMOUNT, amount: bigNumberify(100), asset: 'ETH' },
+      { type: NoteType.WORD, word: 'before 01/02/2027' },
+    ]);
+  });
+
   it('should parse formatted amount with thousand separator', () => {
     const notes = 'Receive 15,123.233 ETH';
     const formatted = get(formatNotes({ notes, amount: bigNumberify(15123.233), assetId: 'ETH' }));

--- a/frontend/app/src/modules/history/events/use-history-event-note.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-note.ts
@@ -3,6 +3,7 @@ import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { arrayify } from '@/modules/core/common/data/array';
 import { uniqueStrings } from '@/modules/core/common/data/data';
+import { logger } from '@/modules/core/common/logging/logging';
 import { useScramble } from '@/modules/settings/use-scramble';
 import { WORD_PROCESSORS, type WordProcessorContext, type WordProcessorResult } from './note-processors';
 
@@ -182,9 +183,19 @@ export function useHistoryEventNote(): UseHistoryEventNoteReturn {
     index: number,
   ): WordProcessorResult | undefined {
     for (const processor of WORD_PROCESSORS) {
-      const result = processor({ ...ctx, word, index });
-      if (result)
-        return result;
+      try {
+        const result = processor({ ...ctx, word, index });
+        if (result)
+          return result;
+      }
+      catch (error: unknown) {
+        // ⚠️ Notes are arbitrary text and this runs inside a computed, so a processor that throws
+        // on one odd word takes down far more than that word: the throw escapes mid-render, Vue
+        // abandons the patch with vnodes left unmounted, and every later patch then dies on them
+        // (`Cannot read properties of null (reading 'emitsOptions')`), which is what left a
+        // history group rendering its header with none of its events. Degrade to plain text.
+        logger.error(`note word processor failed for "${word}"`, error);
+      }
     }
     return undefined;
   }


### PR DESCRIPTION
## Problem

A history event note containing a date took out the whole events table.

`processAmount` decided whether a word was an amount with `!isNaN(parseFloat(word))`. `parseFloat` stops at the first character it cannot read, so for a note like

```
Undelegate 153.912179766381639129 GRT from indexer 0x089f… . Lock expires at 09/09/2026 15:04:56 CEST
```

it reports **9** for `09/09/2026` and **15** for `15:04:56`, and waved the whole string through to `bigNumberify`.

Since bignumber.js 11 an input BigNumber rejects throws instead of yielding NaN, and the throw did not stay local. It escaped the `formatNotes` computed mid-render, Vue abandoned the patch with vnodes left unmounted, and every later patch then failed on those with `Cannot read properties of null (reading 'emitsOptions')`.

The visible damage was larger than the note itself:

- the amount in that note rendered unformatted, because the computed's whole result was discarded after the amount had already been matched
- a history group rendered its header with none of its events
- 657 unhandled errors accumulated in one session, hundreds per sync

The bare `.` in that note throws too, as do `''`, `-`, `+`, `1e`, `1,5`.

## Changes

- `processAmount` rejects on shape first, with an anchored pattern so a numeric prefix cannot pass, then parses with a fallback so no input can throw whatever its shape. Both layers are deliberate: the pattern states the intent (dates and times are not amounts), the fallback guarantees the failure mode.
- `processWord` catches per word. Notes are arbitrary text and this runs inside a computed, so a processor throwing has to cost that one word rendering plain, not the surrounding render.

## Behaviour change worth reviewing

A word now counts as an amount only if it is numeric end to end. Previously any word with a numeric prefix qualified. A note containing something like `1,5` that happened to render as an amount will now render as plain text.

## Tests

`note-processors.spec.ts` asserts on the processors directly, deliberately not through `processWord`, so the new catch cannot hide whether the parse is correct. It covers dates, times, `-`, `.` and friends, and pins that genuine amounts including thousand separators still resolve. The real note above is covered end to end in `use-history-event-note.spec.ts`.

Reverting only the `processAmount` change fails 9 of 11 cases in that spec.

## Verification

Confirmed against the profile where it reproduced: before, hundreds of errors per sync; after, none in the following 25 minutes of use, and the affected note renders in full with its address link intact.