### PR TITLE
Validate the asset price forms with zod

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/AddressBookFormDialog.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookFormDialog.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import type { AddressBookPayload } from '@/modules/accounts/address-book/eth-names';
-import type LatestPriceForm from '@/modules/assets/prices/latest/LatestPriceForm.vue';
 import { useTemplateRef } from 'vue';
 import { type MessageKey, msg } from '@/message-key';
 import AddressBookForm from '@/modules/accounts/address-book/AddressBookForm.vue';
@@ -36,7 +35,7 @@ const { t } = useI18n({ useScope: 'global' });
 const modelValue = ref<AddressBookPayload>();
 const loading = ref(false);
 const errorMessages = ref<Record<string, string[]>>({});
-const form = useTemplateRef<InstanceType<typeof LatestPriceForm>>('form');
+const form = useTemplateRef<InstanceType<typeof AddressBookForm>>('form');
 const stateUpdated = ref(false);
 
 const emptyForm: () => AddressBookPayload = () => ({

--- a/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.spec.ts
+++ b/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.spec.ts
@@ -66,7 +66,7 @@ describe('historicPriceForm', () => {
           DateTimePicker: inputStub('DateTimePicker'),
         },
       },
-      props: { errorMessages: {}, modelValue, ...props },
+      props: { modelValue, ...props },
     });
   }
 

