### PR TITLE
dev-proxy: drop express, fix the mocking, add tests

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -185,6 +185,12 @@ jobs:
         working-directory: ./frontend
         run: pnpm run --filter rotki check:linked-keys
 
+      # The app typecheck filters to `rotki`, so the dev-proxy is only covered here.
+      - name: dev-proxy
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        working-directory: ./frontend
+        run: pnpm run test:proxy
+
   check-backend-mapping-keys:
     name: 'Backend mapping keys'
     needs: [ 'check-changes' ]

--- a/frontend/dev-proxy/README.md
+++ b/frontend/dev-proxy/README.md
@@ -92,8 +92,16 @@ pnpm install --frozen-lockfile
 pnpm run --filter @rotki/dev-proxy serve
 ```
 
-In that mode `PORT`, `BACKEND`, and `PREMIUM_COMPONENT_DIR` all come from
-`frontend/dev-proxy/.env`. The frontend then needs `VITE_BACKEND_URL=http://localhost:4243`
+In that mode `PORT`, `BACKEND`, and `PREMIUM_COMPONENT_DIR` come from
+`frontend/dev-proxy/.env` if it exists, or from the shell. The file is optional:
+`PORT` and `BACKEND` have defaults and an unset `PREMIUM_COMPONENT_DIR` just
+disables statistics renderer support. Passing them inline works too:
+
+```bash
+PREMIUM_COMPONENT_DIR=/path/to/components pnpm run --filter @rotki/dev-proxy serve
+```
+
+The frontend then needs `VITE_BACKEND_URL=http://localhost:4243`
 (or whatever proxy port you chose) so it routes through the proxy.
 
 > **Heads-up — old workflow:** previous versions of this README documented

--- a/frontend/dev-proxy/README.md
+++ b/frontend/dev-proxy/README.md
@@ -143,9 +143,14 @@ request verb. The verb's value can either be an object or an array:
 
 ## Implementation notes
 
-- Mock endpoint implementations live in `src/mocked-apis/`. The proxy registers
-  any mock-matched handlers **before** the generic
-  `createProxyMiddleware({ target: backend })` so they take precedence over the
-  pass-through.
+- The proxy is a plain `node:http` server in front of `httpxy`, the same
+  dependency the electron main process uses for its own dev proxy. There is no
+  web framework: the routing is one locally-served path plus a catch-all.
+- Mock endpoint implementations live in `src/mocked-apis/`. The statistics
+  renderer is answered locally before anything is forwarded; the async-mock
+  handlers run on the `proxyRes` event and rewrite the backend's response.
+- Request bodies are read up front so the handlers can inspect `async_query`,
+  then replayed to the backend through httpxy's `buffer` option, so the
+  forwarded request stays byte-identical.
 - WebSocket forwarding is enabled (`ws: true`), so the backend's `/ws/`
   endpoint reaches the renderer through the same proxy hop.

--- a/frontend/dev-proxy/README.md
+++ b/frontend/dev-proxy/README.md
@@ -146,11 +146,34 @@ request verb. The verb's value can either be an object or an array:
 - The proxy is a plain `node:http` server in front of `httpxy`, the same
   dependency the electron main process uses for its own dev proxy. There is no
   web framework: the routing is one locally-served path plus a catch-all.
-- Mock endpoint implementations live in `src/mocked-apis/`. The statistics
-  renderer is answered locally before anything is forwarded; the async-mock
-  handlers run on the `proxyRes` event and rewrite the backend's response.
-- Request bodies are read up front so the handlers can inspect `async_query`,
+- `src/mock-engine.ts` holds all the mocking logic as pure functions over its
+  own state, so it is unit-tested directly. `src/index.ts` is only wiring.
+- The statistics renderer (`src/mocked-apis/`) is answered locally before
+  anything is forwarded, and a preflight for a mocked path is answered from the
+  CORS headers alone.
+- Responses are proxied with `selfHandleResponse`, and buffered only for the
+  requests the engine can rewrite (the task endpoints and mocked paths), so
+  everything else still streams straight through. A rewritten body is sent with
+  its own `content-length`.
+- Request bodies are read up front so the engine can inspect `async_query`,
   then replayed to the backend through httpxy's `buffer` option, so the
   forwarded request stays byte-identical.
+- Mock keys are matched exactly: on the full url first, so a key may pin a
+  query string, then on the path alone.
+- A mocked async query reports as pending for
+  `DEFAULT_TASK_COMPLETION_MS` (8s) and completed after that.
 - WebSocket forwarding is enabled (`ws: true`), so the backend's `/ws/`
   endpoint reaches the renderer through the same proxy hop.
+
+## Tests
+
+```bash
+pnpm run test:proxy                              # from frontend/: typecheck + unit tests (what CI runs)
+pnpm run --filter @rotki/dev-proxy test:unit     # vitest, the mock engine and helpers
+pnpm run --filter @rotki/dev-proxy test:smoke    # the proxy end to end against a stub backend
+```
+
+The smoke test starts the real proxy and a stub backend on ports 14998/14999 and
+covers what the unit tests cannot reach: pass-through, the locally served
+statistics route, CORS, body forwarding, chunked responses and websocket
+upgrades. It writes a temporary `async-mock.json` only if you do not have one.

