### PR TITLE
Extract the dialog-owned form binding

### DIFF
--- a/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.vue
+++ b/frontend/app/src/modules/assets/prices/historic/HistoricPriceForm.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import type { ZodType } from 'zod';
 import type { HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
-import { isEqual } from 'es-toolkit';
 import { ValueDisplay } from '@/modules/assets/amount-display/components';
 import { historicPriceSchema } from '@/modules/assets/prices/price-forms';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { bigNumberifyFromRef } from '@/modules/core/common/data/bignumbers';
-import { useForm } from '@/modules/core/form/use-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 import DateTimePicker from '@/modules/shell/components/inputs/DateTimePicker.vue';
@@ -29,12 +28,10 @@ const schema = computed<ZodType>(() => historicPriceSchema({
   toAsset: t('price_form.to_non_empty'),
 }));
 
-/** The dialog owns the persist and reads the payload off the model, so submitting here is a no-op. */
-const form = useForm<HistoricalPriceFormPayload, HistoricalPriceFormPayload>({
-  initial: (): HistoricalPriceFormPayload => ({ ...get(modelValue) }),
+const form = useModelForm<HistoricalPriceFormPayload>({
+  model: modelValue,
   schema,
-  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
-  transform: (state): HistoricalPriceFormPayload => ({ ...state }),
+  stateUpdated,
   // Carried for the payload, never edited here, so it must not make the form look edited either.
   transientKeys: ['sourceType'],
 });
@@ -43,26 +40,6 @@ const fromAssetSymbol = useAssetField(computed<string>(() => form.state.fromAsse
 const toAssetSymbol = useAssetField(computed<string>(() => form.state.toAsset), 'symbol');
 
 const numericPrice = bigNumberifyFromRef(() => form.state.price);
-
-// The dialog reads the payload it saves straight off the model, so every edit is written back to it.
-watch(() => form.state, (state) => {
-  set(modelValue, { ...state });
-}, { deep: true });
-
-// And an edit made outside the form (a different row, a reset) is pulled back in.
-watch(modelValue, (value) => {
-  if (!isEqual(value, form.state))
-    Object.assign(form.state, value);
-}, { deep: true });
-
-watch(form.dirty, (dirty) => {
-  set(stateUpdated, dirty);
-});
-
-// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
-onUnmounted(() => {
-  set(stateUpdated, false);
-});
 
 defineExpose({
   validate: (): boolean => form.validate(),

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.vue
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceForm.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import type { ZodType } from 'zod';
 import type { ManualPriceFormPayload } from '@/modules/assets/prices/price-types';
-import { isEqual } from 'es-toolkit';
 import { ValueDisplay } from '@/modules/assets/amount-display/components';
 import { latestPriceSchema } from '@/modules/assets/prices/price-forms';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { bigNumberifyFromRef } from '@/modules/core/common/data/bignumbers';
-import { useForm } from '@/modules/core/form/use-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 
@@ -28,38 +27,16 @@ const schema = computed<ZodType>(() => latestPriceSchema({
   toAsset: t('price_form.to_non_empty'),
 }));
 
-/** The dialog owns the persist and reads the payload off the model, so submitting here is a no-op. */
-const form = useForm<ManualPriceFormPayload, ManualPriceFormPayload>({
-  initial: (): ManualPriceFormPayload => ({ ...get(modelValue) }),
+const form = useModelForm<ManualPriceFormPayload>({
+  model: modelValue,
   schema,
-  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
-  transform: (state): ManualPriceFormPayload => ({ ...state }),
+  stateUpdated,
 });
 
 const fromAssetSymbol = useAssetField(computed<string>(() => form.state.fromAsset), 'symbol');
 const toAssetSymbol = useAssetField(computed<string>(() => form.state.toAsset), 'symbol');
 
 const numericPrice = bigNumberifyFromRef(() => form.state.price);
-
-// The dialog reads the payload it saves straight off the model, so every edit is written back to it.
-watch(() => form.state, (state) => {
-  set(modelValue, { ...state });
-}, { deep: true });
-
-// And an edit made outside the form (a different row, a reset) is pulled back in.
-watch(modelValue, (value) => {
-  if (!isEqual(value, form.state))
-    Object.assign(form.state, value);
-}, { deep: true });
-
-watch(form.dirty, (dirty) => {
-  set(stateUpdated, dirty);
-});
-
-// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
-onUnmounted(() => {
-  set(stateUpdated, false);
-});
 
 defineExpose({
   validate: (): boolean => form.validate(),

--- a/frontend/app/src/modules/core/form/use-model-form.spec.ts
+++ b/frontend/app/src/modules/core/form/use-model-form.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { nextTick, type Ref, ref } from 'vue';
+import { z } from 'zod';
+import { useModelForm } from '@/modules/core/form/use-model-form';
+
+interface PriceState {
+  fromAsset: string;
+  price: string;
+  sourceType: string;
+  /** Nested on purpose: a copied array is a new reference every time, unlike a copied string. */
+  tags: string[];
+}
+
+const PriceSchema = z.object({
+  fromAsset: z.string().min(1, 'from_required'),
+  price: z.string().min(1, 'price_required'),
+  sourceType: z.string(),
+  tags: z.array(z.string()),
+});
+
+function baseModel(): PriceState {
+  return { fromAsset: 'ETH', price: '2500', sourceType: 'manual', tags: ['manual'] };
+}
+
+describe('useModelForm', () => {
+  it('should seed the state from the model', () => {
+    const model = ref<PriceState>(baseModel());
+    const form = useModelForm<PriceState>({ model, schema: PriceSchema });
+
+    expect(form.state.price).toBe('2500');
+  });
+
+  it('should write an edit back into the model', async () => {
+    const model = ref<PriceState>(baseModel());
+    const form = useModelForm<PriceState>({ model, schema: PriceSchema });
+
+    form.state.price = '3000';
+    await nextTick();
+
+    expect(get(model).price).toBe('3000');
+  });
+
+  it('should pull an edit made outside the form back in', async () => {
+    const model = ref<PriceState>(baseModel());
+    const form = useModelForm<PriceState>({ model, schema: PriceSchema });
+
+    set(model, { ...baseModel(), price: '4000' });
+    await nextTick();
+
+    expect(form.state.price).toBe('4000');
+  });
+
+  // Pins convergence, not the equality guard: removing the guard leaves this green, because the
+  // copy is shallow and re-assigning the same nested reference is not a reactive change. Written
+  // with a nested value on purpose, since that is the only shape that could echo at all.
+  it('should settle rather than echo between the two directions', async () => {
+    const model = ref<PriceState>(baseModel());
+    const form = useModelForm<PriceState>({ model, schema: PriceSchema });
+
+    let writes = 0;
+    watch(model, () => {
+      writes += 1;
+    }, { deep: true });
+
+    form.state.price = '3000';
+    await nextTick();
+    await nextTick();
+    await nextTick();
+
+    expect(writes).toBe(1);
+    expect(form.state.price).toBe('3000');
+    expect(get(model).price).toBe('3000');
+  });
+
+  describe('stateUpdated', () => {
+    function createWithFlag(flag: Ref<boolean>): ReturnType<typeof useModelForm<PriceState>> {
+      return useModelForm<PriceState>({ model: ref<PriceState>(baseModel()), schema: PriceSchema, stateUpdated: flag });
+    }
+
+    it('should arm the flag once a field is edited', async () => {
+      const stateUpdated = ref<boolean>(false);
+      const form = createWithFlag(stateUpdated);
+
+      form.state.price = '3000';
+      await nextTick();
+
+      expect(get(stateUpdated)).toBe(true);
+    });
+
+    it('should disarm the flag when the edit is reverted', async () => {
+      const stateUpdated = ref<boolean>(false);
+      const form = createWithFlag(stateUpdated);
+
+      form.state.price = '3000';
+      await nextTick();
+      form.state.price = '2500';
+      await nextTick();
+
+      expect(get(stateUpdated)).toBe(false);
+    });
+
+    // A dialog holds its prompt-on-close flag in its own ref, which outlives the form it passes it
+    // to. Reopening it after an abandoned edit used to rely on the form disarming the flag as it
+    // unmounted; the sync being immediate covers it from the other end.
+    it('should disarm a flag left armed by a previous edit', () => {
+      const stateUpdated = ref<boolean>(true);
+      createWithFlag(stateUpdated);
+
+      expect(get(stateUpdated)).toBe(false);
+    });
+  });
+
+  it('should keep a transient key out of the dirty comparison', async () => {
+    const model = ref<PriceState>(baseModel());
+    const form = useModelForm<PriceState>({ model, schema: PriceSchema, transientKeys: ['sourceType'] });
+
+    form.state.sourceType = 'cryptocompare';
+    await nextTick();
+
+    expect(get(form.dirty)).toBe(false);
+
+    form.state.price = '3000';
+    await nextTick();
+
+    expect(get(form.dirty)).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/core/form/use-model-form.ts
+++ b/frontend/app/src/modules/core/form/use-model-form.ts
@@ -1,0 +1,68 @@
+import type { MaybeRefOrGetter, Ref, UnwrapNestedRefs } from 'vue';
+import type { ZodType } from 'zod';
+import { isEqual } from 'es-toolkit';
+import { type FormApi, useForm } from '@/modules/core/form/use-form';
+
+export interface ModelFormOptions<TState extends object> {
+  /** The payload the parent dialog owns, saves, and reseeds. Edits are mirrored back into it. */
+  readonly model: Ref<TState>;
+  /** The single validation source of truth. A getter for rules that depend on props. */
+  readonly schema: MaybeRefOrGetter<ZodType>;
+  /** The dialog's unsaved-changes flag, kept in step with `dirty`. */
+  readonly stateUpdated?: Ref<boolean>;
+  /** State keys, at any depth, that must not count as an edit. */
+  readonly transientKeys?: readonly string[];
+}
+
+/**
+ * A form whose state belongs to the dialog above it.
+ *
+ * These forms validate and edit, but never persist: the dialog reads the payload straight off the
+ * model when its save button is pressed. That makes the model and the form state two copies of the
+ * same data which have to be kept in step, which is the boilerplate this removes.
+ *
+ * For a form that owns its own state and submits it, use `useForm` directly.
+ */
+export function useModelForm<TState extends object>(
+  options: ModelFormOptions<TState>,
+): FormApi<TState, UnwrapNestedRefs<TState>> {
+  const { model, schema, stateUpdated, transientKeys } = options;
+
+  const form = useForm<TState, UnwrapNestedRefs<TState>>({
+    initial: (): TState => ({ ...get(model) }),
+    schema,
+    // The dialog owns the persist, so there is nothing to submit or reshape here.
+    submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+    transform: (state): UnwrapNestedRefs<TState> => ({ ...state }),
+    transientKeys,
+  });
+
+  // Every edit is written back, because the dialog saves what it reads off the model, not what the
+  // form holds.
+  // Spread over the current payload rather than the state alone: it keeps the result typed as the
+  // payload, which the reactive state is not, without an assertion to bridge the two.
+  watch(() => form.state, (state) => {
+    set(model, { ...get(model), ...state });
+  }, { deep: true });
+
+  // And an edit made outside the form - a reset, a different row seeded while it stays mounted - is
+  // pulled back in.
+  //
+  // The equality guard is defence, not the thing that makes this terminate: measured, the echo dies
+  // on its own, because the copy above is shallow, so both sides end up holding the same nested
+  // references and assigning them back is not a reactive change. That argument stops holding the
+  // day the copy deep-clones, and the failure mode then is an endless update loop, so the guard
+  // stays. `syncRef` handles the same problem by pausing the opposing watcher, but it needs two
+  // refs and a sync flush, and this state is reactive and watched deep.
+  watchImmediate(model, (value) => {
+    if (!isEqual(value, form.state))
+      Object.assign(form.state, value);
+  }, { deep: true });
+
+  if (stateUpdated) {
+    // Immediate, so reopening a dialog that kept its flag from the last edit starts disarmed.
+    syncRefs(form.dirty, stateUpdated);
+  }
+
+  return form;
+}

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue
@@ -2,9 +2,8 @@
 import type { ZodType } from 'zod';
 import type { BalanceSnapshotPayload } from '@/modules/dashboard/snapshots';
 import type { LocationBalancePreview } from '@/modules/dashboard/snapshots/utils/snapshot-location-balance';
-import { isEqual } from 'es-toolkit';
 import { isNft } from '@/modules/assets/nft-utils';
-import { useForm } from '@/modules/core/form/use-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import EditBalancesSnapshotAssetPriceForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotAssetPriceForm.vue';
 import EditBalancesSnapshotLocationSelector from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotLocationSelector.vue';
 import {
@@ -55,12 +54,10 @@ const schema = computed<ZodType>(() => balanceSnapshotSchema({
   },
 }));
 
-/** The dialog owns the persist and reads the entry off the model, so submitting here is a no-op. */
-const form = useForm<BalanceSnapshotFormState, BalanceSnapshotFormState>({
-  initial: (): BalanceSnapshotFormState => ({ ...get(model) }),
+const form = useModelForm<BalanceSnapshotFormState>({
+  model,
   schema,
-  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
-  transform: (state): BalanceSnapshotFormState => ({ ...state }),
+  stateUpdated,
   // Only the fields this form gates count as an edit. The asset, amount and value are derived and
   // rewritten by the price fetch on mount, which must not arm the dialog's unsaved-changes prompt.
   transientKeys: ['amount', 'assetIdentifier', 'timestamp', 'usdValue'],
@@ -86,27 +83,11 @@ watch(assetType, (assetType) => {
     form.state.amount = '1';
 });
 
-// The dialog reads the entry it saves straight off the model, so every edit is written back to it.
-watch(() => form.state, (state) => {
-  set(model, { ...state });
-}, { deep: true });
-
-// And an edit made outside the form (a reset, a different row) is pulled back in.
-watchImmediate(model, (value) => {
-  if (!isEqual(value, form.state))
-    Object.assign(form.state, value);
-
+// An NFT seeded from outside switches the asset input over; the model round trip itself is handled
+// by useModelForm.
+watchImmediate(model, () => {
   checkAssetType();
 }, { deep: true });
-
-watch(form.dirty, (dirty) => {
-  set(stateUpdated, dirty);
-});
-
-// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
-onUnmounted(() => {
-  set(stateUpdated, false);
-});
 
 defineExpose({
   submitPrice,

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import type { ZodType } from 'zod';
 import type { LocationDataSnapshotPayload } from '@/modules/dashboard/snapshots';
-import { isEqual } from 'es-toolkit';
 import LocationSelector from '@/modules/balances/LocationSelector.vue';
-import { useForm } from '@/modules/core/form/use-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import {
   type LocationDataSnapshotFormState,
   locationDataSnapshotSchema,
@@ -27,34 +26,12 @@ const schema = computed<ZodType>(() => locationDataSnapshotSchema({
   value: t('dashboard.snapshot.edit.dialog.location_data.rules.value'),
 }));
 
-/** The dialog owns the persist and reads the payload off the model, so submitting here is a no-op. */
-const form = useForm<LocationDataSnapshotFormState, LocationDataSnapshotFormState>({
-  initial: (): LocationDataSnapshotFormState => ({ ...get(model) }),
+const form = useModelForm<LocationDataSnapshotFormState>({
+  model,
   schema,
-  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
-  transform: (state): LocationDataSnapshotFormState => ({ ...state }),
+  stateUpdated,
   // The timestamp is carried, not edited; only the two fields the form gates count as an edit.
   transientKeys: ['timestamp'],
-});
-
-// The dialog reads the payload it saves straight off the model, so every edit is written back to it.
-watch(() => form.state, (state) => {
-  set(model, { ...state });
-}, { deep: true });
-
-// And an edit made outside the form (a reset, a different row) is pulled back in.
-watch(model, (value) => {
-  if (!isEqual(value, form.state))
-    Object.assign(form.state, value);
-}, { deep: true });
-
-watch(form.dirty, (dirty) => {
-  set(stateUpdated, dirty);
-});
-
-// The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
-onUnmounted(() => {
-  set(stateUpdated, false);
 });
 
 defineExpose({


### PR DESCRIPTION
Follow-up to #12876, before the next migration batches start.

Four forms now edit a payload that the dialog above them owns, and each one repeated the same
three bindings by hand: mirror the state into the model, mirror an outside edit back in, and keep
the dialog's unsaved-changes flag in step with `dirty`. That is about twenty lines per form.

Fourteen of the thirty remaining vuelidate roots have exactly this contract, spread across nearly
every remaining group, so the pattern lands as `useModelForm` now rather than being copied fourteen
more times and reconciled later.

Each call site drops to its schema, its model, and its transient keys.

Two things worth review attention:

- **The dirty mirror is `syncRefs`, which is immediate.** A dialog holds its prompt-on-close flag in
  its own ref, which outlives the form it hands it to, so an abandoned edit used to leave it armed
  and every form carried an `onUnmounted` hook to disarm it on the way out. Syncing immediately
  disarms it at open instead, from the other end, and the hook goes. There is a test for it.
- **`syncRef` does not fit the payload round trip**, despite looking like the obvious tool. It needs
  two refs and a sync flush to pause the opposing watcher, while the form state is `reactive` and
  watched deep. The equality guard stays, but its comment now says what it actually does: measured,
  the echo already converges on its own, because the copy is shallow and both sides end up holding
  the same nested references. The guard is what keeps that true if the copy ever deep-clones, where
  the failure mode would be an endless update loop.

`toReactive` would delete the round trip altogether, and is the trap to avoid here: writing through
it mutates the object inside the `defineModel` ref without going through the ref's setter, so
`update:modelValue` never fires.

Gates: typecheck, full unit suite (809 files), lint at develop's 0 errors / 20 warnings, typos.