### PR TITLE
refactor(frontend): validate the snapshot edit forms with zod

### DIFF
--- a/frontend/app/src/modules/core/common/data/bignumbers.spec.ts
+++ b/frontend/app/src/modules/core/common/data/bignumbers.spec.ts
@@ -1,0 +1,49 @@
+import { bigNumberify, Zero } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { ref } from 'vue';
+import { bigNumberifyFromRef, sortDesc, zeroBalance } from '@/modules/core/common/data/bignumbers';
+
+describe('core/common/data/bignumbers', () => {
+  describe('bigNumberifyFromRef', () => {
+    it('should parse a numeric string', () => {
+      const value = bigNumberifyFromRef(ref('1.5'));
+      expect(value.value.toFixed()).toBe('1.5');
+    });
+
+    it('should track the ref it was built from', () => {
+      const source = ref('2');
+      const value = bigNumberifyFromRef(source);
+      expect(value.value.toFixed()).toBe('2');
+
+      source.value = '3';
+      expect(value.value.toFixed()).toBe('3');
+    });
+
+    it('should read a cleared field as zero', () => {
+      const value = bigNumberifyFromRef(ref(''));
+      expect(value.value).toStrictEqual(Zero);
+    });
+
+    // These are the values bignumber.js throws on. The helper runs inside a computed, so a throw
+    // here is a render-time exception in whichever form is bound to the field.
+    it.each(['abc', '1.2.3', '-', '.', '0,5', '1 000'])('should read %s as zero rather than throw', (input) => {
+      expect(() => bigNumberify(input)).toThrow();
+
+      const value = bigNumberifyFromRef(ref(input));
+      expect(value.value).toStrictEqual(Zero);
+    });
+  });
+
+  describe('zeroBalance', () => {
+    it('should build a balance of zeroes', () => {
+      expect(zeroBalance()).toStrictEqual({ amount: Zero, value: Zero });
+    });
+  });
+
+  describe('sortDesc', () => {
+    it('should order the larger value first', () => {
+      const values = [bigNumberify('1'), bigNumberify('3'), bigNumberify('2')];
+      expect(values.sort(sortDesc).map(value => value.toFixed())).toEqual(['3', '2', '1']);
+    });
+  });
+});

--- a/frontend/app/src/modules/core/common/data/bignumbers.ts
+++ b/frontend/app/src/modules/core/common/data/bignumbers.ts
@@ -4,10 +4,13 @@ import { type Balance, type BigNumber, bigNumberify, Zero } from '@rotki/common'
 export function bigNumberifyFromRef(value: Ref<string | number> | WritableComputedRef<string | number>): ComputedRef<BigNumber> {
   return computed(() => {
     const val = get(value);
+    // Cheap path for a cleared field, which is common enough not to reach it through a throw.
     if (val === '')
       return Zero;
 
-    return bigNumberify(val);
+    // bignumber.js rejects anything it cannot parse by throwing, and this runs inside a computed,
+    // so an unparsable value would surface as a render-time exception rather than a bad number.
+    return bigNumberify(val, Zero);
   });
 }
 

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.spec.ts
@@ -63,13 +63,14 @@ describe('edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue', () => {
     wrapper?.unmount();
   });
 
