### PR TITLE
fix(task-center): show why a row failed or skipped

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5113,7 +5113,8 @@
       "failed": "Failed",
       "queued": "Queued",
       "running": "Running",
-      "skipped": "Skipped"
+      "skipped": "Skipped",
+      "with_reason": "{status}: {reason}"
     },
     "steps": "{current} of {total}"
   },

--- a/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
@@ -103,6 +103,28 @@ describe('pendingTask', () => {
   });
 
   /**
+   * The chip is icon-only, so the reason has to ride on the label the tooltip and `aria-label`
+   * share. A skip is the case that needs it: it raises no notification, so if the row stays a bare
+   * "Skipped" the user is never told the chain was disabled in settings.
+   */
+  it.each([
+    [ActivityStatus.FAILED, 'network unreachable after retries'],
+    [ActivityStatus.SKIPPED, 'disabled in settings'],
+  ])('should caption a %s row with the producer reason', (status, reason) => {
+    const label = outcomeLabel(createWrapper({ activity: activity({ reason, status }) }));
+
+    expect(label).toContain(reason);
+    expect(label).toContain('pending_task.status.with_reason');
+  });
+
+  /** No reason, no colon — a plain status must not grow an empty suffix. */
+  it('should leave a row without a reason on the bare status', () => {
+    const label = outcomeLabel(createWrapper({ activity: activity({ status: ActivityStatus.FAILED }) }));
+
+    expect(label).toBe('pending_task.status.failed');
+  });
+
+  /**
    * No spinner. A running row the producer never counted steps for shows a chip — the panel
    * already has rings, and the elapsed counter beside the chip is what shows it is alive.
    */