--- a/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.spec.ts
+++ b/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.spec.ts
@@ -1,0 +1,215 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@test/i18n';
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn().mockReturnValue({
+    useAssetField: vi.fn().mockImplementation(() => computed<string>(() => 'SYM')),
+  }),
+}));
+
+const HistoricPriceForm = (await import('@/modules/assets/prices/historic/HistoricPriceForm.vue')).default;
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+/** Every field is a third-party input, so they are stubbed down to the two things the form uses. */
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+describe('historicPriceForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof HistoricPriceForm>>;
+
+  const baseModel = (): HistoricalPriceFormPayload => ({
+    fromAsset: 'ETH',
+    price: '2500',
+    // Carried through the form untouched: no field renders it and no rule reads it.
+    sourceType: 'manual',
+    timestamp: 1700000000,
+    toAsset: 'USD',
+  });
+
+  /** Clearing the date input writes an empty value into the model, which is what its rule guards. */
+  function withoutTimestamp(): HistoricalPriceFormPayload {
+    const model = baseModel();
+    Reflect.deleteProperty(model, 'timestamp');
+    return model;
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    modelValue: HistoricalPriceFormPayload = baseModel(),
+    props: Record<string, unknown> = {},
+  ): VueWrapper<InstanceType<typeof HistoricPriceForm>> {
+    return mount(HistoricPriceForm, {
+      global: {
+        stubs: {
+          AmountInput: inputStub('AmountInput'),
+          AssetSelect: inputStub('AssetSelect'),
+          DateTimePicker: inputStub('DateTimePicker'),
+        },
+      },
+      props: { errorMessages: {}, modelValue, ...props },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(testId: string, value: string | number): Promise<void> {
+    const input = field(testId);
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should pass validation when every field is filled', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it.each([
+    ['fromAsset'],
+    ['toAsset'],
+    ['price'],
+  ] as const)('should fail validation when %s is empty', async (key) => {
+    const model = baseModel();
+    model[key] = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should treat a whitespace-only price as empty', async () => {
+    wrapper = createWrapper({ ...baseModel(), price: '   ' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should fail validation when the date is cleared', async () => {
+    wrapper = createWrapper(withoutTimestamp());
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  // The epoch is a real date, not a missing one, so the rule lets it through.
+  it('should accept a zero timestamp', async () => {
+    wrapper = createWrapper({ ...baseModel(), timestamp: 0 });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper({ ...withoutTimestamp(), fromAsset: '', price: '', toAsset: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('historic-price-from-asset')).toEqual([]);
+    expect(messages('historic-price-to-asset')).toEqual([]);
+    expect(messages('historic-price-datetime')).toEqual([]);
+    expect(messages('historic-price-value')).toEqual([]);
+  });
+
+  it('should reveal every message once validate runs', async () => {
+    wrapper = createWrapper({ ...withoutTimestamp(), fromAsset: '', price: '', toAsset: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('historic-price-from-asset')).toEqual(['price_form.from_non_empty']);
+    expect(messages('historic-price-to-asset')).toEqual(['price_form.to_non_empty']);
+    expect(messages('historic-price-datetime')).toEqual(['price_form.date_non_empty']);
+    expect(messages('historic-price-value')).toEqual(['price_form.price_non_empty']);
+  });
+
+  it('should show the price message once the field is emptied', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('historic-price-value', '');
+
+    expect(messages('historic-price-value')).toEqual(['price_form.price_non_empty']);
+    // The untouched fields stay quiet.
+    expect(messages('historic-price-from-asset')).toEqual([]);
+  });
+
+  it('should write an edit back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('historic-price-value', '3000');
+
+    const updates = wrapper.emitted<[HistoricalPriceFormPayload]>('update:modelValue');
+    expect(updates).toBeTruthy();
+    const last = updates!.at(-1)![0];
+    expect(last.price).toBe('3000');
+    expect(last.timestamp).toBe(1700000000);
+    // The field the form never renders still has to survive the round trip.
+    expect(last.sourceType).toBe('manual');
+  });
+
+  it('should flag stateUpdated once a field is edited', async () => {
+    wrapper = createWrapper();
+    // Settle the mounted work first, so what follows is the only edit in play.
+    await vi.advanceTimersByTimeAsync(600);
+
+    await edit('historic-price-value', '3000');
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
+  });
+
+  it('should not flag stateUpdated before anything is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).not.toEqual([true]);
+  });
+
+  it('should lock everything but the price while editing', async () => {
+    wrapper = createWrapper(baseModel(), { editMode: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('historic-price-from-asset').props('disabled')).toBe(true);
+    expect(field('historic-price-to-asset').props('disabled')).toBe(true);
+    expect(field('historic-price-datetime').props('disabled')).toBe(true);
+    expect(field('historic-price-value').props('disabled')).toBeFalsy();
+  });
+
+  // The three locked fields keep their rules, so an edit row seeded without one cannot be saved.
+  it('should still gate the locked fields while editing', async () => {
+    wrapper = createWrapper(withoutTimestamp(), { editMode: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.vue
+++ b/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.vue
@@ -1,72 +1,71 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
-import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import { isEqual } from 'es-toolkit';
 import { ValueDisplay } from '@/modules/assets/amount-display/components';
+import { historicPriceSchema } from '@/modules/assets/prices/price-forms';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { bigNumberifyFromRef } from '@/modules/core/common/data/bignumbers';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 import DateTimePicker from '@/modules/shell/components/inputs/DateTimePicker.vue';
 
 const modelValue = defineModel<HistoricalPriceFormPayload>({ required: true });
-const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
 const { editMode = false } = defineProps<{
   editMode?: boolean;
 }>();
 
-const { useAssetField } = useAssetInfoRetrieval();
-
-const fromAsset = useRefPropVModel(modelValue, 'fromAsset');
-const toAsset = useRefPropVModel(modelValue, 'toAsset');
-const price = useRefPropVModel(modelValue, 'price');
-const timestamp = useRefPropVModel(modelValue, 'timestamp');
-
-const fromAssetSymbol = useAssetField(fromAsset, 'symbol');
-const toAssetSymbol = useAssetField(toAsset, 'symbol');
-
-const numericPrice = bigNumberifyFromRef(price);
-
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  fromAsset: {
-    required: helpers.withMessage(t('price_form.from_non_empty'), required),
-  },
-  price: {
-    required: helpers.withMessage(t('price_form.price_non_empty'), required),
-  },
-  timestamp: {
-    required: helpers.withMessage(t('price_form.date_non_empty'), required),
-  },
-  toAsset: {
-    required: helpers.withMessage(t('price_form.to_non_empty'), required),
-  },
-};
+const { useAssetField } = useAssetInfoRetrieval();
 
-const states = {
-  fromAsset,
-  price,
-  timestamp,
-  toAsset,
-};
+const schema = computed<ZodType>(() => historicPriceSchema({
+  date: t('price_form.date_non_empty'),
+  fromAsset: t('price_form.from_non_empty'),
+  price: t('price_form.price_non_empty'),
+  toAsset: t('price_form.to_non_empty'),
+}));
 
-const v$ = useVuelidate(
-  rules,
-  states,
-  { $autoDirty: true, $externalResults: errors },
-);
+/** The dialog owns the persist and reads the payload off the model, so submitting here is a no-op. */
+const form = useForm<HistoricalPriceFormPayload, HistoricalPriceFormPayload>({
+  initial: (): HistoricalPriceFormPayload => ({ ...get(modelValue) }),
+  schema,
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): HistoricalPriceFormPayload => ({ ...state }),
+  // Carried for the payload, never edited here, so it must not make the form look edited either.
+  transientKeys: ['sourceType'],
+});
 
-useFormStateWatcher(states, stateUpdated);
+const fromAssetSymbol = useAssetField(computed<string>(() => form.state.fromAsset), 'symbol');
+const toAssetSymbol = useAssetField(computed<string>(() => form.state.toAsset), 'symbol');
+
+const numericPrice = bigNumberifyFromRef(() => form.state.price);
+
+// The dialog reads the payload it saves straight off the model, so every edit is written back to it.
+watch(() => form.state, (state) => {
+  set(modelValue, { ...state });
+}, { deep: true });
+
+// And an edit made outside the form (a different row, a reset) is pulled back in.
+watch(modelValue, (value) => {
+  if (!isEqual(value, form.state))
+    Object.assign(form.state, value);
+}, { deep: true });
+
+watch(form.dirty, (dirty) => {
+  set(stateUpdated, dirty);
+});
+
+// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
+onUnmounted(() => {
+  set(stateUpdated, false);
+});
 
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -74,40 +73,44 @@ defineExpose({
   <div class="flex flex-col gap-4">
     <div class="grid md:grid-cols-2 gap-x-4 gap-y-2">
       <AssetSelect
-        v-model="fromAsset"
+        v-model="form.state.fromAsset"
         :label="t('price_form.from_asset')"
         outlined
         :disabled="editMode"
-        :error-messages="toMessages(v$.fromAsset)"
+        :error-messages="form.errors('fromAsset')"
         data-testid="historic-price-from-asset"
+        @update:model-value="form.touch('fromAsset')"
       />
       <AssetSelect
-        v-model="toAsset"
+        v-model="form.state.toAsset"
         :label="t('price_form.to_asset')"
         :disabled="editMode"
         outlined
-        :error-messages="toMessages(v$.toAsset)"
+        :error-messages="form.errors('toAsset')"
         data-testid="historic-price-to-asset"
+        @update:model-value="form.touch('toAsset')"
       />
     </div>
     <DateTimePicker
-      v-model="timestamp"
+      v-model="form.state.timestamp"
       :label="t('common.datetime')"
       :disabled="editMode"
       type="epoch"
       variant="outlined"
-      :error-messages="toMessages(v$.timestamp)"
+      :error-messages="form.errors('timestamp')"
       data-testid="historic-price-datetime"
+      @update:model-value="form.touch('timestamp')"
     />
     <AmountInput
-      v-model="price"
+      v-model="form.state.price"
       variant="outlined"
-      :error-messages="toMessages(v$.price)"
+      :error-messages="form.errors('price')"
       :label="t('common.price')"
       data-testid="historic-price-value"
+      @update:model-value="form.touch('price')"
     />
     <i18n-t
-      v-if="price && fromAssetSymbol && toAssetSymbol"
+      v-if="form.state.price && fromAssetSymbol && toAssetSymbol"
       scope="global"
       tag="div"
       keypath="price_form.historic.hint"

--- a/frontend/app/src/modules/assets/prices/historic/HistoricPriceFormDialog.vue
+++ b/frontend/app/src/modules/assets/prices/historic/HistoricPriceFormDialog.vue
@@ -18,7 +18,6 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 const loading = ref<boolean>(false);
-const errorMessages = ref<Record<string, string[]>>({});
 const form = useTemplateRef<InstanceType<typeof HistoricPriceForm>>('form');
 const stateUpdated = ref<boolean>(false);
 
@@ -35,7 +34,7 @@ async function save() {
     return false;
 
   const formRef = get(form);
-  const valid = await formRef?.validate();
+  const valid = formRef?.validate();
   if (!valid)
     return false;
 
@@ -66,7 +65,6 @@ async function save() {
       v-if="modelValue"
       ref="form"
       v-model="modelValue"
-      v-model:error-messages="errorMessages"
       v-model:state-updated="stateUpdated"
       :edit-mode="editMode"
     />

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.spec.ts
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.spec.ts
@@ -55,7 +55,7 @@ describe('latestPriceForm', () => {
           AssetSelect: inputStub('AssetSelect'),
         },
       },
-      props: { errorMessages: {}, modelValue, ...props },
+      props: { modelValue, ...props },
     });
   }
 

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.spec.ts
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.spec.ts
@@ -1,0 +1,183 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { ManualPriceFormPayload } from '@/modules/assets/prices/price-types';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@test/i18n';
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn().mockReturnValue({
+    useAssetField: vi.fn().mockImplementation(() => computed<string>(() => 'SYM')),
+  }),
+}));
+
+const LatestPriceForm = (await import('@/modules/assets/prices/latest/LatestPriceForm.vue')).default;
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+/** Every field is a third-party input, so they are stubbed down to the two things the form uses. */
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+describe('latestPriceForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LatestPriceForm>>;
+
+  const baseModel = (): ManualPriceFormPayload => ({
+    fromAsset: 'ETH',
+    price: '2500',
+    toAsset: 'USD',
+  });
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    modelValue: ManualPriceFormPayload = baseModel(),
+    props: Record<string, unknown> = {},
+  ): VueWrapper<InstanceType<typeof LatestPriceForm>> {
+    return mount(LatestPriceForm, {
+      global: {
+        stubs: {
+          AmountInput: inputStub('AmountInput'),
+          AssetSelect: inputStub('AssetSelect'),
+        },
+      },
+      props: { errorMessages: {}, modelValue, ...props },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(testId: string, value: string): Promise<void> {
+    const input = field(testId);
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should pass validation when every field is filled', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it.each([
+    ['fromAsset'],
+    ['toAsset'],
+    ['price'],
+  ] as const)('should fail validation when %s is empty', async (key) => {
+    const model = baseModel();
+    model[key] = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should treat a whitespace-only price as empty', async () => {
+    wrapper = createWrapper({ ...baseModel(), price: '   ' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper({ fromAsset: '', price: '', toAsset: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('latest-price-from-asset')).toEqual([]);
+    expect(messages('latest-price-to-asset')).toEqual([]);
+    expect(messages('latest-price-value')).toEqual([]);
+  });
+
+  it('should reveal every message once validate runs', async () => {
+    wrapper = createWrapper({ fromAsset: '', price: '', toAsset: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('latest-price-from-asset')).toEqual(['price_form.from_non_empty']);
+    expect(messages('latest-price-to-asset')).toEqual(['price_form.to_non_empty']);
+    expect(messages('latest-price-value')).toEqual(['price_form.price_non_empty']);
+  });
+
+  it('should show the price message once the field is emptied', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('latest-price-value', '');
+
+    expect(messages('latest-price-value')).toEqual(['price_form.price_non_empty']);
+    // The untouched fields stay quiet.
+    expect(messages('latest-price-from-asset')).toEqual([]);
+  });
+
+  it('should write an edit back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('latest-price-value', '3000');
+
+    const updates = wrapper.emitted<[ManualPriceFormPayload]>('update:modelValue');
+    expect(updates).toBeTruthy();
+    const last = updates!.at(-1)![0];
+    expect(last.price).toBe('3000');
+    expect(last.fromAsset).toBe('ETH');
+  });
+
+  it('should flag stateUpdated once a field is edited', async () => {
+    wrapper = createWrapper();
+    // Settle the mounted work first, so what follows is the only edit in play.
+    await vi.advanceTimersByTimeAsync(600);
+
+    await edit('latest-price-value', '3000');
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
+  });
+
+  it('should not flag stateUpdated before anything is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).not.toEqual([true]);
+  });
+
+  it('should lock the from asset while editing, and leave the price editable', async () => {
+    wrapper = createWrapper(baseModel(), { editMode: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('latest-price-from-asset').props('disabled')).toBe(true);
+    expect(field('latest-price-to-asset').props('disabled')).toBeFalsy();
+    expect(field('latest-price-value').props('disabled')).toBeFalsy();
+  });
+
+  it('should lock the from asset when the caller pins it', async () => {
+    wrapper = createWrapper(baseModel(), { disableFromAsset: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('latest-price-from-asset').props('disabled')).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.vue
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.vue
@@ -1,19 +1,16 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { ManualPriceFormPayload } from '@/modules/assets/prices/price-types';
-import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import { isEqual } from 'es-toolkit';
 import { ValueDisplay } from '@/modules/assets/amount-display/components';
+import { latestPriceSchema } from '@/modules/assets/prices/price-forms';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { bigNumberifyFromRef } from '@/modules/core/common/data/bignumbers';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 
 const modelValue = defineModel<ManualPriceFormPayload>({ required: true });
-const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
 const { disableFromAsset = false, editMode = false } = defineProps<{
@@ -21,47 +18,51 @@ const { disableFromAsset = false, editMode = false } = defineProps<{
   editMode?: boolean;
 }>();
 
-const { useAssetField } = useAssetInfoRetrieval();
-
-const fromAsset = useRefPropVModel(modelValue, 'fromAsset');
-const toAsset = useRefPropVModel(modelValue, 'toAsset');
-const price = useRefPropVModel(modelValue, 'price');
-
-const fromAssetSymbol = useAssetField(fromAsset, 'symbol');
-const toAssetSymbol = useAssetField(toAsset, 'symbol');
-
-const numericPrice = bigNumberifyFromRef(price);
-
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  fromAsset: {
-    required: helpers.withMessage(t('price_form.from_non_empty'), required),
-  },
-  price: {
-    required: helpers.withMessage(t('price_form.price_non_empty'), required),
-  },
-  toAsset: {
-    required: helpers.withMessage(t('price_form.to_non_empty'), required),
-  },
-};
+const { useAssetField } = useAssetInfoRetrieval();
 
-const states = {
-  fromAsset,
-  price,
-  toAsset,
-};
+const schema = computed<ZodType>(() => latestPriceSchema({
+  fromAsset: t('price_form.from_non_empty'),
+  price: t('price_form.price_non_empty'),
+  toAsset: t('price_form.to_non_empty'),
+}));
 
-const v$ = useVuelidate(
-  rules,
-  states,
-  { $autoDirty: true, $externalResults: errors },
-);
+/** The dialog owns the persist and reads the payload off the model, so submitting here is a no-op. */
+const form = useForm<ManualPriceFormPayload, ManualPriceFormPayload>({
+  initial: (): ManualPriceFormPayload => ({ ...get(modelValue) }),
+  schema,
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): ManualPriceFormPayload => ({ ...state }),
+});
 
-useFormStateWatcher(states, stateUpdated);
+const fromAssetSymbol = useAssetField(computed<string>(() => form.state.fromAsset), 'symbol');
+const toAssetSymbol = useAssetField(computed<string>(() => form.state.toAsset), 'symbol');
+
+const numericPrice = bigNumberifyFromRef(() => form.state.price);
+
+// The dialog reads the payload it saves straight off the model, so every edit is written back to it.
+watch(() => form.state, (state) => {
+  set(modelValue, { ...state });
+}, { deep: true });
+
+// And an edit made outside the form (a different row, a reset) is pulled back in.
+watch(modelValue, (value) => {
+  if (!isEqual(value, form.state))
+    Object.assign(form.state, value);
+}, { deep: true });
+
+watch(form.dirty, (dirty) => {
+  set(stateUpdated, dirty);
+});
+
+// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
+onUnmounted(() => {
+  set(stateUpdated, false);
+});
 
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -69,31 +70,34 @@ defineExpose({
   <div class="flex flex-col gap-2">
     <div class="grid md:grid-cols-2 gap-x-4">
       <AssetSelect
-        v-model="fromAsset"
+        v-model="form.state.fromAsset"
         :label="t('price_form.from_asset')"
         outlined
         include-nfts
         :disabled="editMode || disableFromAsset"
-        :error-messages="toMessages(v$.fromAsset)"
+        :error-messages="form.errors('fromAsset')"
         data-testid="latest-price-from-asset"
+        @update:model-value="form.touch('fromAsset')"
       />
       <AssetSelect
-        v-model="toAsset"
+        v-model="form.state.toAsset"
         :label="t('price_form.to_asset')"
         outlined
-        :error-messages="toMessages(v$.toAsset)"
+        :error-messages="form.errors('toAsset')"
         data-testid="latest-price-to-asset"
+        @update:model-value="form.touch('toAsset')"
       />
     </div>
     <AmountInput
-      v-model="price"
+      v-model="form.state.price"
       variant="outlined"
-      :error-messages="toMessages(v$.price)"
+      :error-messages="form.errors('price')"
       :label="t('common.price')"
       data-testid="latest-price-value"
+      @update:model-value="form.touch('price')"
     />
     <i18n-t
-      v-if="price && fromAssetSymbol && toAssetSymbol"
+      v-if="form.state.price && fromAssetSymbol && toAssetSymbol"
       scope="global"
       tag="div"
       keypath="price_form.latest.hint"

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceFormDialog.vue
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceFormDialog.vue
@@ -27,7 +27,6 @@ const { t } = useI18n({ useScope: 'global' });
 
 const modelValue = ref<ManualPriceFormPayload>();
 const loading = ref(false);
-const errorMessages = ref<Record<string, string[]>>({});
 const form = useTemplateRef<InstanceType<typeof LatestPriceForm>>('form');
 const stateUpdated = ref(false);
 
@@ -44,7 +43,7 @@ async function save() {
     return false;
 
   const formRef = get(form);
-  const valid = await formRef?.validate();
+  const valid = formRef?.validate();
   if (!valid)
     return false;
 
@@ -99,7 +98,6 @@ watchImmediate([open, () => editableItem, () => prefill], ([open, editableItemVa
       v-if="modelValue"
       ref="form"
       v-model="modelValue"
-      v-model:error-messages="errorMessages"
       v-model:state-updated="stateUpdated"
       :edit-mode="editMode ?? !!editableItem"
       :disable-from-asset="disableFromAsset"

--- a/frontend/app/src/modules/assets/prices/price-forms.ts
+++ b/frontend/app/src/modules/assets/prices/price-forms.ts
@@ -1,0 +1,44 @@
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface ManualPriceMessages {
+  fromAsset: string;
+  price: string;
+  toAsset: string;
+}
+
+export interface HistoricPriceMessages extends ManualPriceMessages {
+  date: string;
+}
+
+interface ManualPriceFields {
+  fromAsset: ZodType<string>;
+  price: ZodType<string>;
+  toAsset: ZodType<string>;
+}
+
+/** Built per call: a zod builder is mutable, so a shared instance would leak between callers. */
+function manualPriceFields(messages: ManualPriceMessages): ManualPriceFields {
+  return {
+    fromAsset: requiredField(messages.fromAsset),
+    price: requiredField(messages.price),
+    toAsset: requiredField(messages.toAsset),
+  };
+}
+
+export function latestPriceSchema(messages: ManualPriceMessages): ZodType {
+  return z.object(manualPriceFields(messages));
+}
+
+/**
+ * The same three fields plus the date. The timestamp is a number, so the rule it carries only fires
+ * on a cleared picker - the epoch is a date like any other, which is what vuelidate's `required`
+ * reported too. `sourceType` is carried for the payload and never edited here.
+ */
+export function historicPriceSchema(messages: HistoricPriceMessages): ZodType {
+  return z.object({
+    ...manualPriceFields(messages),
+    sourceType: z.string(),
+    timestamp: z.number({ error: messages.date }),
+  });
+}

--- a/frontend/app/src/modules/core/common/data/bignumbers.ts
+++ b/frontend/app/src/modules/core/common/data/bignumbers.ts
@@ -1,9 +1,9 @@
-import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import { type Balance, type BigNumber, bigNumberify, Zero } from '@rotki/common';
 
-export function bigNumberifyFromRef(value: Ref<string | number> | WritableComputedRef<string | number>): ComputedRef<BigNumber> {
+export function bigNumberifyFromRef(value: MaybeRefOrGetter<string | number>): ComputedRef<BigNumber> {
   return computed(() => {
-    const val = get(value);
+    const val = toValue(value);
     // Cheap path for a cleared field, which is common enough not to reach it through a throw.
     if (val === '')
       return Zero;

--- a/frontend/app/src/modules/core/form/fields.ts
+++ b/frontend/app/src/modules/core/form/fields.ts
@@ -1,0 +1,12 @@
+import { z, type ZodType } from 'zod';
+
+/**
+ * A field that must hold something. Vuelidate's `required` treated a whitespace-only string as
+ * empty and reported a missing value under the same message as a wrong-typed one, so both are kept.
+ */
+export function requiredField(message: string): ZodType<string> {
+  return z.string({ error: message }).superRefine((value, ctx) => {
+    if (value.trim() === '')
+      ctx.addIssue({ code: 'custom', message });
+  });
+}

--- a/frontend/app/src/modules/dashboard/edit-snapshot/snapshot-forms.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/snapshot-forms.ts
@@ -1,16 +1,6 @@
 import type { BalanceType } from '@/modules/balances/types/balances';
 import { z, type ZodType } from 'zod';
-
-/**
- * A field that must hold something. Vuelidate's `required` treated a whitespace-only string as
- * empty and reported a missing value under the same message as a wrong-typed one, so both are kept.
- */
-function requiredField(message: string): ZodType<string> {
-  return z.string({ error: message }).superRefine((value, ctx) => {
-    if (value.trim() === '')
-      ctx.addIssue({ code: 'custom', message });
-  });
-}
+import { requiredField } from '@/modules/core/form/fields';
 
 export interface LocationDataSnapshotFormState {
   location: string;


### PR DESCRIPTION
Continues the vuelidate to zod migration. Settings and the dashboard snapshot forms are already
across; this takes the two asset price forms.

- **Promote `requiredField` to `modules/core/form/fields.ts`.** It was kept local to the dashboard
  module to avoid inventing shared API mid-batch. Nearly every remaining form needs it, so it moves
  before the copies multiply. Blank-is-empty semantics are unchanged.
- **Characterize both price forms.** Neither had a spec. The tests assert through the exposed
  `validate()` and the error messages each field receives, so they carry over to the zod version
  unchanged. Both directions are mutation-proved: neutering a rule reddens exactly the tests that
  pin it, before and after the swap.
- **Move both forms to `useForm`.** One shared three-field fragment, extended for the historic form
  with the date and the carried `sourceType`.

Two things found on the way:

- The date rule does not reject a zero timestamp, and never did: vuelidate's `required` ends in
  `!!String(value).length`, so the epoch reads as present. What it actually guards is a cleared
  picker, which `RuiDateTimePicker` emits as `undefined` even though the model is typed `number`.
  The schema preserves that exactly, and a test pins both halves.
- `AddressBookFormDialog` typed its form ref as `LatestPriceForm`, the wrong component. It only ever
  called `validate()`, so nothing caught it. Repointed at `AddressBookForm`.

The `errorMessages` model was declared required on both forms and never assigned by any of the five
callers, so the dead channel is dropped rather than ported. Server errors, if they are ever wanted
here, come back through `setServerErrors`.

`stateUpdated` now tracks `form.dirty`, so reverting an edit un-arms the close prompt where it used
to latch true after a 500 ms timer. Same change the snapshot batch shipped.

Gates: typecheck, full unit suite, lint at develop's 0 errors / 20 warnings, typos, linked keys, and
the price-manager plus address-book e2e specs.