### PR TITLE
test: use createMock instead of hand-rolled mock literals

### DIFF
--- a/frontend/app/src/modules/assets/use-assets.spec.ts
+++ b/frontend/app/src/modules/assets/use-assets.spec.ts
@@ -1,5 +1,6 @@
 import type { useAssetIconApi } from '@/modules/assets/api/use-asset-icon-api';
 import type { AssetMergePayload, AssetUpdatePayload } from '@/modules/assets/types';
+import { createMock } from '@test/utils/create-mock';
 import { createCustomPinia } from '@test/utils/create-pinia';
 import { runSpecWith } from '@test/utils/mocks/native-task';
 import { err, ok, type Result } from 'plainfp/result';
@@ -60,17 +61,14 @@ vi.mock('@/modules/core/notifications/use-notifications-store/index', () => ({
   }),
 }));
 
-vi.mock('@/modules/shell/app/use-electron-interop', () => {
-  const mockInterop = {
-    appSession: vi.fn(),
-    openDirectory: vi.fn(),
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: vi.fn().mockReturnValue(createMock<ReturnType<typeof useInterop>>({
+    // A boolean, not a function: the export path branches on it directly.
+    appSession: true,
     getPath: vi.fn().mockReturnValue(undefined),
-  };
-  return {
-    useInterop: vi.fn().mockReturnValue(mockInterop),
-    interop: mockInterop,
-  };
-});
+    openDirectory: vi.fn(),
+  })),
+}));
 
 describe('useAssets', () => {
   let store: ReturnType<typeof useAssets>;

--- a/frontend/app/src/modules/auth/ConnectionFailureMessage.spec.ts
+++ b/frontend/app/src/modules/auth/ConnectionFailureMessage.spec.ts
@@ -1,5 +1,7 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
 import { assert } from '@rotki/common';
 import { LogLevel } from '@shared/log-level';
+import { createMock } from '@test/utils/create-mock';
 import { type DOMWrapper, flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -39,7 +41,7 @@ vi.mock('@/modules/shell/app/use-backend-management', () => ({
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: (): object => interop,
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>(interop),
 }));
 
 vi.mock('@/modules/core/api/rotki-api', () => ({

--- a/frontend/app/src/modules/auth/ConnectionFailureMessage.spec.ts
+++ b/frontend/app/src/modules/auth/ConnectionFailureMessage.spec.ts
@@ -1,3 +1,4 @@
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
 import type { useInterop } from '@/modules/shell/app/use-electron-interop';
 import { assert } from '@rotki/common';
 import { LogLevel } from '@shared/log-level';
@@ -45,7 +46,7 @@ vi.mock('@/modules/shell/app/use-electron-interop', () => ({
 }));
 
 vi.mock('@/modules/core/api/rotki-api', () => ({
-  api: { defaultBackend: true, serverUrl: 'http://localhost:4242' },
+  api: createMock<RotkiApi>({ defaultBackend: true, serverUrl: 'http://localhost:4242' }),
 }));
 
 describe('connectionFailureMessage', () => {

--- a/frontend/app/src/modules/auth/login/use-login-remember-options.spec.ts
+++ b/frontend/app/src/modules/auth/login/use-login-remember-options.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useLoginRememberOptions } from './use-login-remember-options';
 
@@ -8,7 +10,7 @@ const { clearPassword, interop, storePassword } = vi.hoisted(() => ({
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: (): Record<string, unknown> => ({
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({
     clearPassword,
     get isPackaged(): boolean {
       return interop.isPackaged;

--- a/frontend/app/src/modules/auth/unlock-flow/use-asset-update-steps.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-asset-update-steps.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BackendRestartStatus } from '@/modules/shell/app/use-backend-management';
@@ -23,7 +25,7 @@ vi.mock('@/modules/shell/app/use-backend-management', async importOriginal => ({
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: vi.fn(() => ({ isPackaged: interopState.isPackaged })),
+  useInterop: vi.fn(() => createMock<ReturnType<typeof useInterop>>({ isPackaged: interopState.isPackaged })),
 }));
 
 describe('useAssetUpdateSteps', () => {

--- a/frontend/app/src/modules/auth/unlock-flow/use-stored-credentials.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-stored-credentials.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { none, some } from 'plainfp';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useStoredCredentials } from './use-stored-credentials';
@@ -16,7 +18,7 @@ const { getPassword, isPackagedRef, lastLoginRef, savedRememberPasswordRef } = v
 vi.mock('@/modules/auth/account-management', () => ({ lastLogin: lastLoginRef }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: vi.fn(() => ({ getPassword, isPackaged: isPackagedRef.value })),
+  useInterop: vi.fn(() => createMock<ReturnType<typeof useInterop>>({ getPassword, isPackaged: isPackagedRef.value })),
 }));
 
 vi.mock('@/modules/auth/use-remember-settings', () => ({

--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.spec.ts
@@ -1,3 +1,5 @@
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
+import { createMock } from '@test/utils/create-mock';
 import { flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { none, ok, some } from 'plainfp';
@@ -11,7 +13,7 @@ import { createUnlockFlowController, type UseUnlockFlowControllerReturn } from '
 const authApi = vi.hoisted(() => ({ setOnAuthFailure: vi.fn() }));
 
 vi.mock('@/modules/core/api/rotki-api', () => ({
-  api: authApi,
+  api: createMock<RotkiApi>(authApi),
 }));
 
 vi.mock('@/modules/core/common/logging/logging', () => ({

--- a/frontend/app/src/modules/auth/use-account-management.spec.ts
+++ b/frontend/app/src/modules/auth/use-account-management.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import dayjs from 'dayjs';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccountManagement } from '@/modules/auth/use-account-management';
@@ -41,8 +43,10 @@ const mockInterop = vi.hoisted(() => ({
   premiumUserLoggedIn: vi.fn(),
 }));
 
+// The overrides object is read on every property access, so the tests can keep
+// flipping `mockInterop.isPackaged` between cases.
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: vi.fn().mockReturnValue(mockInterop),
+  useInterop: vi.fn().mockReturnValue(createMock<ReturnType<typeof useInterop>>(mockInterop)),
 }));
 
 vi.mock('@/modules/shell/app/use-backend-management', () => ({

--- a/frontend/app/src/modules/auth/use-logout.spec.ts
+++ b/frontend/app/src/modules/auth/use-logout.spec.ts
@@ -1,3 +1,4 @@
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
 import type { useInterop } from '@/modules/shell/app/use-electron-interop';
 import { createMock } from '@test/utils/create-mock';
 import flushPromises from 'flush-promises';
@@ -63,10 +64,10 @@ vi.mock('@/modules/auth/use-session-auth-store', () => ({
 }));
 
 vi.mock('@/modules/core/api', () => ({
-  api: {
-    cancelAllQueued: vi.fn(),
+  api: createMock<RotkiApi>({
     cancel: vi.fn(),
-  },
+    cancelAllQueued: vi.fn(),
+  }),
 }));
 
 vi.mock('@/modules/core/common/logging/logging', () => ({

--- a/frontend/app/src/modules/auth/use-logout.spec.ts
+++ b/frontend/app/src/modules/auth/use-logout.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useLogout } from '@/modules/auth/use-logout';
@@ -40,7 +42,7 @@ vi.mock('@/modules/wallet/use-wallet-store', () => ({
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: vi.fn(() => ({
+  useInterop: vi.fn(() => createMock<ReturnType<typeof useInterop>>({
     notifyUserLogout: mockNotifyUserLogout,
     resetMcpSession: mockResetMcpSession,
     resetTray: mockResetTray,

--- a/frontend/app/src/modules/auth/use-password-confirmation.spec.ts
+++ b/frontend/app/src/modules/auth/use-password-confirmation.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import dayjs from 'dayjs';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePasswordConfirmation } from '@/modules/auth/use-password-confirmation';
@@ -12,8 +14,10 @@ const mockInterop = vi.hoisted(() => ({
   premiumUserLoggedIn: vi.fn(),
 }));
 
+// The overrides object is read on every property access, so the tests can keep
+// flipping `mockInterop.isPackaged` between cases.
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: vi.fn().mockReturnValue(mockInterop),
+  useInterop: vi.fn().mockReturnValue(createMock<ReturnType<typeof useInterop>>(mockInterop)),
 }));
 
 const REMEMBER_PASSWORD_KEY = 'rotki.remember_password';

--- a/frontend/app/src/modules/core/api/request-queue/use-request-queue-state.spec.ts
+++ b/frontend/app/src/modules/core/api/request-queue/use-request-queue-state.spec.ts
@@ -1,4 +1,6 @@
+import type { RotkiApi } from '../rotki-api';
 import type { QueueState } from './types';
+import { createMock } from '@test/utils/create-mock';
 import { get } from '@vueuse/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { reactive } from 'vue';
@@ -13,11 +15,11 @@ const mockQueueState = reactive<QueueState>({
 });
 
 vi.mock('../rotki-api', () => ({
-  api: {
+  api: createMock<RotkiApi>({
     get queueState(): QueueState {
       return mockQueueState;
     },
-  },
+  }),
 }));
 
 vi.mock('vue-i18n', () => ({

--- a/frontend/app/src/modules/core/control/use-control.spec.ts
+++ b/frontend/app/src/modules/core/control/use-control.spec.ts
@@ -1,8 +1,10 @@
 import type { useControl as UseControl } from '@/modules/core/control/use-control';
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
 import { assert } from '@rotki/common';
 import { StarlingServiceStatus } from '@shared/ipc';
 import { StarlingService } from '@shared/starling/starling-protocol';
 import { server } from '@test/setup-files/server';
+import { createMock } from '@test/utils/create-mock';
 import { http, HttpResponse } from 'msw';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -15,7 +17,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: (): Record<string, unknown> => ({ ...mocks }),
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({ ...mocks }),
 }));
 
 const CONTROL_URL = 'http://localhost:3000/_control';

--- a/frontend/app/src/modules/core/messaging/handlers/missing-api-key.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/missing-api-key.spec.ts
@@ -1,4 +1,5 @@
 import type { Router } from 'vue-router';
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
 import { assert, type Notification, type NotificationAction, NotificationCategory, NotificationGroup, Severity } from '@rotki/common';
 import { mockT } from '@test/i18n';
 import { createMock } from '@test/utils/create-mock';
@@ -11,7 +12,7 @@ const mockSuppressList = ref<string[]>([]);
 const mockPush = vi.fn();
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: vi.fn(() => ({
+  useInterop: vi.fn(() => createMock<ReturnType<typeof useInterop>>({
     openUrl: mockOpenUrl,
   })),
 }));

--- a/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.spec.ts
@@ -1,5 +1,7 @@
+import type { Router } from 'vue-router';
 import { assert, type Notification, type NotificationAction, NotificationGroup } from '@rotki/common';
 import { mockT } from '@test/i18n';
+import { createMock } from '@test/utils/create-mock';
 import { mockUseSupportedChains } from '@test/utils/mocks/supported-chains';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
@@ -21,7 +23,8 @@ vi.mock('@/modules/settings/use-settings-operations', () => ({
 vi.mock('@/modules/core/common/use-supported-chains', () =>
   mockUseSupportedChains({ getChainName: (chain: string): string => chain.toUpperCase() }));
 
-const router = { push: vi.fn() };
+const push = vi.fn<Router['push']>();
+const router = createMock<Router>({ push });
 
 describe('createNoAvailableIndexersHandler', () => {
   beforeEach(() => {
@@ -73,7 +76,7 @@ describe('createNoAvailableIndexersHandler', () => {
 
     await configureAction.action();
 
-    expect(router.push).toHaveBeenCalledWith({ name: '/settings/chains/', hash: '#indexer' });
+    expect(push).toHaveBeenCalledWith({ name: '/settings/chains/', hash: '#indexer' });
   });
 
   it('should return null when the chain is in the suppression list', async () => {

--- a/frontend/app/src/modules/core/messaging/handlers/unmatched-bridge-transactions.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/unmatched-bridge-transactions.spec.ts
@@ -12,11 +12,14 @@ vi.mock('@/modules/core/notifications/use-notifications', () => ({
   useNotifications: (): object => ({ removeMatching }),
 }));
 
+// Not `createMock<Router>`: the typed router makes `currentRoute` a union of one
+// route type per named route, and a deep-partial override of it exceeds TypeScript's
+// instantiation depth. The handler only reads the route name.
 interface RouterMock extends Pick<Router, 'currentRoute'> {
   push: Mock<Router['push']>;
 }
 
-function createRouter(routeName: string): RouterMock {
+function createRouter(routeName: Router['currentRoute']['value']['name']): RouterMock {
   return {
     // @ts-expect-error partial route mock - only the name is read by the handler
     currentRoute: ref({ name: routeName }),
@@ -30,7 +33,7 @@ describe('createUnmatchedBridgeTransactionsHandler', () => {
   });
 
   it('should clear stale grouped notifications on every message', async () => {
-    const handler = createUnmatchedBridgeTransactionsHandler(mockT, createRouter('/dashboard'));
+    const handler = createUnmatchedBridgeTransactionsHandler(mockT, createRouter('/dashboard/'));
 
     await handler.handle({ count: 0 });
 
@@ -41,7 +44,7 @@ describe('createUnmatchedBridgeTransactionsHandler', () => {
   });
 
   it('should return null when the count is zero', async () => {
-    const handler = createUnmatchedBridgeTransactionsHandler(mockT, createRouter('/dashboard'));
+    const handler = createUnmatchedBridgeTransactionsHandler(mockT, createRouter('/dashboard/'));
 
     await expect(handler.handle({ count: 0 })).resolves.toBeNull();
   });
@@ -53,7 +56,7 @@ describe('createUnmatchedBridgeTransactionsHandler', () => {
   });
 
   it('should return a persistent warning notification with the bridge group', async () => {
-    const handler = createUnmatchedBridgeTransactionsHandler(mockT, createRouter('/dashboard'));
+    const handler = createUnmatchedBridgeTransactionsHandler(mockT, createRouter('/dashboard/'));
 
     const result = await handler.handle({ count: 3 });
 
@@ -71,7 +74,7 @@ describe('createUnmatchedBridgeTransactionsHandler', () => {
   });
 
   it('should route to the history events page with the bridge dialog query on action', async () => {
-    const router = createRouter('/dashboard');
+    const router = createRouter('/dashboard/');
     const handler = createUnmatchedBridgeTransactionsHandler(mockT, router);
 
     const result = await handler.handle({ count: 2 });

--- a/frontend/app/src/modules/core/sigil/handlers/history-sync.spec.ts
+++ b/frontend/app/src/modules/core/sigil/handlers/history-sync.spec.ts
@@ -1,9 +1,11 @@
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockFetchHistoryEvents = vi.fn();
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn(() => ({
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>({
     fetchHistoryEvents: mockFetchHistoryEvents,
   })),
 }));

--- a/frontend/app/src/modules/core/table/use-server-table.spec.ts
+++ b/frontend/app/src/modules/core/table/use-server-table.spec.ts
@@ -1,9 +1,11 @@
 import type { EffectScope, MaybeRef, Ref } from 'vue';
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
 import type { Collection } from '@/modules/core/common/collection';
 import type { PaginationRequestPayload } from '@/modules/core/common/common-types';
 import type { MatchedKeywordWithBehaviour } from '@/modules/core/table/filtering';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { LocationQuery } from '@/modules/core/table/route';
+import { createMock } from '@test/utils/create-mock';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, it, type Mock, vi } from 'vitest';
 import { toMatchFieldDef } from '@/modules/core/table/pill/core/field-adapter';
@@ -55,9 +57,9 @@ vi.mock('@/modules/core/api', () => ({
       this.name = 'RequestCancelledError';
     }
   },
-  api: {
+  api: createMock<RotkiApi>({
     cancelByTag: (tag: string): void => cancelByTagSpy(tag),
-  },
+  }),
 }));
 
 vi.mock('vue-router', () => ({

--- a/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-actions.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/composables/use-snapshot-actions.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { withSetup } from '@test/utils/with-setup';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSnapshotActions } from '@/modules/dashboard/snapshots/composables/use-snapshot-actions';
@@ -32,7 +34,7 @@ vi.mock('@/modules/auth/use-logout', () => ({
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: (): { getPath: typeof getPath } => ({ getPath }),
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({ getPath }),
 }));
 
 vi.mock('@/modules/settings/api/use-snapshot-api', () => ({

--- a/frontend/app/src/modules/history/api/events/use-bridge-matching-api.spec.ts
+++ b/frontend/app/src/modules/history/api/events/use-bridge-matching-api.spec.ts
@@ -1,3 +1,5 @@
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useBridgeMatchingApi } from '@/modules/history/api/events/use-bridge-matching-api';
 
@@ -12,12 +14,12 @@ const { spies } = vi.hoisted(() => ({
 }));
 
 vi.mock('@/modules/core/api/rotki-api', () => ({
-  api: {
+  api: createMock<RotkiApi>({
     delete: spies.delete,
     get: spies.get,
     post: spies.post,
     put: spies.put,
-  },
+  }),
 }));
 
 vi.mock('@/modules/core/tasks/use-task-api', () => ({

--- a/frontend/app/src/modules/history/events/tx/use-exchange-events-refresh.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-exchange-events-refresh.spec.ts
@@ -1,4 +1,6 @@
 import type { Exchange } from '@/modules/balances/types/exchanges';
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { createMock } from '@test/utils/create-mock';
 import { err, ok } from 'plainfp/result';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Cancelled, TaskFailed } from '@/modules/core/tasks/task-result';
@@ -25,9 +27,7 @@ vi.mock('@/modules/task-center/use-native-task', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn(() => ({
-    queryExchangeEvents: vi.fn(),
-  })),
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>()),
 }));
 
 vi.mock('@/modules/history/use-events-query-status-store', () => ({

--- a/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.spec.ts
@@ -1,3 +1,5 @@
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { createMock } from '@test/utils/create-mock';
 import { err, ok } from 'plainfp/result';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Cancelled, TaskFailed } from '@/modules/core/tasks/task-result';
@@ -36,10 +38,7 @@ vi.mock('@/modules/core/tasks/use-task-store', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn(() => ({
-    decodeTransactions: vi.fn(),
-    getUndecodedTransactionsBreakdown: vi.fn(),
-  })),
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>()),
 }));
 
 vi.mock('@/modules/history/use-decoding-status-store', () => ({

--- a/frontend/app/src/modules/history/events/tx/use-refresh-handlers.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-handlers.spec.ts
@@ -1,3 +1,5 @@
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { createMock } from '@test/utils/create-mock';
 import { runSpecWith } from '@test/utils/mocks/native-task';
 import { err } from 'plainfp/result';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -32,10 +34,7 @@ vi.mock('@/modules/history/events/tx/use-exchange-events-refresh', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn(() => ({
-    queryExchangeEvents: vi.fn(),
-    queryOnlineHistoryEvents: vi.fn(),
-  })),
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>()),
 }));
 
 vi.mock('@/modules/history/use-events-query-status-store', () => ({

--- a/frontend/app/src/modules/history/events/tx/use-targeted-redecode.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-targeted-redecode.spec.ts
@@ -1,3 +1,5 @@
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { createMock } from '@test/utils/create-mock';
 import { runSpecWith } from '@test/utils/mocks/native-task';
 import { err, ok } from 'plainfp/result';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -29,7 +31,7 @@ vi.mock('@/modules/task-center/use-native-task', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn(() => ({
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>({
     pullAndRecodeEthBlockEventRequest: mocks.pullAndRecodeEthBlockEventRequest,
     pullAndRecodeTransactionRequest: mocks.pullAndRecodeTransactionRequest,
   })),

--- a/frontend/app/src/modules/history/events/tx/use-transaction-sync.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-transaction-sync.spec.ts
@@ -1,4 +1,6 @@
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import type { NativeActivitySpec } from '@/modules/task-center/use-native-task';
+import { createMock } from '@test/utils/create-mock';
 import { err, ok, type Result } from 'plainfp/result';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BackendCancelled, Cancelled, isCancellation, Skipped, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
@@ -43,7 +45,7 @@ vi.mock('@/modules/core/common/use-supported-chains', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn(() => ({ fetchTransactionsTask: vi.fn() })),
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>()),
 }));
 
 vi.mock('@/modules/history/events/tx/use-history-transaction-decoding', () => ({

--- a/frontend/app/src/modules/history/events/use-customized-event-duplicates.spec.ts
+++ b/frontend/app/src/modules/history/events/use-customized-event-duplicates.spec.ts
@@ -1,6 +1,8 @@
 import type { CollectionResponse } from '@/modules/core/common/collection';
 import type { CustomizedEventDuplicates, CustomizedEventDuplicatesFixResult } from '@/modules/history/api/events/use-customized-event-duplicates-api';
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import type { HistoryEventCollectionRow, HistoryEventEntryWithMeta } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
 
@@ -27,7 +29,7 @@ vi.mock('@/modules/history/api/events/use-customized-event-duplicates-api', () =
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: (): object => ({
+  useHistoryEventsApi: (): ReturnType<typeof useHistoryEventsApi> => createMock<ReturnType<typeof useHistoryEventsApi>>({
     fetchHistoryEvents: spies.fetchHistoryEvents,
   }),
 }));

--- a/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-navigation-consumer.spec.ts
@@ -1,5 +1,7 @@
 import type { TablePaginationData } from '@rotki/ui-library';
 import type { ComputedRef, EffectScope, Ref } from 'vue';
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { createMock } from '@test/utils/create-mock';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -19,7 +21,7 @@ vi.mock('vue-router', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn(() => ({
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>({
     getHistoryEventGroupPosition: mockGetHistoryEventGroupPosition,
   })),
 }));

--- a/frontend/app/src/modules/history/events/use-history-event-navigation.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-navigation.spec.ts
@@ -1,5 +1,7 @@
 import type { EffectScope } from 'vue';
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
+import { createMock } from '@test/utils/create-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HighlightTargetTypes, type HistoryEventNavigationRequest } from './use-history-event-navigation';
 
@@ -17,7 +19,7 @@ vi.mock('vue-router', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn(() => ({
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>({
     getHistoryEventGroupPosition: mockGetHistoryEventGroupPosition,
   })),
 }));

--- a/frontend/app/src/modules/history/events/use-history-events-data.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-data.spec.ts
@@ -1,7 +1,9 @@
 import type { Ref } from 'vue';
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
 import type { Collection } from '@/modules/core/common/collection';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import { assert, bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { HistoryEventAccountingRuleStatus, type HistoryEventEntry, type HistoryEventRow } from '@/modules/history/events/schemas';
@@ -21,9 +23,9 @@ vi.mock('@/modules/history/events/use-history-events', () => ({
 }));
 
 vi.mock('@/modules/core/api/rotki-api', () => ({
-  api: {
-    cancelByTag: (...args: any[]): void => mockCancelByTag(...args),
-  },
+  api: createMock<RotkiApi>({
+    cancelByTag: (tag: string): void => mockCancelByTag(tag),
+  }),
 }));
 
 vi.mock('@/modules/core/common/use-ref-debounce', () => ({

--- a/frontend/app/src/modules/history/events/use-history-events-deletion.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-deletion.spec.ts
@@ -1,6 +1,8 @@
 import type { TransactionGroup } from './use-event-analysis';
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHistoryEventsDeletion } from './use-history-events-deletion';
 import { useHistoryEventsSelectionMode } from './use-selection-mode';
@@ -35,7 +37,7 @@ vi.mock('@/modules/core/notifications/use-notifications', async () => ({
   useNotifications: (): object => ({ showErrorMessage: spies.showErrorMessage, showSuccessMessage: spies.showSuccessMessage }),
 }));
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: (): object => ({ deleteHistoryEvent: spies.deleteHistoryEventApi, deleteTransactions: spies.deleteTransactions }),
+  useHistoryEventsApi: (): ReturnType<typeof useHistoryEventsApi> => createMock<ReturnType<typeof useHistoryEventsApi>>({ deleteHistoryEvent: spies.deleteHistoryEventApi, deleteTransactions: spies.deleteTransactions }),
 }));
 vi.mock('@/modules/history/events/use-history-events', () => ({
   useHistoryEvents: (): object => ({ deleteHistoryEvent: spies.deleteHistoryEvent }),

--- a/frontend/app/src/modules/history/events/use-history-events-operations.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-operations.spec.ts
@@ -1,3 +1,4 @@
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import type { PullEventPayload } from '@/modules/history/events/event-payloads';
 import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
 import type { HistoryEventsTableEmitFn } from '@/modules/history/events/types';
@@ -35,7 +36,7 @@ vi.mock('@/modules/core/common/use-supported-chains', () => ({
   useSupportedChains: (): object => ({ getChain: spies.getChain }),
 }));
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: (): object => ({ deleteTransactions: spies.deleteTransactions }),
+  useHistoryEventsApi: (): ReturnType<typeof useHistoryEventsApi> => createMock<ReturnType<typeof useHistoryEventsApi>>({ deleteTransactions: spies.deleteTransactions }),
 }));
 vi.mock('@/modules/history/api/events/use-asset-movement-matching-api', () => ({
   useAssetMovementMatchingApi: (): object => ({ unlinkAssetMovement: spies.unlinkAssetMovement }),

--- a/frontend/app/src/modules/history/events/use-unmatched-asset-movements.spec.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-asset-movements.spec.ts
@@ -1,3 +1,4 @@
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import { type NotificationData, NotificationGroup } from '@rotki/common';
 import { createMock } from '@test/utils/create-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -31,7 +32,7 @@ vi.mock('@/modules/history/api/events/use-asset-movement-matching-api', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: (): object => ({
+  useHistoryEventsApi: (): ReturnType<typeof useHistoryEventsApi> => createMock<ReturnType<typeof useHistoryEventsApi>>({
     fetchHistoryEvents: spies.fetchHistoryEvents,
   }),
 }));

--- a/frontend/app/src/modules/history/events/use-unmatched-bridge-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-bridge-transactions.spec.ts
@@ -1,4 +1,6 @@
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import { NotificationGroup } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { spies } = vi.hoisted(() => ({
@@ -29,7 +31,7 @@ vi.mock('@/modules/history/api/events/use-bridge-matching-api', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: (): object => ({
+  useHistoryEventsApi: (): ReturnType<typeof useHistoryEventsApi> => createMock<ReturnType<typeof useHistoryEventsApi>>({
     fetchHistoryEvents: spies.fetchHistoryEvents,
   }),
 }));

--- a/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.spec.ts
@@ -2,6 +2,7 @@ import type { AssetMap } from '@/modules/assets/types';
 import type { TradeLocationData } from '@/modules/core/common/location';
 import type { AssetMovementEvent } from '@/modules/history/events/schemas';
 import { bigNumberify, HistoryEventEntryType, One } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
@@ -109,36 +110,21 @@ describe('forms/AssetMovementEventForm.vue', () => {
     vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue(mapping);
     vi.mocked(usePriceTaskManager().getHistoricPrice).mockResolvedValue(One);
 
-    vi.mocked(useLocations).mockReturnValue({
-      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
-      getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
+    vi.mocked(useLocations).mockReturnValue(createMock<ReturnType<typeof useLocations>>({
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'kraken',
         name: 'Kraken',
       }]),
-    });
+    }));
 
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
+    }));
 
-    vi.mocked(useAssetPricesApi).mockReturnValue({
+    vi.mocked(useAssetPricesApi).mockReturnValue(createMock<ReturnType<typeof useAssetPricesApi>>({
       addHistoricalPrice: addHistoricalPriceMock,
-      addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
-      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
-      deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
-      deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
-      editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),
-      fetchHistoricalPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchHistoricalPrices']>(),
-      fetchLatestPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchLatestPrices']>(),
-      fetchNftsPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchNftsPrices']>(),
-      fetchOraclePrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchOraclePrices']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/BitcoinEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/BitcoinEventForm.spec.ts
@@ -2,6 +2,7 @@ import type { AssetMap } from '@/modules/assets/types';
 import type { TradeLocationData } from '@/modules/core/common/location';
 import type { BitcoinEvent } from '@/modules/history/events/schemas';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
@@ -85,10 +86,7 @@ describe('forms/BitcoinEventForm.vue', () => {
     editHistoryEventMock = vi.fn<ReturnType<typeof useHistoryEvents>['editHistoryEvent']>();
     addHistoricalPriceMock = vi.fn<ReturnType<typeof useAssetPricesApi>['addHistoricalPrice']>();
     vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue(mapping);
-    vi.mocked(useLocations).mockReturnValue({
-      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
-      getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
+    vi.mocked(useLocations).mockReturnValue(createMock<ReturnType<typeof useLocations>>({
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'bitcoin',
         name: 'Bitcoin',
@@ -96,36 +94,20 @@ describe('forms/BitcoinEventForm.vue', () => {
         identifier: 'bitcoin_cash',
         name: 'Bitcoin Cash',
       }]),
-    });
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    }));
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
-    vi.mocked(useAssetPricesApi).mockReturnValue({
+    }));
+    vi.mocked(useAssetPricesApi).mockReturnValue(createMock<ReturnType<typeof useAssetPricesApi>>({
       addHistoricalPrice: addHistoricalPriceMock,
-      addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
-      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
-      deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
-      deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
-      editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),
-      fetchHistoricalPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchHistoricalPrices']>(),
-      fetchLatestPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchLatestPrices']>(),
-      fetchNftsPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchNftsPrices']>(),
-      fetchOraclePrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchOraclePrices']>(),
-    });
-    vi.mocked(useHistoryEventCounterpartyMappings).mockReturnValue({
+    }));
+    vi.mocked(useHistoryEventCounterpartyMappings).mockReturnValue(createMock<ReturnType<typeof useHistoryEventCounterpartyMappings>>({
       counterparties: computed<string[]>(() => [
         'test-counterparty',
         'uniswap',
       ]),
-      fetchCounterparties: vi.fn<ReturnType<typeof useHistoryEventCounterpartyMappings>['fetchCounterparties']>(),
-      getBaseCounterpartyData: vi.fn<ReturnType<typeof useHistoryEventCounterpartyMappings>['getBaseCounterpartyData']>(),
-      getCounterpartyData: vi.fn<ReturnType<typeof useHistoryEventCounterpartyMappings>['getCounterpartyData']>(),
-      getEventCounterpartyData: vi.fn<ReturnType<typeof useHistoryEventCounterpartyMappings>['getEventCounterpartyData']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/EthBlockEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EthBlockEventForm.spec.ts
@@ -1,6 +1,7 @@
 import type { AssetMap } from '@/modules/assets/types';
 import type { EthBlockEvent } from '@/modules/history/events/schemas';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
@@ -73,26 +74,14 @@ describe('forms/EthBlockEventForm.vue', () => {
     addHistoricalPriceMock = vi.fn<ReturnType<typeof useAssetPricesApi>['addHistoricalPrice']>();
     vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue(mapping);
 
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
+    }));
 
-    vi.mocked(useAssetPricesApi).mockReturnValue({
+    vi.mocked(useAssetPricesApi).mockReturnValue(createMock<ReturnType<typeof useAssetPricesApi>>({
       addHistoricalPrice: addHistoricalPriceMock,
-      addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
-      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
-      deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
-      deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
-      editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),
-      fetchHistoricalPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchHistoricalPrices']>(),
-      fetchLatestPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchLatestPrices']>(),
-      fetchNftsPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchNftsPrices']>(),
-      fetchOraclePrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchOraclePrices']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/EthDepositEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EthDepositEventForm.spec.ts
@@ -1,6 +1,7 @@
 import type { AssetMap } from '@/modules/assets/types';
 import type { EthDepositEvent } from '@/modules/history/events/schemas';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
@@ -73,26 +74,14 @@ describe('form/EthDepositEventForm.vue', () => {
     editHistoryEventMock = vi.fn<ReturnType<typeof useHistoryEvents>['editHistoryEvent']>();
     addHistoricalPriceMock = vi.fn<ReturnType<typeof useAssetPricesApi>['addHistoricalPrice']>();
     vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue(mapping);
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
+    }));
 
-    vi.mocked(useAssetPricesApi).mockReturnValue({
+    vi.mocked(useAssetPricesApi).mockReturnValue(createMock<ReturnType<typeof useAssetPricesApi>>({
       addHistoricalPrice: addHistoricalPriceMock,
-      addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
-      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
-      deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
-      deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
-      editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),
-      fetchHistoricalPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchHistoricalPrices']>(),
-      fetchLatestPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchLatestPrices']>(),
-      fetchNftsPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchNftsPrices']>(),
-      fetchOraclePrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchOraclePrices']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.spec.ts
@@ -1,6 +1,7 @@
 import type { AssetMap } from '@/modules/assets/types';
 import type { EthWithdrawalEvent } from '@/modules/history/events/schemas';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
@@ -27,9 +28,7 @@ vi.mock('@/modules/history/events/use-history-events', () => ({
 }));
 
 vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
-  useAssetPricesApi: vi.fn().mockReturnValue({
-    addHistoricalPrice: vi.fn(),
-  }),
+  useAssetPricesApi: vi.fn(),
 }));
 
 describe('forms/EthWithdrawalEventForm.vue', () => {
@@ -80,33 +79,15 @@ describe('forms/EthWithdrawalEventForm.vue', () => {
     editHistoryEventMock = vi.fn<ReturnType<typeof useHistoryEvents>['editHistoryEvent']>();
     addHistoricalPriceMock = vi.fn<ReturnType<typeof useAssetPricesApi>['addHistoricalPrice']>();
     const assetMapping = vi.fn().mockResolvedValue(mapping);
-    // @ts-expect-error partial store mock for test
-    vi.mocked(useBalancePricesStore).mockReturnValue({});
-    vi.mocked(useAssetInfoApi).mockReturnValue({
-      assetMapping,
-      assetSearch: vi.fn<ReturnType<typeof useAssetInfoApi>['assetSearch']>(),
-      erc20details: vi.fn<ReturnType<typeof useAssetInfoApi>['erc20details']>(),
-    });
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    vi.mocked(useBalancePricesStore).mockReturnValue(createMock<ReturnType<typeof useBalancePricesStore>>());
+    vi.mocked(useAssetInfoApi).mockReturnValue(createMock<ReturnType<typeof useAssetInfoApi>>({ assetMapping }));
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
-
-    vi.mocked(useAssetPricesApi).mockReturnValue({
+    }));
+    vi.mocked(useAssetPricesApi).mockReturnValue(createMock<ReturnType<typeof useAssetPricesApi>>({
       addHistoricalPrice: addHistoricalPriceMock,
-      addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
-      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
-      deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
-      deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
-      editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),
-      fetchHistoricalPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchHistoricalPrices']>(),
-      fetchLatestPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchLatestPrices']>(),
-      fetchNftsPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchNftsPrices']>(),
-      fetchOraclePrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchOraclePrices']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EvmEventForm.spec.ts
@@ -2,6 +2,7 @@ import type { AssetMap } from '@/modules/assets/types';
 import type { TradeLocationData } from '@/modules/core/common/location';
 import type { EvmHistoryEvent } from '@/modules/history/events/schemas';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
@@ -80,34 +81,19 @@ describe('forms/EvmEventForm.vue', () => {
     editHistoryEventMock = vi.fn<ReturnType<typeof useHistoryEvents>['editHistoryEvent']>();
     addHistoricalPriceMock = vi.fn<ReturnType<typeof useAssetPricesApi>['addHistoricalPrice']>();
     vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue(mapping);
-    vi.mocked(useLocations).mockReturnValue({
-      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
-      getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
+    vi.mocked(useLocations).mockReturnValue(createMock<ReturnType<typeof useLocations>>({
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'ethereum',
         name: 'Ethereum',
       }]),
-    });
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    }));
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
-    vi.mocked(useAssetPricesApi).mockReturnValue({
+    }));
+    vi.mocked(useAssetPricesApi).mockReturnValue(createMock<ReturnType<typeof useAssetPricesApi>>({
       addHistoricalPrice: addHistoricalPriceMock,
-      addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
-      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
-      deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
-      deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
-      editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),
-      fetchHistoricalPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchHistoricalPrices']>(),
-      fetchLatestPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchLatestPrices']>(),
-      fetchNftsPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchNftsPrices']>(),
-      fetchOraclePrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchOraclePrices']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/EvmSwapEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/EvmSwapEventForm.spec.ts
@@ -3,6 +3,7 @@ import type { TradeLocationData } from '@/modules/core/common/location';
 import type { AddEvmSwapEventPayload, EditEvmSwapEventPayload, EvmSwapEvent } from '@/modules/history/events/schemas';
 import type { GroupAddEventData, GroupEventData } from '@/modules/history/management/forms/form-types';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -124,42 +125,23 @@ describe('forms/EvmSwapEventForm', () => {
       total: 0,
     });
 
-    vi.mocked(useLocations).mockReturnValue({
-      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
-      getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
+    vi.mocked(useLocations).mockReturnValue(createMock<ReturnType<typeof useLocations>>({
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'ethereum',
         name: 'Ethereum',
       }]),
-    });
+    }));
 
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
+    }));
 
-    vi.mocked(useAssetInfoApi).mockReturnValue({
-      assetMapping: vi.fn<ReturnType<typeof useAssetInfoApi>['assetMapping']>(),
-      assetSearch: vi.fn<ReturnType<typeof useAssetInfoApi>['assetSearch']>(),
-      erc20details: vi.fn<ReturnType<typeof useAssetInfoApi>['erc20details']>(),
-    });
+    vi.mocked(useAssetInfoApi).mockReturnValue(createMock<ReturnType<typeof useAssetInfoApi>>());
 
-    vi.mocked(useAddressesNamesApi).mockReturnValue({
-      addAddressBook: vi.fn<ReturnType<typeof useAddressesNamesApi>['addAddressBook']>(),
-      clearEnsAvatarCache: vi.fn<ReturnType<typeof useAddressesNamesApi>['clearEnsAvatarCache']>(),
-      deleteAddressBook: vi.fn<ReturnType<typeof useAddressesNamesApi>['deleteAddressBook']>(),
-      ensAvatarUrl: vi.fn<ReturnType<typeof useAddressesNamesApi>['ensAvatarUrl']>(),
+    vi.mocked(useAddressesNamesApi).mockReturnValue(createMock<ReturnType<typeof useAddressesNamesApi>>({
       fetchAddressBook: fetchAddressBookMock,
-      getAddressesNames: vi.fn<ReturnType<typeof useAddressesNamesApi>['getAddressesNames']>(),
-      getEnsNames: vi.fn<ReturnType<typeof useAddressesNamesApi>['getEnsNames']>(),
-      getEnsNamesTask: vi.fn<ReturnType<typeof useAddressesNamesApi>['getEnsNamesTask']>(),
-      resolveEnsNames: vi.fn<ReturnType<typeof useAddressesNamesApi>['resolveEnsNames']>(),
-      updateAddressBook: vi.fn<ReturnType<typeof useAddressesNamesApi>['updateAddressBook']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/HistoryEventAssetPriceForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/HistoryEventAssetPriceForm.spec.ts
@@ -1,6 +1,7 @@
 import type { Pinia } from 'pinia';
 import type { PriceIntent } from '@/modules/history/management/forms/price-intent';
 import { bigNumberify } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { updateGeneralSettings } from '@test/utils/general-settings';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
@@ -38,11 +39,7 @@ describe('forms/HistoryEventAssetPriceForm', () => {
     const { findCurrency } = useCurrencies();
     updateGeneralSettings({ mainCurrency: findCurrency('USD') });
 
-    vi.mocked(useAssetInfoApi).mockReturnValue({
-      assetMapping: vi.fn<ReturnType<typeof useAssetInfoApi>['assetMapping']>(),
-      assetSearch: vi.fn<ReturnType<typeof useAssetInfoApi>['assetSearch']>(),
-      erc20details: vi.fn<ReturnType<typeof useAssetInfoApi>['erc20details']>(),
-    });
+    vi.mocked(useAssetInfoApi).mockReturnValue(createMock<ReturnType<typeof useAssetInfoApi>>());
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/OnlineHistoryEventForm.spec.ts
@@ -2,6 +2,7 @@ import type { AssetMap } from '@/modules/assets/types';
 import type { TradeLocationData } from '@/modules/core/common/location';
 import type { OnlineHistoryEvent } from '@/modules/history/events/schemas';
 import { bigNumberify, HistoryEventEntryType, One } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
@@ -83,34 +84,19 @@ describe('forms/OnlineHistoryEventForm.vue', () => {
     addHistoricalPriceMock = vi.fn<ReturnType<typeof useAssetPricesApi>['addHistoricalPrice']>();
     vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue(mapping);
     vi.mocked(usePriceTaskManager().getHistoricPrice).mockResolvedValue(One);
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
-    vi.mocked(useLocations).mockReturnValue({
-      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
-      getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
+    }));
+    vi.mocked(useLocations).mockReturnValue(createMock<ReturnType<typeof useLocations>>({
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'kraken',
         name: 'Kraken',
       }]),
-    });
-    vi.mocked(useAssetPricesApi).mockReturnValue({
+    }));
+    vi.mocked(useAssetPricesApi).mockReturnValue(createMock<ReturnType<typeof useAssetPricesApi>>({
       addHistoricalPrice: addHistoricalPriceMock,
-      addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
-      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
-      deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
-      deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
-      editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),
-      fetchHistoricalPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchHistoricalPrices']>(),
-      fetchLatestPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchLatestPrices']>(),
-      fetchNftsPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchNftsPrices']>(),
-      fetchOraclePrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchOraclePrices']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/SolanaEventForm.spec.ts
@@ -2,6 +2,7 @@ import type { AssetMap } from '@/modules/assets/types';
 import type { TradeLocationData } from '@/modules/core/common/location';
 import type { SolanaEvent } from '@/modules/history/events/schemas';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
@@ -81,44 +82,25 @@ describe('forms/SolanaEventForm.vue', () => {
     editHistoryEventMock = vi.fn<ReturnType<typeof useHistoryEvents>['editHistoryEvent']>();
     addHistoricalPriceMock = vi.fn<ReturnType<typeof useAssetPricesApi>['addHistoricalPrice']>();
     vi.mocked(useAssetInfoApi().assetMapping).mockResolvedValue(mapping);
-    vi.mocked(useLocations).mockReturnValue({
-      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
-      getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
+    vi.mocked(useLocations).mockReturnValue(createMock<ReturnType<typeof useLocations>>({
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'solana',
         name: 'Solana',
       }]),
-    });
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    }));
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
-    vi.mocked(useAssetPricesApi).mockReturnValue({
+    }));
+    vi.mocked(useAssetPricesApi).mockReturnValue(createMock<ReturnType<typeof useAssetPricesApi>>({
       addHistoricalPrice: addHistoricalPriceMock,
-      addLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['addLatestPrice']>(),
-      assetsHadOraclePrice: vi.fn<ReturnType<typeof useAssetPricesApi>['assetsHadOraclePrice']>(),
-      deleteHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteHistoricalPrice']>(),
-      deleteLatestPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['deleteLatestPrice']>(),
-      editHistoricalPrice: vi.fn<ReturnType<typeof useAssetPricesApi>['editHistoricalPrice']>(),
-      fetchHistoricalPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchHistoricalPrices']>(),
-      fetchLatestPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchLatestPrices']>(),
-      fetchNftsPrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchNftsPrices']>(),
-      fetchOraclePrices: vi.fn<ReturnType<typeof useAssetPricesApi>['fetchOraclePrices']>(),
-    });
-    vi.mocked(useHistoryEventCounterpartyMappings).mockReturnValue({
+    }));
+    vi.mocked(useHistoryEventCounterpartyMappings).mockReturnValue(createMock<ReturnType<typeof useHistoryEventCounterpartyMappings>>({
       counterparties: computed<string[]>(() => [
         'test-counterparty',
         'uniswap',
       ]),
-      fetchCounterparties: vi.fn<ReturnType<typeof useHistoryEventCounterpartyMappings>['fetchCounterparties']>(),
-      getBaseCounterpartyData: vi.fn<ReturnType<typeof useHistoryEventCounterpartyMappings>['getBaseCounterpartyData']>(),
-      getCounterpartyData: vi.fn<ReturnType<typeof useHistoryEventCounterpartyMappings>['getCounterpartyData']>(),
-      getEventCounterpartyData: vi.fn<ReturnType<typeof useHistoryEventCounterpartyMappings>['getEventCounterpartyData']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/SolanaSwapEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/SolanaSwapEventForm.spec.ts
@@ -2,6 +2,7 @@ import type { TradeLocationData } from '@/modules/core/common/location';
 import type { AddSolanaSwapEventPayload, EditSolanaSwapEventPayload, SolanaSwapEvent } from '@/modules/history/events/schemas';
 import type { GroupAddEventData, GroupEventData } from '@/modules/history/management/forms/form-types';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
@@ -125,42 +126,23 @@ describe('forms/SolanaSwapEventForm', () => {
       total: 0,
     });
 
-    vi.mocked(useLocations).mockReturnValue({
-      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
-      getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
+    vi.mocked(useLocations).mockReturnValue(createMock<ReturnType<typeof useLocations>>({
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'solana',
         name: 'Solana',
       }]),
-    });
+    }));
 
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
+    }));
 
-    vi.mocked(useAssetInfoApi).mockReturnValue({
-      assetMapping: vi.fn<ReturnType<typeof useAssetInfoApi>['assetMapping']>(),
-      assetSearch: vi.fn<ReturnType<typeof useAssetInfoApi>['assetSearch']>(),
-      erc20details: vi.fn<ReturnType<typeof useAssetInfoApi>['erc20details']>(),
-    });
+    vi.mocked(useAssetInfoApi).mockReturnValue(createMock<ReturnType<typeof useAssetInfoApi>>());
 
-    vi.mocked(useAddressesNamesApi).mockReturnValue({
-      addAddressBook: vi.fn<ReturnType<typeof useAddressesNamesApi>['addAddressBook']>(),
-      clearEnsAvatarCache: vi.fn<ReturnType<typeof useAddressesNamesApi>['clearEnsAvatarCache']>(),
-      deleteAddressBook: vi.fn<ReturnType<typeof useAddressesNamesApi>['deleteAddressBook']>(),
-      ensAvatarUrl: vi.fn<ReturnType<typeof useAddressesNamesApi>['ensAvatarUrl']>(),
+    vi.mocked(useAddressesNamesApi).mockReturnValue(createMock<ReturnType<typeof useAddressesNamesApi>>({
       fetchAddressBook: fetchAddressBookMock,
-      getAddressesNames: vi.fn<ReturnType<typeof useAddressesNamesApi>['getAddressesNames']>(),
-      getEnsNames: vi.fn<ReturnType<typeof useAddressesNamesApi>['getEnsNames']>(),
-      getEnsNamesTask: vi.fn<ReturnType<typeof useAddressesNamesApi>['getEnsNamesTask']>(),
-      resolveEnsNames: vi.fn<ReturnType<typeof useAddressesNamesApi>['resolveEnsNames']>(),
-      updateAddressBook: vi.fn<ReturnType<typeof useAddressesNamesApi>['updateAddressBook']>(),
-    });
+    }));
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/SwapEventForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/SwapEventForm.spec.ts
@@ -3,6 +3,7 @@ import type { TradeLocationData } from '@/modules/core/common/location';
 import type { AddSwapEventPayload, EditSwapEventPayload, SwapEvent } from '@/modules/history/events/schemas';
 import type { GroupEventData } from '@/modules/history/management/forms/form-types';
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { selectorContract } from '@test/utils/selector-contract';
 import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
@@ -92,29 +93,19 @@ describe('forms/SwapEventForm', () => {
     vi.useFakeTimers();
     addHistoryEventMock = vi.fn<ReturnType<typeof useHistoryEvents>['addHistoryEvent']>();
     editHistoryEventMock = vi.fn<ReturnType<typeof useHistoryEvents>['editHistoryEvent']>();
-    vi.mocked(useLocations).mockReturnValue({
-      getExchangeName: vi.fn<ReturnType<typeof useLocations>['getExchangeName']>(),
-      getLocationData: vi.fn<ReturnType<typeof useLocations>['getLocationData']>(),
-      useLocationData: vi.fn<ReturnType<typeof useLocations>['useLocationData']>(),
+    vi.mocked(useLocations).mockReturnValue(createMock<ReturnType<typeof useLocations>>({
       tradeLocations: computed<TradeLocationData[]>(() => [{
         identifier: 'kraken',
         name: 'Kraken',
       }]),
-    });
+    }));
 
-    vi.mocked(useHistoryEvents).mockReturnValue({
+    vi.mocked(useHistoryEvents).mockReturnValue(createMock<ReturnType<typeof useHistoryEvents>>({
       addHistoryEvent: addHistoryEventMock,
-      deleteHistoryEvent: vi.fn<ReturnType<typeof useHistoryEvents>['deleteHistoryEvent']>(),
       editHistoryEvent: editHistoryEventMock,
-      fetchHistoryEvents: vi.fn<ReturnType<typeof useHistoryEvents>['fetchHistoryEvents']>(),
-      getEarliestEventTimestamp: vi.fn<ReturnType<typeof useHistoryEvents>['getEarliestEventTimestamp']>(),
-    });
+    }));
 
-    vi.mocked(useAssetInfoApi).mockReturnValue({
-      assetMapping: vi.fn<ReturnType<typeof useAssetInfoApi>['assetMapping']>(),
-      assetSearch: vi.fn<ReturnType<typeof useAssetInfoApi>['assetSearch']>(),
-      erc20details: vi.fn<ReturnType<typeof useAssetInfoApi>['erc20details']>(),
-    });
+    vi.mocked(useAssetInfoApi).mockReturnValue(createMock<ReturnType<typeof useAssetInfoApi>>());
   });
 
   afterEach(() => {

--- a/frontend/app/src/modules/history/management/forms/use-evm-tx-lookup.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/use-evm-tx-lookup.spec.ts
@@ -1,4 +1,5 @@
 import type { Ref } from 'vue';
+import { createMock } from '@test/utils/create-mock';
 import { mockUseTaskHandler } from '@test/utils/mocks/task-runner';
 import flushPromises from 'flush-promises';
 import { createPinia, setActivePinia } from 'pinia';
@@ -32,9 +33,9 @@ vi.mock('@/modules/history/api/events/use-history-events-api', async (importOrig
   const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
-    useHistoryEventsApi: vi.fn().mockReturnValue({
+    useHistoryEventsApi: vi.fn().mockReturnValue(createMock<ReturnType<typeof useHistoryEventsApi>>({
       lookupEvmTransaction: vi.fn().mockResolvedValue({ taskId: 1 }),
-    }),
+    })),
   };
 });
 

--- a/frontend/app/src/modules/history/use-history-data-fetching.spec.ts
+++ b/frontend/app/src/modules/history/use-history-data-fetching.spec.ts
@@ -1,5 +1,6 @@
 import type { LocationLabel } from '@/modules/core/common/location';
-import type { TransactionStatus } from '@/modules/history/api/events/use-history-events-api';
+import type { TransactionStatus, useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHistoryStore } from '@/modules/history/use-history-store';
 import '@test/i18n';
@@ -19,7 +20,7 @@ vi.mock('@/modules/history/api/use-history-api', () => ({
 }));
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn((): { getTransactionStatusSummary: typeof mockGetTransactionStatusSummary } => ({
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>({
     getTransactionStatusSummary: mockGetTransactionStatusSummary,
   })),
 }));

--- a/frontend/app/src/modules/premium/SponsorshipView.spec.ts
+++ b/frontend/app/src/modules/premium/SponsorshipView.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -5,7 +7,7 @@ import { useMainStore } from '@/modules/core/common/use-main-store';
 import SponsorshipView from '@/modules/premium/SponsorshipView.vue';
 
 vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> => ({
-  useInterop: (): { isPackaged: boolean; openUrl: ReturnType<typeof vi.fn> } => ({
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({
     isPackaged: false,
     openUrl: vi.fn(),
   }),

--- a/frontend/app/src/modules/session/single-tab/use-single-tab.spec.ts
+++ b/frontend/app/src/modules/session/single-tab/use-single-tab.spec.ts
@@ -1,11 +1,13 @@
 import type { UseSingleTabReturn } from './use-single-tab';
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const isPackaged = ref<boolean>(false);
 const reload = vi.fn();
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: (): object => ({
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({
     get isPackaged(): boolean {
       return get(isPackaged);
     },

--- a/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
+++ b/frontend/app/src/modules/session/use-session-state-cleaner.spec.ts
@@ -1,3 +1,5 @@
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
+import { createMock } from '@test/utils/create-mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { effectScope, type EffectScope, nextTick } from 'vue';
 import { BALANCE_HYDRATION_TAG } from '@/modules/balances/api/use-blockchain-balances-api';
@@ -45,7 +47,7 @@ vi.mock('@/modules/shell/app/store-plugins', () => ({
 }));
 
 vi.mock('@/modules/core/api/rotki-api', () => ({
-  api: { cancelByTag: (tag: string): void => cancelByTag(tag) },
+  api: createMock<RotkiApi>({ cancelByTag: (tag: string): void => cancelByTag(tag) }),
 }));
 
 describe('useSessionStateCleaner', () => {

--- a/frontend/app/src/modules/session/use-session-sync.spec.ts
+++ b/frontend/app/src/modules/session/use-session-sync.spec.ts
@@ -1,4 +1,6 @@
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
 import type { WorkStatus } from '@/modules/task-center/core/types';
+import { createMock } from '@test/utils/create-mock';
 import { runSpecWith } from '@test/utils/mocks/native-task';
 import { err, ok } from 'plainfp/result';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -36,10 +38,10 @@ vi.mock('@/modules/session/api/use-sync-api', () => ({
 }));
 
 vi.mock('@/modules/core/api/rotki-api', () => ({
-  api: {
+  api: createMock<RotkiApi>({
     cancel: mockCancel,
     cancelAllQueued: mockCancelAllQueued,
-  },
+  }),
 }));
 
 describe('useSync', () => {

--- a/frontend/app/src/modules/session/use-update-checker.spec.ts
+++ b/frontend/app/src/modules/session/use-update-checker.spec.ts
@@ -1,9 +1,11 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const checkForUpdates = vi.fn();
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: (): { checkForUpdates: typeof checkForUpdates } => ({ checkForUpdates }),
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({ checkForUpdates }),
 }));
 
 async function loadComposable(): Promise<typeof import('./use-update-checker')['useUpdateChecker']> {

--- a/frontend/app/src/modules/settings/OnboardingSettings.spec.ts
+++ b/frontend/app/src/modules/settings/OnboardingSettings.spec.ts
@@ -1,5 +1,7 @@
 import type { BackendOptions } from '@shared/ipc';
 import type { useAssetIconApi } from '@/modules/assets/api/use-asset-icon-api';
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
@@ -24,7 +26,7 @@ const { openDirectoryMock, setLogLevelMock } = vi.hoisted(() => ({
   setLogLevelMock: vi.fn(),
 }));
 vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> => ({
-  useInterop: vi.fn().mockReturnValue({
+  useInterop: vi.fn().mockReturnValue(createMock<ReturnType<typeof useInterop>>({
     isPackaged: true,
     openDirectory: openDirectoryMock,
     restartBackend: vi.fn(),
@@ -37,7 +39,7 @@ vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> 
     // the log directory and left that field permanently disabled.
     config: vi.fn().mockImplementation(async (defaults: boolean): Promise<Partial<BackendOptions>> =>
       defaults ? { logDirectory: '/Users/home/rotki/logs' } : {}),
-  }),
+  })),
 }));
 
 let saveOptions = vi.fn();

--- a/frontend/app/src/modules/settings/accounting/use-accounting-settings.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/use-accounting-settings.spec.ts
@@ -2,6 +2,8 @@ import type {
   AccountingRuleConflictRequestPayload,
   AccountingRuleRequestPayload,
 } from '@/modules/settings/types/accounting';
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { runSpecWith } from '@test/utils/mocks/native-task';
 import { err, ok } from 'plainfp/result';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -56,7 +58,7 @@ vi.mock('@/modules/task-center/use-native-task', () => ({
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: (): object => ({ appSession, getPath, openDirectory }),
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({ appSession, getPath, openDirectory }),
 }));
 
 vi.mock('@/modules/core/common/file/download', () => ({

--- a/frontend/app/src/modules/settings/backend/LogLevelSetting.spec.ts
+++ b/frontend/app/src/modules/settings/backend/LogLevelSetting.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import LogLevelSetting from '@/modules/settings/backend/LogLevelSetting.vue';
@@ -13,10 +15,10 @@ vi.mock('@/modules/core/common/logging/logging', async (): Promise<Record<string
 
 const { setLogLevelMock } = vi.hoisted(() => ({ setLogLevelMock: vi.fn() }));
 vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> => ({
-  useInterop: vi.fn().mockReturnValue({
+  useInterop: vi.fn().mockReturnValue(createMock<ReturnType<typeof useInterop>>({
     isPackaged: true,
     setLogLevel: setLogLevelMock,
-  }),
+  })),
 }));
 
 const { updateBackendConfigurationMock, updateColibriConfigurationMock } = vi.hoisted(() => ({

--- a/frontend/app/src/modules/settings/backend/McpServerSetting.spec.ts
+++ b/frontend/app/src/modules/settings/backend/McpServerSetting.spec.ts
@@ -1,5 +1,7 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
 import { assert } from '@rotki/common';
 import { type McpServerStatus, StarlingServiceStatus } from '@shared/ipc';
+import { createMock } from '@test/utils/create-mock';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -11,13 +13,15 @@ import { useSettingsRepo } from '@/modules/settings/settings-repo';
 import { McpPrivacyMode } from '@/modules/settings/types/mcp';
 
 const mocks = vi.hoisted(() => ({
-  generateMcpToken: vi.fn(),
   getMcpServerStatus: vi.fn(),
   isPackaged: true,
   setMcpAutoStart: vi.fn(),
   startMcpServer: vi.fn(),
   stopMcpServer: vi.fn(),
 }));
+
+/** Token minting is an API call, not an interop member. */
+const mcpApi = vi.hoisted(() => ({ generateMcpToken: vi.fn() }));
 
 /**
  * The component drives the supervisor through the control client, never through
@@ -33,12 +37,12 @@ const control = vi.hoisted(() => ({
 
 vi.mock('@/modules/settings/api/use-mcp-api', () => ({
   useMcpApi: (): Record<string, unknown> => ({
-    generateMcpToken: mocks.generateMcpToken,
+    generateMcpToken: mcpApi.generateMcpToken,
   }),
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: (): Record<string, unknown> => ({
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({
     ...mocks,
   }),
 }));
@@ -166,7 +170,7 @@ describe('mcpServerSetting', () => {
       async (_service: string, running: boolean) =>
         (running ? StarlingServiceStatus.READY : StarlingServiceStatus.IDLE),
     );
-    mocks.generateMcpToken.mockResolvedValue({
+    mcpApi.generateMcpToken.mockResolvedValue({
       accessToken: 'generated-mcp-token',
       expiresAt: 1_800_000_000,
       tokenType: 'Bearer',
@@ -401,7 +405,7 @@ describe('mcpServerSetting', () => {
     await wrapper.find('[data-testid="mcp-generate-token"]').trigger('click');
     await flushPromises();
 
-    expect(mocks.generateMcpToken).toHaveBeenCalledOnce();
+    expect(mcpApi.generateMcpToken).toHaveBeenCalledOnce();
     expect(wrapper.find('[data-testid="mcp-token"]').text()).toBe('••••••••••••••••');
     expect(wrapper.text()).toContain('backend_settings.settings.mcp_server.token_expiry_hint');
 
@@ -413,7 +417,7 @@ describe('mcpServerSetting', () => {
     vi.stubEnv('VITE_DOCKER', 'true');
     mocks.isPackaged = false;
     controlAvailable(false);
-    mocks.generateMcpToken.mockRejectedValueOnce(new Error('token failed'));
+    mcpApi.generateMcpToken.mockRejectedValueOnce(new Error('token failed'));
 
     const wrapper = createWrapper();
     await flushPromises();

--- a/frontend/app/src/modules/settings/backend/use-log-level-update.spec.ts
+++ b/frontend/app/src/modules/settings/backend/use-log-level-update.spec.ts
@@ -1,3 +1,4 @@
+import type { useInterop as useInteropType } from '@/modules/shell/app/use-electron-interop';
 import { LogLevel } from '@shared/log-level';
 import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -16,10 +17,10 @@ vi.mock('@/modules/core/common/logging/logging', async (): Promise<Record<string
 });
 
 vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> => ({
-  useInterop: vi.fn().mockReturnValue({
+  useInterop: vi.fn().mockReturnValue(createMock<ReturnType<typeof useInteropType>>({
     isPackaged: true,
     setLogLevel: setLogLevelMock,
-  }),
+  })),
 }));
 
 vi.mock('@/modules/settings/api/use-settings-api', (): Record<string, unknown> => ({

--- a/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.spec.ts
+++ b/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.spec.ts
@@ -1,4 +1,6 @@
+import type { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import type { GeneralSettings } from '@/modules/settings/types/user-settings';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Currency } from '@/modules/assets/amount-display/currencies';
 import { defaultGeneralSettings } from '@/modules/settings/factories';
@@ -23,7 +25,7 @@ const mockStore: { pendingSuggestions: PendingSuggestion[]; showSuggestionsDialo
 const mockRepo: { frontend: FrontendSettings } = { frontend: getDefaultFrontendSettings() };
 
 vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
-  useHistoryEventsApi: vi.fn(() => ({
+  useHistoryEventsApi: vi.fn(() => createMock<ReturnType<typeof useHistoryEventsApi>>({
     fetchHistoryEvents: mockFetchHistoryEvents,
   })),
 }));

--- a/frontend/app/src/modules/shell/app/use-backend-connection.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-connection.spec.ts
@@ -1,3 +1,5 @@
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
+import { createMock } from '@test/utils/create-mock';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMainStore } from '@/modules/core/common/use-main-store';
@@ -25,9 +27,9 @@ vi.mock('@/modules/shell/app/use-info-api', () => ({
 }));
 
 vi.mock('@/modules/core/api/rotki-api', () => ({
-  api: {
+  api: createMock<RotkiApi>({
     setup: vi.fn(),
-  },
+  }),
 }));
 
 vi.mock('@/modules/core/api/api-urls', () => ({

--- a/frontend/app/src/modules/shell/app/use-backend-management.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-management.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { withSetup } from '@test/utils/with-setup';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -34,7 +36,7 @@ vi.mock('@/modules/shell/app/use-websocket-connection', () => ({
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: vi.fn(() => ({
+  useInterop: vi.fn(() => createMock<ReturnType<typeof useInterop>>({
     get isPackaged(): boolean {
       return packaged;
     },

--- a/frontend/app/src/modules/shell/app/use-websocket-connection.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-websocket-connection.spec.ts
@@ -1,3 +1,5 @@
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
+import { createMock } from '@test/utils/create-mock';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@test/i18n';
@@ -13,11 +15,11 @@ const mockLoggerDebug = vi.fn();
 const mockLoggerError = vi.fn();
 
 vi.mock('@/modules/core/api/rotki-api', () => ({
-  api: {
+  api: createMock<RotkiApi>({
     get serverUrl(): string {
       return mockServerUrl.value;
     },
-  },
+  }),
 }));
 
 vi.mock('@/modules/core/messaging', () => ({

--- a/frontend/app/src/modules/shell/components/ExternalLink.spec.ts
+++ b/frontend/app/src/modules/shell/components/ExternalLink.spec.ts
@@ -1,9 +1,11 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 
 vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> => ({
-  useInterop: (): { isPackaged: boolean; openUrl: ReturnType<typeof vi.fn> } => ({
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({
     isPackaged: false,
     openUrl: vi.fn(),
   }),

--- a/frontend/app/src/modules/staking/api/use-lido-csm-api.spec.ts
+++ b/frontend/app/src/modules/staking/api/use-lido-csm-api.spec.ts
@@ -1,4 +1,6 @@
+import type { RotkiApi } from '@/modules/core/api/rotki-api';
 import type { LidoCsmNodeOperator } from '@/modules/staking/staking-types';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   VALID_STATUS_CODES,
@@ -16,12 +18,12 @@ const { mockDelete, mockGet, mockPost, mockPut } = vi.hoisted(() => ({
 
 vi.mock('@/modules/core/api', async importOriginal => ({
   ...await importOriginal<typeof import('@/modules/core/api')>(),
-  api: {
+  api: createMock<RotkiApi>({
     delete: mockDelete,
     get: mockGet,
     post: mockPost,
     put: mockPut,
-  },
+  }),
 }));
 
 function operator(): LidoCsmNodeOperator {

--- a/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
@@ -1,4 +1,6 @@
 import type { TransactionParams } from './types';
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import { WALLET_MODES } from './constants';
@@ -44,7 +46,7 @@ vi.mock('./use-transaction-manager', () => ({ useTransactionManager: (): Fake =>
 vi.mock('./send/use-trade-api', () => ({ useTradeApi: (): Fake => mocks.state.tradeApi }));
 vi.mock('./use-wallet-connect', () => ({ useWalletConnect: (): Fake => mocks.state.walletConnect }));
 vi.mock('./bridge/use-injected-wallet', () => ({ useInjectedWallet: (): Fake => mocks.state.injectedWallet }));
-vi.mock('@/modules/shell/app/use-electron-interop', () => ({ useInterop: (): Fake => ({ isPackaged: mocks.state.isPackaged }) }));
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({ useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({ isPackaged: mocks.state.isPackaged }) }));
 vi.mock('@/modules/wallet/use-wallet-helper', () => ({ useWalletHelper: (): Fake => mocks.state.walletHelper }));
 vi.mock('@/modules/core/common/use-supported-chains', () => ({ useSupportedChains: (): Fake => mocks.state.supportedChains }));
 
@@ -92,7 +94,9 @@ describe('modules/wallet/use-wallet-store', () => {
 
     mocks.state = {
       injectedWallet: makeInjectedWallet(),
-      isPackaged: ref<boolean>(false),
+      // A plain boolean, as the real interop exposes it. The store reads it once
+      // at construction, so a test must set it before `getStore()`.
+      isPackaged: false,
       supportedChains: { getEvmChainName: vi.fn(() => 'ethereum') },
       tradeApi: { prepareERC20Transfer: vi.fn(), prepareNativeTransfer: vi.fn() },
       transactionManager: {
@@ -175,7 +179,7 @@ describe('modules/wallet/use-wallet-store', () => {
     });
 
     it('should set up the proxy when running packaged', async () => {
-      set(mocks.state.isPackaged, true);
+      mocks.state.isPackaged = true;
       const store = await getStore();
       await store.connect();
       expect(mocks.state.walletProxy.setupProxy).toHaveBeenCalledTimes(1);

--- a/frontend/app/src/pages/api-keys/premium/index.spec.ts
+++ b/frontend/app/src/pages/api-keys/premium/index.spec.ts
@@ -1,3 +1,4 @@
+import { createMock } from '@test/utils/create-mock';
 import { libraryDefaults } from '@test/utils/provide-defaults';
 import { type DOMWrapper, mount, type VueWrapper } from '@vue/test-utils';
 import flushPromises from 'flush-promises/index';
@@ -8,15 +9,11 @@ import { usePremiumCredentialsApi } from '@/modules/premium/use-premium-credenti
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
 import PremiumSettings from '@/pages/api-keys/premium/index.vue';
 
-vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> => {
-  const mockInterop = {
+vi.mock('@/modules/shell/app/use-electron-interop', (): Record<string, unknown> => ({
+  useInterop: vi.fn().mockReturnValue(createMock<ReturnType<typeof useInterop>>({
     premiumUserLoggedIn: vi.fn(),
-  };
-  return {
-    useInterop: vi.fn().mockReturnValue(mockInterop),
-    interop: mockInterop,
-  };
-});
+  })),
+}));
 
 vi.mock('@/modules/premium/use-premium-credentials-api', (): Record<string, unknown> => ({
   usePremiumCredentialsApi: vi.fn().mockReturnValue({

--- a/frontend/app/src/pages/user/login/use-login-initial-checks.spec.ts
+++ b/frontend/app/src/pages/user/login/use-login-initial-checks.spec.ts
@@ -1,3 +1,5 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useLoginInitialChecks } from './use-login-initial-checks';
 
@@ -11,7 +13,7 @@ vi.mock('@/modules/session/use-update-checker', () => ({
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
-  useInterop: vi.fn(() => ({ isPackaged: interopState.isPackaged })),
+  useInterop: vi.fn(() => createMock<ReturnType<typeof useInterop>>({ isPackaged: interopState.isPackaged })),
 }));
 
 describe('pages/user/login/useLoginInitialChecks', () => {

--- a/frontend/app/tests/unit/utils/create-mock.ts
+++ b/frontend/app/tests/unit/utils/create-mock.ts
@@ -15,12 +15,22 @@ export type DeepPartial<T> = T extends (...args: infer A) => infer R
 // the mock look thenable (so `await mock` hangs), and the inspection hooks would
 // break `console.log(mock)` / util.inspect. Returning undefined for them keeps
 // the proxy inert to the runtime.
+//
+// The `__v_*` entries are Vue's reactivity markers. `toRaw` follows `__v_raw`
+// until it is undefined, so auto-materialising it hands back another proxy with
+// its own `__v_raw` and the unwrap never terminates — which is what happens the
+// moment a mocked pinia store reaches Vue.
 const passthroughUndefined = new Set<PropertyKey>([
   'then',
   'catch',
   'finally',
   'asymmetricMatch',
   'inspect',
+  '__v_raw',
+  '__v_isRef',
+  '__v_isReactive',
+  '__v_isReadonly',
+  '__v_skip',
   Symbol.iterator,
   Symbol.asyncIterator,
   Symbol.toPrimitive,


### PR DESCRIPTION
Replaces hand-rolled partial object literals in unit test mocks with the
existing `createMock<T>` helper, so the overrides are checked against the
real type instead of standing in for it untyped.

65 files, net -64 lines. The specs affected mocked a dependency by writing
out a literal with one to four members of an interface that has twenty or
more, often behind a `(): object` or `Record<string, unknown>` return
annotation that opted the mock out of type checking entirely.

## Defects this surfaced

Typing the overrides turned up four real problems:

- `use-assets.spec.ts` mocked `appSession` as `vi.fn()`, where the real
  member is a boolean that the custom-asset export path branches on. A
  function is always truthy, so that branch was taken unconditionally and
  the alternative was never reachable from the test.
- `use-wallet-store.spec.ts` passed `isPackaged` as a `Ref` so a test could
  flip it mid-run, but the store reads it once at construction and the real
  member is a plain boolean. It is a boolean now, set before the store is
  built. Both branches still pass, so the test still discriminates.
- `unmatched-bridge-transactions.spec.ts` built a route named `/dashboard`,
  which is not a route (`/dashboard/` is). Typing the parameter makes that
  unspellable.
- `use-assets.spec.ts` and `pages/api-keys/premium/index.spec.ts` each
  exported an `interop` symbol from their mock factory that the real module
  does not export. Neither spec used it.

Separately, `McpServerSetting.spec.ts` had `generateMcpToken` in its interop
mock bag; it belongs to `useMcpApi`, and a typed mock rejects it.

## Helper change

`createMock` auto-materialised Vue's `__v_raw` marker as another mock
carrying its own `__v_raw`. `toRaw` follows that chain until it is
undefined, so the unwrap recursed until the stack blew the moment a mocked
pinia store reached Vue. The `__v_*` markers now pass through as undefined
alongside the existing `then`/`catch` guard. Without this, `createMock`
could not stand in for a store at all.

## Where it does not fit

Three cases were tried and reverted, and are worth knowing about before
reaching for the helper again:

- `createMock<Router>` cannot take a `currentRoute` override. The typed
  router makes it a union of one route type per named route, and a
  deep-partial over those members exceeds TypeScript's instantiation depth.
- `vi.spyOn` cannot target a member the proxy materialises on access: it
  needs a real own property to replace. `use-history-transactions.spec.ts`
  keeps its literal for that reason.
- Any store the code under test reads through `storeToRefs` must keep its
  literal. The proxy defines no `ownKeys` trap, so `Object.keys`, spread and
  `storeToRefs` all see an empty object. This is why the `useSessionAuthStore`
  and manual-balances mocks are untouched.

## Not included

The repeated `logger` (37 specs), `vue-router` (27) and `useConfirmStore`
(18) literals would be better served by shared factories under
`tests/unit/utils/mocks/` than by inlining `createMock` at each site. That is
a design change rather than a swap, so it is left out of this PR.

## Checks

`pnpm run typecheck`, `pnpm run test:unit` (788 files, 7656 tests) and
eslint all pass on every changed file.
