### PR TITLE
dev: put the premium dev-proxy between starling and core

### DIFF
--- a/crates/starling-proxy/src/lib.rs
+++ b/crates/starling-proxy/src/lib.rs
@@ -2084,7 +2084,10 @@ mod tests {
         // reach it, which is what keeps production behaviour unchanged.
         let _ = dev;
 
-        assert_eq!(get_api_1_ping(dev_upstream_router(core, None)).await, "core");
+        assert_eq!(
+            get_api_1_ping(dev_upstream_router(core, None)).await,
+            "core"
+        );
     }
 
     #[tokio::test]

--- a/crates/starling-proxy/src/lib.rs
+++ b/crates/starling-proxy/src/lib.rs
@@ -147,6 +147,15 @@ pub struct ProxyConfig {
     pub port: u16,
     /// Loopback port of the rotki-core backend.
     pub core_port: u16,
+    /// Development-only override for where `/api/1/*` is forwarded. `None` (the
+    /// only production value) forwards to `core_port` directly.
+    ///
+    /// Set in dev to put the premium dev-proxy between this proxy and core, so
+    /// it can serve locally built premium components while the renderer still
+    /// addresses one origin. It moves the **data route only**: session
+    /// validation and the health probe keep talking to `core_port`, so a dev
+    /// tool never sits in the authentication path.
+    pub api_upstream_port: Option<u16>,
     /// Loopback port of colibri.
     pub colibri_port: u16,
     /// Loopback port of the authenticated MCP server.
@@ -187,7 +196,12 @@ type HttpClient = Client<HttpConnector, Body>;
 #[derive(Clone)]
 pub(crate) struct ProxyState {
     pub(crate) client: HttpClient,
+    /// Core itself: the session-validate call and anything else that must reach
+    /// the backend directly, never through a dev hop.
     pub(crate) core_addr: String,
+    /// Where `/api/1/*` is forwarded. Equals `core_addr` unless a dev upstream
+    /// was configured.
+    api_addr: String,
     colibri_addr: String,
     mcp_addr: String,
     mcp_enabled: bool,
@@ -324,6 +338,10 @@ fn router(config: &ProxyConfig) -> Router {
     let state = ProxyState {
         client: Client::builder(TokioExecutor::new()).build_http(),
         core_addr: format!("127.0.0.1:{}", config.core_port),
+        api_addr: format!(
+            "127.0.0.1:{}",
+            config.api_upstream_port.unwrap_or(config.core_port)
+        ),
         colibri_addr: format!("127.0.0.1:{}", config.colibri_port),
         mcp_addr: format!("127.0.0.1:{}", config.mcp_port),
         mcp_enabled: config.mcp_enabled,
@@ -561,10 +579,11 @@ async fn health(State(state): State<ProxyState>) -> Response {
         .into_response()
 }
 
-/// `/api/1/*` → core, path preserved.
+/// `/api/1/*` → core, path preserved. Goes to `api_addr`, which is core unless a
+/// dev upstream was configured.
 async fn proxy_core(State(state): State<ProxyState>, mut req: Request) -> Response {
     req.headers_mut().remove(MCP_BACKEND_PROOF_HEADER);
-    let target = format!("http://{}{}", state.core_addr, path_and_query(&req));
+    let target = format!("http://{}{}", state.api_addr, path_and_query(&req));
     let peer = peer_addr(&req);
     let req = req_with_target(req, target, peer, &state.trusted_proxies);
     forward(&state, req).await
@@ -1047,6 +1066,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: upstream,
+            api_upstream_port: None,
             colibri_port: upstream,
             mcp_port: upstream,
             mcp_enabled: true,
@@ -1218,6 +1238,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: port,
+            api_upstream_port: None,
             colibri_port: port,
             mcp_port: port,
             mcp_enabled: true,
@@ -1304,6 +1325,7 @@ mod tests {
         router(&ProxyConfig {
             port: 0,
             core_port: 1,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: 1,
             mcp_enabled: true,
@@ -1450,6 +1472,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: port,
+            api_upstream_port: None,
             colibri_port: port,
             mcp_port: port,
             mcp_enabled: true,
@@ -1478,6 +1501,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: port,
+            api_upstream_port: None,
             colibri_port: port,
             mcp_port: port,
             mcp_enabled: true,
@@ -1534,6 +1558,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 1,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: port,
             mcp_enabled: true,
@@ -1570,6 +1595,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 1,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: 1,
             mcp_enabled: true,
@@ -1600,6 +1626,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 1,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: 1,
             mcp_enabled: false,
@@ -1630,6 +1657,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 1,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: 1,
             mcp_enabled: true,
@@ -1705,6 +1733,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 1,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: 1,
             mcp_enabled: true,
@@ -1737,6 +1766,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 1,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: 1,
             mcp_enabled: true,
@@ -1772,6 +1802,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 1,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: 1,
             mcp_enabled: true,
@@ -1806,6 +1837,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 9,
+            api_upstream_port: None,
             colibri_port: 9,
             mcp_port: 9,
             mcp_enabled: true,
@@ -1835,6 +1867,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 9, // discard port; connect refused
+            api_upstream_port: None,
             colibri_port: 9,
             mcp_port: 9,
             mcp_enabled: true,
@@ -1904,6 +1937,7 @@ mod tests {
         let config = ProxyConfig {
             port: proxy_port,
             core_port: upstream_port,
+            api_upstream_port: None,
             colibri_port: upstream_port,
             mcp_port: upstream_port,
             mcp_enabled: true,
@@ -1945,6 +1979,7 @@ mod tests {
         let config = ProxyConfig {
             port: proxy_port,
             core_port: 9,
+            api_upstream_port: None,
             colibri_port: 9,
             mcp_port: 9,
             mcp_enabled: true,
@@ -1996,6 +2031,107 @@ mod tests {
         }
     }
 
+    // ---- dev api upstream -----------------------------------------------
+
+    /// A stub that answers every request with `name`, so a test can tell which
+    /// upstream a route actually reached.
+    async fn spawn_naming_upstream(name: &'static str) -> u16 {
+        let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let app = Router::new().fallback(any(move || async move { name }));
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        port
+    }
+
+    fn dev_upstream_router(core_port: u16, api_upstream_port: Option<u16>) -> Router {
+        router(&ProxyConfig {
+            port: 0,
+            core_port,
+            api_upstream_port,
+            colibri_port: core_port,
+            mcp_port: core_port,
+            mcp_enabled: true,
+            frontend_dir: None,
+            max_body_bytes: 50 * 1024 * 1024,
+            access_log: Default::default(),
+            health: None,
+            control: None,
+        })
+    }
+
+    async fn get_api_1_ping(app: Router) -> String {
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/1/ping")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        body_string(resp).await
+    }
+
+    #[tokio::test]
+    async fn the_api_route_reaches_core_without_a_dev_upstream() {
+        let core = spawn_naming_upstream("core").await;
+        let dev = spawn_naming_upstream("dev-proxy").await;
+        // `dev` is spawned but never named in the config: the default must not
+        // reach it, which is what keeps production behaviour unchanged.
+        let _ = dev;
+
+        assert_eq!(get_api_1_ping(dev_upstream_router(core, None)).await, "core");
+    }
+
+    #[tokio::test]
+    async fn the_api_route_follows_the_dev_upstream() {
+        let core = spawn_naming_upstream("core").await;
+        let dev = spawn_naming_upstream("dev-proxy").await;
+
+        assert_eq!(
+            get_api_1_ping(dev_upstream_router(core, Some(dev))).await,
+            "dev-proxy",
+        );
+    }
+
+    #[tokio::test]
+    async fn session_validation_bypasses_the_dev_upstream() {
+        // The dev-proxy must never sit in the authentication path: the control
+        // surface validates the cookie against core itself, whatever the data
+        // route was pointed at.
+        let (core, calls) = spawn_validating_core(StatusCode::OK).await;
+        let dev = spawn_naming_upstream("dev-proxy").await;
+        let app = router(&ProxyConfig {
+            port: 0,
+            core_port: core,
+            api_upstream_port: Some(dev),
+            colibri_port: 1,
+            mcp_port: 1,
+            mcp_enabled: true,
+            frontend_dir: None,
+            max_body_bytes: 50 * 1024 * 1024,
+            access_log: Default::default(),
+            health: None,
+            control: Some(echo_dispatch()),
+        });
+
+        let resp = app
+            .oneshot(control_post(r#"{"method":"status"}"#))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            calls.load(Ordering::Relaxed),
+            1,
+            "core must be the one asked to validate the cookie",
+        );
+    }
+
     // ---- /_control ------------------------------------------------------
 
     /// A stub core that answers `/api/1/session/validate` with `status` and
@@ -2029,6 +2165,7 @@ mod tests {
         router(&ProxyConfig {
             port: 0,
             core_port,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: 1,
             mcp_enabled: true,
@@ -2091,6 +2228,7 @@ mod tests {
         let app = router(&ProxyConfig {
             port: 0,
             core_port: 1,
+            api_upstream_port: None,
             colibri_port: 1,
             mcp_port: 1,
             mcp_enabled: true,

--- a/crates/starling/src/main.rs
+++ b/crates/starling/src/main.rs
@@ -222,6 +222,17 @@ struct Cli {
     #[arg(long, default_value_t = starling_core::config::DEFAULT_CORE_PORT)]
     core_port: u16,
 
+    /// Development-only: forward `/api/1/*` here instead of to `--core-port`.
+    /// Embedded-only, and ignored in docker.
+    ///
+    /// Puts the premium dev-proxy between this proxy and core, so it can serve
+    /// locally built premium components while the renderer keeps addressing one
+    /// origin. Core is still spawned and supervised on `--core-port`, and the
+    /// session-validate call still goes there directly, so this never places a
+    /// dev tool in the authentication path.
+    #[arg(long)]
+    core_upstream_port: Option<u16>,
+
     #[arg(long, default_value_t = starling_core::config::DEFAULT_COLIBRI_PORT)]
     colibri_port: u16,
 
@@ -506,8 +517,20 @@ async fn main() -> std::process::ExitCode {
                 "ignoring docker-only flags in embedded mode",
             );
         }
-    } else if cli.proxy_port.is_some() {
-        warn!("ignoring embedded-only flag --proxy-port in docker mode");
+    } else {
+        let ignored: Vec<&str> = [
+            ("--proxy-port", cli.proxy_port.is_some()),
+            ("--core-upstream-port", cli.core_upstream_port.is_some()),
+        ]
+        .into_iter()
+        .filter_map(|(name, given)| given.then_some(name))
+        .collect();
+        if !ignored.is_empty() {
+            warn!(
+                flags = ignored.join(", "),
+                "ignoring embedded-only flags in docker mode",
+            );
+        }
     }
 
     // Guard the MiB -> bytes conversion: clap accepts any usize, and an
@@ -894,6 +917,8 @@ async fn main() -> std::process::ExitCode {
         let config = ProxyConfig {
             port,
             core_port: cli.core_port,
+            // Embedded-only; the docker branch above warns and drops it.
+            api_upstream_port: (!docker).then_some(cli.core_upstream_port).flatten(),
             colibri_port: cli.colibri_port,
             mcp_port: cli.mcp_port,
             mcp_enabled: cookie_auth,

--- a/frontend/app/electron/main/app-config.ts
+++ b/frontend/app/electron/main/app-config.ts
@@ -11,5 +11,12 @@ export interface AppConfig {
     corePort: number;
     mcpPort: number;
     proxyPort: number;
+    /**
+     * Dev only: the premium dev-proxy's port, when `pnpm dev` started one.
+     * starling forwards `/api/1/*` there instead of straight to core, so the
+     * proxy can serve locally built premium components. Undefined in every
+     * packaged build and in any dev run without the proxy.
+     */
+    coreUpstreamPort?: number;
   };
 }

--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -30,6 +30,15 @@ function instancePort(envKey: string, fallback: number): number {
   return Number.isFinite(port) && port > 0 ? port : fallback;
 }
 
+/** A port that is meaningful only by its presence, so absence stays undefined. */
+function optionalPort(envKey: string): number | undefined {
+  const raw = process.env[envKey];
+  if (!raw)
+    return undefined;
+  const port = Number.parseInt(raw, 10);
+  return Number.isFinite(port) && port > 0 ? port : undefined;
+}
+
 export class Application {
   private readonly window: WindowManager;
   private readonly tray: TrayManager;
@@ -48,6 +57,9 @@ export class Application {
       corePort: instancePort('ROTKI_INSTANCE_CORE_PORT', DEFAULT_PORT),
       mcpPort: instancePort('ROTKI_INSTANCE_MCP_PORT', DEFAULT_MCP_PORT),
       proxyPort: instancePort('ROTKI_INSTANCE_PROXY_PORT', DEFAULT_PROXY_PORT),
+      // No fallback: absent means no dev-proxy, and starling must then be left
+      // pointing at core.
+      coreUpstreamPort: optionalPort('ROTKI_DEV_CORE_UPSTREAM_PORT'),
     },
   };
 

--- a/frontend/app/electron/main/starling-handler.spec.ts
+++ b/frontend/app/electron/main/starling-handler.spec.ts
@@ -159,6 +159,35 @@ describe('starlingHandler', () => {
     );
   });
 
+  // The dev-proxy sits between starling and core, so starling has to be told its
+  // port. The renderer keeps the proxy origin either way — it is starling that
+  // routes through the dev tool, not the app.
+  it('should not name a core upstream when no dev-proxy was started', async () => {
+    spawnMock.mockImplementation(() => makeFakeChild(nullResponder));
+    const handler = new StarlingHandler(makeLogger(), makeConfig());
+
+    await handler.restartBackend({}, { onProcessError: vi.fn() });
+
+    expect(buildStarlingInvocationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ coreUpstreamPort: undefined }),
+    );
+  });
+
+  it('should pass the dev-proxy port through to starling when one was started', async () => {
+    spawnMock.mockImplementation(() => makeFakeChild(nullResponder));
+    const config = makeConfig();
+    const handler = new StarlingHandler(
+      makeLogger(),
+      { ...config, ports: { ...config.ports, coreUpstreamPort: 4243 } },
+    );
+
+    await handler.restartBackend({}, { onProcessError: vi.fn() });
+
+    expect(buildStarlingInvocationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ coreUpstreamPort: 4243, corePort: 4242 }),
+    );
+  });
+
   it('should publish and launch MCP on an available port', async () => {
     selectPortMock.mockImplementation(async (port: number) => port === 4445 ? 4450 : port);
     const child = makeFakeChild(nullResponder);

--- a/frontend/app/electron/main/starling-handler.spec.ts
+++ b/frontend/app/electron/main/starling-handler.spec.ts
@@ -188,6 +188,35 @@ describe('starlingHandler', () => {
     );
   });
 
+  it('should refuse to start when core cannot bind the port the dev-proxy forwards to', async () => {
+    // Coming up on another port would leave the proxy pointed at nothing, so
+    // every /api/1/* request would fail with the app looking healthy otherwise.
+    selectPortMock.mockImplementation(async (port: number) => port === 4242 ? 4250 : port);
+    spawnMock.mockImplementation(() => makeFakeChild(nullResponder));
+    const config = makeConfig();
+    const handler = new StarlingHandler(
+      makeLogger(),
+      { ...config, ports: { ...config.ports, coreUpstreamPort: 4243 } },
+    );
+    const onProcessError = vi.fn();
+
+    await handler.restartBackend({}, { onProcessError });
+
+    expect(onProcessError).toHaveBeenCalledWith(expect.stringContaining('4242'), BackendCode.TERMINATED);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('should still let core move to a free port when no dev-proxy is in the chain', async () => {
+    selectPortMock.mockImplementation(async (port: number) => port === 4242 ? 4250 : port);
+    spawnMock.mockImplementation(() => makeFakeChild(nullResponder));
+    const onProcessError = vi.fn();
+
+    await new StarlingHandler(makeLogger(), makeConfig()).restartBackend({}, { onProcessError });
+
+    expect(onProcessError).not.toHaveBeenCalled();
+    expect(buildStarlingInvocationMock).toHaveBeenCalledWith(expect.objectContaining({ corePort: 4250 }));
+  });
+
   it('should publish and launch MCP on an available port', async () => {
     selectPortMock.mockImplementation(async (port: number) => port === 4445 ? 4450 : port);
     const child = makeFakeChild(nullResponder);

--- a/frontend/app/electron/main/starling-handler.ts
+++ b/frontend/app/electron/main/starling-handler.ts
@@ -151,6 +151,10 @@ export class StarlingHandler {
       colibriPort,
       mcpPort,
       proxyPort,
+      // Only set when `pnpm dev` started the premium dev-proxy, which then sits
+      // between starling and core. The renderer keeps addressing the proxy origin
+      // set above either way.
+      coreUpstreamPort: this.config.ports.coreUpstreamPort,
       apiHost: API_HOST,
       logsDir,
       options,

--- a/frontend/app/electron/main/starling-handler.ts
+++ b/frontend/app/electron/main/starling-handler.ts
@@ -134,6 +134,19 @@ export class StarlingHandler {
     this.exiting = false;
 
     const corePort = await this.resolvePort(StarlingService.CORE);
+    // The dev-proxy is handed core's port when `pnpm dev` spawns it and cannot
+    // learn a new one, so core probing upward would leave it forwarding
+    // `/api/1/*` to a dead port. Refuse rather than come up broken: the whole
+    // point of the proxy being in the chain is that it is in the chain.
+    if (this.config.ports.coreUpstreamPort !== undefined && corePort !== this.config.ports.corePort) {
+      listener.onProcessError(
+        `The dev-proxy is forwarding to port ${this.config.ports.corePort}, but that port is taken `
+        + `and core would bind ${corePort} instead. Free it, or restart without the dev-proxy `
+        + '(unset PREMIUM_COMPONENT_DIR, or pass --no-proxy).',
+        BackendCode.TERMINATED,
+      );
+      return;
+    }
     const colibriPort = await this.resolvePort(StarlingService.COLIBRI);
     const mcpPort = await this.resolvePort(StarlingService.MCP);
     const proxyPort = await this.resolvePort(StarlingService.PROXY);

--- a/frontend/app/scripts/start-starling.ts
+++ b/frontend/app/scripts/start-starling.ts
@@ -2,8 +2,9 @@ import path from 'node:path';
 import process from 'node:process';
 import { cac } from 'cac';
 import consola from 'consola';
-import { buildStarlingInvocation, describeResolvedCore, SHUTDOWN_GRACE_SECS, type StarlingBackendOptions, type StarlingInvocation } from '../shared/starling/starling-args';
+import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingBackendOptions, type StarlingInvocation } from '../shared/starling/starling-args';
 import { requestStarlingStart, spawnStarling } from '../shared/starling/starling-launch';
+import { describeResolvedCore } from '../shared/starling/starling-launchers';
 import { StarlingMethod } from '../shared/starling/starling-protocol';
 import { StarlingRpc } from '../shared/starling/starling-rpc';
 

--- a/frontend/app/shared/port-utils.ts
+++ b/frontend/app/shared/port-utils.ts
@@ -23,6 +23,23 @@ async function checkAvailability(port: number, host: string): Promise<number> {
   });
 }
 
+/**
+ * Whether a port can be bound right now. For callers that must have one exact
+ * port rather than the next free one, so they can fail with their own message
+ * instead of silently landing somewhere else.
+ */
+export async function isPortFree(port: number, host: string = 'localhost'): Promise<boolean> {
+  try {
+    await checkAvailability(port, host);
+    return true;
+  }
+  catch (error: any) {
+    if (['EADDRINUSE', 'EACCES'].includes(error.code))
+      return false;
+    throw error;
+  }
+}
+
 export async function selectPort(startPort: number = DEFAULT_PORT, host: string = 'localhost'): Promise<number> {
   for (let portNumber = startPort; portNumber <= 65535; portNumber++) {
     try {

--- a/frontend/app/shared/starling/starling-args.spec.ts
+++ b/frontend/app/shared/starling/starling-args.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { describeResolvedCore } from './starling-args';
+import { describeResolvedCore } from './starling-launchers';
 
 // The dev launchers probe the filesystem (is the warm-up build there?) and shell
 // out to uv (which interpreter?). Both are mocked so these run identically on a
@@ -223,6 +223,25 @@ describe('buildStarlingInvocation (dev launchers)', () => {
     existsSyncMock.mockReturnValue(true);
     const invocation = await buildDevInvocation();
     expect(invocation.env).toBeUndefined();
+  });
+
+  // The dev-proxy sits between starling and core, so starling has to be told to
+  // forward `/api/1/*` through it. Off by default: without the flag a run is
+  // byte-identical to what it was before the option existed.
+  it('should not name a core upstream unless the dev-proxy is on', async () => {
+    existsSyncMock.mockReturnValue(true);
+    const { args } = await buildDevInvocation();
+    expect(args).not.toContain('--core-upstream-port');
+  });
+
+  it('should point starling at the dev-proxy when one was allocated', async () => {
+    existsSyncMock.mockReturnValue(true);
+    vi.resetModules();
+    const { buildStarlingInvocation } = await import('./starling-args');
+    const { args } = buildStarlingInvocation({ ...devInput, coreUpstreamPort: 4243 });
+    expect(flagValue(args, '--core-upstream-port')).toBe('4243');
+    // Core is still spawned and supervised on its own port; only the data route moves.
+    expect(flagValue(args, '--core-port')).toBe('4242');
   });
 
   // StarlingHandler.stop() outwaits this same constant before it SIGKILLs, so

--- a/frontend/app/shared/starling/starling-args.ts
+++ b/frontend/app/shared/starling/starling-args.ts
@@ -1,22 +1,14 @@
-import { execSync } from 'node:child_process';
-import fs from 'node:fs';
 import path from 'node:path';
-import process from 'node:process';
 import { buildCargoEnv } from '../cargo-env';
-import { shouldUseUv } from '../uv';
-import { BACKEND_DIRECTORY, findCoreBinary, resolveCoreBinary, resourcesDir } from './starling-paths';
-
-const COLIBRI_DIRECTORY = 'colibri';
-const STARLING_DIRECTORY = 'starling';
-
-/**
- * Where a frozen core lands outside a packaged build, repo-root relative. Under
- * `target/` alongside the Rust binaries because that is where CI already drops
- * the artifacts it builds once and ships to the jobs that consume them, and it
- * is gitignored. Nothing writes here by default: a dev run without a freeze
- * falls through to the interpreter.
- */
-const DEV_BACKEND_DIRECTORY = path.join('target', BACKEND_DIRECTORY);
+import {
+  devBuiltBinary,
+  devColibriLauncherArgs,
+  devCoreLauncherArgs,
+  packagedLauncherArgs,
+  repoRoot,
+  resolveStarlingBinary,
+  STARLING_DIRECTORY,
+} from './starling-launchers';
 
 /**
  * Grace period starling gives the backend tree to exit before escalating to a
@@ -74,6 +66,12 @@ export interface StarlingLaunchInput {
   mcpPort: number;
   /** Loopback port the in-process reverse proxy binds; the single renderer origin. */
   proxyPort: number;
+  /**
+   * Dev only: forward `/api/1/*` here instead of straight to `corePort`, putting
+   * the premium dev-proxy between starling and core. The renderer keeps
+   * addressing starling either way, so nothing downstream changes.
+   */
+  coreUpstreamPort?: number;
   /** Loopback host the backends bind (always 127.0.0.1 in embedded mode). */
   apiHost: string;
   /** Directory starling writes service logs to (owned by LogService). */
@@ -100,67 +98,6 @@ export interface StarlingLaunchInput {
    * refreshes. A launch fact, so it rides the CLI rather than BackendOptions.
    */
   disableTaskManager?: boolean;
-}
-
-/**
- * Ask uv for the interpreter path rather than launching through `uv run`.
- *
- * starling must spawn the service itself, never a wrapper around it: it signals
- * the whole process group but `wait()`s only on its direct child, so a wrapper
- * that dies faster than the service reports "stopped" while the service is still
- * shutting down - starling then exits and the process-tree reap kills it
- * mid-flight. `uv run` does exactly that on windows: it installs no console-ctrl
- * handler, so CTRL_BREAK kills it instantly (0xC000013A) while python is still
- * closing its database, which leaves the sqlite WAL/SHM behind. Resolving the
- * interpreter up front keeps uv's environment handling and gives starling the
- * real process, matching the packaged launcher exactly.
- *
- * Returns undefined when uv can't answer, leaving the caller on its `python`
- * fallback.
- */
-let resolvedUvPython: string | null | undefined;
-
-function uvPythonPath(root: string): string | undefined {
-  // Re-resolve if the cached interpreter has since gone (a venv recreated mid
-  // session): the path is cached for the whole electron run, and a stale one
-  // would otherwise fail every restart with ENOENT until the app is restarted.
-  if (resolvedUvPython && !fs.existsSync(resolvedUvPython))
-    resolvedUvPython = undefined;
-
-  if (resolvedUvPython === undefined) {
-    try {
-      // `--no-sync`: the dev warm-up has already run `uv sync --locked`, so this
-      // only has to report the interpreter. Skipping the resolve keeps it off the
-      // seconds-long path — this runs synchronously on the electron main thread.
-      const out = execSync('uv run --no-sync python -c "import sys; print(sys.executable)"', {
-        cwd: root,
-        encoding: 'utf-8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-      });
-      // Only the last line is ours: anything else uv chose to put on stdout would
-      // otherwise be spliced into the path and spawned verbatim. `trimEnd` first
-      // so the trailing newline does not make the last line an empty one.
-      // (`findLast` would read better but this file is typechecked under the
-      // renderer's DOM config, which pins lib to ES2022 to match vite's target.)
-      const exe = out.trimEnd().split('\n').pop()?.trim();
-      resolvedUvPython = exe && fs.existsSync(exe) ? exe : null;
-    }
-    catch {
-      resolvedUvPython = null;
-    }
-  }
-  return resolvedUvPython ?? undefined;
-}
-
-/** Absolute repo root, resolved from the electron app's cwd (`frontend/app`). */
-function repoRoot(): string {
-  return path.resolve(process.cwd(), '..', '..');
-}
-
-/** The bundled `starling` supervisor binary path for packaged builds. */
-function resolveStarlingBinary(): string {
-  const binary = process.platform === 'win32' ? 'starling.exe' : 'starling';
-  return path.join(resourcesDir(), STARLING_DIRECTORY, binary);
 }
 
 /**
@@ -225,137 +162,13 @@ function commonStarlingArgs(input: StarlingLaunchInput): string[] {
     args.push('--disable-task-manager');
   }
 
+  // Omitted unless the dev-proxy is on, so a normal run is byte-identical to
+  // what it was before the flag existed.
+  if (input.coreUpstreamPort !== undefined) {
+    args.push('--core-upstream-port', input.coreUpstreamPort.toString());
+  }
+
   return args;
-}
-
-/** `[--flag=token, …]` for a launcher prefix (`--locked` etc. need the `=` form). */
-function prefixFlags(flag: string, tokens: string[]): string[] {
-  return tokens.map(token => `${flag}=${token}`);
-}
-
-/** Which core a built invocation resolved to, for launchers that want to report it. */
-export interface ResolvedCore {
-  kind: 'frozen' | 'interpreter';
-  binary?: string;
-}
-
-/**
- * Read back the core an invocation resolved to.
- *
- * `devCoreLauncherArgs` falls back to the interpreter silently when it finds no frozen build, and
- * nothing downstream records which one ran, so a wrong artifact path yields a passing run that
- * looks identical to a real one. The interpreter branch is the only one needing a prefix, since it
- * has to say `-m rotkehlchen`; the frozen binary is its own entrypoint. Prefix tokens arrive one
- * per flag as `--core-prefix=<token>`, so this matches the `=` form and not a bare flag.
- */
-export function describeResolvedCore(args: string[]): ResolvedCore {
-  const index = args.indexOf('--core-binary');
-  return {
-    binary: index === -1 ? undefined : args[index + 1],
-    kind: args.some(arg => arg.startsWith('--core-prefix=')) ? 'interpreter' : 'frozen',
-  };
-}
-
-/**
- * The dev core launcher: a profiling command, the interpreter uv resolves, or a
- * bare `python -m rotkehlchen` - whichever the dev environment dictates. Every
- * branch hands starling a real interpreter rather than a wrapper (see
- * `uvPythonPath`); with a venv active, `python` is already the venv's own.
- */
-function devCoreLauncherArgs(root: string): string[] {
-  // A frozen core, when the build job shipped one (see DEV_BACKEND_DIRECTORY).
-  // Preferred over the interpreter for the same reason the packaged build uses
-  // it: it exercises what actually ships, so a missing hidden import or data
-  // file fails the e2e run rather than a release. No prefix - the binary is the
-  // entrypoint, so `-m rotkehlchen` must not be passed - and its own directory
-  // is the cwd, exactly as `packagedLauncherArgs` does.
-  const frozen = findCoreBinary(path.join(root, DEV_BACKEND_DIRECTORY));
-  if (frozen)
-    return ['--core-binary', frozen.binary, '--core-cwd', frozen.dir];
-
-  const profilingCmd = process.env.ROTKI_BACKEND_PROFILING_CMD;
-  const profilingArgs = process.env.ROTKI_BACKEND_PROFILING_ARGS;
-  // Interpreter args, so they precede `-m`: opt out of the GIL on a free-threaded
-  // build. Same switch the web-mode launcher reads (`scripts/dev/services.ts`).
-  const interpreterArgs = process.env.ROTKI_GIL === 'false' ? ['-X', 'gil=0'] : [];
-  const moduleArgs = ['-m', 'rotkehlchen'];
-
-  let binary: string;
-  let prefix: string[];
-  if (profilingCmd) {
-    // The profiler runs python, so its own args come first and the interpreter
-    // args attach to the `python` it launches.
-    prefix = [
-      ...(profilingArgs?.split(' ') ?? []).filter(Boolean),
-      'python',
-      ...interpreterArgs,
-      ...moduleArgs,
-    ];
-    binary = profilingCmd;
-  }
-  else {
-    binary = (shouldUseUv() ? uvPythonPath(root) : undefined) ?? 'python';
-    prefix = [...interpreterArgs, ...moduleArgs];
-  }
-
-  return ['--core-binary', binary, ...prefixFlags('--core-prefix', prefix), '--core-cwd', root];
-}
-
-/**
- * A prebuilt binary for one of the Rust services, if there is one. Debug first,
- * since that is what the dev warm-up builds and what a developer expects their
- * last `cargo build` to have produced. Release is the fallback because CI builds
- * the services once with `--release` and ships only those binaries to the jobs
- * that consume them, where there is no cargo to fall back to.
- */
-function devBuiltBinary(targetDir: string, name: string): string | undefined {
-  const exe = process.platform === 'win32' ? `${name}.exe` : name;
-  return ['debug', 'release']
-    .map(profile => path.join(targetDir, profile, exe))
-    .find(candidate => fs.existsSync(candidate));
-}
-
-/**
- * The dev colibri launcher: the binary the Rust warm-up built, falling back to
- * `cargo run --locked --` when it is missing (electron started without the
- * warm-up). The binary is preferred for the same reason core resolves its
- * interpreter - `cargo run` is a wrapper starling would `wait()` on instead of
- * colibri itself. The fallback keeps a warm-less launch working; colibri shuts
- * down in well under a millisecond, so losing the race there is unlikely.
- */
-function devColibriLauncherArgs(root: string): { args: string[]; usesCargo: boolean } {
-  const cwd = path.join(root, COLIBRI_DIRECTORY);
-  const built = devBuiltBinary(path.join(root, 'target'), COLIBRI_DIRECTORY);
-  if (built)
-    return { args: ['--colibri-binary', built, '--colibri-cwd', cwd], usesCargo: false };
-
-  return {
-    args: [
-      '--colibri-binary',
-      'cargo',
-      ...prefixFlags('--colibri-prefix', ['run', '--locked', '--']),
-      '--colibri-cwd',
-      cwd,
-    ],
-    usesCargo: true,
-  };
-}
-
-/** Packaged launchers: direct binaries, each run from its own directory. */
-function packagedLauncherArgs(): string[] {
-  const core = resolveCoreBinary();
-  const colibriDir = path.join(resourcesDir(), COLIBRI_DIRECTORY);
-  const colibriBinary = process.platform === 'win32' ? 'colibri.exe' : 'colibri';
-  return [
-    '--core-binary',
-    core.binary,
-    '--core-cwd',
-    core.dir,
-    '--colibri-binary',
-    path.join(colibriDir, colibriBinary),
-    '--colibri-cwd',
-    colibriDir,
-  ];
 }
 
 /**

--- a/frontend/app/shared/starling/starling-launchers.ts
+++ b/frontend/app/shared/starling/starling-launchers.ts
@@ -1,0 +1,216 @@
+/**
+ * How each service is actually launched: which binary, from which directory,
+ * behind which prefix. Split out of `starling-args.ts`, which owns the
+ * supervisor's own arguments — this half answers "what runs", that half answers
+ * "how it is configured".
+ */
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { shouldUseUv } from '../uv';
+import { BACKEND_DIRECTORY, findCoreBinary, resolveCoreBinary, resourcesDir } from './starling-paths';
+
+const COLIBRI_DIRECTORY = 'colibri';
+
+export const STARLING_DIRECTORY = 'starling';
+
+/**
+ * Where a frozen core lands outside a packaged build, repo-root relative. Under
+ * `target/` alongside the Rust binaries because that is where CI already drops
+ * the artifacts it builds once and ships to the jobs that consume them, and it
+ * is gitignored. Nothing writes here by default: a dev run without a freeze
+ * falls through to the interpreter.
+ */
+const DEV_BACKEND_DIRECTORY = path.join('target', BACKEND_DIRECTORY);
+
+/**
+ * Ask uv for the interpreter path rather than launching through `uv run`.
+ *
+ * starling must spawn the service itself, never a wrapper around it: it signals
+ * the whole process group but `wait()`s only on its direct child, so a wrapper
+ * that dies faster than the service reports "stopped" while the service is still
+ * shutting down - starling then exits and the process-tree reap kills it
+ * mid-flight. `uv run` does exactly that on windows: it installs no console-ctrl
+ * handler, so CTRL_BREAK kills it instantly (0xC000013A) while python is still
+ * closing its database, which leaves the sqlite WAL/SHM behind. Resolving the
+ * interpreter up front keeps uv's environment handling and gives starling the
+ * real process, matching the packaged launcher exactly.
+ *
+ * Returns undefined when uv can't answer, leaving the caller on its `python`
+ * fallback.
+ */
+let resolvedUvPython: string | null | undefined;
+
+function uvPythonPath(root: string): string | undefined {
+  // Re-resolve if the cached interpreter has since gone (a venv recreated mid
+  // session): the path is cached for the whole electron run, and a stale one
+  // would otherwise fail every restart with ENOENT until the app is restarted.
+  if (resolvedUvPython && !fs.existsSync(resolvedUvPython))
+    resolvedUvPython = undefined;
+
+  if (resolvedUvPython === undefined) {
+    try {
+      // `--no-sync`: the dev warm-up has already run `uv sync --locked`, so this
+      // only has to report the interpreter. Skipping the resolve keeps it off the
+      // seconds-long path — this runs synchronously on the electron main thread.
+      const out = execSync('uv run --no-sync python -c "import sys; print(sys.executable)"', {
+        cwd: root,
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      // Only the last line is ours: anything else uv chose to put on stdout would
+      // otherwise be spliced into the path and spawned verbatim. `trimEnd` first
+      // so the trailing newline does not make the last line an empty one.
+      // (`findLast` would read better but this file is typechecked under the
+      // renderer's DOM config, which pins lib to ES2022 to match vite's target.)
+      const exe = out.trimEnd().split('\n').pop()?.trim();
+      resolvedUvPython = exe && fs.existsSync(exe) ? exe : null;
+    }
+    catch {
+      resolvedUvPython = null;
+    }
+  }
+  return resolvedUvPython ?? undefined;
+}
+
+/** Absolute repo root, resolved from the electron app's cwd (`frontend/app`). */
+export function repoRoot(): string {
+  return path.resolve(process.cwd(), '..', '..');
+}
+
+/** The bundled `starling` supervisor binary path for packaged builds. */
+export function resolveStarlingBinary(): string {
+  const binary = process.platform === 'win32' ? 'starling.exe' : 'starling';
+  return path.join(resourcesDir(), STARLING_DIRECTORY, binary);
+}
+
+/** `[--flag=token, …]` for a launcher prefix (`--locked` etc. need the `=` form). */
+function prefixFlags(flag: string, tokens: string[]): string[] {
+  return tokens.map(token => `${flag}=${token}`);
+}
+
+/** Which core a built invocation resolved to, for launchers that want to report it. */
+export interface ResolvedCore {
+  kind: 'frozen' | 'interpreter';
+  binary?: string;
+}
+
+/**
+ * Read back the core an invocation resolved to.
+ *
+ * `devCoreLauncherArgs` falls back to the interpreter silently when it finds no frozen build, and
+ * nothing downstream records which one ran, so a wrong artifact path yields a passing run that
+ * looks identical to a real one. The interpreter branch is the only one needing a prefix, since it
+ * has to say `-m rotkehlchen`; the frozen binary is its own entrypoint. Prefix tokens arrive one
+ * per flag as `--core-prefix=<token>`, so this matches the `=` form and not a bare flag.
+ */
+export function describeResolvedCore(args: string[]): ResolvedCore {
+  const index = args.indexOf('--core-binary');
+  return {
+    binary: index === -1 ? undefined : args[index + 1],
+    kind: args.some(arg => arg.startsWith('--core-prefix=')) ? 'interpreter' : 'frozen',
+  };
+}
+
+/**
+ * The dev core launcher: a profiling command, the interpreter uv resolves, or a
+ * bare `python -m rotkehlchen` - whichever the dev environment dictates. Every
+ * branch hands starling a real interpreter rather than a wrapper (see
+ * `uvPythonPath`); with a venv active, `python` is already the venv's own.
+ */
+export function devCoreLauncherArgs(root: string): string[] {
+  // A frozen core, when the build job shipped one (see DEV_BACKEND_DIRECTORY).
+  // Preferred over the interpreter for the same reason the packaged build uses
+  // it: it exercises what actually ships, so a missing hidden import or data
+  // file fails the e2e run rather than a release. No prefix - the binary is the
+  // entrypoint, so `-m rotkehlchen` must not be passed - and its own directory
+  // is the cwd, exactly as `packagedLauncherArgs` does.
+  const frozen = findCoreBinary(path.join(root, DEV_BACKEND_DIRECTORY));
+  if (frozen)
+    return ['--core-binary', frozen.binary, '--core-cwd', frozen.dir];
+
+  const profilingCmd = process.env.ROTKI_BACKEND_PROFILING_CMD;
+  const profilingArgs = process.env.ROTKI_BACKEND_PROFILING_ARGS;
+  // Interpreter args, so they precede `-m`: opt out of the GIL on a free-threaded
+  // build. Same switch the web-mode launcher reads (`scripts/dev/services.ts`).
+  const interpreterArgs = process.env.ROTKI_GIL === 'false' ? ['-X', 'gil=0'] : [];
+  const moduleArgs = ['-m', 'rotkehlchen'];
+
+  let binary: string;
+  let prefix: string[];
+  if (profilingCmd) {
+    // The profiler runs python, so its own args come first and the interpreter
+    // args attach to the `python` it launches.
+    prefix = [
+      ...(profilingArgs?.split(' ') ?? []).filter(Boolean),
+      'python',
+      ...interpreterArgs,
+      ...moduleArgs,
+    ];
+    binary = profilingCmd;
+  }
+  else {
+    binary = (shouldUseUv() ? uvPythonPath(root) : undefined) ?? 'python';
+    prefix = [...interpreterArgs, ...moduleArgs];
+  }
+
+  return ['--core-binary', binary, ...prefixFlags('--core-prefix', prefix), '--core-cwd', root];
+}
+
+/**
+ * A prebuilt binary for one of the Rust services, if there is one. Debug first,
+ * since that is what the dev warm-up builds and what a developer expects their
+ * last `cargo build` to have produced. Release is the fallback because CI builds
+ * the services once with `--release` and ships only those binaries to the jobs
+ * that consume them, where there is no cargo to fall back to.
+ */
+export function devBuiltBinary(targetDir: string, name: string): string | undefined {
+  const exe = process.platform === 'win32' ? `${name}.exe` : name;
+  return ['debug', 'release']
+    .map(profile => path.join(targetDir, profile, exe))
+    .find(candidate => fs.existsSync(candidate));
+}
+
+/**
+ * The dev colibri launcher: the binary the Rust warm-up built, falling back to
+ * `cargo run --locked --` when it is missing (electron started without the
+ * warm-up). The binary is preferred for the same reason core resolves its
+ * interpreter - `cargo run` is a wrapper starling would `wait()` on instead of
+ * colibri itself. The fallback keeps a warm-less launch working; colibri shuts
+ * down in well under a millisecond, so losing the race there is unlikely.
+ */
+export function devColibriLauncherArgs(root: string): { args: string[]; usesCargo: boolean } {
+  const cwd = path.join(root, COLIBRI_DIRECTORY);
+  const built = devBuiltBinary(path.join(root, 'target'), COLIBRI_DIRECTORY);
+  if (built)
+    return { args: ['--colibri-binary', built, '--colibri-cwd', cwd], usesCargo: false };
+
+  return {
+    args: [
+      '--colibri-binary',
+      'cargo',
+      ...prefixFlags('--colibri-prefix', ['run', '--locked', '--']),
+      '--colibri-cwd',
+      cwd,
+    ],
+    usesCargo: true,
+  };
+}
+
+/** Packaged launchers: direct binaries, each run from its own directory. */
+export function packagedLauncherArgs(): string[] {
+  const core = resolveCoreBinary();
+  const colibriDir = path.join(resourcesDir(), COLIBRI_DIRECTORY);
+  const colibriBinary = process.platform === 'win32' ? 'colibri.exe' : 'colibri';
+  return [
+    '--core-binary',
+    core.binary,
+    '--core-cwd',
+    core.dir,
+    '--colibri-binary',
+    path.join(colibriDir, colibriBinary),
+    '--colibri-cwd',
+    colibriDir,
+  ];
+}

--- a/frontend/dev-proxy/README.md
+++ b/frontend/dev-proxy/README.md
@@ -136,6 +136,12 @@ Look into the `async-mock.example.json` file in this directory and copy it to
 You can put the mocked URL on the root of the JSON and under that add the
 request verb. The verb's value can either be an object or an array:
 
+A declared mock replaces the response **whatever the backend answered**, including
+a rejection: faking a premium endpoint the dev backend answers with 402, or one it
+has not implemented, is most of what this is for. The task endpoints are the
+exception — they merge into the backend's own answer, so they are left alone
+unless it returned a 2xx.
+
 - **Object** — returned every time you query the same endpoint/verb combination.
 - **Array** — each request returns the next index. The first request serves
   index `0`, the second serves `1`, etc. When the end is reached the last item
@@ -162,8 +168,13 @@ request verb. The verb's value can either be an object or an array:
   query string, then on the path alone.
 - A mocked async query reports as pending for
   `DEFAULT_TASK_COMPLETION_MS` (8s) and completed after that.
-- WebSocket forwarding is enabled (`ws: true`), so the backend's `/ws/`
-  endpoint reaches the renderer through the same proxy hop.
+- Under `pnpm dev` the proxy is an internal hop **inside** starling
+  (`frontend → starling → dev-proxy → core`), so it only ever sees `/api/1/*`.
+  `/colibri/*`, `/ws/*` and `/_control` never leave starling. WebSocket
+  forwarding (`ws: true`) and the CORS headers therefore matter only when
+  something addresses the proxy directly, as in the standalone run below.
+- A backend it cannot reach is answered with a 502 rather than left hanging,
+  which matters because every `/api/1/*` call now passes through here.
 
 ## Tests
 

--- a/frontend/dev-proxy/src/index.ts
+++ b/frontend/dev-proxy/src/index.ts
@@ -120,8 +120,11 @@ function onProxyRes(proxyRes: IncomingMessage, req: IncomingMessage, res: Server
     // The rewritten payload has its own length, and is never chunked.
     copyHeaders(proxyRes, res, ['content-length', 'transfer-encoding']);
     res.setHeader('content-length', payload.byteLength.toString());
+    // Deliberately unlogged: the task poll runs on a timer, so a line per
+    // rewrite is one every couple of seconds and drowns everything else. What is
+    // worth seeing already logs itself — a mock task appearing and completing,
+    // and each renderer bundle served.
     res.end(payload);
-    consola.info('Handled request:', req.method, req.url);
   });
 }
 

--- a/frontend/dev-proxy/src/index.ts
+++ b/frontend/dev-proxy/src/index.ts
@@ -13,6 +13,8 @@ import { applyCors } from './setup';
 
 consola.level = LogLevels.debug;
 
+const HTTP_BAD_GATEWAY = 502;
+
 const port = Number.parseInt(process.env.PORT ?? '4243', 10);
 const backend = process.env.BACKEND ?? 'http://127.0.0.1:4242';
 const componentsDir = process.env.PREMIUM_COMPONENT_DIR;
@@ -56,9 +58,28 @@ function describe(req: IncomingMessage): MockRequest {
   };
 }
 
+/**
+ * Per-connection headers, which describe the hop they arrived on and must not be
+ * forwarded to the next one. `selfHandleResponse` skips httpxy's own outgoing
+ * passes, which would otherwise strip these, so this is the only thing between
+ * the backend and the client: an upstream `Connection: close` copied through
+ * would tear down the client's keep-alive for no reason.
+ */
+const HOP_BY_HOP_HEADERS = [
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+];
+
 function copyHeaders(proxyRes: IncomingMessage, res: ServerResponse, omit: string[] = []): void {
   for (const [key, value] of Object.entries(proxyRes.headers)) {
-    if (value === undefined || omit.includes(key.toLocaleLowerCase()))
+    const name = key.toLocaleLowerCase();
+    if (value === undefined || omit.includes(name) || HOP_BY_HOP_HEADERS.includes(name))
       continue;
 
     res.setHeader(key, value);
@@ -72,16 +93,24 @@ function copyHeaders(proxyRes: IncomingMessage, res: ServerResponse, omit: strin
  * have to be inflated to be parsed, and the backend does not compress in dev.
  */
 function canRewrite(req: IncomingMessage, proxyRes: IncomingMessage): boolean {
-  if (!engine.handles(describe(req)))
-    return false;
-
-  // Rewriting an error into a 200 would hide it: a 401 on the task endpoint
-  // would read as "no tasks running" rather than as a failure.
-  const status = proxyRes.statusCode ?? 200;
-  if (status < 200 || status > 299)
+  const request = describe(req);
+  if (!engine.handles(request))
     return false;
 
   if (proxyRes.headers['content-encoding'])
+    return false;
+
+  // A declared mock replaces the response outright, so it applies whatever the
+  // backend said — faking an endpoint the dev backend rejects (a premium 402, an
+  // unimplemented 404) is most of what async-mock.json is for.
+  if (engine.isMocked(request))
+    return true;
+
+  // The task endpoints merge into the backend's own answer, so they need it to be
+  // one: rewriting an error into a 200 would report "no tasks running" for what
+  // is actually a failure.
+  const status = proxyRes.statusCode ?? 200;
+  if (status < 200 || status > 299)
     return false;
 
   return (proxyRes.headers['content-type'] ?? '').toLocaleLowerCase().includes('application/json');
@@ -99,9 +128,20 @@ function onProxyRes(proxyRes: IncomingMessage, req: IncomingMessage, res: Server
   proxyRes.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
   proxyRes.on('end', () => {
     const raw = Buffer.concat(chunks);
+    // A rejected or non-JSON body is still worth handing to the engine: a mock
+    // ignores it entirely. Only the task merge needs it, and that path is gated
+    // on a 2xx JSON response above.
+    let backend: unknown;
+    try {
+      backend = JSON.parse(raw.toString());
+    }
+    catch {
+      backend = undefined;
+    }
+
     let rewritten: unknown;
     try {
-      rewritten = engine.transformResponse(describe(req), JSON.parse(raw.toString()));
+      rewritten = engine.transformResponse(describe(req), backend);
     }
     catch (error) {
       consola.error(error);
@@ -117,8 +157,8 @@ function onProxyRes(proxyRes: IncomingMessage, req: IncomingMessage, res: Server
     const payload = Buffer.from(JSON.stringify(rewritten));
     res.statusCode = 200;
     res.statusMessage = 'OK';
-    // The rewritten payload has its own length, and is never chunked.
-    copyHeaders(proxyRes, res, ['content-length', 'transfer-encoding']);
+    // The rewritten payload has its own length.
+    copyHeaders(proxyRes, res, ['content-length']);
     res.setHeader('content-length', payload.byteLength.toString());
     // Deliberately unlogged: the task poll runs on a timer, so a line per
     // rewrite is one every couple of seconds and drowns everything else. What is
@@ -132,8 +172,32 @@ const proxy = createProxyServer({ selfHandleResponse: true, target: backend, ws:
 
 proxy.on('proxyRes', onProxyRes);
 
-proxy.on('error', (error) => {
+// httpxy emits `error` and resolves; it writes no response of its own, and with
+// an `error` listener registered it never will. Without this the client is left
+// hanging until it times out — and since starling now routes every `/api/1/*`
+// through here, a core that is down or restarting would hang the whole app
+// rather than failing fast. http-proxy-middleware answered 502 for us before.
+proxy.on('error', (error, _req, res) => {
   consola.error(error);
+  if (!res)
+    return;
+
+  if (res instanceof net.Socket) {
+    res.destroy();
+    return;
+  }
+
+  if (res.headersSent) {
+    res.end();
+    return;
+  }
+
+  res.statusCode = HTTP_BAD_GATEWAY;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify({
+    message: `dev-proxy could not reach the backend at ${backend}: ${error.message}`,
+    result: null,
+  }));
 });
 
 const server = http.createServer((req, res) => {

--- a/frontend/dev-proxy/src/mocked-apis/statistics.ts
+++ b/frontend/dev-proxy/src/mocked-apis/statistics.ts
@@ -28,13 +28,25 @@ export function pickLatestBundle(candidates: BundleCandidate[]): string | undefi
 
 export function serveStatisticsRenderer(componentsDir: string, res: ServerResponse): void {
   const dist = path.resolve(componentsDir, 'dist');
-  const candidates = fs.readdirSync(dist).map(name => ({
-    birthtimeMs: fs.statSync(path.join(dist, name)).birthtimeMs,
-    name,
-  }));
 
-  const latest = pickLatestBundle(candidates);
-  const result = latest ? fs.readFileSync(path.join(dist, latest), 'utf8') : '';
+  // Every read here is synchronous and runs inside the request listener, so an
+  // unhandled throw takes the process down — and starling now depends on this
+  // process for every `/api/1/*` request. `dist` legitimately may not exist yet
+  // (components checked out but never built) or may vanish mid-rebuild, so answer
+  // with an empty renderer instead: the app renders without premium components.
+  let result: string = '';
+  let latest: string | undefined;
+  try {
+    const candidates = fs.readdirSync(dist).map(name => ({
+      birthtimeMs: fs.statSync(path.join(dist, name)).birthtimeMs,
+      name,
+    }));
+    latest = pickLatestBundle(candidates);
+    result = latest ? fs.readFileSync(path.join(dist, latest), 'utf8') : '';
+  }
+  catch (error: any) {
+    consola.warn(`Could not read ${dist}, serving no renderer: ${error.message}`);
+  }
 
   consola.info(`Serving renderer from ${latest ?? '<nothing found>'}`);
 

--- a/frontend/dev-proxy/test/smoke.mjs
+++ b/frontend/dev-proxy/test/smoke.mjs
@@ -40,8 +40,16 @@ const backend = http.createServer((req, res) => {
   req.on('end', () => {
     received.push({ body: Buffer.concat(chunks).toString(), method: req.method, url: req.url });
     res.setHeader('Content-Type', 'application/json');
-    // A mocked path that the backend rejects: the mock must not turn it into a 200.
+    // A mocked path the backend rejects: the mock still applies, since faking an
+    // endpoint the dev backend refuses is most of what the mock file is for.
     if (req.url === '/api/1/premium/sync') {
+      res.statusCode = 402;
+      res.end(JSON.stringify({ message: 'no premium subscription', result: null }));
+      return;
+    }
+    // A task poll the backend rejects: NOT mocked, so the error must survive
+    // rather than being merged into a 200 that reads as "nothing running".
+    if (req.url === '/api/1/tasks/999') {
       res.statusCode = 401;
       res.end(JSON.stringify({ message: 'not logged in', result: null }));
       return;
@@ -148,9 +156,12 @@ try {
   const tasks = await request('GET', '/api/1/tasks');
   check('task status keeps the backend ids, from a chunked response', JSON.parse(tasks.body).result?.pending?.includes(1), tasks.body);
 
-  const rejected = await request('GET', '/api/1/premium/sync');
-  check('a rejected request is not rewritten into a 200', rejected.status === 401, `${rejected.status} ${rejected.body}`);
-  check('a rejected request keeps the backend body', JSON.parse(rejected.body).message === 'not logged in', rejected.body);
+  const mockedButRejected = await request('GET', '/api/1/premium/sync');
+  check('a mock applies even when the backend rejects the request', JSON.parse(mockedButRejected.body).result === 'mocked', `${mockedButRejected.status} ${mockedButRejected.body}`);
+
+  const rejectedPoll = await request('GET', '/api/1/tasks/999');
+  check('a rejected task poll is not rewritten into a 200', rejectedPoll.status === 401, `${rejectedPoll.status} ${rejectedPoll.body}`);
+  check('a rejected task poll keeps the backend body', JSON.parse(rejectedPoll.body).message === 'not logged in', rejectedPoll.body);
 
   const postBody = JSON.stringify({ async_query: false, name: 'value' });
   const post = await request('POST', '/api/1/settings', postBody, { 'Content-Type': 'application/json' });
@@ -169,6 +180,24 @@ try {
   check('preflight for a mocked path is answered locally', preflight.status === 200, String(preflight.status));
 
   check('websocket upgrade forwarded', (await upgrade()) === 101);
+
+  // The premium components exist but were never built, or a rebuild removed dist
+  // mid-run. The reads are synchronous inside the request listener, so an
+  // unhandled throw would take the whole proxy down with it.
+  fs.rmSync(path.join(componentsDir, 'dist'), { force: true, recursive: true });
+  const noDist = await request('GET', '/api/1/statistics/renderer');
+  check('a missing dist serves an empty renderer', noDist.status === 200 && JSON.parse(noDist.body).result === '', `${noDist.status} ${noDist.body}`);
+  const stillAlive = await request('GET', '/api/1/settings');
+  check('the proxy survives a missing dist', stillAlive.status === 200, String(stillAlive.status));
+
+  // Last, since it takes the stub backend down: an unreachable backend must fail
+  // fast rather than hang, now that every /api/1/* call passes through here.
+  await new Promise(resolve => backend.close(resolve));
+  const unreachable = await Promise.race([
+    request('GET', '/api/1/settings'),
+    new Promise(resolve => setTimeout(resolve, 5000, { status: 'timed out' })),
+  ]);
+  check('an unreachable backend answers 502 rather than hanging', unreachable.status === 502, String(unreachable.status));
 }
 finally {
   proxy.kill();

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -4,6 +4,7 @@ import { platform } from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { buildCargoEnv, STRAWBERRY_MISSING_WARNING } from '../../app/shared/cargo-env';
+import { isPortFree } from '../../app/shared/port-utils';
 import { DEFAULT_PORTS, type InstanceRuntime } from '../dev-instance';
 import { formatPort } from '../dev-instance/format';
 import { createDevLogger } from './logger';
@@ -175,6 +176,9 @@ async function startBackendForMode(
   if (!fs.existsSync(logDir))
     fs.mkdirSync(logDir);
 
+  if (opts.useProxy)
+    await assertDevProxyPortFree(devProxyPort(instance));
+
   const { env, ports } = await startStarlingSupervisor({
     logDir,
     dataDir: instance?.dir,
@@ -195,6 +199,24 @@ async function startBackendForMode(
 
 function devProxyPort(instance: InstanceRuntime | null): number {
   return instance?.ports.proxy ?? DEFAULT_PORTS.proxy;
+}
+
+/**
+ * starling is told the dev-proxy's port at launch, before the proxy has bound it,
+ * and unlike starling's own ports it never walks upward. A leftover proxy from an
+ * earlier run still holding the port would take the new one's place silently —
+ * still pointed at that run's core — so every `/api/1/*` call would reach the
+ * wrong backend with nothing reporting it. Refuse instead.
+ */
+async function assertDevProxyPortFree(port: number): Promise<void> {
+  if (await isPortFree(port, '127.0.0.1'))
+    return;
+
+  throw new Error(
+    `The dev-proxy port ${formatPort(String(port))} is already in use, most likely by a dev-proxy `
+    + 'from an earlier run. starling would forward every /api/1/* request to it instead of to this '
+    + 'run\'s backend. Stop it, or start without the proxy (--no-proxy).',
+  );
 }
 
 function spawnProxyForBackend(instance: InstanceRuntime | null, corePort: number): void {
@@ -289,8 +311,10 @@ export async function startDevelopmentEnvironment(opts: DevEnvironmentOptions): 
     // `pnpm dev` leaves devPort undefined, keeping the default 8080.
     extraEnv = envForElectron(instance, useProxy);
     devPort = instance?.ports.dev;
-    if (useProxy)
+    if (useProxy) {
+      await assertDevProxyPortFree(devProxyPort(instance));
       spawnProxyForElectron(instance);
+    }
   }
 
   startDevServer({ noElectron, devPort, backendEnv, extraEnv, onExit: onChildExit });

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -213,16 +213,16 @@ function spawnProxyForBackend(instance: InstanceRuntime | null, corePort: number
 }
 
 function spawnProxyForElectron(instance: InstanceRuntime | null): void {
-  // Electron mode — electron's main process spawns its own backend. In instance
-  // mode we tell electron which ports to bind (via instanceEnvForElectron), so
-  // the proxy fronts those same ports; otherwise fall back to the defaults
-  // (backend on restApi, proxy on proxy). Set VITE_BACKEND_URL so the
-  // Vite-served renderer hits the proxy.
-  const proxyPort = instance?.ports.proxy ?? DEFAULT_PORTS.proxy;
+  // Electron spawns its own starling, which routes `/api/1/*` through this proxy
+  // once it is told the port (ROTKI_DEV_CORE_UPSTREAM_PORT, below). The renderer
+  // is handed starling's origin over IPC and must keep it, so nothing here
+  // touches VITE_BACKEND_URL: redirecting it would only be overridden by that
+  // IPC value anyway, which is how the proxy came to be bypassed entirely.
+  //
+  // The backend port is the one electron is told to bind, or the default.
   const backendPort = instance?.ports.restApi ?? DEFAULT_PORTS.restApi;
-  process.env.VITE_BACKEND_URL = `http://127.0.0.1:${proxyPort}`;
   startDevProxy({
-    PORT: String(proxyPort),
+    PORT: String(devProxyPort(instance)),
     BACKEND: `http://127.0.0.1:${backendPort}`,
   });
 }
@@ -233,9 +233,9 @@ function spawnProxyForElectron(instance: InstanceRuntime | null): void {
  * bind there instead of the shared defaults. Returns undefined outside instance
  * mode, leaving electron on its default ports / configured data dir.
  */
-function instanceEnvForElectron(instance: InstanceRuntime | null): Record<string, string> | undefined {
+function instanceEnvForElectron(instance: InstanceRuntime | null): Record<string, string> {
   if (!instance)
-    return undefined;
+    return {};
   return {
     ROTKI_INSTANCE_CORE_PORT: String(instance.ports.restApi),
     ROTKI_INSTANCE_COLIBRI_PORT: String(instance.ports.colibri),
@@ -243,6 +243,19 @@ function instanceEnvForElectron(instance: InstanceRuntime | null): Record<string
     ROTKI_INSTANCE_MCP_PORT: String(instance.ports.mcp),
     ROTKI_INSTANCE_DATA_DIR: instance.dir,
   };
+}
+
+/**
+ * Env for the electron child: the instance's ports when there is one, plus the
+ * dev-proxy port when the proxy is on — that one is independent of instance mode,
+ * since a plain `pnpm dev` can enable the proxy too.
+ */
+function envForElectron(instance: InstanceRuntime | null, useProxy: boolean): Record<string, string> | undefined {
+  const env: Record<string, string> = { ...instanceEnvForElectron(instance) };
+  if (useProxy)
+    env.ROTKI_DEV_CORE_UPSTREAM_PORT = String(devProxyPort(instance));
+
+  return Object.keys(env).length > 0 ? env : undefined;
 }
 
 function pointFrontendAtBackend(backendEnv: StarlingDevEnv): void {
@@ -274,7 +287,7 @@ export async function startDevelopmentEnvironment(opts: DevEnvironmentOptions): 
     // binds there rather than on the shared defaults, and run the Vite dev
     // server on the instance's dev port (electron loads that origin). Plain
     // `pnpm dev` leaves devPort undefined, keeping the default 8080.
-    extraEnv = instanceEnvForElectron(instance);
+    extraEnv = envForElectron(instance, useProxy);
     devPort = instance?.ports.dev;
     if (useProxy)
       spawnProxyForElectron(instance);

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -170,34 +170,46 @@ export interface DevEnvironmentOptions {
 async function startBackendForMode(
   instance: InstanceRuntime | null,
   opts: DevEnvironmentOptions,
-): Promise<{ backendEnv: StarlingDevEnv; devPort: number | undefined }> {
+): Promise<{ backendEnv: StarlingDevEnv; corePort: number; devPort: number | undefined }> {
   const logDir = path.join(process.cwd(), 'logs');
   if (!fs.existsSync(logDir))
     fs.mkdirSync(logDir);
 
-  const backendEnv = await startStarlingSupervisor({
+  const { env, ports } = await startStarlingSupervisor({
     logDir,
     dataDir: instance?.dir,
     corePort: instance ? instance.ports.restApi : opts.webPort,
     colibriPort: instance ? instance.ports.colibri : opts.colibriPort,
     proxyPort: instance ? instance.ports.starlingProxy : DEFAULT_PORTS.starlingProxy,
     mcpPort: instance ? instance.ports.mcp : DEFAULT_PORTS.mcp,
+    // With the dev-proxy on, starling forwards `/api/1/*` through it. The port is
+    // known up front (a slot reservation or the default), so it can be named at
+    // launch even though the proxy itself starts once starling is up.
+    coreUpstreamPort: opts.useProxy ? devProxyPort(instance) : undefined,
     // An instance owns its slot outright; otherwise the defaults are only a
     // starting point and a busy port walks up, as it did before starling.
     strictPorts: instance !== null,
   });
-  return { backendEnv, devPort: instance?.ports.dev };
+  return { backendEnv: env, corePort: ports.corePort, devPort: instance?.ports.dev };
 }
 
-function spawnProxyForBackend(instance: InstanceRuntime | null, backendEnv: StarlingDevEnv): void {
-  // The premium dev-proxy is the outermost hop, so it fronts starling's proxy
-  // rather than core directly: frontend -> dev-proxy -> starling proxy -> core.
-  // Colibri now rides the same chain: the dev-proxy mounts a catch-all with no
-  // path filter and only intercepts `/api/1/*`, so `/colibri/*` passes straight
-  // through to starling, which strips the prefix.
-  const proxyPort = instance?.ports.proxy ?? DEFAULT_PORTS.proxy;
-  process.env.VITE_BACKEND_URL = `http://127.0.0.1:${proxyPort}`;
-  startDevProxy({ PORT: String(proxyPort), BACKEND: backendEnv.VITE_BACKEND_URL });
+function devProxyPort(instance: InstanceRuntime | null): number {
+  return instance?.ports.proxy ?? DEFAULT_PORTS.proxy;
+}
+
+function spawnProxyForBackend(instance: InstanceRuntime | null, corePort: number): void {
+  // The premium dev-proxy sits *between* starling and core:
+  // frontend -> starling proxy -> dev-proxy -> core. starling stays the single
+  // renderer origin in every mode, so `VITE_BACKEND_URL` is untouched here — it
+  // used to be redirected at the proxy, which the vite child then overrode with
+  // starling's url anyway, leaving the proxy running with nothing routed to it.
+  //
+  // Only `/api/1/*` is routed through it, which is the whole of what it
+  // intercepts. `/colibri/*`, `/ws/*` and `/_control` never leave starling.
+  startDevProxy({
+    PORT: String(devProxyPort(instance)),
+    BACKEND: `http://127.0.0.1:${corePort}`,
+  });
 }
 
 function spawnProxyForElectron(instance: InstanceRuntime | null): void {
@@ -234,10 +246,11 @@ function instanceEnvForElectron(instance: InstanceRuntime | null): Record<string
 }
 
 function pointFrontendAtBackend(backendEnv: StarlingDevEnv): void {
-  // No dev-proxy — Vite talks straight to starling's proxy, the same single
-  // origin the packaged renderer uses. Core answers `/api/1/*`, colibri
-  // `/colibri/*`, and the CORS allowance starling passes both backends permits
-  // the Vite origin.
+  // Vite talks to starling's proxy, the same single origin the packaged renderer
+  // uses, whether or not the dev-proxy is enabled — with it on, starling routes
+  // `/api/1/*` through it upstream, which the renderer never sees. Core answers
+  // `/api/1/*`, colibri `/colibri/*`, and the CORS allowance starling passes both
+  // backends permits the Vite origin.
   process.env.VITE_BACKEND_URL = backendEnv.VITE_BACKEND_URL;
 }
 
@@ -249,11 +262,11 @@ export async function startDevelopmentEnvironment(opts: DevEnvironmentOptions): 
   let extraEnv: Record<string, string> | undefined;
 
   if (noElectron) {
-    ({ backendEnv, devPort } = await startBackendForMode(instance, opts));
+    let corePort: number;
+    ({ backendEnv, corePort, devPort } = await startBackendForMode(instance, opts));
+    pointFrontendAtBackend(backendEnv);
     if (useProxy)
-      spawnProxyForBackend(instance, backendEnv);
-    else
-      pointFrontendAtBackend(backendEnv);
+      spawnProxyForBackend(instance, corePort);
   }
   else {
     // Electron mode: electron's main process spawns its own backend + colibri.

--- a/frontend/scripts/dev/starling.ts
+++ b/frontend/scripts/dev/starling.ts
@@ -27,6 +27,12 @@ export interface StarlingDevOptions {
   /** Port starling's MCP server binds, or starts probing from. */
   mcpPort: number;
   /**
+   * Port of the premium dev-proxy, when it is enabled. starling forwards
+   * `/api/1/*` there instead of straight to core, so the proxy can serve locally
+   * built premium components without the renderer changing origin.
+   */
+  coreUpstreamPort?: number;
+  /**
    * Bind the given ports exactly rather than probing upward. Set for
    * `--instance` runs, which reserve a slot and must land on it.
    */
@@ -36,6 +42,12 @@ export interface StarlingDevOptions {
 export interface StarlingDevEnv {
   /** The single origin the renderer talks to: starling's reverse proxy. */
   VITE_BACKEND_URL: string;
+}
+
+/** What starling resolved, for callers that need to reach a backend directly. */
+export interface StarlingDevPorts {
+  /** The port core actually bound, after any probing. */
+  corePort: number;
 }
 
 async function wait(ms: number): Promise<void> {
@@ -52,7 +64,9 @@ async function wait(ms: number): Promise<void> {
  * The `start` request is the readiness gate — it resolves only once the whole
  * tree is up — so there is nothing here to poll.
  */
-export async function startStarlingSupervisor(options: StarlingDevOptions): Promise<StarlingDevEnv> {
+export async function startStarlingSupervisor(
+  options: StarlingDevOptions,
+): Promise<{ env: StarlingDevEnv; ports: StarlingDevPorts }> {
   // In instance mode every port is reserved by the slot, so bind it exactly and
   // fail loudly if something else holds it. Otherwise the caller's values are
   // only a starting point and a busy port walks up, which is how two concurrent
@@ -91,6 +105,7 @@ export async function startStarlingSupervisor(options: StarlingDevOptions): Prom
     colibriPort,
     mcpPort,
     proxyPort,
+    coreUpstreamPort: options.coreUpstreamPort,
     apiHost: API_HOST,
     logsDir: options.logDir,
     options: backendOptions,
@@ -103,7 +118,12 @@ export async function startStarlingSupervisor(options: StarlingDevOptions): Prom
     repoRoot: path.resolve(process.cwd(), '..'),
   });
 
-  logger.info(`Starting starling supervisor (proxy on ${proxyPort}, core ${corePort}, colibri ${colibriPort})`);
+  const upstreamNote = options.coreUpstreamPort === undefined
+    ? ''
+    : `, /api/1/* via dev-proxy ${options.coreUpstreamPort}`;
+  logger.info(
+    `Starting starling supervisor (proxy on ${proxyPort}, core ${corePort}, colibri ${colibriPort}${upstreamNote})`,
+  );
 
   const rpc = new StarlingRpc({ warn: message => logger.warn(message) }, (method) => {
     // The `start` reply is the readiness gate, so events are informational here;
@@ -156,6 +176,7 @@ export async function startStarlingSupervisor(options: StarlingDevOptions): Prom
   const proxyOrigin = `http://${API_HOST}:${proxyPort}`;
   logger.info(`backend services ready behind ${proxyOrigin}`);
   return {
-    VITE_BACKEND_URL: proxyOrigin,
+    env: { VITE_BACKEND_URL: proxyOrigin },
+    ports: { corePort },
   };
 }


### PR DESCRIPTION
### The premium dev-proxy has been inert

Not broken recently — the renderer never addressed it, in either mode, for two independent reasons.

`start-dev` pointed `VITE_BACKEND_URL` at the proxy **on `process.env`**, but the vite child is spawned with starling's env as an explicit override, and `startProcess` applies that override *last*. The renderer therefore addressed starling and nothing ever reached the proxy. In electron the same thing happened again for a different reason: `use-backend-connection.ts` prefers `window.interop.apiUrl()` — starling's origin, set by `StarlingHandler` — over `defaultApiUrl`.

The symptom is invisible: set `PREMIUM_COMPONENT_DIR`, watch the app come up, and it looks like it worked. It was serving the released bundle from the real API the whole time.

### Move the proxy, not the origin

```
frontend → starling → dev-proxy → core
                    ↘ colibri, /ws/*, /_control   (untouched)
```

The renderer addresses starling in web, electron and docker alike, whether or not the proxy is enabled, so no component can disagree about the origin — the bug class goes away rather than being arbitrated. Putting the proxy in front instead would need an override knob per mode and would make it relay `/ws`, `/colibri/*`, `/_control` and cookies for no reason.

It also matches what the proxy intercepts: only `/api/1/*`, which is exactly core's namespace.

**Shape.** `ProxyConfig.api_upstream_port` feeds a new `api_addr` read *only* by `proxy_core`. `core_addr` is deliberately untouched, so the session-validate call in `control.rs` and `/ws/*` still go straight to core — a dev tool is never in the authentication or websocket path. The CLI flag `--core-upstream-port` is embedded-only, warns and is ignored under docker, and is omitted entirely unless the proxy is on, so an ordinary run is byte-identical to before.

**Electron** gets the same treatment via `ROTKI_DEV_CORE_UPSTREAM_PORT`, and `spawnProxyForElectron` no longer redirects `VITE_BACKEND_URL` — the IPC origin won over that redirect anyway.

`starling-args.ts` was at the 400-line ceiling, so the launcher-resolution half moves to `starling-launchers.ts`: that file answers "what runs", the other "how it is configured".

### Failure modes closed

Once starling routes every `/api/1/*` through the proxy, a fault in it is the whole app rather than a missing chart:

- httpxy emits `error` and writes nothing, so an unreachable backend left clients **hanging until timeout**. Now 502.
- the statistics reads are synchronous inside the request listener, so a `PREMIUM_COMPONENT_DIR` whose `dist` is not built yet threw ENOENT and **killed the process**. Now serves an empty renderer.
- electron probes for a free core port while the proxy was told the default at spawn: it now **refuses to start** when they disagree instead of forwarding to a dead port.
- a leftover proxy from an earlier run holding the port would have quietly served this run's traffic from the *old* backend. The port is checked first.
- a declared mock stopped applying when the backend rejected the request, which is most of what `async-mock.json` is for. The 2xx gate now covers only the task endpoints, which merge into the backend's own answer.
- `selfHandleResponse` skips httpxy's outgoing passes, so hop-by-hop headers were copied verbatim and an upstream `Connection: close` tore down the client's keep-alive.

### Tests

Three Rust cases (data route follows the upstream, default still reaches core, session-validate bypasses it), four frontend cases (flag off by default and passed through when set, in both the args builder and electron's handler), the port-mismatch refusal, and three new smoke checks (502, missing `dist`, mock over a rejected request).

Every one was verified by reintroducing the bug it pins: 69 Rust tests, 72 frontend specs for the touched files, 29 dev-proxy unit tests, 18 smoke checks.

### Verified in-app

Web and electron, with real premium components loading through the proxy. Note this needs a rebuilt starling — an older binary exits on the unknown argument.

### Not addressed

Outside instance mode there is still no way for electron to tell the proxy which core port it resolved; the guard above turns that into a clear refusal rather than a fix. Instance runs reserve their ports, so they are unaffected.

