### PR TITLE
Remove dead GitPOAP badge and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@
 [![GitHub forks](https://img.shields.io/github/forks/rotki/rotki)](https://github.com/rotki/rotki/forks)
 [![GitHub stars](https://img.shields.io/github/stars/rotki/rotki)](https://github.com/rotki/rotki/stargazers)
 [![GitHub last commit](https://img.shields.io/github/last-commit/rotki/rotki)](https://github.com/rotki/rotki/commits/master)
-[![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/rotki/rotki/badge)](https://www.gitpoap.io/gh/rotki/rotki)
 [![Github downloads](https://img.shields.io/github/downloads/rotki/rotki/total.svg)](https://GitHub.com/rotki/rotki/releases/)
 [![Hiring](https://img.shields.io/badge/Hiring-Open-brightgreen)](https://rotki.com/jobs/)
 [![X Follow](https://img.shields.io/twitter/follow/rotkiapp)](https://x.com/rotkiapp)
@@ -129,9 +128,6 @@ We welcome contributions from the community! 🎉
 - Read the [Contribution Guide](CONTRIBUTING.md)
 - Explore the [Developer Guide](https://docs.rotki.com/contribution-guides/)
 - Check out [Open Issues](https://github.com/rotki/rotki/issues)
-
-📌 **Claim Your Contributor Badge!**  
-Contributors receive a **GitPOAP Badge** for each year they contribute! 🎖 [Claim yours here](https://www.gitpoap.io/rp/62).
 
 ---
 


### PR DESCRIPTION
gitpoap.io no longer resolves (DNS failure), so the README badge image is broken and the contributor badge claim link is dead. Removes both.

Checked the rest of the README's links while here: everything else resolves. One soft spot left alone, the changelog link points at rotki.readthedocs.io, which still loads but is frozen at the 1.43.2 docs while the live docs are on docs.rotki.com (which has no changelog page).