--- a/frontend/app/src/modules/core/notifications/PendingTask.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTask.vue
@@ -59,6 +59,18 @@ const meta = computed<string | undefined>(() => {
 
 const outcome = computed<ActivityOutcome>(() => activityOutcome(activity.status));
 
+/**
+ * The status word, plus the producer's reason when there is one ("Skipped: disabled in settings").
+ *
+ * Used for the tooltip and the `aria-label` alike, so the reason is not sighted-hover-only — the
+ * chip is icon-only, and this is the sole place a skip's reason is ever shown.
+ */
+const outcomeText = computed<string>(() => {
+  const status = t(get(outcome).key);
+  const { reason } = activity;
+  return reason ? t('pending_task.status.with_reason', { reason, status }) : status;
+});
+
 // The ring only earns the slot when it has a real number to put in it. Everything else — including
 // a running row the producer never counted steps for — says its status in words instead.
 const showRing = computed<boolean>(() => get(isRunning) && get(hasDeterminateProgress));
@@ -128,7 +140,7 @@ const showRing = computed<boolean>(() => get(isRunning) && get(hasDeterminatePro
           tabindex="-1"
           :color="outcome.color"
           :variant="outcome.variant"
-          :aria-label="t(outcome.key)"
+          :aria-label="outcomeText"
           :class-names="{ content: '!px-1' }"
           class="shrink-0"
           data-testid="activity-outcome"
@@ -139,7 +151,7 @@ const showRing = computed<boolean>(() => get(isRunning) && get(hasDeterminatePro
           />
         </RuiChip>
       </template>
-      {{ t(outcome.key) }}
+      <span data-testid="activity-outcome-text">{{ outcomeText }}</span>
     </RuiTooltip>
 
     <RuiTooltip

--- a/frontend/app/src/modules/task-center/core/orchestrator/lifecycle.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/lifecycle.ts
@@ -64,6 +64,27 @@ export function terminalStatus(cancelRequested: boolean, outcome: Result<unknown
 }
 
 /**
+ * The user-facing reason an activity ended the way it did, or `undefined` when there is nothing
+ * worth saying.
+ *
+ * Only FAILED and SKIPPED get one. A cancellation carries a message too, but the user is the one
+ * who asked for it, so repeating it on the row is noise; COMPLETE has nothing to explain.
+ *
+ * ⭐ SKIPPED is the case that needs this most. Notifications are raised per producer behind
+ * `isActionable`, which `Skipped` deliberately is not, so a skip that drops its reason here drops
+ * it everywhere — the row is the only surface it could ever have reached.
+ */
+export function terminalReason(
+  status: ActivityStatus,
+  outcome: Result<unknown, TaskError>,
+): string | undefined {
+  if (outcome.ok || (status !== Status.FAILED && status !== Status.SKIPPED))
+    return undefined;
+
+  return outcome.error.message || undefined;
+}
+
+/**
  * Run a spec's body under its declared timeout and retry policy, as a value.
  *
  * ⚠️ The catch is not defensive dressing: a producer's `ResultAsync` should never reject, and one

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
@@ -121,6 +121,54 @@ describe('createTaskOrchestrator', () => {
     expect(orchestrator.statusOf(Kind.OTHER, 's').everCompleted).toBe(false);
   });
 
+  it('should carry the producer reason onto a failed and a skipped activity', async () => {
+    const orchestrator = createTaskOrchestrator();
+    const failed = controllable('r1');
+    const skipped = controllable('r2');
+    const failedId = orchestrator.submit(failed.spec);
+    const skippedId = orchestrator.submit(skipped.spec);
+
+    failed.settle({ error: TaskFailed({ message: 'network unreachable after retries' }), ok: false });
+    skipped.settle({ error: Skipped({ message: 'disabled in settings' }), ok: false });
+    await flush();
+
+    // Without this the row renders a bare "Failed"/"Skipped" chip. A skip raises no notification
+    // either, so dropping it here drops the reason everywhere.
+    expect(byId(orchestrator, failedId)?.reason).toBe('network unreachable after retries');
+    expect(byId(orchestrator, skippedId)?.reason).toBe('disabled in settings');
+  });
+
+  it('should leave a success and a cancellation without a reason', async () => {
+    const orchestrator = createTaskOrchestrator();
+    const done = controllable('r3');
+    const cancelled = controllable('r4');
+    const doneId = orchestrator.submit(done.spec);
+    const cancelledId = orchestrator.submit(cancelled.spec);
+
+    done.settle({ ok: true, value: 1 });
+    // The user asked for the cancel, so captioning the row with the reason is noise.
+    cancelled.settle({ error: Cancelled({ message: 'cancelled by user' }), ok: false });
+    await flush();
+
+    expect(byId(orchestrator, doneId)?.reason).toBeUndefined();
+    expect(byId(orchestrator, cancelledId)?.reason).toBeUndefined();
+  });
+
+  it('should clear a stale reason when a failed activity is rerun', async () => {
+    const orchestrator = createTaskOrchestrator();
+    const work = controllable('r5', { rerunnable: true });
+    const id = orchestrator.submit(work.spec);
+
+    work.settle({ error: TaskFailed({ message: 'network unreachable after retries' }), ok: false });
+    await flush();
+    expect(byId(orchestrator, id)?.reason).toBe('network unreachable after retries');
+
+    // `rerun` reuses the record, so a reason left behind would caption the new run — and survive it
+    // to caption a success.
+    orchestrator.rerun(id);
+    expect(byId(orchestrator, id)?.reason).toBeUndefined();
+  });
+
   it('should keep an earlier success when work is later skipped', async () => {
     const orchestrator = createTaskOrchestrator();
     const first = controllable('s2');

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
@@ -16,7 +16,7 @@ import {
 } from '../types';
 import { AlreadyTerminal, type ControlError, NotCancellable, NotFound, NotRerunnable } from './errors';
 import { dropCompletions, markStaleAfter, recordCompletion, recordSettlement } from './ledger';
-import { endedIncomplete, liveChildrenOf, runActivity, terminalStatus } from './lifecycle';
+import { endedIncomplete, liveChildrenOf, runActivity, terminalReason, terminalStatus } from './lifecycle';
 import { aggregateStatus, childProgress, projectActivity, statusForId } from './projection';
 import { allRulesPass, DEFAULT_RULES } from './rules';
 import { createScheduler } from './scheduler';
@@ -27,6 +27,11 @@ interface ActivityRecord {
   status: ActivityStatus;
   steps?: ActivitySteps;
   startedAt?: number;
+  /**
+   * Why this activity failed or was skipped, in the producer's words. Cleared on re-run — see
+   * {@link terminalReason} for which outcomes get one.
+   */
+  reason?: string;
   /** Set when the user cancelled a running activity; forces the terminal status to CANCELLED. */
   cancelRequested: boolean;
   /** Guards the spec's `cleanup` to fire once per run-cycle; re-armed on re-run. */
@@ -73,11 +78,12 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
    * and fired `markStaleAfter` for work that had barely started, so `everCompleted` read true and
    * downstream consumers were invalidated off a run that was not theirs.
    */
-  function settleTerminal(record: ActivityRecord, status: ActivityStatus): void {
+  function settleTerminal(record: ActivityRecord, status: ActivityStatus, reason?: string): void {
     if (records.get(record.spec.id) !== record)
       return;
 
     record.status = status;
+    record.reason = reason;
     // A container groups work and produces nothing of its own, so it never claims freshness for
     // its kind — see {@link ActivitySpec.container}.
     if (!record.spec.container)
@@ -211,7 +217,8 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
     const report: ReportProgress = steps => reportProgress(record.spec.id, steps);
     const outcome = await runActivity(record.spec, report);
 
-    settleTerminal(record, terminalStatus(record.cancelRequested, outcome));
+    const status = terminalStatus(record.cancelRequested, outcome);
+    settleTerminal(record, status, terminalReason(status, outcome));
   }
 
   function schedule(record: ActivityRecord): void {
@@ -319,6 +326,9 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
     record.status = Status.PENDING;
     record.steps = undefined;
     record.startedAt = undefined;
+    // 🔴 The record is reused, so a stale reason would outlive the run it described and caption a
+    // re-run that succeeded with the previous attempt's failure.
+    record.reason = undefined;
     record.cancelRequested = false;
     record.cleanedUp = false;
     schedule(record);

--- a/frontend/app/src/modules/task-center/core/orchestrator/projection.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/projection.ts
@@ -163,6 +163,7 @@ export interface RenderableRecord {
   readonly status: ActivityStatus;
   readonly steps?: ActivitySteps;
   readonly startedAt?: number;
+  readonly reason?: string;
   readonly spec: {
     readonly id: ActivityId;
     readonly kind: ActivityKind;
@@ -185,7 +186,7 @@ export interface RenderableRecord {
  * the queue, while a RUNNING one needs a handle to interrupt the work it started.
  */
 export function projectActivity(record: RenderableRecord, childSteps?: ActivitySteps): Activity {
-  const { spec, status, steps, startedAt } = record;
+  const { spec, status, steps, startedAt, reason } = record;
   return {
     cancellable: status === Status.RUNNING ? Boolean(spec.cancel) : status === Status.PENDING,
     ephemeral: spec.ephemeral,
@@ -195,6 +196,7 @@ export function projectActivity(record: RenderableRecord, childSteps?: ActivityS
     parent: spec.parent,
     percentage: percentageOf(status, steps, childSteps),
     priority: spec.priority,
+    reason,
     rerunnable: Boolean(spec.rerunnable),
     resets: spec.resets,
     source: { type: ActivitySourceType.NATIVE },

--- a/frontend/app/src/modules/task-center/core/types.ts
+++ b/frontend/app/src/modules/task-center/core/types.ts
@@ -176,6 +176,8 @@ export interface Activity {
   readonly subtitle?: ActivityText;
   readonly status: ActivityStatus;
   readonly steps?: ActivitySteps;
+  /** Why a FAILED or SKIPPED activity ended so, already translated. See {@link terminalReason}. */
+  readonly reason?: string;
   /** Derived 0-100; `-1` for indeterminate kinds. */
   readonly percentage: number;
   /** Whether the controller knows how to cancel this item. */


### PR DESCRIPTION
A settled task-centre row rendered a bare "Failed" or "Skipped" chip with the producer's reason discarded.

## The drop

`terminalStatus` reads the outcome's error to pick a terminal status and then throws it away, and neither `ActivityRecord` nor `Activity` had a field to carry it. Two layers, so a fix at only the orchestrator would still not have rendered.

## SKIPPED was the worse half

Failure notifications are raised per producer behind `isActionable`, which `Skipped` deliberately is not. So a failure usually still toasts its message and only the row is mute, while **a skip's reason reached no surface at all**: a chain skipped because the user disabled it in settings said only "Skipped".

Two comments in the tree already claimed the task centre rendered the reason (`use-blockchain-balances.ts`, and the doc comment on the `Skipped` tag itself). Neither was wired. Four of the five `Skipped({message})` producers carry a real user-facing reason.

## The change

- `terminalReason(status, outcome)` in `lifecycle.ts`, pure: a reason for FAILED and SKIPPED only. A cancellation gets none, because the user asked for it.
- `reason` on `ActivityRecord` and on `Activity`, carried through `settleTerminal` and copied in `projectActivity`.
- Rendered on the status chip's tooltip **and** `aria-label` — the chip is icon-only, so the reason must not be sighted-hover-only. Reads as "Skipped: disabled in settings". No layout change.
- `rerun` clears the field. It reuses the record, so a stale reason would otherwise caption the next run and survive it to caption a success.

## Verification

Each rule was proven by removing it and checking the right tests fail:

| Rule removed | Result |
|---|---|
| the `rerun` reset | 1 failure, the rerun test |
| the `projectActivity` copy | 2 failures, both orchestrator tests |
| the reason branch in the row | 2 failures, both caption tests |

Full unit suite green (808 files, 7887 tests), lint and typecheck green.

## Note

`core/types.ts` sits at exactly the 400-line `max-lines` ceiling, so the new field's doc comment had to be one line. The file needs a split before it can take another field; out of scope here.

Found while fixing the 404 path in rotki/rotki#12865.