### PR TITLE
Allow setting an unset single-value RPC endpoint

### DIFF
--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.spec.ts
@@ -1,0 +1,137 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import SimpleRpcNodeManager from '@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue';
+import '@test/i18n';
+
+/**
+ * Single-value endpoints (KSM, DOT, beacon, mempool) do not get the header "Add node" button, so
+ * the empty state is the only entry point for setting one. Without it an unset endpoint - the
+ * shipped default for Polkadot - is unreachable from the UI.
+ */
+const { readSetting, show, write } = vi.hoisted(() => ({
+  readSetting: vi.fn(),
+  show: vi.fn(),
+  write: vi.fn(),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: readSetting,
+}));
+
+vi.mock('@/modules/settings/settings-writer', () => ({
+  useSettingsWriter: (): Record<string, unknown> => ({ write }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({ show }),
+}));
+
+// Stubbed down to the seam the manager uses: the url model and the exposed `validate`.
+vi.mock('@/modules/settings/general/rpc/simple/SimpleRpcNodeManagerForm.vue', async () => {
+  const { defineComponent, h } = await import('vue');
+  return {
+    default: defineComponent({
+      emits: ['update:modelValue', 'update:stateUpdated', 'update:errorMessages'],
+      name: 'SimpleRpcNodeManagerForm',
+      props: {
+        errorMessages: { default: () => ({}), type: Object },
+        modelValue: { default: '', type: String },
+        stateUpdated: { default: false, type: Boolean },
+      },
+      setup: (props, { expose }) => {
+        expose({ validate: (): boolean => true });
+        return (): VNode => h('div', { 'class': 'rpc-form', 'data-url': props.modelValue });
+      },
+    }),
+  };
+});
+
+const BigDialogStub = defineComponent({
+  emits: ['confirm', 'cancel'],
+  name: 'BigDialog',
+  props: {
+    display: { default: false, type: Boolean },
+  },
+  setup: (props, { slots }) => (): VNode => h(
+    'div',
+    { 'class': 'big-dialog', 'data-display': String(props.display) },
+    slots.default?.(),
+  ),
+});
+
+describe('settings/general/rpc/simple/SimpleRpcNodeManager.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<InstanceType<typeof SimpleRpcNodeManager>>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    readSetting.mockReturnValue(ref<string>(''));
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(): VueWrapper<InstanceType<typeof SimpleRpcNodeManager>> {
+    return mount(SimpleRpcNodeManager, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          BigDialog: BigDialogStub,
+        },
+      },
+      props: {
+        setting: 'dotRpcEndpoint',
+      },
+    });
+  }
+
+  it('should offer an add button when no endpoint is set', async () => {
+    wrapper = createWrapper();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=add-simple-node]').exists()).toBe(true);
+  });
+
+  it('should open the dialog with an empty url when adding', async () => {
+    wrapper = createWrapper();
+    await nextTick();
+
+    expect(wrapper.find('.big-dialog').attributes('data-display')).toBe('false');
+
+    await wrapper.find('[data-testid=add-simple-node]').trigger('click');
+    await nextTick();
+
+    expect(wrapper.find('.big-dialog').attributes('data-display')).toBe('true');
+    expect(wrapper.find('.rpc-form').attributes('data-url')).toBe('');
+  });
+
+  it('should save the entered url to the setting', async () => {
+    write.mockResolvedValue({ success: true });
+    wrapper = createWrapper();
+    await nextTick();
+
+    await wrapper.find('[data-testid=add-simple-node]').trigger('click');
+    await nextTick();
+
+    wrapper.findComponent({ name: 'SimpleRpcNodeManagerForm' }).vm.$emit('update:modelValue', 'https://rpc.polkadot.io');
+    await nextTick();
+    wrapper.findComponent(BigDialogStub).vm.$emit('confirm');
+    await flushPromises();
+
+    expect(write).toHaveBeenCalledWith('dotRpcEndpoint', 'https://rpc.polkadot.io');
+  });
+
+  it('should not offer an add button when an endpoint is already set', async () => {
+    readSetting.mockReturnValue(ref<string>('https://rpc.polkadot.io'));
+    wrapper = createWrapper();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=add-simple-node]').exists()).toBe(false);
+    expect(wrapper.text()).toContain('https://rpc.polkadot.io');
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
@@ -135,7 +135,24 @@ defineExpose({
           colspan="2"
           class="!py-4 text-rui-text-secondary text-center w-full"
         >
-          {{ t('data_table.no_data') }}
+          <div class="flex flex-col gap-3 items-center">
+            {{ t('data_table.no_data') }}
+            <!-- The header "Add node" button is hidden for single-value
+                 endpoints, so this is the only way to set an empty one. -->
+            <RuiButton
+              color="primary"
+              data-testid="add-simple-node"
+              @click="addNewRpcNode()"
+            >
+              <template #prepend>
+                <RuiIcon
+                  name="lu-plus"
+                  size="16"
+                />
+              </template>
+              {{ t('evm_rpc_node_manager.add_button') }}
+            </RuiButton>
+          </div>
         </td>
       </tr>
     </tbody>

--- a/frontend/app/tests/e2e/pages/rpc-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/rpc-settings-page.ts
@@ -32,6 +32,10 @@ export class RpcSettingsPage {
     await expect(this.page.getByTestId('add-node')).toHaveCount(0);
   }
 
+  async expectEmptyStateAddVisible(): Promise<void> {
+    await expect(this.page.getByTestId('add-simple-node')).toBeVisible();
+  }
+
   async visitWithTab(tab: string): Promise<void> {
     await this.page.goto(`/#/settings/rpc?tab=${tab}`);
     await this.page.getByTestId('rpc-settings-rail').waitFor({ state: 'visible' });

--- a/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
@@ -58,6 +58,14 @@ test.describe.serial('settings::rpc', () => {
     }
   });
 
+  test('an unset single-value endpoint can still be added from the empty state', async () => {
+    for (const label of ['Kusama', 'Polkadot']) {
+      await pageRpc.clickRailTab(label);
+      await pageRpc.expectAddNodeHidden();
+      await pageRpc.expectEmptyStateAddVisible();
+    }
+  });
+
   test('Add Node is visible on EVM chains and Solana', async () => {
     for (const label of ['Ethereum', 'Solana']) {
       await pageRpc.clickRailTab(label);


### PR DESCRIPTION
## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

## Problem

Single-value endpoints (Kusama, Polkadot, ETH Beacon, BTC Mempool) cannot be set at all when they are empty.

Since #12250 the header "Add node" button is hidden for those tabs (`canAddNode` is false whenever the tab carries a `setting` key), and `SimpleRpcNodeManager` only renders the row with its edit/delete actions when a value exists. With no value there is no row, so there is no edit action and no add button.

The backend defaults both `ksm_rpc_endpoint` and `dot_rpc_endpoint` to an empty string (`rotkehlchen/db/settings.py`), so out of the box Kusama and Polkadot can never be configured from the UI. Deleting any of the four endpoints made the loss permanent.

## Fix

Render an "Add node" button in the empty state of `SimpleRpcNodeManager`, wired to the already-exposed `addNewRpcNode()`. The header button stays hidden for these endpoints as intended, so nothing changes once a value is set.

## Tests

- New `SimpleRpcNodeManager.spec.ts` (the component had no spec): the add button appears only when the endpoint is empty, clicking it opens the dialog with an empty url, and confirming writes the entered url to the setting. Suppressing the button fails three of the four tests.
- e2e: on Kusama and Polkadot, assert the header button is hidden and the empty-state one is visible.