### PR TITLE
feat(prices): link to the price oracle settings

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5056,6 +5056,7 @@
       "source": "Source"
     },
     "refresh_tooltip": "Refresh the oracle prices list",
+    "settings_tooltip": "Price oracle settings: choose which oracles are used, and in which order",
     "sources": {
       "cryptocompare": "CryptoCompare"
     },

--- a/frontend/app/src/pages/price-manager/oracle/index.vue
+++ b/frontend/app/src/pages/price-manager/oracle/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router';
 import { msg } from '@/message-key';
 import OracleCacheContent from '@/modules/assets/prices/components/oracle/OracleCacheContent.vue';
 import OraclePriceContent from '@/modules/assets/prices/components/oracle/OraclePriceContent.vue';
@@ -13,12 +14,36 @@ definePage({
 const { t } = useI18n({ useScope: 'global' });
 
 const tab = ref<'prices' | 'caches'>('prices');
+
+const oracleSettingsRoute: RouteLocationRaw = { name: '/settings/oracle/' };
 </script>
 
 <template>
   <TablePageLayout
     :title="[t('navigation_menu.manage_prices'), t('navigation_menu.manage_prices_sub.oracle_prices')]"
   >
+    <template #buttons>
+      <RuiTooltip
+        :popper="{ placement: 'top' }"
+        :open-delay="400"
+      >
+        <template #activator>
+          <RouterLink :to="oracleSettingsRoute">
+            <RuiButton
+              variant="text"
+              icon
+              color="primary"
+              size="lg"
+              data-testid="oracle-settings-link"
+            >
+              <RuiIcon name="lu-settings" />
+            </RuiButton>
+          </RouterLink>
+        </template>
+        <span>{{ t('oracle_prices.settings_tooltip') }}</span>
+      </RuiTooltip>
+    </template>
+
     <div>
       <RuiTabs
         v-model="tab"


### PR DESCRIPTION
Manage Prices > Oracle Prices shows cached oracle price *data*; the oracle *configuration* lives under Settings > Oracles. The two names are near-identical but mean opposite things, so looking for where to add a price oracle leads to the prices page first.

Adds a settings icon button in the page header linking to the oracle settings. It sits in the `TablePageLayout` header, so it is present on both the Prices and Caches tabs.

Embedding the settings in a popover was considered and rejected: `PriceOracleSettings` is two drag-orderable priority lists plus a refresh action, which is too much for a popover.

The button follows the existing header settings affordance (`CalendarSettingsMenu`, `ReportGenerator`): `variant="text" icon color="primary" size="lg"` with `lu-settings` and a tooltip.

Note that a bare gear is only discoverable on hover. If that turns out not to be enough, a follow-up could add `keywords` to the settings/oracle route nav meta so the global search palette also matches "oracle prices".