-  function createWrapper(amount = '1.5', usdValue = '0'): VueWrapper<FormInstance> {
-    const model = ref({ amount, asset: 'ETH', usdValue });
+  function createWrapper(amount = '1.5', usdValue = '0', asset = 'ETH', disableAsset = false): VueWrapper<FormInstance> {
+    const model = ref({ amount, asset, usdValue });
     return mount(EditBalancesSnapshotAssetPriceForm, {
       global: { plugins: [pinia] },
       props: {
         'amount': model.value.amount,
         'asset': model.value.asset,
+        disableAsset,
         timestamp,
         'usdValue': model.value.usdValue,
         'onUpdate:amount': (v: string) => { model.value.amount = v; },
@@ -109,6 +110,47 @@ describe('edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue', () => {
 
     // 3600 EUR / 0.9 = 4000 USD
     expect(lastUsdValue()).toBe('4000');
+  });
+
+  it('should show the required messages once the fields are left empty', async () => {
+    setCurrency('USD');
+    wrapper = createWrapper('', '0', '');
+    await flushPromises();
+
+    await wrapper.find('[data-testid=amount] input').trigger('blur');
+    // The asset picker keeps its fallthrough listeners on its root, not on the inner input.
+    await wrapper.find('[data-testid=asset]').trigger('blur');
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=amount] .details .text-rui-error').text())
+      .toBe('dashboard.snapshot.edit.dialog.balances.rules.amount');
+    expect(wrapper.find('[data-testid=asset] .details').text())
+      .toBe('dashboard.snapshot.edit.dialog.balances.rules.asset');
+  });
+
+  it('should suppress the asset message while the asset is locked', async () => {
+    setCurrency('USD');
+    wrapper = createWrapper('', '0', '', true);
+    await flushPromises();
+
+    await wrapper.find('[data-testid=asset]').trigger('blur');
+    await flushPromises();
+    await nextTick();
+
+    // Negative control: the sibling test proves the same empty, blurred asset does show a message
+    // when it isn't locked, so an absent message here is suppression rather than an unreached rule.
+    expect(wrapper.find('[data-testid=asset] .details').exists()).toBe(false);
+  });
+
+  // The form validates for display only: it exposes no `validate`, so nothing it reports can stop a
+  // save. The dialog's gate lives in EditBalancesSnapshotForm, over category and location alone.
+  it('should expose no validate, leaving its messages purely decorative', async () => {
+    setCurrency('USD');
+    wrapper = createWrapper();
+    await flushPromises();
+
+    expect('validate' in wrapper.vm).toBe(false);
   });
 
   it('should not touch the historic FX path in a USD main currency', async () => {

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import type { ZodType } from 'zod';
+import { useForm } from '@/modules/core/form/use-form';
+import {
+  type AssetPriceFormState,
+  assetPriceSchema,
+} from '@/modules/dashboard/edit-snapshot/snapshot-forms';
 import { useSnapshotAssetPrice } from '@/modules/dashboard/snapshots/composables/use-snapshot-asset-price';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
@@ -21,6 +24,26 @@ const { disableAsset = false, nft = false, timestamp } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
+const schema = computed<ZodType>(() => assetPriceSchema({
+  amount: t('dashboard.snapshot.edit.dialog.balances.rules.amount'),
+  asset: t('dashboard.snapshot.edit.dialog.balances.rules.asset'),
+  value: t('dashboard.snapshot.edit.dialog.balances.rules.value'),
+}));
+
+/**
+ * Display only: this form exposes no `validate`, so nothing it reports can stop a save. The gate is
+ * EditBalancesSnapshotForm's, over the category and location. Submitting here is a no-op too - the
+ * price is persisted through `submitPrice`, not the form core.
+ */
+const form = useForm<AssetPriceFormState, AssetPriceFormState>({
+  initial: (): AssetPriceFormState => ({ amount: get(amount), asset: get(asset), usdValue: get(usdValue) }),
+  schema,
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): AssetPriceFormState => ({ ...state }),
+});
+
+// The price state machine writes back to the fields it derives, so it is given the form's state to
+// drive rather than the parent's models, and the two are mirrored below.
 const {
   modelAssetToFiatPrice,
   modelAssetToUsdPrice,
@@ -31,31 +54,25 @@ const {
   isCurrentCurrencyUsd,
   reset,
   submitPrice,
-} = useSnapshotAssetPrice({ amount, asset, timestamp: () => timestamp, usdValue });
+} = useSnapshotAssetPrice({
+  amount: toRef(form.state, 'amount'),
+  asset: toRef(form.state, 'asset'),
+  timestamp: () => timestamp,
+  usdValue: toRef(form.state, 'usdValue'),
+});
 
-const rules = {
-  amount: {
-    required: helpers.withMessage(t('dashboard.snapshot.edit.dialog.balances.rules.amount'), required),
-  },
-  asset: {
-    required: helpers.withMessage(t('dashboard.snapshot.edit.dialog.balances.rules.asset'), required),
-  },
-  usdValue: {
-    required: helpers.withMessage(t('dashboard.snapshot.edit.dialog.balances.rules.value'), required),
-  },
-};
+// Both directions write the value they were handed, so an echo settles rather than looping.
+watchImmediate([amount, asset, usdValue], ([nextAmount, nextAsset, nextUsdValue]) => {
+  form.state.amount = nextAmount;
+  form.state.asset = nextAsset;
+  form.state.usdValue = nextUsdValue;
+});
 
-const v$ = useVuelidate(
-  rules,
-  {
-    amount,
-    asset,
-    usdValue,
-  },
-  {
-    $autoDirty: true,
-  },
-);
+watch(() => form.state, (state) => {
+  set(amount, state.amount);
+  set(asset, state.asset);
+  set(usdValue, state.usdValue);
+}, { deep: true });
 
 defineExpose({
   reset,
@@ -65,45 +82,42 @@ defineExpose({
 
 <template>
   <div>
-    <div
-      v-if="v$"
-      class="grid md:grid-cols-2 gap-4 mb-4"
-    >
+    <div class="grid md:grid-cols-2 gap-4 mb-4">
       <AssetSelect
         v-if="!nft"
-        v-model="asset"
+        v-model="form.state.asset"
         outlined
         :disabled="disableAsset"
         show-ignored
         data-testid="asset"
-        :error-messages="disableAsset ? [''] : toMessages(v$.asset)"
-        @blur="v$.asset.$touch()"
+        :error-messages="disableAsset ? [''] : form.errors('asset')"
+        @blur="form.touch('asset')"
       />
       <RuiTextField
         v-else
-        v-model="asset"
+        v-model="form.state.asset"
         :label="t('common.asset')"
         variant="outlined"
         color="primary"
         :disabled="disableAsset"
         class="mb-1.5"
-        :error-messages="disableAsset ? [''] : toMessages(v$.asset)"
+        :error-messages="disableAsset ? [''] : form.errors('asset')"
         :hint="t('dashboard.snapshot.edit.dialog.balances.nft_hint')"
-        @blur="v$.asset.$touch()"
+        @blur="form.touch('asset')"
       />
       <AmountInput
-        v-model="amount"
+        v-model="form.state.amount"
         variant="outlined"
         data-testid="amount"
         :label="t('common.amount')"
-        :error-messages="toMessages(v$.amount)"
-        @blur="v$.amount.$touch()"
+        :error-messages="form.errors('amount')"
+        @blur="form.touch('amount')"
       />
     </div>
     <TwoFieldsAmountInput
       v-if="isCurrentCurrencyUsd"
       v-model:primary-value="modelAssetToUsdPrice"
-      v-model:secondary-value="usdValue"
+      v-model:secondary-value="form.state.usdValue"
       class="mb-5"
       :loading="fetching"
       :disabled="fetching"
@@ -116,8 +130,8 @@ defineExpose({
         }),
       }"
       :error-messages="{
-        primary: toMessages(v$.usdValue),
-        secondary: toMessages(v$.usdValue),
+        primary: form.errors('usdValue'),
+        secondary: form.errors('usdValue'),
       }"
       :hint="t('transactions.events.form.asset_price.hint')"
       @update:reversed="modelFiatValueFocused = $event"

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.spec.ts
@@ -4,12 +4,13 @@ import { mount, type VueWrapper } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { nextTick, ref } from 'vue';
+import { nextTick } from 'vue';
 import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
 import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
 import { BalanceType } from '@/modules/balances/types/balances';
 import EditBalancesSnapshotAssetPriceForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue';
 import EditBalancesSnapshotForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue';
+import EditBalancesSnapshotLocationSelector from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue';
 
 vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
   usePriceTaskManager: vi.fn().mockReturnValue({
@@ -61,8 +62,10 @@ describe('edit-snapshot/EditBalancesSnapshotForm.vue', () => {
   });
 
   function createWrapper(modelValue: BalanceSnapshotPayloadAndLocation = baseModel(), hideLocation = false, disabledLocations: string[] = []): VueWrapper<FormInstance> {
-    const model = ref<BalanceSnapshotPayloadAndLocation>(modelValue);
-    return mount(EditBalancesSnapshotForm, {
+    // The model has to be fed back as a prop, not just captured: with an `onUpdate:modelValue`
+    // listener attached, `defineModel` reads the prop rather than a local value, so a harness that
+    // only records the emission leaves the form frozen on its initial model.
+    wrapper = mount(EditBalancesSnapshotForm, {
       global: {
         plugins: [pinia],
       },
@@ -70,13 +73,13 @@ describe('edit-snapshot/EditBalancesSnapshotForm.vue', () => {
         disabledLocations,
         hideLocation,
         'locations': ['blockchain', 'kraken'],
-        'modelValue': model.value,
+        modelValue,
         timestamp,
-        'onUpdate:modelValue': (value: BalanceSnapshotPayloadAndLocation) => {
-          model.value = value;
-        },
+        'onUpdate:modelValue': async (value: BalanceSnapshotPayloadAndLocation): Promise<void> =>
+          wrapper.setProps({ modelValue: value }),
       },
     });
+    return wrapper;
   }
 
   it('should pre-populate fields from the v-model', async () => {
@@ -148,6 +151,52 @@ describe('edit-snapshot/EditBalancesSnapshotForm.vue', () => {
 
     const valid = await wrapper.vm.validate();
     expect(valid).toBe(false);
+  });
+
+  it('should show no validation message before anything is edited', async () => {
+    const model = baseModel();
+    model.location = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.find('[data-testid=snapshot-location] .details').exists()).toBe(false);
+  });
+
+  it('should reveal the location message once validate runs', async () => {
+    const model = baseModel();
+    model.location = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersByTimeAsync(700);
+
+    expect(wrapper.find('[data-testid=snapshot-location] .details').text())
+      .toBe('dashboard.snapshot.edit.dialog.balances.rules.location');
+  });
+
+  it('should reveal the insufficient-location message once validate runs', async () => {
+    const model = baseModel();
+    model.location = 'blockchain';
+    wrapper = createWrapper(model, false, ['blockchain']);
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersByTimeAsync(700);
+
+    expect(wrapper.find('[data-testid=snapshot-location] .details').text())
+      .toBe('dashboard.snapshot.edit.dialog.balances.rules.location_insufficient');
+  });
+
+  it('should flag stateUpdated once a field is edited', async () => {
+    wrapper = createWrapper();
+    // `useFormStateWatcher` only arms its watcher after a 500ms delay.
+    await vi.advanceTimersByTimeAsync(600);
+
+    wrapper.findComponent(EditBalancesSnapshotLocationSelector).vm.$emit('update:modelValue', 'kraken');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
   });
 
   it('should forward update:asset emitted by the inner price form', async () => {

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.spec.ts
@@ -188,9 +188,23 @@ describe('edit-snapshot/EditBalancesSnapshotForm.vue', () => {
       .toBe('dashboard.snapshot.edit.dialog.balances.rules.location_insufficient');
   });
 
+  // The price machine rewrites the value on mount, so a dirty check over the whole entry would
+  // arm the dialog's unsaved-changes prompt before the user has touched anything.
+  it('should not flag stateUpdated for the price fetched on mount', async () => {
+    const model = baseModel();
+    // Seed a value the mounted price fetch will overwrite (1.5 * 2000 = 3000), so this fails if the
+    // dirty check covers the fetched value rather than the fields the user edits.
+    model.usdValue = '1';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersByTimeAsync(600);
+
+    const updates = wrapper.emitted<[BalanceSnapshotPayloadAndLocation]>('update:modelValue');
+    expect(updates?.at(-1)?.[0].usdValue).toBe('3000');
+    expect(wrapper.emitted('update:stateUpdated')?.flat() ?? []).not.toContain(true);
+  });
+
   it('should flag stateUpdated once a field is edited', async () => {
     wrapper = createWrapper();
-    // `useFormStateWatcher` only arms its watcher after a 500ms delay.
     await vi.advanceTimersByTimeAsync(600);
 
     wrapper.findComponent(EditBalancesSnapshotLocationSelector).vm.$emit('update:modelValue', 'kraken');

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue
@@ -117,6 +117,7 @@ defineExpose({
   <div class="flex flex-col gap-2">
     <BalanceTypeInput
       v-model="category"
+      data-testid="category"
       :label="t('common.category')"
       :error-messages="toMessages(v$.category)"
     />

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { BalanceSnapshotPayload } from '@/modules/dashboard/snapshots';
 import type { LocationBalancePreview } from '@/modules/dashboard/snapshots/utils/snapshot-location-balance';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required, requiredIf } from '@vuelidate/validators';
+import { isEqual } from 'es-toolkit';
 import { isNft } from '@/modules/assets/nft-utils';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import EditBalancesSnapshotAssetPriceForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue';
 import EditBalancesSnapshotLocationSelector from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue';
+import {
+  type BalanceSnapshotFormState,
+  balanceSnapshotSchema,
+} from '@/modules/dashboard/edit-snapshot/snapshot-forms';
 import BalanceTypeInput from '@/modules/shell/components/inputs/BalanceTypeInput.vue';
 
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
@@ -38,57 +40,38 @@ interface BalanceSnapshotPayloadAndLocation extends BalanceSnapshotPayload {
   location: string;
 }
 
-const category = useRefPropVModel(model, 'category');
-const assetIdentifier = useRefPropVModel(model, 'assetIdentifier');
-const amount = useRefPropVModel(model, 'amount');
-const usdValue = useRefPropVModel(model, 'usdValue');
-const location = useRefPropVModel(model, 'location');
-
 const { t } = useI18n({ useScope: 'global' });
 
 const assetType = ref<string>('token');
 const assetPriceForm = useTemplateRef<InstanceType<typeof EditBalancesSnapshotAssetPriceForm>>('assetPriceForm');
 
-const rules = {
-  category: {
-    required: helpers.withMessage(t('dashboard.snapshot.edit.dialog.balances.rules.category'), required),
+const schema = computed<ZodType>(() => balanceSnapshotSchema({
+  disabledLocations,
+  hideLocation,
+  messages: {
+    category: t('dashboard.snapshot.edit.dialog.balances.rules.category'),
+    location: t('dashboard.snapshot.edit.dialog.balances.rules.location'),
+    locationInsufficient: t('dashboard.snapshot.edit.dialog.balances.rules.location_insufficient'),
   },
-  // Required whenever the single-location selector is shown: every balance must
-  // be attributed so the location subtotals reconcile with the net worth. In
-  // split mode the selector is hidden and the split drives attribution instead.
-  location: {
-    required: helpers.withMessage(
-      t('dashboard.snapshot.edit.dialog.balances.rules.location'),
-      requiredIf(() => !hideLocation),
-    ),
-    // Reject a location that can't absorb the edited value without going negative.
-    sufficient: helpers.withMessage(
-      t('dashboard.snapshot.edit.dialog.balances.rules.location_insufficient'),
-      (value: string) => !value || !disabledLocations.includes(value),
-    ),
-  },
-};
+}));
 
-const states = {
-  category,
-  location,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  {
-    $autoDirty: true,
-  },
-);
-useFormStateWatcher(states, stateUpdated);
+/** The dialog owns the persist and reads the entry off the model, so submitting here is a no-op. */
+const form = useForm<BalanceSnapshotFormState, BalanceSnapshotFormState>({
+  initial: (): BalanceSnapshotFormState => ({ ...get(model) }),
+  schema,
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): BalanceSnapshotFormState => ({ ...state }),
+  // Only the fields this form gates count as an edit. The asset, amount and value are derived and
+  // rewritten by the price fetch on mount, which must not arm the dialog's unsaved-changes prompt.
+  transientKeys: ['amount', 'assetIdentifier', 'timestamp', 'usdValue'],
+});
 
 function updateAsset(asset: string) {
   emit('update:asset', asset);
 }
 
 function checkAssetType() {
-  if (isNft(get(assetIdentifier)))
+  if (isNft(form.state.assetIdentifier))
     set(assetType, 'nft');
 }
 
@@ -100,26 +83,45 @@ function submitPrice() {
 
 watch(assetType, (assetType) => {
   if (assetType === 'nft')
-    set(amount, '1');
+    form.state.amount = '1';
 });
 
-watchImmediate(model, () => {
+// The dialog reads the entry it saves straight off the model, so every edit is written back to it.
+watch(() => form.state, (state) => {
+  set(model, { ...state });
+}, { deep: true });
+
+// And an edit made outside the form (a reset, a different row) is pulled back in.
+watchImmediate(model, (value) => {
+  if (!isEqual(value, form.state))
+    Object.assign(form.state, value);
+
   checkAssetType();
+}, { deep: true });
+
+watch(form.dirty, (dirty) => {
+  set(stateUpdated, dirty);
+});
+
+// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
+onUnmounted(() => {
+  set(stateUpdated, false);
 });
 
 defineExpose({
   submitPrice,
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
 <template>
   <div class="flex flex-col gap-2">
     <BalanceTypeInput
-      v-model="category"
+      v-model="form.state.category"
       data-testid="category"
       :label="t('common.category')"
-      :error-messages="toMessages(v$.category)"
+      :error-messages="form.errors('category')"
+      @update:model-value="form.touch('category')"
     />
     <div>
       <div class="text-rui-text-secondary text-caption">
@@ -146,9 +148,9 @@ defineExpose({
 
     <EditBalancesSnapshotAssetPriceForm
       ref="assetPriceForm"
-      v-model:asset="assetIdentifier"
-      v-model:amount="amount"
-      v-model:usd-value="usdValue"
+      v-model:asset="form.state.assetIdentifier"
+      v-model:amount="form.state.amount"
+      v-model:usd-value="form.state.usdValue"
       :timestamp="timestamp"
       :disable-asset="edit"
       :nft="assetType === 'nft'"
@@ -161,13 +163,14 @@ defineExpose({
 
     <EditBalancesSnapshotLocationSelector
       v-if="!hideLocation"
-      v-model="location"
+      v-model="form.state.location"
       optional-show-existing
-      :error-messages="toMessages(v$.location)"
+      :error-messages="form.errors('location')"
       :disabled-locations="disabledLocations"
       :locations="locations"
       :preview-location-balance="previewLocationBalance"
       :timestamp="timestamp"
+      @update:model-value="form.touch('location')"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue
@@ -30,7 +30,7 @@ function isLocationDisabled(item: TradeLocationData): boolean {
     <LocationSelector
       v-model="model"
       :items="showOnlyExisting ? locations : []"
-      class="edit-balances-snapshot__location"
+      data-testid="snapshot-location"
       clearable
       :item-disabled="isLocationDisabled"
       :menu-options="{ menuClass: 'z-[10001]' }"

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.spec.ts
@@ -123,7 +123,7 @@ describe('edit-snapshot/EditLocationDataSnapshotForm.vue', () => {
 
   it('should flag stateUpdated once a field is edited', async () => {
     wrapper = createWrapper();
-    // `useFormStateWatcher` only arms its watcher after a 500ms delay.
+    // Settle the mounted work first, so what follows is the only edit in play.
     await vi.advanceTimersByTimeAsync(600);
 
     await wrapper.find('[data-testid=edit-location-value] input').setValue('6000');

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.spec.ts
@@ -2,6 +2,7 @@ import type { LocationDataSnapshotPayload } from '@/modules/dashboard/snapshots'
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
 import EditLocationDataSnapshotForm from '@/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 
@@ -76,6 +77,59 @@ describe('edit-snapshot/EditLocationDataSnapshotForm.vue', () => {
 
     const valid = await wrapper.vm.validate();
     expect(valid).toBe(false);
+  });
+
+  it('should show no validation message before anything is edited', async () => {
+    const model = baseModel();
+    model.location = '';
+    model.usdValue = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.find('[data-testid=edit-location-location] .details').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=edit-location-value] .details .text-rui-error').exists()).toBe(false);
+  });
+
+  it('should reveal both required messages once validate runs', async () => {
+    const model = baseModel();
+    model.location = '';
+    model.usdValue = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersByTimeAsync(700);
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=edit-location-location] .details').text())
+      .toBe('dashboard.snapshot.edit.dialog.location_data.rules.location');
+    expect(wrapper.find('[data-testid=edit-location-value] .details .text-rui-error').text())
+      .toBe('dashboard.snapshot.edit.dialog.location_data.rules.value');
+  });
+
+  it('should show the value message once the field is emptied and left', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const value = wrapper.find('[data-testid=edit-location-value] input');
+    await value.setValue('');
+    await value.trigger('blur');
+    // The field's message sits behind an enter transition, so it is not in the DOM immediately.
+    await vi.advanceTimersByTimeAsync(700);
+
+    expect(wrapper.find('[data-testid=edit-location-value] .details .text-rui-error').text())
+      .toBe('dashboard.snapshot.edit.dialog.location_data.rules.value');
+  });
+
+  it('should flag stateUpdated once a field is edited', async () => {
+    wrapper = createWrapper();
+    // `useFormStateWatcher` only arms its watcher after a 500ms delay.
+    await vi.advanceTimersByTimeAsync(600);
+
+    await wrapper.find('[data-testid=edit-location-value] input').setValue('6000');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
   });
 
   it('should emit update:modelValue when the value field changes', async () => {

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
@@ -53,6 +53,7 @@ defineExpose({
   <div class="flex flex-col gap-2">
     <LocationSelector
       v-model="location"
+      data-testid="edit-location-location"
       :excludes="excludedLocations"
       :label="t('common.location')"
       :error-messages="toMessages(v$.location)"

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { LocationDataSnapshotPayload } from '@/modules/dashboard/snapshots';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import { isEqual } from 'es-toolkit';
 import LocationSelector from '@/modules/balances/LocationSelector.vue';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
+import {
+  type LocationDataSnapshotFormState,
+  locationDataSnapshotSchema,
+} from '@/modules/dashboard/edit-snapshot/snapshot-forms';
 import { useSetting } from '@/modules/settings/use-setting';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 
@@ -16,50 +18,62 @@ const { excludedLocations = [] } = defineProps<{
   excludedLocations?: string[];
 }>();
 
-const location = useRefPropVModel(model, 'location');
-const value = useRefPropVModel(model, 'usdValue');
-
 const currencySymbol = useSetting('currencySymbol');
 
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  location: {
-    required: helpers.withMessage(t('dashboard.snapshot.edit.dialog.location_data.rules.location'), required),
-  },
-  value: {
-    required: helpers.withMessage(t('dashboard.snapshot.edit.dialog.location_data.rules.value'), required),
-  },
-};
+const schema = computed<ZodType>(() => locationDataSnapshotSchema({
+  location: t('dashboard.snapshot.edit.dialog.location_data.rules.location'),
+  value: t('dashboard.snapshot.edit.dialog.location_data.rules.value'),
+}));
 
-const states = {
-  location,
-  value,
-};
+/** The dialog owns the persist and reads the payload off the model, so submitting here is a no-op. */
+const form = useForm<LocationDataSnapshotFormState, LocationDataSnapshotFormState>({
+  initial: (): LocationDataSnapshotFormState => ({ ...get(model) }),
+  schema,
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): LocationDataSnapshotFormState => ({ ...state }),
+  // The timestamp is carried, not edited; only the two fields the form gates count as an edit.
+  transientKeys: ['timestamp'],
+});
 
-const v$ = useVuelidate(
-  rules,
-  states,
-  { $autoDirty: true },
-);
-useFormStateWatcher(states, stateUpdated);
+// The dialog reads the payload it saves straight off the model, so every edit is written back to it.
+watch(() => form.state, (state) => {
+  set(model, { ...state });
+}, { deep: true });
+
+// And an edit made outside the form (a reset, a different row) is pulled back in.
+watch(model, (value) => {
+  if (!isEqual(value, form.state))
+    Object.assign(form.state, value);
+}, { deep: true });
+
+watch(form.dirty, (dirty) => {
+  set(stateUpdated, dirty);
+});
+
+// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
+onUnmounted(() => {
+  set(stateUpdated, false);
+});
 
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
 <template>
   <div class="flex flex-col gap-2">
     <LocationSelector
-      v-model="location"
+      v-model="form.state.location"
       data-testid="edit-location-location"
       :excludes="excludedLocations"
       :label="t('common.location')"
-      :error-messages="toMessages(v$.location)"
+      :error-messages="form.errors('location')"
+      @update:model-value="form.touch('location')"
     />
     <AmountInput
-      v-model="value"
+      v-model="form.state.usdValue"
       variant="outlined"
       data-testid="edit-location-value"
       :label="
@@ -67,7 +81,8 @@ defineExpose({
           symbol: currencySymbol,
         })
       "
-      :error-messages="toMessages(v$.value)"
+      :error-messages="form.errors('usdValue')"
+      @blur="form.touch('usdValue')"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/dashboard/edit-snapshot/snapshot-forms.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/snapshot-forms.ts
@@ -1,0 +1,106 @@
+import type { BalanceType } from '@/modules/balances/types/balances';
+import { z, type ZodType } from 'zod';
+
+/**
+ * A field that must hold something. Vuelidate's `required` treated a whitespace-only string as
+ * empty and reported a missing value under the same message as a wrong-typed one, so both are kept.
+ */
+function requiredField(message: string): ZodType<string> {
+  return z.string({ error: message }).superRefine((value, ctx) => {
+    if (value.trim() === '')
+      ctx.addIssue({ code: 'custom', message });
+  });
+}
+
+export interface LocationDataSnapshotFormState {
+  location: string;
+  timestamp: number;
+  usdValue: string;
+}
+
+export interface LocationDataSnapshotMessages {
+  location: string;
+  value: string;
+}
+
+export function locationDataSnapshotSchema(messages: LocationDataSnapshotMessages): ZodType {
+  return z.object({
+    location: requiredField(messages.location),
+    timestamp: z.number(),
+    usdValue: requiredField(messages.value),
+  });
+}
+
+export interface BalanceSnapshotFormState {
+  amount: string;
+  assetIdentifier: string;
+  category: BalanceType;
+  location: string;
+  timestamp: number;
+  usdValue: string;
+}
+
+export interface BalanceSnapshotMessages {
+  category: string;
+  location: string;
+  locationInsufficient: string;
+}
+
+export interface BalanceSnapshotRules {
+  /** Location ids that cannot absorb the edited value. */
+  disabledLocations: readonly string[];
+  /** While the single-location selector is hidden, the caller drives attribution itself. */
+  hideLocation: boolean;
+  messages: BalanceSnapshotMessages;
+}
+
+/**
+ * The balance form gates on the category and the location alone. The asset, amount and value are
+ * carried so the form owns one state, but they are validated by the price sub-form, whose messages
+ * are for display only - see `assetPriceSchema`.
+ */
+export function balanceSnapshotSchema(rules: BalanceSnapshotRules): ZodType {
+  const { disabledLocations, hideLocation, messages } = rules;
+
+  return z.object({
+    amount: z.string(),
+    assetIdentifier: z.string(),
+    category: requiredField(messages.category),
+    location: z.string(),
+    timestamp: z.number(),
+    usdValue: z.string(),
+  }).superRefine((state, ctx) => {
+    // Required whenever the selector is shown: every balance must be attributed so the location
+    // subtotals reconcile with the net worth. In split mode the split drives attribution instead.
+    if (!hideLocation && state.location.trim() === '')
+      ctx.addIssue({ code: 'custom', message: messages.location, path: ['location'] });
+
+    // Checked even in split mode, matching the rule it replaces.
+    if (state.location !== '' && disabledLocations.includes(state.location))
+      ctx.addIssue({ code: 'custom', message: messages.locationInsufficient, path: ['location'] });
+  });
+}
+
+export interface AssetPriceFormState {
+  amount: string;
+  asset: string;
+  usdValue: string;
+}
+
+export interface AssetPriceMessages {
+  amount: string;
+  asset: string;
+  value: string;
+}
+
+/**
+ * Display-only rules for the price sub-form. That form exposes no `validate`, so nothing here can
+ * block a save; it decorates the fields while `balanceSnapshotSchema` holds the actual gate.
+ */
+export function assetPriceSchema(messages: AssetPriceMessages): ZodType {
+  return z.object({
+    amount: requiredField(messages.amount),
+    asset: requiredField(messages.asset),
+    usdValue: requiredField(messages.value),
+  });
+}


### PR DESCRIPTION
Continues the vuelidate to zod migration. The settings forms landed earlier; this
takes the three dashboard snapshot edit forms.

`EditLocationDataSnapshotForm`, `EditBalancesSnapshotForm` and
`EditBalancesSnapshotAssetPriceForm` now validate through the `useForm` core, with
the rules in a pure `snapshot-forms.ts` module. The vuelidate-era plumbing goes with
them rather than being translated: `useForm` owns one reactive state the templates
bind into, so the seven `useRefPropVModel` calls, both `useFormStateWatcher` calls
and `toMessages` are deleted. `modules/dashboard/` is now free of vuelidate.

The gate is unchanged. `EditBalancesSnapshotForm` still validates only the category
and the location, and the price sub-form still exposes no `validate()`, so its
messages remain decorative.

## Behaviour notes

- `stateUpdated` now tracks `form.dirty`. A plain dirty check covers the whole entry,
  and the price fetch rewrites the value on mount, which armed the dialog's
  unsaved-changes prompt before the user had touched anything. `transientKeys`
  narrows it back to the fields each form actually gates.
- Validation messages appear on blur rather than on the first keystroke, matching how
  `$autoDirty` was replaced across the forms migrated so far.

## Also here

`bigNumberifyFromRef` used the throwing `bigNumberify` overload and guarded only the
empty string. bignumber.js rejects anything it cannot parse by throwing, so an
unparsable field value surfaced as a render-time exception in whichever form is bound
to it rather than as a bad number. It now passes the fallback and reads as zero, the
same as a cleared field already did. This is opt-in at that one helper and does not
change the strict behaviour anywhere else.

The dead `edit-balances-snapshot__location` class, which nothing styled or selected,
is replaced by a `data-testid`.

## Testing

The three forms were characterized first, so the migration commit could be checked
against pinned behaviour rather than against its own output. The specs grew from 18
to 30 tests. Two problems surfaced that way:

- The balances spec attached an `onUpdate:modelValue` listener but never fed the value
  back as a prop. With a listener attached `defineModel` reads the prop, so the form
  stayed frozen on its initial model and no downstream watcher ran, which left a test
  that could not fail.
- The mount-time dirty regression above. Its first test passed only because the
  fixture's seeded value happened to equal what the price fetch computed, so the
  committed version seeds a value the fetch actually changes.

Typecheck, lint and typos are clean, and 3969 tests pass across every module the
`bigNumberify` change touches.