### PR TITLE
Restore STRAWBERRY_MISSING_WARNING, broken dev launch

### DIFF
--- a/frontend/app/shared/cargo-env.ts
+++ b/frontend/app/shared/cargo-env.ts
@@ -64,3 +64,8 @@ export function buildCargoEnv(): Record<string, string> | null | undefined {
   merged[pathKey] = [...existing, ...parts].join(';');
   return merged;
 }
+
+/** Shared wording so every cargo call site reports a missing Strawberry the same way. */
+export const STRAWBERRY_MISSING_WARNING
+  = 'Strawberry Perl not found at C:\\Strawberry - the vendored OpenSSL build will likely fail. '
+    + 'Install Strawberry Perl from https://strawberryperl.com and re-run.';


### PR DESCRIPTION
Fixes a regression I introduced in #12893: `pnpm dev` and `pnpm dev:web` are currently broken on develop.

```
SyntaxError: The requested module '../../app/shared/cargo-env' does not provide
an export named 'STRAWBERRY_MISSING_WARNING'
```

`frontend/scripts/dev/services.ts:6` imports the constant and `:63` logs it when `buildCargoEnv()` returns `null` (Windows without Strawberry Perl). I deleted it as dead code on knip's say-so. It was not dead.

## Why nothing caught it

- `pnpm run typecheck` filters to the `rotki` package, so `frontend/scripts/**` is never type-checked. That is where the only consumer lives.
- knip resolves the *module*, not the named export, so a missing export is invisible to it.
- My own grep for call sites ran with the working directory inside `frontend/app`, so `frontend/scripts/` was never searched. That is the actual mistake: I reported the warning as never emitted when it is emitted on every dev launch.
- CI does not run `pnpm dev`, so all checks stayed green.

## Verification

```
pnpm exec tsx --eval "import('./scripts/dev/services.ts').then(...)"
  before: IMPORT FAILED ... does not provide an export named 'STRAWBERRY_MISSING_WARNING'
  after:  IMPORT OK
```

Run with the fix stashed and unstashed in the same worktree, so the check is proven to discriminate rather than passing for an unrelated reason.

## Follow-up worth considering

`frontend/tsconfig.node.json` already covers `scripts/**` plus the shared files they import, but nothing runs it. Turning it into a gate would catch this whole class. It currently reports 3 pre-existing errors (`process.resourcesPath` twice in `starling-paths.ts`, one env-key narrowing in `env-file.ts`), so it needs its own PR rather than riding along here.