### PR TITLE
Validate the notes and tag forms with zod

### DIFF
--- a/frontend/app/src/modules/core/common/notes.ts
+++ b/frontend/app/src/modules/core/common/notes.ts
@@ -13,6 +13,12 @@ export const UserNote = z.object({
 
 export type UserNote = z.infer<typeof UserNote>;
 
+/**
+ * A note being written. The identifier and timestamp only exist once it is saved, but the two fields
+ * the form edits are always present: a new note starts with both empty rather than absent.
+ */
+export type UserNoteDraft = Partial<UserNote> & Pick<UserNote, 'content' | 'title'>;
+
 export const UserNoteCollectionResponse = CollectionCommonFields.extend({
   entries: z.array(UserNote),
 });

--- a/frontend/app/src/modules/notes/UserNotesForm.spec.ts
+++ b/frontend/app/src/modules/notes/UserNotesForm.spec.ts
@@ -1,0 +1,144 @@
+import type { UserNote } from '@/modules/core/common/notes';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import UserNotesForm from '@/modules/notes/UserNotesForm.vue';
+import '@test/i18n';
+
+describe('userNotesForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof UserNotesForm>>;
+
+  const baseModel = (): Partial<UserNote> => ({
+    content: 'a note',
+    title: 'a title',
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(modelValue: Partial<UserNote> = baseModel()): VueWrapper<InstanceType<typeof UserNotesForm>> {
+    return mount(UserNotesForm, { props: { modelValue } });
+  }
+
+  function contentMessages(): string[] {
+    const value: unknown = wrapper.findComponent({ name: 'RuiTextArea' }).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  /** `auto-grow` renders a second, mirror textarea, so the model is driven through the component. */
+  async function editContent(value: string): Promise<void> {
+    wrapper.findComponent({ name: 'RuiTextArea' }).vm.$emit('update:modelValue', value);
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should pass validation when the content is filled', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should fail validation when the content is empty', async () => {
+    wrapper = createWrapper({ ...baseModel(), content: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should treat whitespace-only content as empty', async () => {
+    wrapper = createWrapper({ ...baseModel(), content: '   ' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  // The title carries a placeholder rule object, not a rule: a note saves without one.
+  it('should not require a title', async () => {
+    wrapper = createWrapper({ content: 'a note', title: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should show a missing title as an empty field rather than undefined', async () => {
+    wrapper = createWrapper({ content: 'a note' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.find('input').element.value).toBe('');
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper({ content: '', title: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(contentMessages()).toEqual([]);
+  });
+
+  it('should reveal the content message once validate runs', async () => {
+    wrapper = createWrapper({ content: '', title: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(contentMessages()).toEqual(['notes_menu.rules.content.non_empty']);
+  });
+
+  it('should show the content message once the field is emptied', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await editContent('');
+
+    expect(contentMessages()).toEqual(['notes_menu.rules.content.non_empty']);
+  });
+
+  it('should write an edit back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await editContent('edited');
+
+    const updates = wrapper.emitted<[Partial<UserNote>]>('update:modelValue');
+    expect(updates).toBeTruthy();
+    const last = updates!.at(-1)![0];
+    expect(last.content).toBe('edited');
+    expect(last.title).toBe('a title');
+  });
+
+  it('should write a cleared title back as an empty string', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.find('input').setValue('');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const updates = wrapper.emitted<[Partial<UserNote>]>('update:modelValue');
+    expect(updates!.at(-1)![0].title).toBe('');
+  });
+
+  // The title is validated by nothing, but it is still watched for changes: editing only the title
+  // has to arm the dialog's unsaved-changes prompt.
+  it('should flag stateUpdated when only the title is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    await wrapper.find('input').setValue('a new title');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
+  });
+
+  it('should not flag stateUpdated before anything is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).not.toEqual([true]);
+  });
+});

--- a/frontend/app/src/modules/notes/UserNotesForm.spec.ts
+++ b/frontend/app/src/modules/notes/UserNotesForm.spec.ts
@@ -1,4 +1,4 @@
-import type { UserNote } from '@/modules/core/common/notes';
+import type { UserNoteDraft } from '@/modules/core/common/notes';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import UserNotesForm from '@/modules/notes/UserNotesForm.vue';
@@ -7,7 +7,7 @@ import '@test/i18n';
 describe('userNotesForm', () => {
   let wrapper: VueWrapper<InstanceType<typeof UserNotesForm>>;
 
-  const baseModel = (): Partial<UserNote> => ({
+  const baseModel = (): UserNoteDraft => ({
     content: 'a note',
     title: 'a title',
   });
@@ -21,7 +21,7 @@ describe('userNotesForm', () => {
     vi.useRealTimers();
   });
 
-  function createWrapper(modelValue: Partial<UserNote> = baseModel()): VueWrapper<InstanceType<typeof UserNotesForm>> {
+  function createWrapper(modelValue: UserNoteDraft = baseModel()): VueWrapper<InstanceType<typeof UserNotesForm>> {
     return mount(UserNotesForm, { props: { modelValue } });
   }
 
@@ -66,8 +66,8 @@ describe('userNotesForm', () => {
     expect(await wrapper.vm.validate()).toBe(true);
   });
 
-  it('should show a missing title as an empty field rather than undefined', async () => {
-    wrapper = createWrapper({ content: 'a note' });
+  it('should show an untitled note as an empty field', async () => {
+    wrapper = createWrapper({ content: 'a note', title: '' });
     await vi.advanceTimersToNextTimerAsync();
 
     expect(wrapper.find('input').element.value).toBe('');
@@ -105,7 +105,7 @@ describe('userNotesForm', () => {
 
     await editContent('edited');
 
-    const updates = wrapper.emitted<[Partial<UserNote>]>('update:modelValue');
+    const updates = wrapper.emitted<[UserNoteDraft]>('update:modelValue');
     expect(updates).toBeTruthy();
     const last = updates!.at(-1)![0];
     expect(last.content).toBe('edited');
@@ -119,7 +119,7 @@ describe('userNotesForm', () => {
     await wrapper.find('input').setValue('');
     await vi.advanceTimersToNextTimerAsync();
 
-    const updates = wrapper.emitted<[Partial<UserNote>]>('update:modelValue');
+    const updates = wrapper.emitted<[UserNoteDraft]>('update:modelValue');
     expect(updates!.at(-1)![0].title).toBe('');
   });
 

--- a/frontend/app/src/modules/notes/UserNotesForm.vue
+++ b/frontend/app/src/modules/notes/UserNotesForm.vue
@@ -1,54 +1,49 @@
 <script setup lang="ts">
-import type { UserNote } from '@/modules/core/common/notes';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { refOptional, useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import type { ZodType } from 'zod';
+import type { UserNoteDraft } from '@/modules/core/common/notes';
+import { useModelForm } from '@/modules/core/form/use-model-form';
+import { userNoteSchema } from '@/modules/notes/note-forms';
 
-const modelValue = defineModel<Partial<UserNote>>({ required: true });
+const modelValue = defineModel<UserNoteDraft>({ required: true });
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 
 const { t } = useI18n({ useScope: 'global' });
 
-const title = refOptional(useRefPropVModel(modelValue, 'title'), '');
-const content = refOptional(useRefPropVModel(modelValue, 'content'), '');
+const schema = computed<ZodType>(() => userNoteSchema({
+  content: t('notes_menu.rules.content.non_empty'),
+}));
 
-const rules = {
-  content: {
-    required: helpers.withMessage(t('notes_menu.rules.content.non_empty'), required),
-  },
-  title: {},
-};
-
-const states = { content, title };
-
-const v$ = useVuelidate(rules, states, { $autoDirty: true });
-
-useFormStateWatcher(states, stateUpdated);
+const form = useModelForm<UserNoteDraft>({
+  model: modelValue,
+  schema,
+  stateUpdated,
+  // The note carries these through the form; only the two fields it renders count as an edit.
+  transientKeys: ['identifier', 'isPinned', 'lastUpdateTimestamp', 'location'],
+});
 
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
 <template>
   <div>
     <RuiTextField
-      v-model="title"
+      v-model="form.state.title"
       variant="outlined"
       color="primary"
       :label="t('notes_menu.labels.title')"
     />
     <RuiTextArea
-      v-model="content"
+      v-model="form.state.content"
       variant="outlined"
       color="primary"
       min-rows="3"
       rows="10"
       auto-grow
       :label="t('notes_menu.labels.content')"
-      :error-messages="toMessages(v$.content)"
+      :error-messages="form.errors('content')"
+      @update:model-value="form.touch('content')"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/notes/UserNotesFormDialog.vue
+++ b/frontend/app/src/modules/notes/UserNotesFormDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { UserNote } from '@/modules/core/common/notes';
+import type { UserNoteDraft } from '@/modules/core/common/notes';
 import { useTemplateRef } from 'vue';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useUserNotesApi } from '@/modules/notes/use-user-notes-api';
@@ -7,7 +7,7 @@ import UserNotesForm from '@/modules/notes/UserNotesForm.vue';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 
 const open = defineModel<boolean>('open', { required: true });
-const model = defineModel<Partial<UserNote>>({ required: true });
+const model = defineModel<UserNoteDraft>({ required: true });
 
 const { editMode, location } = defineProps<{
   editMode: boolean;

--- a/frontend/app/src/modules/notes/UserNotesList.vue
+++ b/frontend/app/src/modules/notes/UserNotesList.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { getCollectionData, setupEntryLimit } from '@/modules/core/common/data/collection-utils';
-import { NoteLocation, type UserNote, type UserNotesRequestPayload } from '@/modules/core/common/notes';
+import { NoteLocation, type UserNote, type UserNoteDraft, type UserNotesRequestPayload } from '@/modules/core/common/notes';
 import { useServerTable } from '@/modules/core/table/use-server-table';
 import { useNotesCount } from '@/modules/notes/use-notes-count';
 import { useUserNotesApi } from '@/modules/notes/use-user-notes-api';
@@ -14,7 +14,7 @@ const open = defineModel<boolean>('open', { required: true });
 
 const { location = NoteLocation.GLOBAL } = defineProps<{ location?: string }>();
 
-function getDefaultForm() {
+function getDefaultForm(): UserNoteDraft {
   return {
     content: '',
     isPinned: false,
@@ -27,7 +27,7 @@ const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
 
 const showDeleteConfirmation = ref<boolean>(false);
 const idToDelete = ref<number | null>(null);
-const form = ref<Partial<UserNote>>(getDefaultForm());
+const form = ref<UserNoteDraft>(getDefaultForm());
 const editMode = ref<boolean>(false);
 const loading = ref<boolean>(false);
 const search = ref<string>('');

--- a/frontend/app/src/modules/notes/note-forms.ts
+++ b/frontend/app/src/modules/notes/note-forms.ts
@@ -1,0 +1,17 @@
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface UserNoteMessages {
+  content: string;
+}
+
+/**
+ * Only the content is required. The title is optional and may be absent altogether, and the rest of
+ * the note is carried through the form untouched.
+ */
+export function userNoteSchema(messages: UserNoteMessages): ZodType {
+  return z.object({
+    content: requiredField(messages.content),
+    title: z.string().optional(),
+  });
+}

--- a/frontend/app/src/modules/tags/TagForm.spec.ts
+++ b/frontend/app/src/modules/tags/TagForm.spec.ts
@@ -1,0 +1,186 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { Tag } from '@/modules/tags/tags';
+import { invertColor } from '@rotki/common';
+import { type DOMWrapper, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@test/i18n';
+
+// The shuffle is random, and `invertColor` of a light colour is legitimately '000000', so a test
+// asserting "the colour changed" against the real generator passes or fails on the draw.
+vi.mock('@rotki/common', async importOriginal => ({
+  ...await importOriginal<typeof import('@rotki/common')>(),
+  randomColor: vi.fn<() => string>().mockReturnValue('123456'),
+}));
+
+const TagForm = (await import('@/modules/tags/TagForm.vue')).default;
+
+describe('tagForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TagForm>>;
+
+  const baseModel = (): Tag => ({
+    backgroundColor: 'ffffff',
+    description: 'a description',
+    foregroundColor: '000000',
+    name: 'a tag',
+  });
+
+  beforeEach(() => {
+    // The tag preview renders a TagIcon, which reads a display setting from the store.
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(modelValue: Tag = baseModel()): VueWrapper<InstanceType<typeof TagForm>> {
+    return mount(TagForm, { props: { modelValue, stateUpdated: false } });
+  }
+
+  function field(testId: string): DOMWrapper<HTMLInputElement> {
+    return wrapper.find<HTMLInputElement>(`[data-testid=${testId}] input`);
+  }
+
+  function nameMessages(): string[] {
+    const name = wrapper.findComponent<ComponentPublicInstance<Record<string, unknown>>>('[data-testid=tag-creator-name]');
+    const value: unknown = name.props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  function lastModel(): Tag {
+    const updates = wrapper.emitted<[Tag]>('update:modelValue');
+    expect(updates).toBeTruthy();
+    return updates!.at(-1)![0];
+  }
+
+  it('should pass validation when the name is filled', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should fail validation when the name is empty', async () => {
+    wrapper = createWrapper({ ...baseModel(), name: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should treat a whitespace-only name as empty', async () => {
+    wrapper = createWrapper({ ...baseModel(), name: '   ' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  // The description carries a placeholder that always passes, not a rule.
+  it('should not require a description', async () => {
+    wrapper = createWrapper({ ...baseModel(), description: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper({ ...baseModel(), name: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(nameMessages()).toEqual([]);
+  });
+
+  it('should reveal the name message once validate runs', async () => {
+    wrapper = createWrapper({ ...baseModel(), name: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(nameMessages()).toEqual(['tag_creator.validation.empty_name']);
+  });
+
+  it('should show the name message once the field is emptied', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await field('tag-creator-name').setValue('');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(nameMessages()).toEqual(['tag_creator.validation.empty_name']);
+  });
+
+  it('should write a name edit back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await field('tag-creator-name').setValue('renamed');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(lastModel().name).toBe('renamed');
+  });
+
+  // The backend column is nullable, and the form is what decides between "" and null.
+  it('should trim a description on the way into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await field('tag-creator-description').setValue('  padded  ');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(lastModel().description).toBe('padded');
+  });
+
+  it('should write a blank description into the model as null', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await field('tag-creator-description').setValue('   ');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(lastModel().description).toBeNull();
+  });
+
+  it('should show a null description as an empty field', async () => {
+    wrapper = createWrapper({ ...baseModel(), description: null });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('tag-creator-description').element.value).toBe('');
+  });
+
+  it('should replace both colours when shuffled', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.findComponent({ name: 'RuiButton' }).trigger('click');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const model = lastModel();
+    expect(model.backgroundColor).toBe('123456');
+    // The foreground is always derived from the background, never chosen independently. Compared
+    // case-insensitively because the colour picker echoes the value back lower-cased.
+    expect(model.foregroundColor?.toLowerCase()).toBe(invertColor('123456').toLowerCase());
+    expect(model.name).toBe('a tag');
+  });
+
+  // Two of the four watched keys carry no rule at all: changing only a colour still has to arm the
+  // dialog's unsaved-changes prompt.
+  it('should flag stateUpdated when only a colour is shuffled', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    await wrapper.findComponent({ name: 'RuiButton' }).trigger('click');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
+  });
+
+  it('should not flag stateUpdated before anything is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).not.toEqual([true]);
+  });
+});

--- a/frontend/app/src/modules/tags/TagForm.vue
+++ b/frontend/app/src/modules/tags/TagForm.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { Tag } from '@/modules/tags/tags';
 import { invertColor, randomColor } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useModelForm } from '@/modules/core/form/use-model-form';
+import { tagSchema } from '@/modules/tags/tag-forms';
 import TagIcon from '@/modules/tags/TagIcon.vue';
 
 const modelValue = defineModel<Tag>({ required: true });
@@ -14,58 +12,35 @@ const stateUpdated = defineModel<boolean>('stateUpdated', { required: true });
 
 const { t } = useI18n({ useScope: 'global' });
 
-const name = useRefPropVModel(modelValue, 'name');
-const description = useRefPropVModel(modelValue, 'description');
-const backgroundColor = useRefPropVModel(modelValue, 'backgroundColor');
-const foregroundColor = useRefPropVModel(modelValue, 'foregroundColor');
+const schema = computed<ZodType>(() => tagSchema({
+  name: t('tag_creator.validation.empty_name'),
+}));
 
+const form = useModelForm<Tag>({
+  model: modelValue,
+  schema,
+  stateUpdated,
+});
+
+/** The column is nullable, and a description of only spaces is stored as no description at all. */
 const descriptionModel = computed<string>({
   get() {
-    return get(description) || '';
+    return form.state.description || '';
   },
   set(value: string) {
-    const trimmedValue = value.trim();
-    set(description, trimmedValue.length > 0 ? trimmedValue : null);
+    const trimmed = value.trim();
+    form.state.description = trimmed.length > 0 ? trimmed : null;
   },
 });
 
-useFormStateWatcher({
-  backgroundColor,
-  description,
-  foregroundColor,
-  name,
-}, stateUpdated);
-
-const rules = {
-  description: {
-    optional: () => true,
-  },
-  name: {
-    required: helpers.withMessage(t('tag_creator.validation.empty_name'), required),
-  },
-};
-
-const v$ = useVuelidate(
-  rules,
-  {
-    description,
-    name,
-  },
-  { $autoDirty: true },
-);
-
-function randomize() {
-  const newBgColor = randomColor();
-  const newFgColor = invertColor(newBgColor);
-  set(modelValue, {
-    ...get(modelValue),
-    backgroundColor: newBgColor,
-    foregroundColor: newFgColor,
-  });
+function randomize(): void {
+  const background = randomColor();
+  form.state.backgroundColor = background;
+  form.state.foregroundColor = invertColor(background);
 }
 
 defineExpose({
-  validate: async (): Promise<boolean> => await get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -83,7 +58,7 @@ defineExpose({
       </template>
       <TagIcon
         class="min-w-[7rem] min-h-8"
-        :tag="modelValue"
+        :tag="form.state"
       />
       <RuiButton
         size="sm"
@@ -98,13 +73,14 @@ defineExpose({
       </RuiButton>
     </RuiCard>
     <RuiTextField
-      v-model="name"
+      v-model="form.state.name"
       variant="outlined"
       color="primary"
       class="tag_creator__name"
       data-testid="tag-creator-name"
       :label="t('common.name')"
-      :error-messages="toMessages(v$.name)"
+      :error-messages="form.errors('name')"
+      @update:model-value="form.touch('name')"
     />
     <RuiTextField
       v-model="descriptionModel"
@@ -123,7 +99,7 @@ defineExpose({
           {{ t('tag_creator.labels.foreground') }}
         </template>
         <RuiColorPicker
-          v-model="foregroundColor"
+          v-model="form.state.foregroundColor"
           class="w-full"
           data-testid="tag-creator__color-picker__foreground"
         />
@@ -133,7 +109,7 @@ defineExpose({
           {{ t('tag_creator.labels.background') }}
         </template>
         <RuiColorPicker
-          v-model="backgroundColor"
+          v-model="form.state.backgroundColor"
           class="w-full"
           data-testid="tag-creator__color-picker__background"
         />

--- a/frontend/app/src/modules/tags/TagFormDialog.vue
+++ b/frontend/app/src/modules/tags/TagFormDialog.vue
@@ -65,7 +65,6 @@ async function save() {
       ref="form"
       v-model="modelValue"
       v-model:state-updated="stateUpdated"
-      :edit-mode="editMode"
     />
   </BigDialog>
 </template>

--- a/frontend/app/src/modules/tags/TagFormDialog.vue
+++ b/frontend/app/src/modules/tags/TagFormDialog.vue
@@ -32,7 +32,7 @@ function closeDialog(): void {
 async function save() {
   set(submitting, true);
   const newTag = get(modelValue);
-  if (!await get(form)?.validate() || !newTag) {
+  if (!get(form)?.validate() || !newTag) {
     set(submitting, false);
     return;
   }

--- a/frontend/app/src/modules/tags/tag-forms.ts
+++ b/frontend/app/src/modules/tags/tag-forms.ts
@@ -1,0 +1,19 @@
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface TagMessages {
+  name: string;
+}
+
+/**
+ * Only the name is required. The description is nullable on the backend, and the colours are always
+ * set, either from the seed or from the shuffle.
+ */
+export function tagSchema(messages: TagMessages): ZodType {
+  return z.object({
+    backgroundColor: z.string(),
+    description: z.string().nullish(),
+    foregroundColor: z.string(),
+    name: requiredField(messages.name),
+  });
+}


### PR DESCRIPTION
Next batch of the vuelidate to zod migration, after #12876 and #12882. `modules/notes/` and
`modules/tags/` are now vuelidate-free.

- **Characterize both forms.** Neither had a spec of its own: `TagForm` was only ever mounted inside
  `TagInput`'s. Both pin their rules through the exposed `validate()` and the messages their fields
  receive, so they carry over to the zod version unchanged, and both are mutation-proved on each
  side of the swap: neutering a rule reddens exactly the four tests that pin it, before and after.
- **Drop a prop `TagForm` never declared.** `TagFormDialog` passed `:edit-mode` to a component that
  declares no props at all, so it landed on the form's root div as a stray attribute. Own commit.
- **Move both to `useModelForm`.**

Two behaviours the rules alone do not describe, now pinned by tests:

- **Fields with no rule are still watched.** `TagForm` validates two of the four keys it tracks, so
  shuffling only the colours has to arm the dialog's unsaved-changes prompt, and the same goes for
  editing only a note's title. Reading the rules and inferring the tracked state would have dropped
  that.
- **The tag description is trimmed and stored as `null` when blank.** That mapping is the form's
  decision rather than the schema's, and the column is nullable, so it stays a computed over the
  form state.

**The note form's model type was wrong**, which is worth a look. It was `Partial<UserNote>`, so the
two fields the form edits were typed as possibly absent, and the component carried a pair of
fallback computeds to keep the inputs fed. Neither seed path can actually produce that: a new note
starts with both fields empty, and an edited one comes from the API with both set. Tightening it to
a `UserNoteDraft` deletes both computeds with no runtime change. The API keeps taking
`Partial<UserNote>`, which is correct for a PATCH.

The shuffle test mocks `randomColor`, because `invertColor` of a light colour is legitimately
`'000000'`, so asserting "the colour changed" against the real generator passes or fails on the draw.

Gates: typecheck, full unit suite (813 files), lint at develop's 0 errors / 20 warnings, typos.