### PR TITLE
Silence toasts for unmatched event notifications

### DIFF
--- a/frontend/app/src/modules/core/messaging/handlers/unmatched-asset-movements.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/unmatched-asset-movements.ts
@@ -37,7 +37,7 @@ export function createUnmatchedAssetMovementsHandler(
           persist: true,
         },
         category: NotificationCategory.DEFAULT,
-        display: true,
+        display: false,
         group: NotificationGroup.UNMATCHED_ASSET_MOVEMENTS,
         message: t('notification_messages.unmatched_asset_movements.message', {
           count: data.count,

--- a/frontend/app/src/modules/core/messaging/handlers/unmatched-bridge-transactions.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/unmatched-bridge-transactions.spec.ts
@@ -62,7 +62,7 @@ describe('createUnmatchedBridgeTransactionsHandler', () => {
 
     expect(result).toMatchObject({
       category: NotificationCategory.DEFAULT,
-      display: true,
+      display: false,
       group: NotificationGroup.UNMATCHED_BRIDGE_TRANSACTIONS,
       priority: Priority.ACTION,
       severity: Severity.WARNING,

--- a/frontend/app/src/modules/core/messaging/handlers/unmatched-bridge-transactions.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/unmatched-bridge-transactions.ts
@@ -38,7 +38,7 @@ export function createUnmatchedBridgeTransactionsHandler(
           persist: true,
         },
         category: NotificationCategory.DEFAULT,
-        display: true,
+        display: false,
         group: NotificationGroup.UNMATCHED_BRIDGE_TRANSACTIONS,
         message: t('notification_messages.unmatched_bridge_transactions.message', {
           count: data.count,


### PR DESCRIPTION
The unmatched asset movement and unmatched bridge transaction handlers both set `display: true`, so each one popped a toast on top of adding an entry to the notification drawer.

Both notifications are persistent, `Priority.ACTION` entries with a "Review" action, so the drawer entry is enough. This sets `display: false` on both, leaving the group, severity, priority and action untouched.

Spec for the bridge handler updated accordingly; `pnpm run test:unit` on it passes (5 tests).