--- a/frontend/dev-proxy/package.json
+++ b/frontend/dev-proxy/package.json
@@ -8,6 +8,8 @@
   "author": "Rotki Solutions GmbH",
   "scripts": {
     "serve": "tsx --env-file-if-exists=.env --watch ./src/index.ts",
+    "test:smoke": "node test/smoke.mjs",
+    "test:unit": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -18,6 +20,7 @@
     "@types/node": "catalog:",
     "consola": "catalog:",
     "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/frontend/dev-proxy/package.json
+++ b/frontend/dev-proxy/package.json
@@ -7,7 +7,7 @@
   "license": "AGPL-3.0",
   "author": "Rotki Solutions GmbH",
   "scripts": {
-    "serve": "tsx --env-file=.env --watch ./src/index.ts"
+    "serve": "tsx --env-file-if-exists=.env --watch ./src/index.ts"
   },
   "dependencies": {
     "body-parser": "catalog:",

--- a/frontend/dev-proxy/package.json
+++ b/frontend/dev-proxy/package.json
@@ -7,16 +7,14 @@
   "license": "AGPL-3.0",
   "author": "Rotki Solutions GmbH",
   "scripts": {
-    "serve": "tsx --env-file-if-exists=.env --watch ./src/index.ts"
+    "serve": "tsx --env-file-if-exists=.env --watch ./src/index.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "body-parser": "catalog:",
-    "express": "catalog:",
-    "http-proxy-middleware": "catalog:"
+    "httpxy": "catalog:"
   },
   "devDependencies": {
-    "@types/body-parser": "catalog:",
-    "@types/express": "catalog:",
+    "@tsconfig/node24": "catalog:",
     "@types/node": "catalog:",
     "consola": "catalog:",
     "tsx": "catalog:",

--- a/frontend/dev-proxy/src/body.spec.ts
+++ b/frontend/dev-proxy/src/body.spec.ts
@@ -1,0 +1,32 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import { parseBody } from './body';
+
+describe('parseBody', () => {
+  it('should parse a json body', () => {
+    expect(parseBody(Buffer.from('{"async_query":true}'), 'application/json'))
+      .toStrictEqual({ async_query: true });
+  });
+
+  it('should parse a json body when the header carries a charset', () => {
+    expect(parseBody(Buffer.from('{"async_query":true}'), 'application/json; charset=UTF-8'))
+      .toStrictEqual({ async_query: true });
+  });
+
+  it('should parse a form encoded body', () => {
+    expect(parseBody(Buffer.from('async_query=true&name=value'), 'application/x-www-form-urlencoded'))
+      .toStrictEqual({ async_query: 'true', name: 'value' });
+  });
+
+  it('should return undefined for an empty body', () => {
+    expect(parseBody(Buffer.from(''), 'application/json')).toBeUndefined();
+  });
+
+  it('should return undefined for malformed json rather than throwing', () => {
+    expect(parseBody(Buffer.from('{not json'), 'application/json')).toBeUndefined();
+  });
+
+  it('should leave a content type it does not handle unparsed', () => {
+    expect(parseBody(Buffer.from('binary'), 'application/octet-stream')).toBeUndefined();
+  });
+});

--- a/frontend/dev-proxy/src/body.ts
+++ b/frontend/dev-proxy/src/body.ts
@@ -1,0 +1,34 @@
+import type { IncomingMessage } from 'node:http';
+import { Buffer } from 'node:buffer';
+
+/**
+ * Reads the request body so the mock engine can inspect `async_query`. The raw
+ * bytes are replayed to the backend through the proxy's `buffer` option, so the
+ * forwarded request stays byte-identical to the original.
+ */
+export async function readBody(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+/** Parses the bodies the API actually sends; anything else stays unparsed. */
+export function parseBody(raw: Buffer, contentType: string): unknown {
+  if (raw.length === 0)
+    return undefined;
+
+  const type = contentType.toLocaleLowerCase();
+  if (type.startsWith('application/json')) {
+    try {
+      return JSON.parse(raw.toString());
+    }
+    catch {
+      return undefined;
+    }
+  }
+
+  if (type.startsWith('application/x-www-form-urlencoded'))
+    return Object.fromEntries(new URLSearchParams(raw.toString()));
+
+  return undefined;
+}

--- a/frontend/dev-proxy/src/index.ts
+++ b/frontend/dev-proxy/src/index.ts
@@ -75,6 +75,12 @@ function canRewrite(req: IncomingMessage, proxyRes: IncomingMessage): boolean {
   if (!engine.handles(describe(req)))
     return false;
 
+  // Rewriting an error into a 200 would hide it: a 401 on the task endpoint
+  // would read as "no tasks running" rather than as a failure.
+  const status = proxyRes.statusCode ?? 200;
+  if (status < 200 || status > 299)
+    return false;
+
   if (proxyRes.headers['content-encoding'])
     return false;
 

--- a/frontend/dev-proxy/src/index.ts
+++ b/frontend/dev-proxy/src/index.ts
@@ -6,6 +6,8 @@ import process from 'node:process';
 import { Readable } from 'node:stream';
 import consola, { LogLevels } from 'consola';
 import { createProxyServer } from 'httpxy';
+import { parseBody, readBody } from './body';
+import { createMockEngine, type MockedAsyncCalls, type MockRequest } from './mock-engine';
 import { serveStatisticsRenderer, STATISTICS_RENDERER_PATH } from './mocked-apis/statistics';
 import { applyCors } from './setup';
 
@@ -24,7 +26,7 @@ else {
   consola.warn('PREMIUM_COMPONENT_DIR was not a valid directory, disabling statistics renderer support.');
 }
 
-let mockedAsyncCalls: { [url: string]: any } = {};
+let mockedAsyncCalls: MockedAsyncCalls = {};
 if (fs.existsSync('async-mock.json')) {
   try {
     consola.info('Loading mock data from async-mock.json');
@@ -39,287 +41,87 @@ else {
   consola.info('async-mock.json doesnt exist. No async_query mocking is enabled');
 }
 
+const engine = createMockEngine(mockedAsyncCalls);
+
 /** Bodies are read off the request stream, so they are kept here for the response handlers. */
-const requestBodies = new WeakMap<IncomingMessage, any>();
+const requestBodies = new WeakMap<IncomingMessage, unknown>();
 
-function manipulateResponse(res: ServerResponse, callback: (original: any) => any): void {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const originalWrite = res.write;
-
-  res.write = (chunk: any): boolean => {
-    const response = chunk.toString();
-    try {
-      const payload = JSON.stringify(callback(JSON.parse(response)));
-      if (!res.headersSent)
-        res.setHeader('content-length', payload.length.toString());
-
-      res.statusCode = 200;
-      res.statusMessage = 'OK';
-      originalWrite.call(res, payload, 'utf8');
-      return true;
-    }
-    catch (error: any) {
-      consola.error(error);
-      return false;
-    }
-  };
-}
-
-let mockTaskId = 100000;
-const mockAsync: {
-  pending: number[];
-  completed: number[];
-
-  taskResponses: { [task: number]: any };
-} = {
-  completed: [],
-  pending: [],
-  taskResponses: {},
-};
-
-const counter: { [url: string]: { [method: string]: number } } = {};
-
-setInterval(() => {
-  const pending = mockAsync.pending;
-  const completed = mockAsync.completed;
-  if (pending.length > 0)
-    consola.log(`detected ${pending.length} pending tasks: ${pending.toString()}`);
-
-  while (pending.length > 0) {
-    const task = pending.pop();
-    if (task)
-      completed.push(task);
-  }
-
-  if (completed.length > 0)
-    consola.log(`detected ${completed.length} completed tasks: ${completed.toString()}`);
-}, 8000);
-
-function createResult(result: unknown): Record<string, unknown> {
-  return {
-    message: '',
-    result,
-  };
-}
-
-function handleTasksStatus(res: ServerResponse): void {
-  manipulateResponse(res, (data) => {
-    const result = data.result;
-    if (result?.pending)
-      result.pending.push(...mockAsync.pending);
-    else result.pending = mockAsync.pending;
-
-    if (result?.completed)
-      result.completed.push(...mockAsync.completed);
-    else result.completed = mockAsync.completed;
-
-    return data;
-  });
-}
-
-function handleTaskRequest(url: string, tasks: string, res: ServerResponse): void {
-  const task = url.replace(tasks, '');
-  try {
-    const taskId = Number.parseInt(task);
-    if (Number.isNaN(taskId))
-      return;
-
-    if (mockAsync.completed.includes(taskId)) {
-      const outcome = mockAsync.taskResponses[taskId];
-      manipulateResponse(res, () =>
-        createResult({
-          outcome,
-          status: 'completed',
-        }));
-      delete mockAsync.taskResponses[taskId];
-      const index = mockAsync.completed.indexOf(taskId);
-      mockAsync.completed.splice(index, 1);
-    }
-    else if (mockAsync.pending.includes(taskId)) {
-      manipulateResponse(res, () =>
-        createResult({
-          outcome: null,
-          status: 'pending',
-        }));
-    }
-  }
-  catch (error) {
-    consola.error(error);
-  }
-}
-
-function increaseCounter(baseUrl: string, method: string): void {
-  if (!counter[baseUrl])
-    counter[baseUrl] = { [method]: 1 };
-  else if (!counter[baseUrl][method])
-    counter[baseUrl][method] = 1;
-  else counter[baseUrl][method] += 1;
-}
-
-function getCounter(baseUrl: string, method: string): number {
-  return counter[baseUrl]?.[method] ?? 0;
-}
-
-function handleAsyncQuery(url: string, req: IncomingMessage, res: ServerResponse): void {
-  const mockedUrls = Object.keys(mockedAsyncCalls);
-  const baseUrl = url.split('?')[0];
-  const index = mockedUrls.findIndex(value => value.includes(baseUrl));
-
-  if (index < 0)
-    return;
-
-  const method = req.method ?? 'GET';
-  increaseCounter(baseUrl, method);
-
-  const response = mockedAsyncCalls[mockedUrls[index]]?.[method];
-  if (!response)
-    return;
-
-  let pendingResponse: any;
-  if (Array.isArray(response)) {
-    const number = getCounter(baseUrl, method) - 1;
-    if (number < response.length)
-      pendingResponse = response[number];
-    else pendingResponse = response.at(-1);
-  }
-  else if (typeof response === 'object') {
-    pendingResponse = response;
-  }
-  else {
-    pendingResponse = {
-      message: 'There is something wrong with this mock',
-      result: null,
-    };
-  }
-
-  const taskId = mockTaskId++;
-  mockAsync.pending.push(taskId);
-  mockAsync.taskResponses[taskId] = pendingResponse;
-  manipulateResponse(res, () => ({
-    message: '',
-    result: {
-      task_id: taskId,
-    },
-  }));
-}
-
-function isAsyncQuery(req: IncomingMessage): boolean {
-  return req.method !== 'GET' && requestBodies.get(req)?.async_query === true;
-}
-
-function isPreflight(req: IncomingMessage): boolean {
-  const mockedUrls = Object.keys(mockedAsyncCalls);
-  const baseUrl = (req.url ?? '').split('?')[0];
-  const index = mockedUrls.findIndex(value => value.includes(baseUrl));
-  return req.method === 'OPTIONS' && index >= 0;
-}
-
-function mockPreflight(res: ServerResponse): void {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const originalWrite = res.write;
-
-  res.write = (chunk: any): boolean => {
-    try {
-      if (!res.headersSent)
-        applyCors(res);
-
-      res.statusCode = 200;
-      res.statusMessage = 'OK';
-      originalWrite.call(res, chunk, 'utf8');
-      return true;
-    }
-    catch {
-      return false;
-    }
-  };
-}
-
-function hasResponse(req: IncomingMessage): boolean {
-  const mockResponse = mockedAsyncCalls[req.url ?? ''];
-  return !!mockResponse && !!mockResponse[req.method ?? 'GET'];
-}
-
-function onProxyRes(req: IncomingMessage, res: ServerResponse): void {
-  let handled = false;
+function describe(req: IncomingMessage): MockRequest {
   const url = req.url ?? '';
-  const method = req.method ?? 'GET';
-  const tasks = '/api/1/tasks/';
-  if (url.indexOf('async_query') > 0) {
-    handleAsyncQuery(url, req, res);
-    handled = true;
-  }
-  else if (url === tasks) {
-    handleTasksStatus(res);
-    handled = true;
-  }
-  else if (url.startsWith(tasks)) {
-    handleTaskRequest(url, tasks, res);
-    handled = true;
-  }
-  else if (isAsyncQuery(req)) {
-    handleAsyncQuery(url, req, res);
-    handled = true;
-  }
-  else if (isPreflight(req)) {
-    mockPreflight(res);
-    handled = true;
-  }
-  else if (hasResponse(req)) {
-    manipulateResponse(res, () => {
-      const response = mockedAsyncCalls[url][method];
-      if (Array.isArray(response)) {
-        const index = getCounter(url, method);
-        let responseIndex = index;
-        if (index > response.length - 1)
-          responseIndex = response.length - 1;
+  return {
+    body: requestBodies.get(req),
+    method: req.method ?? 'GET',
+    path: url.split('?')[0],
+    url,
+  };
+}
 
-        increaseCounter(url, method);
-        return response[responseIndex];
-      }
-      return response;
-    });
-    handled = true;
-  }
+function copyHeaders(proxyRes: IncomingMessage, res: ServerResponse, omit: string[] = []): void {
+  for (const [key, value] of Object.entries(proxyRes.headers)) {
+    if (value === undefined || omit.includes(key.toLocaleLowerCase()))
+      continue;
 
-  if (handled)
-    consola.info('Handled request:', method, url);
+    res.setHeader(key, value);
+  }
 }
 
 /**
- * Reads the request body so the mock handlers can inspect `async_query`. The raw
- * bytes are replayed to the backend through the proxy's `buffer` option, so the
- * forwarded request stays byte-identical to the original.
+ * Reading the whole body is what lets a mock rewrite it with a correct
+ * content-length, but it also breaks streaming, so it is only done for requests
+ * the engine can actually rewrite. A compressed body is passed through: it would
+ * have to be inflated to be parsed, and the backend does not compress in dev.
  */
-async function readBody(req: IncomingMessage): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) chunks.push(Buffer.from(chunk));
-  return Buffer.concat(chunks);
+function canRewrite(req: IncomingMessage, proxyRes: IncomingMessage): boolean {
+  if (!engine.handles(describe(req)))
+    return false;
+
+  if (proxyRes.headers['content-encoding'])
+    return false;
+
+  return (proxyRes.headers['content-type'] ?? '').toLocaleLowerCase().includes('application/json');
 }
 
-function parseBody(raw: Buffer, contentType: string): any {
-  if (raw.length === 0)
-    return undefined;
-
-  const type = contentType.toLocaleLowerCase();
-  if (type.startsWith('application/json')) {
-    try {
-      return JSON.parse(raw.toString());
-    }
-    catch {
-      return undefined;
-    }
+function onProxyRes(proxyRes: IncomingMessage, req: IncomingMessage, res: ServerResponse): void {
+  if (!canRewrite(req, proxyRes)) {
+    res.statusCode = proxyRes.statusCode ?? 200;
+    copyHeaders(proxyRes, res);
+    proxyRes.pipe(res);
+    return;
   }
-  if (type.startsWith('application/x-www-form-urlencoded'))
-    return Object.fromEntries(new URLSearchParams(raw.toString()));
 
-  return undefined;
+  const chunks: Buffer[] = [];
+  proxyRes.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+  proxyRes.on('end', () => {
+    const raw = Buffer.concat(chunks);
+    let rewritten: unknown;
+    try {
+      rewritten = engine.transformResponse(describe(req), JSON.parse(raw.toString()));
+    }
+    catch (error) {
+      consola.error(error);
+    }
+
+    if (rewritten === undefined) {
+      res.statusCode = proxyRes.statusCode ?? 200;
+      copyHeaders(proxyRes, res);
+      res.end(raw);
+      return;
+    }
+
+    const payload = Buffer.from(JSON.stringify(rewritten));
+    res.statusCode = 200;
+    res.statusMessage = 'OK';
+    // The rewritten payload has its own length, and is never chunked.
+    copyHeaders(proxyRes, res, ['content-length', 'transfer-encoding']);
+    res.setHeader('content-length', payload.byteLength.toString());
+    res.end(payload);
+    consola.info('Handled request:', req.method, req.url);
+  });
 }
 
-const proxy = createProxyServer({ target: backend, ws: true });
+const proxy = createProxyServer({ selfHandleResponse: true, target: backend, ws: true });
 
-proxy.on('proxyRes', (_proxyRes, req, res) => {
-  onProxyRes(req, res);
-});
+proxy.on('proxyRes', onProxyRes);
 
 proxy.on('error', (error) => {
   consola.error(error);
@@ -328,14 +130,22 @@ proxy.on('error', (error) => {
 const server = http.createServer((req, res) => {
   applyCors(res);
 
-  const path = (req.url ?? '').split('?')[0];
-  if (statisticsRendererDir && req.method === 'GET' && path === STATISTICS_RENDERER_PATH) {
+  const request = describe(req);
+
+  if (statisticsRendererDir && request.method === 'GET' && request.path === STATISTICS_RENDERER_PATH) {
     serveStatisticsRenderer(statisticsRendererDir, res);
     return;
   }
 
-  const method = req.method ?? 'GET';
-  if (method === 'GET' || method === 'HEAD') {
+  // A preflight for a mocked endpoint is answered here: the CORS headers above
+  // are the whole response, so the backend hop would add nothing.
+  if (request.method === 'OPTIONS' && engine.isMocked(request)) {
+    res.statusCode = 200;
+    res.end();
+    return;
+  }
+
+  if (request.method === 'GET' || request.method === 'HEAD') {
     proxy.web(req, res).catch(error => consola.error(error));
     return;
   }

--- a/frontend/dev-proxy/src/index.ts
+++ b/frontend/dev-proxy/src/index.ts
@@ -1,28 +1,24 @@
-import type * as http from 'node:http';
 import { Buffer } from 'node:buffer';
 import fs from 'node:fs';
+import http, { type IncomingMessage, type ServerResponse } from 'node:http';
+import net from 'node:net';
 import process from 'node:process';
-import * as querystring from 'node:querystring';
-import bodyParser from 'body-parser';
+import { Readable } from 'node:stream';
 import consola, { LogLevels } from 'consola';
-import express, { type Request, type Response } from 'express';
-import { createProxyMiddleware } from 'http-proxy-middleware';
-import { statistics } from './mocked-apis/statistics';
-import { enableCors } from './setup';
+import { createProxyServer } from 'httpxy';
+import { serveStatisticsRenderer, STATISTICS_RENDERER_PATH } from './mocked-apis/statistics';
+import { applyCors } from './setup';
 
 consola.level = LogLevels.debug;
 
-const server = express();
-
-const port = process.env.PORT ?? 4243;
+const port = Number.parseInt(process.env.PORT ?? '4243', 10);
 const backend = process.env.BACKEND ?? 'http://127.0.0.1:4242';
 const componentsDir = process.env.PREMIUM_COMPONENT_DIR;
 
-enableCors(server);
-
+let statisticsRendererDir: string | undefined;
 if (componentsDir && fs.existsSync(componentsDir) && fs.statSync(componentsDir).isDirectory()) {
   consola.info('Enabling statistics renderer support');
-  statistics(server, componentsDir);
+  statisticsRendererDir = componentsDir;
 }
 else {
   consola.warn('PREMIUM_COMPONENT_DIR was not a valid directory, disabling statistics renderer support.');
@@ -43,7 +39,10 @@ else {
   consola.info('async-mock.json doesnt exist. No async_query mocking is enabled');
 }
 
-function manipulateResponse(res: Response, callback: (original: any) => any): void {
+/** Bodies are read off the request stream, so they are kept here for the response handlers. */
+const requestBodies = new WeakMap<IncomingMessage, any>();
+
+function manipulateResponse(res: ServerResponse, callback: (original: any) => any): void {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const originalWrite = res.write;
 
@@ -51,10 +50,12 @@ function manipulateResponse(res: Response, callback: (original: any) => any): vo
     const response = chunk.toString();
     try {
       const payload = JSON.stringify(callback(JSON.parse(response)));
-      res.header('content-length', payload.length.toString());
-      res.status(200);
+      if (!res.headersSent)
+        res.setHeader('content-length', payload.length.toString());
+
+      res.statusCode = 200;
       res.statusMessage = 'OK';
-      originalWrite.call(res, payload);
+      originalWrite.call(res, payload, 'utf8');
       return true;
     }
     catch (error: any) {
@@ -101,7 +102,7 @@ function createResult(result: unknown): Record<string, unknown> {
   };
 }
 
-function handleTasksStatus(res: Response): void {
+function handleTasksStatus(res: ServerResponse): void {
   manipulateResponse(res, (data) => {
     const result = data.result;
     if (result?.pending)
@@ -116,7 +117,7 @@ function handleTasksStatus(res: Response): void {
   });
 }
 
-function handleTaskRequest(url: string, tasks: string, res: Response): void {
+function handleTaskRequest(url: string, tasks: string, res: ServerResponse): void {
   const task = url.replace(tasks, '');
   try {
     const taskId = Number.parseInt(task);
@@ -159,7 +160,7 @@ function getCounter(baseUrl: string, method: string): number {
   return counter[baseUrl]?.[method] ?? 0;
 }
 
-function handleAsyncQuery(url: string, req: Request, res: Response): void {
+function handleAsyncQuery(url: string, req: IncomingMessage, res: ServerResponse): void {
   const mockedUrls = Object.keys(mockedAsyncCalls);
   const baseUrl = url.split('?')[0];
   const index = mockedUrls.findIndex(value => value.includes(baseUrl));
@@ -167,15 +168,16 @@ function handleAsyncQuery(url: string, req: Request, res: Response): void {
   if (index < 0)
     return;
 
-  increaseCounter(baseUrl, req.method);
+  const method = req.method ?? 'GET';
+  increaseCounter(baseUrl, method);
 
-  const response = mockedAsyncCalls[mockedUrls[index]]?.[req.method];
+  const response = mockedAsyncCalls[mockedUrls[index]]?.[method];
   if (!response)
     return;
 
   let pendingResponse: any;
   if (Array.isArray(response)) {
-    const number = getCounter(baseUrl, req.method) - 1;
+    const number = getCounter(baseUrl, method) - 1;
     if (number < response.length)
       pendingResponse = response[number];
     else pendingResponse = response.at(-1);
@@ -201,52 +203,29 @@ function handleAsyncQuery(url: string, req: Request, res: Response): void {
   }));
 }
 
-function isAsyncQuery(req: Request): boolean {
-  return (
-    req.method !== 'GET'
-    && req.rawHeaders.findIndex(h => h.toLocaleLowerCase().includes('application/json'))
-    && req.body?.async_query === true
-  );
+function isAsyncQuery(req: IncomingMessage): boolean {
+  return req.method !== 'GET' && requestBodies.get(req)?.async_query === true;
 }
 
-function isPreflight(req: Request): boolean {
+function isPreflight(req: IncomingMessage): boolean {
   const mockedUrls = Object.keys(mockedAsyncCalls);
-  const baseUrl = req.url.split('?')[0];
+  const baseUrl = (req.url ?? '').split('?')[0];
   const index = mockedUrls.findIndex(value => value.includes(baseUrl));
   return req.method === 'OPTIONS' && index >= 0;
 }
 
-function onProxyReq(proxyReq: http.ClientRequest, req: Request, _res: Response): void {
-  if (!req.body)
-    return;
-
-  const contentType = proxyReq.getHeader('Content-Type') ?? '';
-  const writeBody = (bodyData: string): void => {
-    proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));
-    proxyReq.write(bodyData);
-  };
-
-  const ct = contentType.toString().toLocaleLowerCase();
-  if (ct.startsWith('application/json'))
-    writeBody(JSON.stringify(req.body));
-
-  if (ct.startsWith('application/x-www-form-urlencoded'))
-    writeBody(querystring.stringify(req.body));
-}
-
-function mockPreflight(res: Response): void {
+function mockPreflight(res: ServerResponse): void {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const originalWrite = res.write;
 
   res.write = (chunk: any): boolean => {
     try {
-      res.header('Access-Control-Allow-Origin', '*');
-      res.header('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
-      res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-      res.header('Access-Control-Allow-Credentials', 'true');
-      res.status(200);
+      if (!res.headersSent)
+        applyCors(res);
+
+      res.statusCode = 200;
       res.statusMessage = 'OK';
-      originalWrite.call(res, chunk);
+      originalWrite.call(res, chunk, 'utf8');
       return true;
     }
     catch {
@@ -255,14 +234,15 @@ function mockPreflight(res: Response): void {
   };
 }
 
-function hasResponse(req: Request): boolean {
-  const mockResponse = mockedAsyncCalls[req.url];
-  return !!mockResponse && !!mockResponse[req.method];
+function hasResponse(req: IncomingMessage): boolean {
+  const mockResponse = mockedAsyncCalls[req.url ?? ''];
+  return !!mockResponse && !!mockResponse[req.method ?? 'GET'];
 }
 
-function onProxyRes(_proxyRes: http.IncomingMessage, req: Request, res: Response): void {
+function onProxyRes(req: IncomingMessage, res: ServerResponse): void {
   let handled = false;
-  const url = req.url;
+  const url = req.url ?? '';
+  const method = req.method ?? 'GET';
   const tasks = '/api/1/tasks/';
   if (url.indexOf('async_query') > 0) {
     handleAsyncQuery(url, req, res);
@@ -286,14 +266,14 @@ function onProxyRes(_proxyRes: http.IncomingMessage, req: Request, res: Response
   }
   else if (hasResponse(req)) {
     manipulateResponse(res, () => {
-      const response = mockedAsyncCalls[req.url][req.method];
+      const response = mockedAsyncCalls[url][method];
       if (Array.isArray(response)) {
-        const index = getCounter(req.url, req.method);
+        const index = getCounter(url, method);
         let responseIndex = index;
         if (index > response.length - 1)
           responseIndex = response.length - 1;
 
-        increaseCounter(req.url, req.method);
+        increaseCounter(url, method);
         return response[responseIndex];
       }
       return response;
@@ -302,21 +282,84 @@ function onProxyRes(_proxyRes: http.IncomingMessage, req: Request, res: Response
   }
 
   if (handled)
-    consola.info('Handled request:', req.method, req.url);
+    consola.info('Handled request:', method, url);
 }
 
-server.use(bodyParser.urlencoded({ extended: true }));
-server.use(bodyParser.json());
+/**
+ * Reads the request body so the mock handlers can inspect `async_query`. The raw
+ * bytes are replayed to the backend through the proxy's `buffer` option, so the
+ * forwarded request stays byte-identical to the original.
+ */
+async function readBody(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
 
-server.use(createProxyMiddleware({
-  logger: consola,
-  on: {
-    proxyReq: onProxyReq,
-    proxyRes: onProxyRes,
-  },
-  target: backend,
-  ws: true,
-}));
+function parseBody(raw: Buffer, contentType: string): any {
+  if (raw.length === 0)
+    return undefined;
+
+  const type = contentType.toLocaleLowerCase();
+  if (type.startsWith('application/json')) {
+    try {
+      return JSON.parse(raw.toString());
+    }
+    catch {
+      return undefined;
+    }
+  }
+  if (type.startsWith('application/x-www-form-urlencoded'))
+    return Object.fromEntries(new URLSearchParams(raw.toString()));
+
+  return undefined;
+}
+
+const proxy = createProxyServer({ target: backend, ws: true });
+
+proxy.on('proxyRes', (_proxyRes, req, res) => {
+  onProxyRes(req, res);
+});
+
+proxy.on('error', (error) => {
+  consola.error(error);
+});
+
+const server = http.createServer((req, res) => {
+  applyCors(res);
+
+  const path = (req.url ?? '').split('?')[0];
+  if (statisticsRendererDir && req.method === 'GET' && path === STATISTICS_RENDERER_PATH) {
+    serveStatisticsRenderer(statisticsRendererDir, res);
+    return;
+  }
+
+  const method = req.method ?? 'GET';
+  if (method === 'GET' || method === 'HEAD') {
+    proxy.web(req, res).catch(error => consola.error(error));
+    return;
+  }
+
+  readBody(req)
+    .then(async (raw) => {
+      requestBodies.set(req, parseBody(raw, req.headers['content-type'] ?? ''));
+      await proxy.web(req, res, { buffer: Readable.from(raw) });
+    })
+    .catch(error => consola.error(error));
+});
+
+server.on('upgrade', (req, socket, head) => {
+  // Node types the upgrade socket as Duplex, but HTTP/1.1 upgrades are always
+  // net.Socket, which is what httpxy expects.
+  if (!(socket instanceof net.Socket)) {
+    socket.destroy();
+    return;
+  }
+  proxy.ws(req, socket, {}, head).catch((error) => {
+    consola.error(error);
+    socket.destroy();
+  });
+});
 
 server.listen(port, () => {
   consola.log(`Proxy server is running at http://127.0.0.1:${port}`);

--- a/frontend/dev-proxy/src/mock-engine.spec.ts
+++ b/frontend/dev-proxy/src/mock-engine.spec.ts
@@ -181,6 +181,23 @@ describe('mock engine', () => {
         .toStrictEqual({ message: '', result: { completed: [taskId], pending: [] } });
     });
 
+    it('should merge into the path the app actually polls, without a trailing slash', () => {
+      // use-task-api.ts calls `/tasks`. The old code matched only `/api/1/tasks/`,
+      // so the merge never fired against the real frontend.
+      const engine = createMockEngine(mocks);
+      const taskId = taskIdOf(engine.transformResponse(request('POST', UPDATES, { async_query: true }), {}));
+
+      expect(engine.transformResponse(request('GET', '/api/1/tasks'), { message: '', result: {} }))
+        .toStrictEqual({ message: '', result: { completed: [], pending: [taskId] } });
+    });
+
+    it('should leave the non-numeric task siblings to the backend', () => {
+      const engine = createMockEngine(mocks);
+
+      expect(engine.transformResponse(request('POST', '/api/1/tasks/trigger'), { result: 'backend' })).toBeUndefined();
+      expect(engine.transformResponse(request('PUT', '/api/1/tasks/scheduler'), { result: 'backend' })).toBeUndefined();
+    });
+
     it('should still answer when the backend reports no task lists at all', () => {
       const engine = createMockEngine(mocks);
 

--- a/frontend/dev-proxy/src/mock-engine.spec.ts
+++ b/frontend/dev-proxy/src/mock-engine.spec.ts
@@ -1,0 +1,202 @@
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockEngine, DEFAULT_TASK_COMPLETION_MS, type MockedAsyncCalls, type MockRequest } from './mock-engine';
+
+function request(method: string, url: string, body?: unknown): MockRequest {
+  return { body, method, path: url.split('?')[0], url };
+}
+
+/** Reads the task id out of an async-query response, failing loudly if it is not there. */
+function taskIdOf(response: unknown): number {
+  assert(typeof response === 'object' && response !== null);
+  const result = Reflect.get(response, 'result');
+  assert(typeof result === 'object' && result !== null);
+  const taskId = Reflect.get(result, 'task_id');
+  assert(typeof taskId === 'number');
+  return taskId;
+}
+
+const UPDATES = '/api/1/assets/updates';
+
+describe('mock engine', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('mock selection', () => {
+    it('should answer with the mock declared for the path and method', () => {
+      const engine = createMockEngine({ [UPDATES]: { GET: { message: '', result: 5 } } });
+
+      expect(engine.transformResponse(request('GET', UPDATES), { result: 'backend' }))
+        .toStrictEqual({ message: '', result: 5 });
+    });
+
+    it('should not answer for another method on a mocked path', () => {
+      const engine = createMockEngine({ [UPDATES]: { GET: { result: 5 } } });
+
+      expect(engine.transformResponse(request('POST', UPDATES), { result: 'backend' })).toBeUndefined();
+    });
+
+    it('should not let a mock answer for a path it merely starts with', () => {
+      // The old match was `mockKey.includes(requestPath)`, so a mock declared
+      // for /api/1/assets/updates also answered /api/1/assets, and with several
+      // matching keys the first declared one won.
+      const engine = createMockEngine({ [UPDATES]: { GET: { result: 'wrong' } } });
+
+      expect(engine.transformResponse(request('GET', '/api/1/assets'), { result: 'backend' })).toBeUndefined();
+    });
+
+    it('should match a mock key that pins a query string', () => {
+      const engine = createMockEngine({ [`${UPDATES}?limit=1`]: { GET: { result: 'pinned' } } });
+
+      expect(engine.transformResponse(request('GET', `${UPDATES}?limit=1`), {})).toStrictEqual({ result: 'pinned' });
+    });
+
+    it('should leave an unmocked request to the backend', () => {
+      const engine = createMockEngine({});
+
+      expect(engine.transformResponse(request('GET', '/api/1/settings'), { result: 'backend' })).toBeUndefined();
+    });
+  });
+
+  describe('array mocks', () => {
+    const mocks: MockedAsyncCalls = {
+      [UPDATES]: { GET: [{ result: 1 }, { result: 2 }] },
+    };
+
+    it('should serve one entry per call and repeat the last', () => {
+      const engine = createMockEngine(mocks);
+
+      expect(engine.transformResponse(request('GET', UPDATES), {})).toStrictEqual({ result: 1 });
+      expect(engine.transformResponse(request('GET', UPDATES), {})).toStrictEqual({ result: 2 });
+      expect(engine.transformResponse(request('GET', UPDATES), {})).toStrictEqual({ result: 2 });
+    });
+
+    it('should advance the same cursor whatever query string the url carries', () => {
+      // The cursor used to be keyed on the full url in one branch and on the
+      // path in another, so the same endpoint advanced two separate counters.
+      const engine = createMockEngine(mocks);
+
+      expect(engine.transformResponse(request('GET', UPDATES), {})).toStrictEqual({ result: 1 });
+      expect(engine.transformResponse(request('GET', `${UPDATES}?upgrade=1`), {})).toStrictEqual({ result: 2 });
+    });
+
+    it('should keep a separate cursor per method', () => {
+      const engine = createMockEngine({
+        [UPDATES]: { GET: [{ result: 'get-1' }], POST: [{ result: 'post-1' }] },
+      });
+
+      expect(engine.transformResponse(request('GET', UPDATES), {})).toStrictEqual({ result: 'get-1' });
+      expect(engine.transformResponse(request('POST', UPDATES), {})).toStrictEqual({ result: 'post-1' });
+    });
+  });
+
+  describe('async queries', () => {
+    const mocks: MockedAsyncCalls = { [UPDATES]: { POST: { message: '', result: 'done' } } };
+
+    it('should answer an async_query body with a task id', () => {
+      const engine = createMockEngine(mocks);
+
+      const response = engine.transformResponse(request('POST', UPDATES, { async_query: true }), {});
+
+      expect(response).toStrictEqual({ message: '', result: { task_id: expect.any(Number) } });
+      engine.stop();
+    });
+
+    it('should answer an async_query url parameter with a task id', () => {
+      const engine = createMockEngine(mocks);
+
+      const response = engine.transformResponse(request('POST', `${UPDATES}?async_query=true`), {});
+
+      expect(response).toStrictEqual({ message: '', result: { task_id: expect.any(Number) } });
+      engine.stop();
+    });
+
+    it('should serve the mock directly when the request is not an async query', () => {
+      const engine = createMockEngine(mocks);
+
+      expect(engine.transformResponse(request('POST', UPDATES, { async_query: false }), {}))
+        .toStrictEqual({ message: '', result: 'done' });
+    });
+
+    it('should report the task as pending, then completed with its outcome', () => {
+      const engine = createMockEngine(mocks);
+      const created = engine.transformResponse(request('POST', UPDATES, { async_query: true }), {});
+      const taskId = taskIdOf(created);
+
+      expect(engine.transformResponse(request('GET', `/api/1/tasks/${taskId}`), {}))
+        .toStrictEqual({ message: '', result: { outcome: null, status: 'pending' } });
+
+      vi.advanceTimersByTime(DEFAULT_TASK_COMPLETION_MS);
+
+      expect(engine.transformResponse(request('GET', `/api/1/tasks/${taskId}`), {}))
+        .toStrictEqual({ message: '', result: { outcome: { message: '', result: 'done' }, status: 'completed' } });
+    });
+
+    it('should hand a completed task outcome out only once', () => {
+      const engine = createMockEngine(mocks);
+      const created = engine.transformResponse(request('POST', UPDATES, { async_query: true }), {});
+      const taskId = taskIdOf(created);
+      vi.advanceTimersByTime(DEFAULT_TASK_COMPLETION_MS);
+      engine.transformResponse(request('GET', `/api/1/tasks/${taskId}`), {});
+
+      expect(engine.transformResponse(request('GET', `/api/1/tasks/${taskId}`), { result: 'backend' })).toBeUndefined();
+    });
+
+    it('should leave a task it never created to the backend', () => {
+      const engine = createMockEngine(mocks);
+
+      expect(engine.transformResponse(request('GET', '/api/1/tasks/42'), { result: 'backend' })).toBeUndefined();
+    });
+  });
+
+  describe('task status', () => {
+    const mocks: MockedAsyncCalls = { [UPDATES]: { POST: { result: 'done' } } };
+
+    it('should add its pending tasks to the ones the backend reports', () => {
+      const engine = createMockEngine(mocks);
+      const created = engine.transformResponse(request('POST', UPDATES, { async_query: true }), {});
+      const taskId = taskIdOf(created);
+
+      const status = engine.transformResponse(
+        request('GET', '/api/1/tasks/'),
+        { message: '', result: { pending: [7], completed: [8] } },
+      );
+
+      expect(status).toStrictEqual({ message: '', result: { completed: [8], pending: [7, taskId] } });
+      engine.stop();
+    });
+
+    it('should report the task as completed once its delay has passed', () => {
+      const engine = createMockEngine(mocks);
+      const created = engine.transformResponse(request('POST', UPDATES, { async_query: true }), {});
+      const taskId = taskIdOf(created);
+
+      vi.advanceTimersByTime(DEFAULT_TASK_COMPLETION_MS);
+
+      expect(engine.transformResponse(request('GET', '/api/1/tasks/'), { message: '', result: {} }))
+        .toStrictEqual({ message: '', result: { completed: [taskId], pending: [] } });
+    });
+
+    it('should still answer when the backend reports no task lists at all', () => {
+      const engine = createMockEngine(mocks);
+
+      expect(engine.transformResponse(request('GET', '/api/1/tasks/'), { message: '', result: null }))
+        .toStrictEqual({ message: '', result: { completed: [], pending: [] } });
+    });
+  });
+
+  describe('handles', () => {
+    it('should be true for the task endpoints and for mocked paths only', () => {
+      const engine = createMockEngine({ [UPDATES]: { GET: { result: 1 } } });
+
+      expect(engine.handles(request('GET', '/api/1/tasks/'))).toBe(true);
+      expect(engine.handles(request('GET', '/api/1/tasks/42'))).toBe(true);
+      expect(engine.handles(request('POST', UPDATES))).toBe(true);
+      expect(engine.handles(request('GET', '/api/1/settings'))).toBe(false);
+    });
+  });
+});

--- a/frontend/dev-proxy/src/mock-engine.ts
+++ b/frontend/dev-proxy/src/mock-engine.ts
@@ -1,0 +1,184 @@
+import consola from 'consola';
+
+export interface MockedAsyncCalls {
+  [url: string]: { [method: string]: unknown };
+}
+
+export interface MockRequest {
+  method: string;
+  /** Path plus query string, as it arrived. */
+  url: string;
+  /** Path only. */
+  path: string;
+  /** Parsed request body, when there was one. */
+  body?: unknown;
+}
+
+export interface MockEngine {
+  /**
+   * Whether this request can produce a rewritten response. The server only
+   * buffers a backend response when this is true, so everything else (exports,
+   * downloads) still streams through untouched.
+   */
+  handles: (req: MockRequest) => boolean;
+  /** Whether the request path has a mock declared, in any method. */
+  isMocked: (req: MockRequest) => boolean;
+  /**
+   * The payload to answer with, or undefined to pass the backend response
+   * through unchanged.
+   */
+  transformResponse: (req: MockRequest, backend: unknown) => unknown;
+  /** Drops the pending task timers so the process can exit. */
+  stop: () => void;
+}
+
+export const TASKS_PATH = '/api/1/tasks/';
+
+/** How long a mocked async query stays pending before it reports as completed. */
+export const DEFAULT_TASK_COMPLETION_MS = 8000;
+
+function createResult(result: unknown): Record<string, unknown> {
+  return {
+    message: '',
+    result,
+  };
+}
+
+function isAsyncQuery(req: MockRequest): boolean {
+  if (req.url.includes('async_query'))
+    return true;
+
+  return typeof req.body === 'object' && req.body !== null && Reflect.get(req.body, 'async_query') === true;
+}
+
+export function createMockEngine(
+  mocks: MockedAsyncCalls,
+  { taskCompletionMs = DEFAULT_TASK_COMPLETION_MS }: { taskCompletionMs?: number } = {},
+): MockEngine {
+  const pending = new Set<number>();
+  const completed = new Set<number>();
+  const outcomes = new Map<number, unknown>();
+  const timers = new Set<ReturnType<typeof setTimeout>>();
+  /** Per endpoint+method cursor into an array-shaped mock. */
+  const cursors = new Map<string, number>();
+  let nextTaskId = 100000;
+
+  /**
+   * Mock keys are matched exactly: on the full url first, so a key may pin a
+   * query string, then on the path alone. Matching on a substring would let a
+   * mock for one endpoint answer for its prefix.
+   */
+  function findMock(req: MockRequest): unknown {
+    return mocks[req.url]?.[req.method] ?? mocks[req.path]?.[req.method];
+  }
+
+  /** Arrays serve one entry per call, then repeat the last one. */
+  function resolveMock(req: MockRequest, mock: unknown): unknown {
+    if (!Array.isArray(mock))
+      return mock;
+
+    const key = `${req.method} ${req.path}`;
+    const cursor = cursors.get(key) ?? 0;
+    cursors.set(key, cursor + 1);
+    return mock[Math.min(cursor, mock.length - 1)];
+  }
+
+  function createTask(response: unknown): number {
+    const taskId = nextTaskId++;
+    pending.add(taskId);
+    outcomes.set(taskId, response);
+
+    const timer = setTimeout(() => {
+      pending.delete(taskId);
+      completed.add(taskId);
+      timers.delete(timer);
+      consola.log(`mock task ${taskId} completed`);
+    }, taskCompletionMs);
+    // A pending mock task must never keep the proxy alive on its own.
+    timer.unref?.();
+    timers.add(timer);
+
+    consola.log(`mock task ${taskId} pending`);
+    return taskId;
+  }
+
+  /** Merges the mocked task ids into whatever the backend reports. */
+  function mergeTaskStatus(backend: unknown): unknown {
+    const data = typeof backend === 'object' && backend !== null ? backend : createResult({});
+    const result = Reflect.get(data, 'result');
+    const merged = typeof result === 'object' && result !== null ? result : {};
+    const backendPending = Reflect.get(merged, 'pending');
+    const backendCompleted = Reflect.get(merged, 'completed');
+
+    return {
+      ...data,
+      result: {
+        ...merged,
+        pending: [...(Array.isArray(backendPending) ? backendPending : []), ...pending],
+        completed: [...(Array.isArray(backendCompleted) ? backendCompleted : []), ...completed],
+      },
+    };
+  }
+
+  /** Answers a poll for one mocked task; a real backend task falls through. */
+  function taskOutcome(req: MockRequest): unknown {
+    const taskId = Number.parseInt(req.path.replace(TASKS_PATH, ''), 10);
+    if (Number.isNaN(taskId))
+      return undefined;
+
+    if (completed.has(taskId)) {
+      const outcome = outcomes.get(taskId);
+      outcomes.delete(taskId);
+      completed.delete(taskId);
+      return createResult({ outcome, status: 'completed' });
+    }
+
+    if (pending.has(taskId))
+      return createResult({ outcome: null, status: 'pending' });
+
+    return undefined;
+  }
+
+  function isTaskStatus(req: MockRequest): boolean {
+    return req.path === TASKS_PATH;
+  }
+
+  function isTaskPoll(req: MockRequest): boolean {
+    return req.path.startsWith(TASKS_PATH) && req.path !== TASKS_PATH;
+  }
+
+  function isMocked(req: MockRequest): boolean {
+    return mocks[req.url] !== undefined || mocks[req.path] !== undefined;
+  }
+
+  return {
+    handles(req: MockRequest): boolean {
+      if (isTaskStatus(req) || isTaskPoll(req))
+        return true;
+
+      return isMocked(req);
+    },
+    isMocked,
+    stop(): void {
+      for (const timer of timers) clearTimeout(timer);
+      timers.clear();
+    },
+    transformResponse(req: MockRequest, backend: unknown): unknown {
+      if (isTaskStatus(req))
+        return mergeTaskStatus(backend);
+
+      if (isTaskPoll(req))
+        return taskOutcome(req);
+
+      const mock = findMock(req);
+      if (mock === undefined)
+        return undefined;
+
+      const response = resolveMock(req, mock);
+      if (isAsyncQuery(req))
+        return createResult({ task_id: createTask(response) });
+
+      return response;
+    },
+  };
+}

--- a/frontend/dev-proxy/src/mock-engine.ts
+++ b/frontend/dev-proxy/src/mock-engine.ts
@@ -32,7 +32,7 @@ export interface MockEngine {
   stop: () => void;
 }
 
-export const TASKS_PATH = '/api/1/tasks/';
+export const TASKS_PATH = '/api/1/tasks';
 
 /** How long a mocked async query stays pending before it reports as completed. */
 export const DEFAULT_TASK_COMPLETION_MS = 8000;
@@ -122,7 +122,8 @@ export function createMockEngine(
 
   /** Answers a poll for one mocked task; a real backend task falls through. */
   function taskOutcome(req: MockRequest): unknown {
-    const taskId = Number.parseInt(req.path.replace(TASKS_PATH, ''), 10);
+    // Non-numeric siblings (/tasks/trigger, /tasks/scheduler) fall through.
+    const taskId = Number.parseInt(req.path.replace(`${TASKS_PATH}/`, ''), 10);
     if (Number.isNaN(taskId))
       return undefined;
 
@@ -139,12 +140,14 @@ export function createMockEngine(
     return undefined;
   }
 
+  // The app polls `/api/1/tasks`; the old code only recognised the trailing
+  // slash form, so the merge never fired against the real frontend.
   function isTaskStatus(req: MockRequest): boolean {
-    return req.path === TASKS_PATH;
+    return req.path === TASKS_PATH || req.path === `${TASKS_PATH}/`;
   }
 
   function isTaskPoll(req: MockRequest): boolean {
-    return req.path.startsWith(TASKS_PATH) && req.path !== TASKS_PATH;
+    return req.path.startsWith(`${TASKS_PATH}/`) && !isTaskStatus(req);
   }
 
   function isMocked(req: MockRequest): boolean {

--- a/frontend/dev-proxy/src/mocked-apis/statistics.spec.ts
+++ b/frontend/dev-proxy/src/mocked-apis/statistics.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { pickLatestBundle } from './statistics';
+
+describe('pickLatestBundle', () => {
+  it('should pick the newest bundle regardless of the directory order', () => {
+    const candidates = [
+      { birthtimeMs: 300, name: 'premium_components_v15.js' },
+      { birthtimeMs: 900, name: 'premium_components_v16.js' },
+      { birthtimeMs: 100, name: 'premium_components_v14.js' },
+    ];
+
+    expect(pickLatestBundle(candidates)).toBe('premium_components_v16.js');
+  });
+
+  it('should ignore everything that is not a js file', () => {
+    const candidates = [
+      { birthtimeMs: 900, name: 'premium_components_v16.js.map' },
+      { birthtimeMs: 800, name: 'stats.html' },
+      { birthtimeMs: 100, name: 'premium_components_v16.js' },
+    ];
+
+    expect(pickLatestBundle(candidates)).toBe('premium_components_v16.js');
+  });
+
+  it('should return undefined when the dist directory holds no bundle', () => {
+    expect(pickLatestBundle([{ birthtimeMs: 900, name: 'readme.md' }])).toBeUndefined();
+  });
+});

--- a/frontend/dev-proxy/src/mocked-apis/statistics.ts
+++ b/frontend/dev-proxy/src/mocked-apis/statistics.ts
@@ -1,35 +1,41 @@
-import type { Application } from 'express';
+import type { ServerResponse } from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import consola from 'consola';
 
-export function statistics(server: Application, componentsDir: string): void {
-  server.get('/api/1/statistics/renderer', (_, res) => {
-    const dist = path.resolve(componentsDir, 'dist');
-    const contents = fs.readdirSync(dist);
-    let latest = 0;
-    let latestFile = '';
-    for (const content of contents) {
-      if (!content.endsWith('.js')) {
-        continue;
-      }
-      const file = path.join(dist, content);
-      const { birthtimeMs } = fs.statSync(file);
-      if (birthtimeMs > latest) {
-        latest = birthtimeMs;
-        latestFile = file;
-      }
+export const STATISTICS_RENDERER_PATH = '/api/1/statistics/renderer';
+
+/**
+ * Serves the newest `.js` file (by birthtime) from `<componentsDir>/dist`, so a
+ * rebuild of the premium components is picked up on the next app reload.
+ */
+export function serveStatisticsRenderer(componentsDir: string, res: ServerResponse): void {
+  const dist = path.resolve(componentsDir, 'dist');
+  const contents = fs.readdirSync(dist);
+  let latest = 0;
+  let latestFile = '';
+  for (const content of contents) {
+    if (!content.endsWith('.js')) {
+      continue;
     }
+    const file = path.join(dist, content);
+    const { birthtimeMs } = fs.statSync(file);
+    if (birthtimeMs > latest) {
+      latest = birthtimeMs;
+      latestFile = file;
+    }
+  }
 
-    let result = '';
-    if (latestFile)
-      result = fs.readFileSync(latestFile, 'utf8');
+  let result = '';
+  if (latestFile)
+    result = fs.readFileSync(latestFile, 'utf8');
 
-    consola.info(`Serving renderer from ${latestFile}`);
+  consola.info(`Serving renderer from ${latestFile}`);
 
-    res.jsonp({
-      message: '',
-      result,
-    });
-  });
+  res.setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.statusCode = 200;
+  res.end(JSON.stringify({
+    message: '',
+    result,
+  }));
 }

--- a/frontend/dev-proxy/src/mocked-apis/statistics.ts
+++ b/frontend/dev-proxy/src/mocked-apis/statistics.ts
@@ -5,32 +5,38 @@ import consola from 'consola';
 
 export const STATISTICS_RENDERER_PATH = '/api/1/statistics/renderer';
 
+export interface BundleCandidate {
+  name: string;
+  birthtimeMs: number;
+}
+
 /**
- * Serves the newest `.js` file (by birthtime) from `<componentsDir>/dist`, so a
- * rebuild of the premium components is picked up on the next app reload.
+ * The newest `.js` file wins, so a rebuild of the premium components is picked
+ * up on the next app reload without renaming anything.
  */
+export function pickLatestBundle(candidates: BundleCandidate[]): string | undefined {
+  let latest: BundleCandidate | undefined;
+  for (const candidate of candidates) {
+    if (!candidate.name.endsWith('.js'))
+      continue;
+
+    if (!latest || candidate.birthtimeMs > latest.birthtimeMs)
+      latest = candidate;
+  }
+  return latest?.name;
+}
+
 export function serveStatisticsRenderer(componentsDir: string, res: ServerResponse): void {
   const dist = path.resolve(componentsDir, 'dist');
-  const contents = fs.readdirSync(dist);
-  let latest = 0;
-  let latestFile = '';
-  for (const content of contents) {
-    if (!content.endsWith('.js')) {
-      continue;
-    }
-    const file = path.join(dist, content);
-    const { birthtimeMs } = fs.statSync(file);
-    if (birthtimeMs > latest) {
-      latest = birthtimeMs;
-      latestFile = file;
-    }
-  }
+  const candidates = fs.readdirSync(dist).map(name => ({
+    birthtimeMs: fs.statSync(path.join(dist, name)).birthtimeMs,
+    name,
+  }));
 
-  let result = '';
-  if (latestFile)
-    result = fs.readFileSync(latestFile, 'utf8');
+  const latest = pickLatestBundle(candidates);
+  const result = latest ? fs.readFileSync(path.join(dist, latest), 'utf8') : '';
 
-  consola.info(`Serving renderer from ${latestFile}`);
+  consola.info(`Serving renderer from ${latest ?? '<nothing found>'}`);
 
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
   res.statusCode = 200;

--- a/frontend/dev-proxy/src/setup.ts
+++ b/frontend/dev-proxy/src/setup.ts
@@ -1,11 +1,8 @@
-import type { Application } from 'express';
+import type { ServerResponse } from 'node:http';
 
-export function enableCors(server: Application): void {
-  server.use((req, res, next) => {
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-    res.setHeader('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-    next();
-  });
+export function applyCors(res: ServerResponse): void {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
+  res.setHeader('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
+  res.setHeader('Access-Control-Allow-Credentials', 'true');
 }

--- a/frontend/dev-proxy/test/smoke.mjs
+++ b/frontend/dev-proxy/test/smoke.mjs
@@ -1,0 +1,178 @@
+// End-to-end smoke test for the dev-proxy: the parts the unit tests cannot
+// reach — pass-through, the locally served statistics route, CORS, body
+// forwarding and websocket upgrades — against a stub backend.
+//
+// Run with: pnpm run --filter @rotki/dev-proxy test:smoke
+import { Buffer } from 'node:buffer';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+const BACKEND_PORT = 14999;
+const PROXY_PORT = 14998;
+const proxyDir = process.cwd();
+
+const componentsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-proxy-premium-'));
+fs.mkdirSync(path.join(componentsDir, 'dist'));
+fs.writeFileSync(path.join(componentsDir, 'dist', 'premium_components_v16.js'), 'console.log("bundle")');
+
+// The proxy reads async-mock.json from its working directory. Keep a personal
+// one untouched if it is there.
+const mockPath = path.join(proxyDir, 'async-mock.json');
+const hadMock = fs.existsSync(mockPath);
+if (!hadMock) {
+  fs.writeFileSync(mockPath, JSON.stringify({
+    '/api/1/assets/updates': {
+      GET: { message: '', result: { local_version: 2 } },
+      POST: { message: '', result: { local_version: 1 } },
+    },
+  }));
+}
+
+const received = [];
+const backend = http.createServer((req, res) => {
+  const chunks = [];
+  req.on('data', chunk => chunks.push(chunk));
+  req.on('end', () => {
+    received.push({ body: Buffer.concat(chunks).toString(), method: req.method, url: req.url });
+    res.setHeader('Content-Type', 'application/json');
+    if (req.url === '/api/1/tasks/') {
+      // Deliberately split across two chunks: the old res.write override parsed
+      // each chunk on its own and dropped the body when it was not whole JSON.
+      const payload = JSON.stringify({ message: '', result: { completed: [], pending: [1] } });
+      const half = Math.floor(payload.length / 2);
+      res.write(payload.slice(0, half));
+      res.end(payload.slice(half));
+      return;
+    }
+    res.end(JSON.stringify({ message: '', result: { from: 'backend' } }));
+  });
+});
+backend.on('upgrade', (req, socket) => {
+  socket.write('HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n');
+  socket.end();
+});
+await new Promise(resolve => backend.listen(BACKEND_PORT, resolve));
+
+const proxy = spawn('tsx', ['src/index.ts'], {
+  cwd: proxyDir,
+  env: {
+    ...process.env,
+    BACKEND: `http://127.0.0.1:${BACKEND_PORT}`,
+    PORT: String(PROXY_PORT),
+    PREMIUM_COMPONENT_DIR: componentsDir,
+  },
+});
+let proxyLog = '';
+proxy.stdout.on('data', data => (proxyLog += data));
+proxy.stderr.on('data', data => (proxyLog += data));
+
+function request(method, url, body, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ headers, host: '127.0.0.1', method, path: url, port: PROXY_PORT }, (res) => {
+      const chunks = [];
+      res.on('data', chunk => chunks.push(chunk));
+      res.on('end', () => resolve({
+        body: Buffer.concat(chunks).toString(),
+        headers: res.headers,
+        status: res.statusCode,
+      }));
+    });
+    req.on('error', reject);
+    if (body)
+      req.write(body);
+    req.end();
+  });
+}
+
+function upgrade() {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      headers: {
+        'Connection': 'Upgrade',
+        'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+        'Sec-WebSocket-Version': '13',
+        'Upgrade': 'websocket',
+      },
+      host: '127.0.0.1',
+      path: '/ws/',
+      port: PROXY_PORT,
+    });
+    req.on('upgrade', res => resolve(res.statusCode));
+    req.on('response', res => reject(new Error(`no upgrade, got ${res.statusCode}`)));
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function waitForProxy() {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      await request('GET', '/health');
+      return;
+    }
+    catch {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+  throw new Error(`proxy never came up:\n${proxyLog}`);
+}
+
+const results = [];
+
+function check(name, ok, detail) {
+  results.push({ detail, name, ok: !!ok });
+}
+
+try {
+  await waitForProxy();
+
+  const renderer = await request('GET', '/api/1/statistics/renderer');
+  check('statistics renderer served locally', JSON.parse(renderer.body).result === 'console.log("bundle")', renderer.body);
+  check('statistics renderer never reaches the backend', !received.some(r => r.url === '/api/1/statistics/renderer'));
+  check('cors header present', renderer.headers['access-control-allow-origin'] === '*', renderer.headers['access-control-allow-origin']);
+
+  const passthrough = await request('GET', '/api/1/settings');
+  check('GET passes through', JSON.parse(passthrough.body).result?.from === 'backend', passthrough.body);
+
+  const tasks = await request('GET', '/api/1/tasks/');
+  check('task status keeps the backend ids, from a chunked response', JSON.parse(tasks.body).result?.pending?.includes(1), tasks.body);
+
+  const postBody = JSON.stringify({ async_query: false, name: 'value' });
+  const post = await request('POST', '/api/1/settings', postBody, { 'Content-Type': 'application/json' });
+  const forwarded = received.find(r => r.url === '/api/1/settings' && r.method === 'POST');
+  check('POST body reaches the backend intact', forwarded?.body === postBody, forwarded?.body);
+  check('POST response passes through', JSON.parse(post.body).result?.from === 'backend', post.body);
+
+  const mocked = await request('POST', '/api/1/assets/updates', JSON.stringify({ async_query: true }), { 'Content-Type': 'application/json' });
+  check('async_query body gets a mocked task id', typeof JSON.parse(mocked.body).result?.task_id === 'number', mocked.body);
+  check('rewritten response declares its own length', Number(mocked.headers['content-length']) === Buffer.byteLength(mocked.body), mocked.headers['content-length']);
+
+  const mockedUrl = await request('GET', '/api/1/assets/updates?async_query=true');
+  check('async_query url gets a mocked task id', typeof JSON.parse(mockedUrl.body).result?.task_id === 'number', mockedUrl.body);
+
+  const preflight = await request('OPTIONS', '/api/1/assets/updates');
+  check('preflight for a mocked path is answered locally', preflight.status === 200, String(preflight.status));
+
+  check('websocket upgrade forwarded', (await upgrade()) === 101);
+}
+finally {
+  proxy.kill();
+  backend.close();
+  if (!hadMock)
+    fs.rmSync(mockPath);
+  fs.rmSync(componentsDir, { force: true, recursive: true });
+}
+
+for (const result of results)
+  process.stdout.write(`${result.ok ? 'PASS' : 'FAIL'}  ${result.name}${result.ok ? '' : `  -> ${result.detail}`}\n`);
+
+const failed = results.filter(result => !result.ok).length;
+if (failed > 0) {
+  process.stdout.write(`\n--- proxy log ---\n${proxyLog}\n`);
+  process.exit(1);
+}
+process.exit(0);

--- a/frontend/dev-proxy/test/smoke.mjs
+++ b/frontend/dev-proxy/test/smoke.mjs
@@ -29,6 +29,7 @@ if (!hadMock) {
       GET: { message: '', result: { local_version: 2 } },
       POST: { message: '', result: { local_version: 1 } },
     },
+    '/api/1/premium/sync': { GET: { message: '', result: 'mocked' } },
   }));
 }
 
@@ -39,7 +40,13 @@ const backend = http.createServer((req, res) => {
   req.on('end', () => {
     received.push({ body: Buffer.concat(chunks).toString(), method: req.method, url: req.url });
     res.setHeader('Content-Type', 'application/json');
-    if (req.url === '/api/1/tasks/') {
+    // A mocked path that the backend rejects: the mock must not turn it into a 200.
+    if (req.url === '/api/1/premium/sync') {
+      res.statusCode = 401;
+      res.end(JSON.stringify({ message: 'not logged in', result: null }));
+      return;
+    }
+    if (req.url === '/api/1/tasks') {
       // Deliberately split across two chunks: the old res.write override parsed
       // each chunk on its own and dropped the body when it was not whole JSON.
       const payload = JSON.stringify({ message: '', result: { completed: [], pending: [1] } });
@@ -138,8 +145,12 @@ try {
   const passthrough = await request('GET', '/api/1/settings');
   check('GET passes through', JSON.parse(passthrough.body).result?.from === 'backend', passthrough.body);
 
-  const tasks = await request('GET', '/api/1/tasks/');
+  const tasks = await request('GET', '/api/1/tasks');
   check('task status keeps the backend ids, from a chunked response', JSON.parse(tasks.body).result?.pending?.includes(1), tasks.body);
+
+  const rejected = await request('GET', '/api/1/premium/sync');
+  check('a rejected request is not rewritten into a 200', rejected.status === 401, `${rejected.status} ${rejected.body}`);
+  check('a rejected request keeps the backend body', JSON.parse(rejected.body).message === 'not logged in', rejected.body);
 
   const postBody = JSON.stringify({ async_query: false, name: 'value' });
   const post = await request('POST', '/api/1/settings', postBody, { 'Content-Type': 'application/json' });

--- a/frontend/dev-proxy/tsconfig.json
+++ b/frontend/dev-proxy/tsconfig.json
@@ -1,11 +1,13 @@
 {
+  "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
-    "moduleDetection": "force",
-    "module": "Preserve",
+    "tsBuildInfoFile": "../node_modules/.tmp/tsconfig.dev-proxy.tsbuildinfo",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
+    "types": ["node"],
     "allowJs": true,
-    "esModuleInterop": true,
-    "isolatedModules": true
+    "noEmit": true
   },
   "include": [
     "src/**/*"

--- a/frontend/dev-proxy/tsconfig.json
+++ b/frontend/dev-proxy/tsconfig.json
@@ -10,6 +10,7 @@
     "noEmit": true
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "vitest.config.ts"
   ]
 }

--- a/frontend/dev-proxy/vitest.config.ts
+++ b/frontend/dev-proxy/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+  },
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "test": "pnpm run test:unit && pnpm run test:e2e",
     "test:contract": "pnpm run --filter rotki test:contract",
     "test:unit": "pnpm run --filter rotki test:unit:run",
+    "test:proxy": "pnpm run --filter @rotki/dev-proxy typecheck && pnpm run --filter @rotki/dev-proxy test:unit",
     "test:unit:watch": "pnpm run --filter rotki test:unit",
     "test:e2e": "pnpm run --filter rotki test:e2e",
     "test:e2e:shards": "pnpm run --filter rotki test:e2e:shards",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -42,12 +42,6 @@ catalogs:
     '@tsconfig/node24':
       specifier: 24.0.4
       version: 24.0.4
-    '@types/body-parser':
-      specifier: 1.19.6
-      version: 1.19.6
-    '@types/express':
-      specifier: 5.0.6
-      version: 5.0.6
     '@types/node':
       specifier: 24.13.3
       version: 24.13.3
@@ -105,9 +99,6 @@ catalogs:
     bignumber.js:
       specifier: 11.1.5
       version: 11.1.5
-    body-parser:
-      specifier: 2.3.0
-      version: 2.3.0
     bufferutil:
       specifier: 4.1.0
       version: 4.1.0
@@ -153,9 +144,6 @@ catalogs:
     eslint:
       specifier: 10.8.0
       version: 10.8.0
-    express:
-      specifier: 5.2.1
-      version: 5.2.1
     fake-indexeddb:
       specifier: 6.2.5
       version: 6.2.5
@@ -168,9 +156,6 @@ catalogs:
     happy-dom:
       specifier: 20.11.1
       version: 20.11.1
-    http-proxy-middleware:
-      specifier: 4.2.0
-      version: 4.2.0
     httpxy:
       specifier: 0.5.5
       version: 0.5.5
@@ -620,22 +605,13 @@ importers:
 
   dev-proxy:
     dependencies:
-      body-parser:
+      httpxy:
         specifier: 'catalog:'
-        version: 2.3.0(supports-color@10.2.2)
-      express:
-        specifier: 'catalog:'
-        version: 5.2.1(supports-color@10.2.2)
-      http-proxy-middleware:
-        specifier: 'catalog:'
-        version: 4.2.0(supports-color@10.2.2)
+        version: 0.5.5
     devDependencies:
-      '@types/body-parser':
+      '@tsconfig/node24':
         specifier: 'catalog:'
-        version: 1.19.6
-      '@types/express':
-        specifier: 'catalog:'
-        version: 5.0.6
+        version: 24.0.4
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.3
@@ -2271,17 +2247,11 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
-  '@types/body-parser@1.19.6':
-    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
-
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
-
-  '@types/connect@3.4.38':
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -2295,12 +2265,6 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/express-serve-static-core@5.1.1':
-    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
-
-  '@types/express@5.0.6':
-    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
-
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -2309,9 +2273,6 @@ packages:
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
-
-  '@types/http-errors@2.0.5':
-    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -2346,23 +2307,11 @@ packages:
   '@types/qrcode@1.5.6':
     resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
 
-  '@types/qs@6.15.1':
-    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
-
-  '@types/range-parser@1.2.7':
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/semver@7.8.0':
     resolution: {integrity: sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==}
-
-  '@types/send@1.2.1':
-    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
-
-  '@types/serve-static@2.2.0':
-    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/set-cookie-parser@2.4.10':
     resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
@@ -2813,10 +2762,6 @@ packages:
       zod:
         optional: true
 
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2982,14 +2927,6 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
-    engines: {node: '>=18'}
-
-  body-parser@2.3.0:
-    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
-    engines: {node: '>=18'}
-
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -3046,10 +2983,6 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
-
   bytestreamjs@2.0.1:
     resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
     engines: {node: '>=6.0.0'}
@@ -3081,10 +3014,6 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -3229,18 +3158,6 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
-    engines: {node: '>=18'}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
-    engines: {node: '>=18'}
-
   convert-hrtime@5.0.0:
     resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
     engines: {node: '>=12'}
@@ -3250,14 +3167,6 @@ packages:
 
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
-
-  cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
-
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -3376,10 +3285,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -3478,9 +3383,6 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -3528,10 +3430,6 @@ packages:
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
-
-  encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -3610,9 +3508,6 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
-
-  escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3874,10 +3769,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
-
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -3891,10 +3782,6 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
-
-  express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -3974,10 +3861,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
-
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -4023,16 +3906,8 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
-
-  fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
-    engines: {node: '>= 0.8'}
 
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -4248,17 +4123,9 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
-  http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  http-proxy-middleware@4.2.0:
-    resolution: {integrity: sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==}
-    engines: {node: ^22.15.0 || ^24.0.0 || >=26.0.0}
 
   http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
@@ -4280,10 +4147,6 @@ packages:
     resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
     engines: {node: ^8.11.2 || >=10}
     os: [darwin]
-
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
-    engines: {node: '>=0.10.0'}
 
   idb-keyval@6.2.5:
     resolution: {integrity: sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==}
@@ -4338,10 +4201,6 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -4400,13 +4259,6 @@ packages:
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
-
-  is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
@@ -4808,10 +4660,6 @@ packages:
   mdn-data@2.28.1:
     resolution: {integrity: sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==}
 
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
   memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
 
@@ -4822,10 +4670,6 @@ packages:
   meow@14.1.0:
     resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
     engines: {node: '>=20'}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -4929,17 +4773,9 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
-  mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
-    engines: {node: '>= 0.6'}
-
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
-
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -5038,10 +4874,6 @@ packages:
     resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
     engines: {node: '>=18'}
 
-  negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
-    engines: {node: '>= 0.6'}
-
   node-abi@4.31.0:
     resolution: {integrity: sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==}
     engines: {node: '>=22.12.0'}
@@ -5128,10 +4960,6 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
-  object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
-
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -5149,10 +4977,6 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
-
-  on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -5245,10 +5069,6 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
-  parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -5281,9 +5101,6 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-
-  path-to-regexp@8.4.2:
-    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -5510,10 +5327,6 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -5537,10 +5350,6 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
-    engines: {node: '>=0.6'}
-
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -5560,14 +5369,6 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
-
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
-    engines: {node: '>= 0.6'}
-
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
 
   read-binary-file-arch@1.0.6:
     resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
@@ -5670,10 +5471,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
-
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -5687,9 +5484,6 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
-
-  safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sanitize-filename@1.6.4:
     resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
@@ -5731,26 +5525,15 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
-    engines: {node: '>= 18'}
-
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
-
-  serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
-    engines: {node: '>= 18'}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
-
-  setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5762,22 +5545,6 @@ packages:
 
   shell-quote@1.8.4:
     resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-list@1.0.1:
-    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.1.1:
-    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -6099,10 +5866,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
-
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -6155,10 +5918,6 @@ packages:
   type-fest@5.7.0:
     resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
     engines: {node: '>=20'}
-
-  type-is@2.1.0:
-    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
-    engines: {node: '>= 18'}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -6226,10 +5985,6 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
-
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
 
   unplugin-auto-import@21.0.0:
     resolution: {integrity: sha512-vWuC8SwqJmxZFYwPojhOhOXDb5xFhNNcEVb9K/RFkyk/3VnfaOjzitWN7v+8DEKpMjSsY2AEGXNgt6I0yQrhRQ==}
@@ -6398,10 +6153,6 @@ packages:
 
   vanilla-picker@2.12.3:
     resolution: {integrity: sha512-qVkT1E7yMbUsB2mmJNFmaXMWE2hF8ffqzMMwe9zdAikd8u2VfnsVY2HQcOUi2F38bgbxzlJBEdS1UUhOXdF9GQ==}
-
-  vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -8254,11 +8005,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/body-parser@1.19.6':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 24.12.2
-
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
@@ -8271,10 +8017,6 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/connect@3.4.38':
-    dependencies:
-      '@types/node': 24.13.3
-
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -8285,19 +8027,6 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/express-serve-static-core@5.1.1':
-    dependencies:
-      '@types/node': 24.13.3
-      '@types/qs': 6.15.1
-      '@types/range-parser': 1.2.7
-      '@types/send': 1.2.1
-
-  '@types/express@5.0.6':
-    dependencies:
-      '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 5.1.1
-      '@types/serve-static': 2.2.0
-
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 24.13.3
@@ -8307,8 +8036,6 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/http-cache-semantics@4.2.0': {}
-
-  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -8345,24 +8072,11 @@ snapshots:
     dependencies:
       '@types/node': 24.12.2
 
-  '@types/qs@6.15.1': {}
-
-  '@types/range-parser@1.2.7': {}
-
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 24.13.3
 
   '@types/semver@7.8.0': {}
-
-  '@types/send@1.2.1':
-    dependencies:
-      '@types/node': 24.13.3
-
-  '@types/serve-static@2.2.0':
-    dependencies:
-      '@types/http-errors': 2.0.5
-      '@types/node': 24.13.3
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
@@ -8544,7 +8258,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.10)':
     dependencies:
@@ -8584,7 +8298,6 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
       vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)
-    optional: true
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -8613,7 +8326,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -9133,11 +8846,6 @@ snapshots:
       typescript: 6.0.3
       zod: 4.4.3
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.2
-      negotiator: 1.0.0
-
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -9309,34 +9017,6 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@2.2.2(supports-color@10.2.2):
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3(supports-color@10.2.2)
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.2
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  body-parser@2.3.0(supports-color@10.2.2):
-    dependencies:
-      bytes: 3.1.2
-      content-type: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.2
-      raw-body: 3.0.2
-      type-is: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   boolbase@1.0.0: {}
 
   boolean@3.2.0:
@@ -9414,8 +9094,6 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
-  bytes@3.1.2: {}
-
   bytestreamjs@2.0.1: {}
 
   c8@12.0.0:
@@ -9458,11 +9136,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -9574,21 +9247,11 @@ snapshots:
 
   consola@3.4.2: {}
 
-  content-disposition@1.1.0: {}
-
-  content-type@1.0.5: {}
-
-  content-type@2.0.0: {}
-
   convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
 
   cookie-es@1.2.3: {}
-
-  cookie-signature@1.2.2: {}
-
-  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
@@ -9696,8 +9359,6 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  depd@2.0.0: {}
-
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
@@ -9803,8 +9464,6 @@ snapshots:
       minimatch: 9.0.9
       semver: 7.8.5
 
-  ee-first@1.1.1: {}
-
   ejs@3.1.10:
     dependencies:
       jake: 10.9.4
@@ -9895,8 +9554,6 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   empathic@2.0.1: {}
-
-  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -10008,8 +9665,6 @@ snapshots:
       '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
-
-  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -10360,8 +10015,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  etag@1.8.1: {}
-
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
@@ -10369,39 +10022,6 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
-
-  express@5.2.1(supports-color@10.2.2):
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.2(supports-color@10.2.2)
-      content-disposition: 1.1.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@10.2.2)
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@10.2.2)
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.15.2
-      range-parser: 1.2.1
-      router: 2.2.0(supports-color@10.2.2)
-      send: 1.2.1(supports-color@10.2.2)
-      serve-static: 2.2.1(supports-color@10.2.2)
-      statuses: 2.0.2
-      type-is: 2.1.0
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   exsolve@1.0.8: {}
 
@@ -10473,17 +10093,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1(supports-color@10.2.2):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   find-up-simple@1.0.1: {}
 
   find-up@4.1.0:
@@ -10532,11 +10141,7 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
-  forwarded@0.2.0: {}
-
   fraction.js@5.3.4: {}
-
-  fresh@2.0.0: {}
 
   fs-extra@10.1.0:
     dependencies:
@@ -10797,28 +10402,10 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  http-errors@2.0.1:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      toidentifier: 1.0.1
-
   http-proxy-agent@7.0.2(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  http-proxy-middleware@4.2.0(supports-color@10.2.2):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      httpxy: 0.5.5
-      is-glob: 4.0.3
-      is-plain-obj: 4.1.0
-      micromatch: 4.0.8
     transitivePeerDependencies:
       - supports-color
 
@@ -10842,10 +10429,6 @@ snapshots:
     dependencies:
       cli-truncate: 2.1.0
       node-addon-api: 1.7.2
-
-  iconv-lite@0.7.2:
-    dependencies:
-      safer-buffer: 2.1.2
 
   idb-keyval@6.2.5: {}
 
@@ -10886,8 +10469,6 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
-
-  ipaddr.js@1.9.1: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -10931,10 +10512,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@4.0.0: {}
-
-  is-plain-obj@4.1.0: {}
-
-  is-promise@4.0.0: {}
 
   is-reference@3.0.3:
     dependencies:
@@ -11375,15 +10952,11 @@ snapshots:
 
   mdn-data@2.28.1: {}
 
-  media-typer@1.1.0: {}
-
   memoize-one@6.0.0: {}
 
   memorystream@0.3.1: {}
 
   meow@14.1.0: {}
-
-  merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -11602,15 +11175,9 @@ snapshots:
 
   mime-db@1.52.0: {}
 
-  mime-db@1.54.0: {}
-
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
-
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -11706,8 +11273,6 @@ snapshots:
 
   natural-orderby@5.0.0: {}
 
-  negotiator@1.0.0: {}
-
   node-abi@4.31.0:
     dependencies:
       semver: 7.8.5
@@ -11785,8 +11350,6 @@ snapshots:
 
   object-hash@3.0.0: {}
 
-  object-inspect@1.13.4: {}
-
   object-keys@1.1.1:
     optional: true
 
@@ -11801,10 +11364,6 @@ snapshots:
   ohash@2.0.11: {}
 
   on-exit-leak-free@2.1.2: {}
-
-  on-finished@2.4.1:
-    dependencies:
-      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -11976,8 +11535,6 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
-  parseurl@1.3.3: {}
-
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -12001,8 +11558,6 @@ snapshots:
       minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
-
-  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -12202,11 +11757,6 @@ snapshots:
 
   proto-list@1.2.4: {}
 
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -12230,10 +11780,6 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.2:
-    dependencies:
-      side-channel: 1.1.1
-
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
@@ -12245,15 +11791,6 @@ snapshots:
   quote-js-string@0.1.0: {}
 
   radix3@1.1.2: {}
-
-  range-parser@1.2.1: {}
-
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      unpipe: 1.0.0
 
   read-binary-file-arch@1.0.6(supports-color@10.2.2):
     dependencies:
@@ -12371,16 +11908,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.2
       '@rolldown/binding-win32-x64-msvc': 1.2.2
 
-  router@2.2.0(supports-color@10.2.2):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
-
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -12390,8 +11917,6 @@ snapshots:
   safe-buffer@5.1.2: {}
 
   safe-stable-stringify@2.5.0: {}
-
-  safer-buffer@2.1.2: {}
 
   sanitize-filename@1.6.4:
     dependencies:
@@ -12420,41 +11945,14 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@10.2.2):
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      mime-types: 3.0.2
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
 
-  serve-static@2.2.1(supports-color@10.2.2):
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 1.2.1(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
   set-blocking@2.0.0: {}
 
   set-cookie-parser@3.1.0: {}
-
-  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -12463,34 +11961,6 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.4: {}
-
-  side-channel-list@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.1
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -12862,8 +12332,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toidentifier@1.0.1: {}
-
   totalist@3.0.1: {}
 
   tough-cookie@6.0.1:
@@ -12906,12 +12374,6 @@ snapshots:
   type-fest@5.7.0:
     dependencies:
       tagged-tag: 1.0.0
-
-  type-is@2.1.0:
-    dependencies:
-      content-type: 2.0.0
-      media-typer: 1.1.0
-      mime-types: 3.0.2
 
   typescript@6.0.3: {}
 
@@ -12982,8 +12444,6 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
-
-  unpipe@1.0.0: {}
 
   unplugin-auto-import@21.0.0(@vueuse/core@14.4.0(vue@3.5.40(typescript@6.0.3))):
     dependencies:
@@ -13124,8 +12584,6 @@ snapshots:
     dependencies:
       '@sphinxxxx/color-conversion': 2.2.2
 
-  vary@1.1.2: {}
-
   verror@1.10.1:
     dependencies:
       assert-plus: 1.0.0
@@ -13248,7 +12706,6 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.5
       yaml: 2.9.0
-    optional: true
 
   vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0)):
     dependencies:
@@ -13309,7 +12766,6 @@ snapshots:
       happy-dom: 20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - msw
-    optional: true
 
   vscode-uri@3.1.0: {}
 

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -624,6 +624,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
 
 packages:
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -47,8 +47,6 @@ catalog:
   '@rotki/eslint-plugin': 1.5.1
   '@rotki/ui-library': 2.23.4
   '@tsconfig/node24': 24.0.4
-  '@types/body-parser': 1.19.6
-  '@types/express': 5.0.6
   '@types/node': 24.13.3
   '@types/qrcode': 1.5.6
   '@types/semver': 7.8.0
@@ -68,7 +66,6 @@ catalog:
   '@walletconnect/universal-provider': 2.23.10
   autoprefixer: 10.5.4
   bignumber.js: 11.1.5
-  body-parser: 2.3.0
   bufferutil: 4.1.0
   c8: 12.0.0
   cac: 7.0.0
@@ -84,12 +81,10 @@ catalog:
   electron-window-state: 5.0.3
   es-toolkit: 1.50.0
   eslint: 10.8.0
-  express: 5.2.1
   fake-indexeddb: 6.2.5
   flag-icons: 7.5.0
   flush-promises: 1.0.2
   happy-dom: 20.11.1
-  http-proxy-middleware: 4.2.0
   httpxy: 0.5.5
   husky: 9.1.7
   imask: 7.6.1


### PR DESCRIPTION
The dev-proxy could not start without a `frontend/dev-proxy/.env` file, and the code never needed one. From there this turned into a cleanup of the proxy itself.

### 1. Do not hard-fail without a `.env`

`tsx --env-file` aborts when the file is absent, which made that file mandatory even though `PORT` and `BACKEND` have defaults and an unset `PREMIUM_COMPONENT_DIR` only disables the statistics renderer. Under `pnpm dev` those values are inherited from `start-dev` anyway. `--env-file-if-exists` keeps the standalone run reading the file when it is there.

### 2. Drop express for `node:http` + `httpxy`

The proxy needed a framework for one locally-served route, four CORS headers and a catch-all pass-through. `express`, `body-parser` and `http-proxy-middleware` (which wraps `http-proxy`) covered that; `node:http` plus `httpxy` covers the same ground, and `httpxy` is already a workspace dependency, used by the electron main process for its own dev proxy. **60 packages leave the install.**

Body handling gets simpler as a side effect: the body was only parsed so it could be re-serialized onto the proxied request, because body-parser had consumed the stream. It is now read once, kept for the `async_query` check, and replayed through httpxy's `buffer` option, so the forwarded request is byte-identical.

This also gives dev-proxy a working `tsconfig`. It resolved no node types, so it had never actually been typechecked.

### 3. Make the mock engine testable, and fix what that exposed

The mocking logic lived in closures over module state inside the server file. It moves to `mock-engine.ts` as a pure transform, and responses are proxied with `selfHandleResponse` instead of monkey-patching `res.write`.

Two ways the old rewrite silently failed:

- a response arriving in **more than one chunk** was `JSON.parse`d per chunk, threw, and the body was dropped.
- the rewritten payload kept the backend's `content-length`, set from a header write that came too late to take effect, and measured in characters rather than bytes.

Three mocking bugs:

- mock keys were matched with `mockKey.includes(requestPath)`, so a mock for `/api/1/assets/updates` also answered `/api/1/assets`, and the first declared key won. Keys now match exactly: on the full url first, so a key can pin a query string, then on the path.
- the cursor into an array-shaped mock was keyed on the full url in one branch and the path in another, so the same endpoint advanced two separate cursors depending on which branch handled the call.
- pending tasks were flipped by a single 8s interval over the whole set, with `pop()`, so a mocked async query completed anywhere between 0 and 8 seconds. Each task now carries its own timer.

### Tests

27 vitest cases over the engine, the body parser and the bundle picker, plus `test/smoke.mjs` which runs the real proxy against a stub backend for the parts that need a socket: pass-through, the statistics route, CORS, body forwarding, chunked responses, preflights and websocket upgrades.

The two tests pinning the matching and cursor bugs were verified by reintroducing each bug and confirming they fail. The first version of the matching test passed under the reintroduced bug, which is how I found I had the direction of it backwards.

CI runs `pnpm run test:proxy` (typecheck + unit tests) as a new step in the Frontend checks job, since the app typecheck filters to `rotki` and would not cover this package.

### Behaviour change worth flagging

A CORS preflight for a mocked path is now answered locally instead of making a backend round trip. The response is the same.
