### PR TITLE
Migrate the history transaction forms to zod

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -6717,6 +6717,11 @@
           "non_empty": "The account field cannot be empty"
         }
       },
+      "chain": {
+        "validation": {
+          "non_empty": "The chain field cannot be empty"
+        }
+      },
       "no_accounts": "No accounts to add the transaction. Please add an account first before continuing.",
       "tx_hash": {
         "validation": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -6766,7 +6766,12 @@
       },
       "loading_tooltip": "Re-pulling is currently disabled because the transactions are still being fetched. Please wait a moment.",
       "no_accounts": "You don't have any blockchain accounts registered. Please {link} first.",
-      "no_exchanges": "You don't have any exchanges connected. Please {link} first."
+      "no_exchanges": "You don't have any exchanges connected. Please {link} first.",
+      "validation": {
+        "date_non_empty": "The date cannot be empty",
+        "entry_type_non_empty": "Please select an event type",
+        "exchange_non_empty": "Please select an exchange"
+      }
     },
     "title": "History Events",
     "unignore": "Include in Accounting"

--- a/frontend/app/src/modules/core/api/types/errors.spec.ts
+++ b/frontend/app/src/modules/core/api/types/errors.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+
+/**
+ * This is what decides, for every form in the app, whether an api error lands under the field it
+ * names or in a message box: a dialog hands the payload it sent, and gets back either a map to
+ * spread over the form's fields or a single string to show on its own.
+ */
+describe('apiValidationError', () => {
+  function error(errors: Record<string, string[] | string>): ApiValidationError {
+    return new ApiValidationError(JSON.stringify(errors));
+  }
+
+  it('should read the api field names as the frontend spells them', () => {
+    expect(error({ from_timestamp: ['too late'] }).errors).toEqual({ fromTimestamp: ['too late'] });
+  });
+
+  it('should return the map when every field it names was sent', () => {
+    const result = error({ address: ['unknown address'] })
+      .getValidationErrors({ address: '', chain: 'all' });
+
+    expect(result).toEqual({ address: ['unknown address'] });
+  });
+
+  /*
+   * The repull dialog sends three different requests but reports all of them against the blockchain
+   * payload, so an exchange error names `location`, which that payload has no field for. The whole
+   * map collapses to one string rather than being dropped - the dialog shows it in a message box.
+   */
+  it('should fall back to a single message when a field was not sent', () => {
+    const result = error({ location: ['unknown exchange'] })
+      .getValidationErrors({ address: '', chain: 'all' });
+
+    expect(result).toBe('unknown exchange');
+  });
+
+  it('should fall back for a message the api sent unwrapped', () => {
+    const result = error({ location: 'unknown exchange' })
+      .getValidationErrors({ address: '' });
+
+    expect(result).toBe('unknown exchange');
+  });
+
+  // One unsendable field is enough: the fields that were sent lose their place too.
+  it('should fall back even when another field would have had somewhere to go', () => {
+    const result = error({ from_timestamp: ['too late'], location: ['unknown exchange'] })
+      .getValidationErrors({ fromTimestamp: 1 });
+
+    expect(result).toBe('unknown exchange');
+  });
+
+  it('should keep the map when the caller has no payload to check against', () => {
+    const result = error({ location: ['unknown exchange'] }).getValidationErrors({});
+
+    expect(result).toEqual({ location: ['unknown exchange'] });
+  });
+
+  it('should fall back to the raw message when the body is not field errors', () => {
+    const plain = new ApiValidationError('the backend is on fire');
+
+    expect(plain.errors).toEqual({});
+    expect(plain.getValidationErrors({ address: '' })).toBe('the backend is on fire');
+  });
+});

--- a/frontend/app/src/modules/core/form/use-model-form.spec.ts
+++ b/frontend/app/src/modules/core/form/use-model-form.spec.ts
@@ -1,5 +1,7 @@
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { startPromise } from '@shared/utils';
 import { describe, expect, it } from 'vitest';
-import { nextTick, type Ref, ref } from 'vue';
+import { customRef, nextTick, type Ref, ref } from 'vue';
 import { z } from 'zod';
 import { useModelForm } from '@/modules/core/form/use-model-form';
 
@@ -107,6 +109,122 @@ describe('useModelForm', () => {
       createWithFlag(stateUpdated);
 
       expect(get(stateUpdated)).toBe(false);
+    });
+  });
+
+  describe('seed', () => {
+    it('should open on the seeded value', () => {
+      const model = ref<PriceState>(baseModel());
+      const form = useModelForm<PriceState>({
+        model,
+        schema: PriceSchema,
+        seed: state => ({ ...state, sourceType: 'oracle' }),
+      });
+
+      expect(form.state.sourceType).toBe('oracle');
+    });
+
+    it('should not count the seeding as an edit', async () => {
+      const stateUpdated = ref<boolean>(false);
+      const form = useModelForm<PriceState>({
+        model: ref<PriceState>(baseModel()),
+        schema: PriceSchema,
+        seed: state => ({ ...state, sourceType: 'oracle' }),
+        stateUpdated,
+      });
+      await nextTick();
+
+      expect(get(form.dirty)).toBe(false);
+      expect(get(stateUpdated)).toBe(false);
+    });
+
+    it('should put the seeded value in the model the dialog saves', () => {
+      const model = ref<PriceState>(baseModel());
+      useModelForm<PriceState>({
+        model,
+        schema: PriceSchema,
+        seed: state => ({ ...state, sourceType: 'oracle' }),
+      });
+
+      expect(get(model).sourceType).toBe('oracle');
+    });
+
+    /*
+     * A `defineModel` ref reads back the value from before the write until the parent catches up, so
+     * the model still reports the pre-seed payload right after the form seeds it. Asserted on the
+     * spot, with no tick in between: let the ref catch up first and the state converges either way,
+     * which is what made an earlier version of this test unable to fail.
+     */
+    it('should not let a stale model read undo the seeding', () => {
+      const inner = ref<PriceState>(baseModel());
+      const lagging = customRef<PriceState>((track, trigger) => ({
+        get: (): PriceState => {
+          track();
+          return get(inner);
+        },
+        set: (value): void => {
+          startPromise(nextTick().then(() => {
+            set(inner, value);
+            trigger();
+          }));
+        },
+      }));
+
+      const form = useModelForm<PriceState>({
+        model: lagging,
+        schema: PriceSchema,
+        seed: state => ({ ...state, sourceType: 'oracle' }),
+      });
+
+      expect(form.state.sourceType).toBe('oracle');
+      expect(get(form.dirty)).toBe(false);
+    });
+
+    it('should still edit normally after seeding', async () => {
+      const model = ref<PriceState>(baseModel());
+      const form = useModelForm<PriceState>({
+        model,
+        schema: PriceSchema,
+        seed: state => ({ ...state, sourceType: 'oracle' }),
+      });
+
+      form.state.price = '3000';
+      await nextTick();
+
+      expect(get(model).price).toBe('3000');
+      expect(get(form.dirty)).toBe(true);
+    });
+  });
+
+  describe('serverErrors', () => {
+    it('should surface errors the dialog is already holding when the form mounts', () => {
+      const form = useModelForm<PriceState>({
+        model: ref<PriceState>(baseModel()),
+        schema: PriceSchema,
+        serverErrors: ref({ price: 'already known' }),
+      });
+
+      expect(form.errors('price')).toEqual(['already known']);
+    });
+
+    it('should surface errors reported after a failed save', async () => {
+      const serverErrors = ref<ValidationErrors>({});
+      const form = useModelForm<PriceState>({ model: ref<PriceState>(baseModel()), schema: PriceSchema, serverErrors });
+
+      set(serverErrors, { price: ['too high', 'and wrong'] });
+      await nextTick();
+
+      expect(form.errors('price')).toEqual(['too high', 'and wrong']);
+    });
+
+    it('should drop a server error once the field it names is edited', async () => {
+      const serverErrors = ref<ValidationErrors>({ price: 'already known' });
+      const form = useModelForm<PriceState>({ model: ref<PriceState>(baseModel()), schema: PriceSchema, serverErrors });
+
+      form.state.price = '3000';
+      await nextTick();
+
+      expect(form.errors('price')).toEqual([]);
     });
   });
 

--- a/frontend/app/src/modules/core/form/use-model-form.ts
+++ b/frontend/app/src/modules/core/form/use-model-form.ts
@@ -1,6 +1,8 @@
 import type { MaybeRefOrGetter, Ref, UnwrapNestedRefs } from 'vue';
 import type { ZodType } from 'zod';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import { isEqual } from 'es-toolkit';
+import { toServerErrors } from '@/modules/core/form/server-errors';
 import { type FormApi, useForm } from '@/modules/core/form/use-form';
 
 export interface ModelFormOptions<TState extends object> {
@@ -8,6 +10,17 @@ export interface ModelFormOptions<TState extends object> {
   readonly model: Ref<TState>;
   /** The single validation source of truth. A getter for rules that depend on props. */
   readonly schema: MaybeRefOrGetter<ZodType>;
+  /**
+   * The state the form opens on, for a form that decides part of it itself: a remembered chain, a
+   * suggested name. It is folded into the baseline rather than written over it, so what the form
+   * chose for the user does not read back as something the user typed.
+   */
+  readonly seed?: (state: TState) => TState;
+  /**
+   * Field errors reported by the api, mirrored in as they arrive. Immediate, because the dialog may
+   * already be holding errors from a failed save when the form mounts.
+   */
+  readonly serverErrors?: Ref<ValidationErrors>;
   /** The dialog's unsaved-changes flag, kept in step with `dirty`. */
   readonly stateUpdated?: Ref<boolean>;
   /** State keys, at any depth, that must not count as an edit. */
@@ -26,10 +39,16 @@ export interface ModelFormOptions<TState extends object> {
 export function useModelForm<TState extends object>(
   options: ModelFormOptions<TState>,
 ): FormApi<TState, UnwrapNestedRefs<TState>> {
-  const { model, schema, stateUpdated, transientKeys } = options;
+  const { model, schema, seed, serverErrors, stateUpdated, transientKeys } = options;
 
   const form = useForm<TState, UnwrapNestedRefs<TState>>({
-    initial: (): TState => ({ ...get(model) }),
+    // Seeded here rather than by the caller writing the model first: a write to the model is only
+    // readable back on the next tick, so a caller doing it by hand takes its baseline from the
+    // payload as it was before the write, and the seeding then counts as the first edit.
+    initial: (): TState => {
+      const current = { ...get(model) };
+      return seed ? seed(current) : current;
+    },
     schema,
     // The dialog owns the persist, so there is nothing to submit or reshape here.
     submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
@@ -45,6 +64,19 @@ export function useModelForm<TState extends object>(
     set(model, { ...get(model), ...state });
   }, { deep: true });
 
+  if (seed) {
+    // The dialog saves what it reads off the model, so the opening state has to land there too. It
+    // is not readable back on this tick, which is why the sync below skips its immediate run: the
+    // state is already the newer of the two, and reading the model now would undo the seeding.
+    set(model, { ...get(model), ...form.state });
+  }
+
+  if (serverErrors) {
+    watchImmediate(serverErrors, (value) => {
+      form.setServerErrors(toServerErrors(value));
+    }, { deep: true });
+  }
+
   // And an edit made outside the form - a reset, a different row seeded while it stays mounted - is
   // pulled back in.
   //
@@ -54,10 +86,10 @@ export function useModelForm<TState extends object>(
   // day the copy deep-clones, and the failure mode then is an endless update loop, so the guard
   // stays. `syncRef` handles the same problem by pausing the opposing watcher, but it needs two
   // refs and a sync flush, and this state is reactive and watched deep.
-  watchImmediate(model, (value) => {
+  watch(model, (value) => {
     if (!isEqual(value, form.state))
       Object.assign(form.state, value);
-  }, { deep: true });
+  }, { deep: true, immediate: !seed });
 
   if (stateUpdated) {
     // Immediate, so reopening a dialog that kept its flag from the last edit starts disarmed.

--- a/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.spec.ts
+++ b/frontend/app/src/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.spec.ts
@@ -121,6 +121,15 @@ describe('edit-snapshot/EditLocationDataSnapshotForm.vue', () => {
       .toBe('dashboard.snapshot.edit.dialog.location_data.rules.value');
   });
 
+  // The other side of the flag: a dialog the user has not touched must not prompt about unsaved
+  // changes on close, which is what any state the form writes for itself on open would cause.
+  it('should not flag stateUpdated before anything is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.emitted('update:stateUpdated')?.flat() ?? []).not.toContain(true);
+  });
+
   it('should flag stateUpdated once a field is edited', async () => {
     wrapper = createWrapper();
     // Settle the mounted work first, so what follows is the only edit in play.

--- a/frontend/app/src/modules/history/events/tx/RepullingBlockchainForm.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/RepullingBlockchainForm.spec.ts
@@ -1,0 +1,202 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComponentPublicInstance } from 'vue';
+import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type { RepullingTransactionPayload } from '@/modules/history/events/event-payloads';
+import { Blockchain } from '@rotki/common';
+import { type ModelFormHarness, mountModelForm } from '@test/utils/model-form-harness';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import RepullingBlockchainForm from '@/modules/history/events/tx/RepullingBlockchainForm.vue';
+import '@test/i18n';
+
+const ADDRESS = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12';
+
+const chains = ref<string[]>(['all', Blockchain.ETH]);
+
+vi.mock('@/modules/history/events/tx/use-repulling-transaction-form', () => ({
+  shouldShowDateRangePicker: (): boolean => true,
+  useRepullingTransactionForm: (): Record<string, unknown> => ({
+    chainOptions: computed<string[]>(() => get(chains)),
+    getUsableChains: (chain: string | undefined): string[] =>
+      !chain || chain === 'all' ? get(chains).filter(item => item !== 'all') : [chain],
+  }),
+}));
+
+function stub(name: string, props: string[]): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'update:start', 'update:end'],
+    name,
+    props,
+    template: '<div />',
+  };
+}
+
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function addressAccount(chain: string, address: string): BlockchainAccount {
+  return {
+    chain,
+    data: { address, type: 'address' },
+    nativeAsset: 'ETH',
+  };
+}
+
+describe('history/events/tx/RepullingBlockchainForm.vue', () => {
+  let pinia: Pinia;
+  let harness: ModelFormHarness<RepullingTransactionPayload>;
+
+  function basePayload(): RepullingTransactionPayload {
+    return {
+      address: '',
+      chain: 'all',
+      fromTimestamp: 1600000000,
+      toTimestamp: 1700000000,
+    };
+  }
+
+  beforeEach(() => {
+    set(chains, ['all', Blockchain.ETH]);
+    pinia = createPinia();
+    setActivePinia(pinia);
+    useBlockchainAccountsStore().updateAccounts(Blockchain.ETH, [addressAccount(Blockchain.ETH, ADDRESS)]);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    harness?.wrapper.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    payload: RepullingTransactionPayload = basePayload(),
+    errors: Record<string, string[] | string> = {},
+  ): ModelFormHarness<RepullingTransactionPayload> {
+    return mountModelForm(RepullingBlockchainForm, {
+      errors,
+      global: {
+        plugins: [pinia],
+        stubs: {
+          BlockchainAccountSelector: stub('BlockchainAccountSelector', ['modelValue', 'errorMessages', 'chains']),
+          ChainSelect: stub('ChainSelect', ['modelValue', 'errorMessages', 'items']),
+          DateTimeRangePicker: stub('DateTimeRangePicker', ['start', 'end', 'startErrorMessages', 'endErrorMessages']),
+          RuiAlert: stub('RuiAlert', ['type']),
+        },
+      },
+      payload,
+    });
+  }
+
+  function field(name: string): VueWrapper<StubInstance> {
+    return harness.wrapper.findComponent<StubInstance>({ name });
+  }
+
+  function messages(name: string, prop = 'errorMessages'): string[] {
+    const value: unknown = field(name).props(prop);
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  it('should accept a fully filled payload', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await harness.validate()).toBe(true);
+  });
+
+  it.each([
+    ['fromTimestamp'],
+    ['toTimestamp'],
+  ] as const)('should reject a payload with no %s', async (key) => {
+    harness = createWrapper({ ...basePayload(), [key]: undefined });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await harness.validate()).toBe(false);
+  });
+
+  /*
+   * The epoch is a date like any other. Vuelidate's `required` reports on a cleared picker, which
+   * arrives as undefined, and stringifies 0 to something non-empty - so this passes today, and a
+   * port that reaches for a truthiness check would silently start rejecting it.
+   */
+  it('should accept the epoch as a timestamp', async () => {
+    harness = createWrapper({ ...basePayload(), fromTimestamp: 0 });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await harness.validate()).toBe(true);
+  });
+
+  it('should accept a payload with no chain and no address', async () => {
+    harness = createWrapper({ ...basePayload(), address: '', chain: undefined });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await harness.validate()).toBe(true);
+  });
+
+  // The address carries no rule of its own; it exists only so the api can report against it.
+  it('should show a server error reported against the address', async () => {
+    harness = createWrapper(basePayload(), { address: ['unknown address'] });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await harness.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('BlockchainAccountSelector')).toContain('unknown address');
+  });
+
+  it('should show the message for a cleared start date', async () => {
+    harness = createWrapper({ ...basePayload(), fromTimestamp: undefined });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await harness.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('DateTimeRangePicker', 'startErrorMessages')).not.toEqual([]);
+  });
+
+  it('should write a chosen account into the model', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    field('BlockchainAccountSelector').vm.$emit('update:modelValue', [addressAccount(Blockchain.ETH, ADDRESS)]);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(harness.model().address).toBe(ADDRESS);
+  });
+
+  it('should write a chosen chain into the model', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    field('ChainSelect').vm.$emit('update:modelValue', Blockchain.ETH);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(harness.model().chain).toBe(Blockchain.ETH);
+  });
+
+  it('should not arm the close prompt before anything is edited', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(harness.stateUpdated()).toBe(false);
+  });
+
+  it('should arm the close prompt once a field is edited', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    field('ChainSelect').vm.$emit('update:modelValue', Blockchain.ETH);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(harness.stateUpdated()).toBe(true);
+  });
+
+  it('should offer nothing to fill in when no chain has an account', async () => {
+    set(chains, []);
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('ChainSelect').exists()).toBe(false);
+    expect(field('RuiAlert').exists()).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/history/events/tx/RepullingBlockchainForm.vue
+++ b/frontend/app/src/modules/history/events/tx/RepullingBlockchainForm.vue
@@ -1,17 +1,15 @@
 <script lang="ts" setup>
+import type { ZodType } from 'zod';
 import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { RepullingTransactionPayload } from '@/modules/history/events/event-payloads';
-import useVuelidate from '@vuelidate/core';
-import { required } from '@vuelidate/validators';
 import { hasAccountAddress } from '@/modules/accounts/account-helpers';
 import { getAccountAddress } from '@/modules/accounts/account-utils';
 import ChainSelect from '@/modules/accounts/blockchain/ChainSelect.vue';
 import BlockchainAccountSelector from '@/modules/accounts/BlockchainAccountSelector.vue';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useModelForm } from '@/modules/core/form/use-model-form';
+import { type RepullingBlockchainFormState, repullingBlockchainSchema } from '@/modules/history/events/tx/repulling-forms';
 import { useRepullingTransactionForm } from '@/modules/history/events/tx/use-repulling-transaction-form';
 import DateTimeRangePicker from '@/modules/shell/components/inputs/DateTimeRangePicker.vue';
 
@@ -21,28 +19,32 @@ const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, requ
 
 const { t } = useI18n({ useScope: 'global' });
 
-const chain = useRefPropVModel(modelValue, 'chain');
-const address = useRefPropVModel(modelValue, 'address');
-const fromTimestamp = useRefPropVModel(modelValue, 'fromTimestamp');
-const toTimestamp = useRefPropVModel(modelValue, 'toTimestamp');
-
 const { accounts: accountsPerChain } = storeToRefs(useBlockchainAccountsStore());
 const { chainOptions, getUsableChains } = useRepullingTransactionForm();
 
+const schema = computed<ZodType>(() => repullingBlockchainSchema(t('transactions.repulling.validation.date_non_empty')));
+
+const form = useModelForm<RepullingBlockchainFormState>({
+  model: modelValue,
+  schema,
+  serverErrors: errors,
+  stateUpdated,
+});
+
 const hasNoAccounts = computed<boolean>(() => get(chainOptions).length === 0);
 
-const usableChains = computed<string[]>(() => getUsableChains(get(chain)));
+const usableChains = computed<string[]>(() => getUsableChains(form.state.chain));
 
 const accounts = computed<BlockchainAccount<AddressData>[]>({
   get: () => {
-    const model = get(modelValue);
+    const { address, chain } = form.state;
     const accountFound = Object.values(get(accountsPerChain))
       .flatMap(x => x)
       .filter(hasAccountAddress)
       .find(
         item =>
-          getAccountAddress(item) === model.address
-          && (!model.chain || model.chain === 'all' || model.chain === item.chain),
+          getAccountAddress(item) === address
+          && (!chain || chain === 'all' || chain === item.chain),
       );
 
     if (accountFound) {
@@ -53,48 +55,17 @@ const accounts = computed<BlockchainAccount<AddressData>[]>({
   },
   set: (value: BlockchainAccount<AddressData>[]) => {
     const account = value[0];
-    const addr = account
-      ? getAccountAddress(account)
-      : '';
-
-    set(modelValue, {
-      ...get(modelValue),
-      address: addr,
-    });
+    form.state.address = account ? getAccountAddress(account) : '';
+    form.touch('address');
   },
 });
-
-const rules = {
-  address: { externalServerValidation: () => true },
-  chain: {},
-  fromTimestamp: { required },
-  toTimestamp: { required },
-};
-
-const states = {
-  address,
-  chain,
-  fromTimestamp,
-  toTimestamp,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  {
-    $autoDirty: true,
-    $externalResults: errors,
-  },
-);
-
-useFormStateWatcher(states, stateUpdated);
 
 onBeforeUnmount(() => {
   set(errors, {});
 });
 
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -126,10 +97,11 @@ defineExpose({
     <template v-else>
       <div class="flex gap-2">
         <ChainSelect
-          v-model="chain"
+          v-model="form.state.chain"
           class="max-w-[20rem]"
           :items="chainOptions"
-          :error-messages="toMessages(v$.chain)"
+          :error-messages="form.errors('chain')"
+          @update:model-value="form.touch('chain')"
         />
         <BlockchainAccountSelector
           v-model="accounts"
@@ -142,18 +114,20 @@ defineExpose({
           unique
           :custom-hint="t('transactions.repulling.address_hint')"
           :label="t('common.address')"
-          :error-messages="toMessages(v$.address)"
+          :error-messages="form.errors('address')"
           :no-data-text="t('transactions.form.account.no_address_found')"
         />
       </div>
 
       <DateTimeRangePicker
-        v-model:start="fromTimestamp"
-        v-model:end="toTimestamp"
+        v-model:start="form.state.fromTimestamp"
+        v-model:end="form.state.toTimestamp"
         allow-empty
         max-end-date="now"
-        :start-error-messages="toMessages(v$.fromTimestamp)"
-        :end-error-messages="toMessages(v$.toTimestamp)"
+        :start-error-messages="form.errors('fromTimestamp')"
+        :end-error-messages="form.errors('toTimestamp')"
+        @update:start="form.touch('fromTimestamp')"
+        @update:end="form.touch('toTimestamp')"
       />
     </template>
   </div>

--- a/frontend/app/src/modules/history/events/tx/RepullingEthStakingForm.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/RepullingEthStakingForm.spec.ts
@@ -1,0 +1,217 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComponentPublicInstance } from 'vue';
+import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type { RepullingEthStakingPayload } from '@/modules/history/events/event-payloads';
+import { Blockchain, type Eth2ValidatorEntry } from '@rotki/common';
+import { type ModelFormHarness, mountModelForm } from '@test/utils/model-form-harness';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
+import RepullingEthStakingForm from '@/modules/history/events/tx/RepullingEthStakingForm.vue';
+import '@test/i18n';
+
+const WITHDRAWAL_ADDRESS = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12';
+
+const VALIDATOR: Eth2ValidatorEntry = {
+  index: 42,
+  publicKey: '0xaaa',
+  status: 'active',
+};
+
+function stub(name: string, props: string[]): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'update:start', 'update:end'],
+    name,
+    props,
+    template: '<div />',
+  };
+}
+
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function validatorAccount(): BlockchainAccount {
+  return {
+    chain: Blockchain.ETH2,
+    data: {
+      index: VALIDATOR.index,
+      publicKey: VALIDATOR.publicKey,
+      status: 'active',
+      type: 'validator',
+      withdrawalAddress: WITHDRAWAL_ADDRESS,
+    },
+    nativeAsset: 'ETH',
+  };
+}
+
+describe('history/events/tx/RepullingEthStakingForm.vue', () => {
+  let pinia: Pinia;
+  let harness: ModelFormHarness<RepullingEthStakingPayload>;
+
+  function basePayload(): RepullingEthStakingPayload {
+    return {
+      entryType: OnlineHistoryEventsQueryType.ETH_WITHDRAWALS,
+      fromTimestamp: 1600000000,
+      toTimestamp: 1700000000,
+    };
+  }
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    // The validator list the form offers is derived from these accounts, not set on its own store.
+    useBlockchainAccountsStore().updateAccounts(Blockchain.ETH2, [validatorAccount()]);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    harness?.wrapper.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(payload: RepullingEthStakingPayload = basePayload()): ModelFormHarness<RepullingEthStakingPayload> {
+    return mountModelForm(RepullingEthStakingForm, {
+      errors: {},
+      global: {
+        plugins: [pinia],
+        stubs: {
+          AccountDisplay: stub('AccountDisplay', ['account']),
+          DateTimeRangePicker: stub('DateTimeRangePicker', ['start', 'end', 'startErrorMessages', 'endErrorMessages']),
+          RuiAlert: stub('RuiAlert', ['type']),
+          RuiAutoComplete: stub('RuiAutoComplete', ['modelValue', 'options', 'errorMessages']),
+          ValidatorFilterInput: stub('ValidatorFilterInput', ['modelValue', 'items', 'hint']),
+        },
+      },
+      payload,
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return harness.wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function picker(): VueWrapper<StubInstance> {
+    return harness.wrapper.findComponent<StubInstance>({ name: 'DateTimeRangePicker' });
+  }
+
+  async function choose(testId: string, value: unknown): Promise<void> {
+    field(testId).vm.$emit('update:modelValue', value);
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  async function chooseValidator(): Promise<void> {
+    harness.wrapper.findComponent<StubInstance>({ name: 'ValidatorFilterInput' }).vm.$emit('update:modelValue', [VALIDATOR]);
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should accept the payload it opens on', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await harness.validate()).toBe(true);
+  });
+
+  it('should reject a payload with no entry type', async () => {
+    harness = createWrapper({ ...basePayload(), entryType: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await harness.validate()).toBe(false);
+  });
+
+  it.each([
+    ['fromTimestamp'],
+    ['toTimestamp'],
+  ] as const)('should reject withdrawals with no %s', async (key) => {
+    harness = createWrapper({ ...basePayload(), [key]: undefined });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await harness.validate()).toBe(false);
+  });
+
+  it('should show the message for a cleared start date', async () => {
+    harness = createWrapper({ ...basePayload(), fromTimestamp: undefined });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await harness.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const value: unknown = picker().props('startErrorMessages');
+    assert(Array.isArray(value));
+    expect(value).not.toEqual([]);
+  });
+
+  // Block productions are fetched whole rather than over a range, so the picker goes away and its
+  // rules go with it.
+  it('should drop the range and its rules for block productions', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await choose('eth-staking-entry-type', OnlineHistoryEventsQueryType.BLOCK_PRODUCTIONS);
+
+    expect(picker().exists()).toBe(false);
+    expect(harness.model().fromTimestamp).toBeUndefined();
+    expect(harness.model().toTimestamp).toBeUndefined();
+    expect(await harness.validate()).toBe(true);
+  });
+
+  it('should send the chosen validators and no addresses', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await chooseValidator();
+
+    expect(harness.model().validatorIndices).toEqual([VALIDATOR.index]);
+    expect(harness.model().addresses).toBeUndefined();
+  });
+
+  it('should send the chosen addresses and no validators', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await choose('eth-staking-filter-mode', 'addresses');
+    await choose('eth-staking-addresses', [WITHDRAWAL_ADDRESS]);
+
+    expect(harness.model().addresses).toEqual([WITHDRAWAL_ADDRESS]);
+    expect(harness.model().validatorIndices).toBeUndefined();
+  });
+
+  it('should drop a selection made under the other filter mode', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await chooseValidator();
+    await choose('eth-staking-filter-mode', 'addresses');
+
+    expect(harness.model().addresses).toEqual([]);
+    expect(harness.model().validatorIndices).toBeUndefined();
+  });
+
+  it('should not arm the close prompt before anything is edited', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(harness.stateUpdated()).toBe(false);
+  });
+
+  /*
+   * The selection is not validated, but it is still an edit. The dirty set is wider than the
+   * validated one here, which is the only form in this group where the two differ.
+   */
+  it('should arm the close prompt when only the selection changes', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    await chooseValidator();
+
+    expect(harness.stateUpdated()).toBe(true);
+  });
+
+  it('should offer nothing to fill in when no validator is tracked', async () => {
+    useBlockchainAccountsStore().updateAccounts(Blockchain.ETH2, []);
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('eth-staking-entry-type').exists()).toBe(false);
+    expect(harness.wrapper.findComponent({ name: 'RuiAlert' }).exists()).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/history/events/tx/RepullingEthStakingForm.vue
+++ b/frontend/app/src/modules/history/events/tx/RepullingEthStakingForm.vue
@@ -1,21 +1,24 @@
 <script lang="ts" setup>
+import type { ZodType } from 'zod';
 import type { BlockchainAccount, ValidatorData } from '@/modules/accounts/blockchain-accounts';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { RepullingEthStakingPayload } from '@/modules/history/events/event-payloads';
-import { Blockchain, type Eth2ValidatorEntry, toHumanReadable } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { required } from '@vuelidate/validators';
+import { Blockchain, toHumanReadable } from '@rotki/common';
 import { isValidatorAccount } from '@/modules/accounts/account-utils';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { toServerErrors } from '@/modules/core/form/server-errors';
+import { type FormApi, useForm } from '@/modules/core/form/use-form';
 import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
+import {
+  type RepullingEthStakingFormState,
+  repullingEthStakingSchema,
+  type RepullingFilterMode,
+  toEthStakingPayload,
+} from '@/modules/history/events/tx/repulling-forms';
 import AccountDisplay from '@/modules/shell/components/display/AccountDisplay.vue';
 import DateTimeRangePicker from '@/modules/shell/components/inputs/DateTimeRangePicker.vue';
 import ValidatorFilterInput from '@/modules/staking/eth2/ValidatorFilterInput.vue';
 import { useBlockchainValidatorsStore } from '@/modules/staking/use-blockchain-validators-store';
-
-type FilterMode = 'addresses' | 'validator_indices';
 
 const modelValue = defineModel<RepullingEthStakingPayload>({ required: true });
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
@@ -23,12 +26,28 @@ const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, requ
 
 const { t } = useI18n({ useScope: 'global' });
 
-const entryType = ref<string>(get(modelValue).entryType);
-const fromTimestamp = ref<number | undefined>(get(modelValue).fromTimestamp);
-const toTimestamp = ref<number | undefined>(get(modelValue).toTimestamp);
-const filterMode = ref<FilterMode>('validator_indices');
-const selectedValidators = ref<Eth2ValidatorEntry[]>([]);
-const selectedAddresses = ref<string[]>([]);
+/*
+ * `useForm` rather than `useModelForm`: the payload is a projection of this state, not a copy of it.
+ * The filter mode picks which of the two selections is sent and never travels itself, so syncing the
+ * model back in would push request-shaped keys into the state.
+ */
+const form: FormApi<RepullingEthStakingFormState, RepullingEthStakingPayload> = useForm({
+  initial: (): RepullingEthStakingFormState => ({
+    entryType: get(modelValue).entryType,
+    filterMode: 'validator_indices',
+    fromTimestamp: get(modelValue).fromTimestamp,
+    selectedAddresses: [],
+    selectedValidators: [],
+    toTimestamp: get(modelValue).toTimestamp,
+  }),
+  schema: (): ZodType => repullingEthStakingSchema({
+    entryTypeRequired: t('transactions.repulling.validation.entry_type_non_empty'),
+    rangeRequired: t('transactions.repulling.validation.date_non_empty'),
+  }, form.state.entryType !== OnlineHistoryEventsQueryType.BLOCK_PRODUCTIONS),
+  // The dialog owns the persist and reads the payload off the model.
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: toEthStakingPayload,
+});
 
 const { accounts: accountsPerChain } = storeToRefs(useBlockchainAccountsStore());
 const { ethStakingValidators } = storeToRefs(useBlockchainValidatorsStore());
@@ -44,7 +63,7 @@ const entryTypeOptions: { id: string; label: string }[] = [
   },
 ];
 
-const filterModeOptions = computed<{ id: FilterMode; label: string }[]>(() => [
+const filterModeOptions = computed<{ id: RepullingFilterMode; label: string }[]>(() => [
   {
     id: 'validator_indices',
     label: t('transactions.repulling.eth_staking.filter_mode.validator_indices'),
@@ -72,87 +91,47 @@ const withdrawalAddressOptions = computed<string[]>(() => {
 
 const hasNoValidators = computed<boolean>(() => get(eth2Accounts).length === 0);
 
-const isBlockProductions = computed<boolean>(() => get(entryType) === OnlineHistoryEventsQueryType.BLOCK_PRODUCTIONS);
+const isBlockProductions = computed<boolean>(() => form.state.entryType === OnlineHistoryEventsQueryType.BLOCK_PRODUCTIONS);
 
 const showDateRangePicker = computed<boolean>(() => !get(isBlockProductions));
 
-const rules = computed(() => {
-  const timestampRules = get(showDateRangePicker) ? { required } : {};
-  return {
-    entryType: { required },
-    fromTimestamp: timestampRules,
-    toTimestamp: timestampRules,
-  };
+// The dialog reads the request off the model, so every edit is projected into it.
+watchDeep(() => form.state, (state) => {
+  set(modelValue, toEthStakingPayload(state));
 });
 
-const states = computed(() => ({
-  entryType: get(entryType),
-  fromTimestamp: get(fromTimestamp),
-  toTimestamp: get(toTimestamp),
-}));
-
-const watchedStates = {
-  entryType,
-  filterMode,
-  fromTimestamp,
-  selectedAddresses,
-  selectedValidators,
-  toTimestamp,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  {
-    $autoDirty: true,
-    $externalResults: errors,
-  },
-);
-
-useFormStateWatcher(watchedStates, stateUpdated);
-
-const payload = computed<RepullingEthStakingPayload>(() => {
-  const base: RepullingEthStakingPayload = {
-    entryType: get(entryType),
-    fromTimestamp: get(fromTimestamp),
-    toTimestamp: get(toTimestamp),
-  };
-
-  if (get(filterMode) === 'validator_indices') {
-    return {
-      ...base,
-      validatorIndices: get(selectedValidators).map(v => v.index),
-    };
-  }
-
-  return {
-    ...base,
-    addresses: get(selectedAddresses),
-  };
+watch(() => form.state.filterMode, () => {
+  form.state.selectedValidators = [];
+  form.state.selectedAddresses = [];
 });
 
-watch(payload, (val) => {
-  set(modelValue, val);
-});
-
-watch(filterMode, () => {
-  set(selectedValidators, []);
-  set(selectedAddresses, []);
-});
-
+// Block productions are fetched whole, so a range left over from withdrawals is dropped rather
+// than sent.
 watch(showDateRangePicker, (show) => {
   if (!show) {
-    set(fromTimestamp, undefined);
-    set(toTimestamp, undefined);
+    form.state.fromTimestamp = undefined;
+    form.state.toTimestamp = undefined;
   }
+});
+
+watchImmediate(errors, (value) => {
+  form.setServerErrors(toServerErrors(value));
+}, { deep: true });
+
+watch(form.dirty, (dirty) => {
+  set(stateUpdated, dirty);
 });
 
 onBeforeUnmount(() => {
   set(errors, {});
 });
 
+onUnmounted(() => {
+  set(stateUpdated, false);
+});
+
 defineExpose({
-  validate: (): Promise<boolean> => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -167,18 +146,21 @@ defineExpose({
 
     <template v-else>
       <RuiAutoComplete
-        v-model="entryType"
+        v-model="form.state.entryType"
+        data-testid="eth-staking-entry-type"
         :options="entryTypeOptions"
         :label="t('transactions.repulling.eth_staking.type_label')"
         variant="outlined"
         auto-select-first
         key-attr="id"
         text-attr="label"
-        :error-messages="toMessages(v$.entryType)"
+        :error-messages="form.errors('entryType')"
+        @update:model-value="form.touch('entryType')"
       />
 
       <RuiAutoComplete
-        v-model="filterMode"
+        v-model="form.state.filterMode"
+        data-testid="eth-staking-filter-mode"
         :options="filterModeOptions"
         :label="t('transactions.repulling.eth_staking.filter_by_label')"
         variant="outlined"
@@ -188,15 +170,16 @@ defineExpose({
       />
 
       <ValidatorFilterInput
-        v-if="filterMode === 'validator_indices'"
-        v-model="selectedValidators"
+        v-if="form.state.filterMode === 'validator_indices'"
+        v-model="form.state.selectedValidators"
         :items="ethStakingValidators"
         :hint="t('transactions.repulling.eth_staking.validator_indices_hint')"
       />
 
       <RuiAutoComplete
         v-else
-        v-model="selectedAddresses"
+        v-model="form.state.selectedAddresses"
+        data-testid="eth-staking-addresses"
         :options="withdrawalAddressOptions"
         :label="t('transactions.repulling.eth_staking.addresses_label')"
         variant="outlined"
@@ -223,12 +206,14 @@ defineExpose({
 
       <DateTimeRangePicker
         v-if="showDateRangePicker"
-        v-model:start="fromTimestamp"
-        v-model:end="toTimestamp"
+        v-model:start="form.state.fromTimestamp"
+        v-model:end="form.state.toTimestamp"
         allow-empty
         max-end-date="now"
-        :start-error-messages="toMessages(v$.fromTimestamp)"
-        :end-error-messages="toMessages(v$.toTimestamp)"
+        :start-error-messages="form.errors('fromTimestamp')"
+        :end-error-messages="form.errors('toTimestamp')"
+        @update:start="form.touch('fromTimestamp')"
+        @update:end="form.touch('toTimestamp')"
       />
 
       <RuiAlert

--- a/frontend/app/src/modules/history/events/tx/RepullingEthStakingForm.vue
+++ b/frontend/app/src/modules/history/events/tx/RepullingEthStakingForm.vue
@@ -118,16 +118,11 @@ watchImmediate(errors, (value) => {
   form.setServerErrors(toServerErrors(value));
 }, { deep: true });
 
-watch(form.dirty, (dirty) => {
-  set(stateUpdated, dirty);
-});
+// Immediate, so arriving from an edited sibling tab hands the dialog's flag back disarmed.
+syncRefs(form.dirty, stateUpdated);
 
 onBeforeUnmount(() => {
   set(errors, {});
-});
-
-onUnmounted(() => {
-  set(stateUpdated, false);
 });
 
 defineExpose({

--- a/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.spec.ts
@@ -105,7 +105,8 @@ describe('history/events/tx/RepullingExchangeForm.vue', () => {
     expect(await harness.validate()).toBe(false);
   });
 
-  // Kraken reports no date range, so the picker is hidden and its rules go with it.
+  // Bitmex is one of the exchanges that reports no date range, so the picker is hidden for it and
+  // its rules go with it. Kraken, used everywhere else here, is not.
   it('should accept a missing range for an exchange that has no picker', async () => {
     harness = createWrapper({ ...basePayload(), fromTimestamp: undefined, toTimestamp: undefined });
     await vi.advanceTimersToNextTimerAsync();

--- a/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.spec.ts
@@ -4,17 +4,21 @@ import type { Exchange } from '@/modules/balances/types/exchanges';
 import type { RepullingTransactionPayload } from '@/modules/history/events/event-payloads';
 import { type ModelFormHarness, mountModelForm } from '@test/utils/model-form-harness';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import RepullingExchangeForm from '@/modules/history/events/tx/RepullingExchangeForm.vue';
 import '@test/i18n';
 
 const KRAKEN: Exchange = { location: 'kraken', name: 'my kraken' };
+/** One of the exchanges that reports no date range, so the picker is hidden for it. */
+const BITMEX: Exchange = { location: 'bitmex', name: 'my bitmex' };
 
 vi.mock('@/modules/balances/exchanges/use-exchange-data', () => ({
   useExchangeData: (): Record<string, unknown> => ({
-    syncingExchanges: computed<Exchange[]>(() => [KRAKEN]),
+    syncingExchanges: computed<Exchange[]>(() => [KRAKEN, BITMEX]),
   }),
 }));
+
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
 
 function stub(name: string, props: string[]): Record<string, unknown> {
   return {
@@ -64,9 +68,12 @@ describe('history/events/tx/RepullingExchangeForm.vue', () => {
     });
   }
 
-  async function chooseExchange(): Promise<void> {
-    const select: VueWrapper<ComponentPublicInstance> = harness.wrapper.findComponent({ name: 'RuiAutoComplete' });
-    select.vm.$emit('update:modelValue', KRAKEN);
+  function autocomplete(): VueWrapper<StubInstance> {
+    return harness.wrapper.findComponent<StubInstance>({ name: 'RuiAutoComplete' });
+  }
+
+  async function chooseExchange(exchange: Exchange = KRAKEN): Promise<void> {
+    autocomplete().vm.$emit('update:modelValue', exchange);
     await vi.advanceTimersToNextTimerAsync();
   }
 
@@ -84,6 +91,77 @@ describe('history/events/tx/RepullingExchangeForm.vue', () => {
     await chooseExchange();
 
     expect(await harness.validate()).toBe(true);
+  });
+
+  it.each([
+    ['fromTimestamp'],
+    ['toTimestamp'],
+  ] as const)('should reject a payload with no %s once an exchange is chosen', async (key) => {
+    harness = createWrapper({ ...basePayload(), [key]: undefined });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await chooseExchange();
+
+    expect(await harness.validate()).toBe(false);
+  });
+
+  // Kraken reports no date range, so the picker is hidden and its rules go with it.
+  it('should accept a missing range for an exchange that has no picker', async () => {
+    harness = createWrapper({ ...basePayload(), fromTimestamp: undefined, toTimestamp: undefined });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await chooseExchange(BITMEX);
+
+    expect(await harness.validate()).toBe(true);
+  });
+
+  it('should clear a range carried over when the picker goes away', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await chooseExchange(BITMEX);
+
+    expect(harness.model().fromTimestamp).toBeUndefined();
+    expect(harness.model().toTimestamp).toBeUndefined();
+  });
+
+  it('should show the message for a missing exchange once validate runs', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await harness.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const value: unknown = autocomplete().props('errorMessages');
+    assert(Array.isArray(value));
+    // The text, not just its presence: a schema that rejects a missing key rather than an empty
+    // value reports zod's own wording here and would pass a non-empty check.
+    expect(value).toEqual(['transactions.repulling.validation.exchange_non_empty']);
+  });
+
+  it('should not arm the close prompt before anything is edited', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(harness.stateUpdated()).toBe(false);
+  });
+
+  it('should arm the close prompt once an exchange is chosen', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    await chooseExchange();
+
+    expect(harness.stateUpdated()).toBe(true);
+  });
+
+  it('should tell the dialog which exchange was chosen', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await chooseExchange();
+
+    expect(harness.wrapper.findComponent(RepullingExchangeForm).vm.getExchangeData()).toEqual(KRAKEN);
   });
 
   /*

--- a/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.spec.ts
@@ -1,0 +1,102 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComponentPublicInstance } from 'vue';
+import type { Exchange } from '@/modules/balances/types/exchanges';
+import type { RepullingTransactionPayload } from '@/modules/history/events/event-payloads';
+import { type ModelFormHarness, mountModelForm } from '@test/utils/model-form-harness';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RepullingExchangeForm from '@/modules/history/events/tx/RepullingExchangeForm.vue';
+import '@test/i18n';
+
+const KRAKEN: Exchange = { location: 'kraken', name: 'my kraken' };
+
+vi.mock('@/modules/balances/exchanges/use-exchange-data', () => ({
+  useExchangeData: (): Record<string, unknown> => ({
+    syncingExchanges: computed<Exchange[]>(() => [KRAKEN]),
+  }),
+}));
+
+function stub(name: string, props: string[]): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'update:start', 'update:end'],
+    name,
+    props,
+    template: '<div />',
+  };
+}
+
+describe('history/events/tx/RepullingExchangeForm.vue', () => {
+  let pinia: Pinia;
+  let harness: ModelFormHarness<RepullingTransactionPayload>;
+
+  function basePayload(): RepullingTransactionPayload {
+    return {
+      address: '',
+      chain: 'all',
+      fromTimestamp: 1600000000,
+      toTimestamp: 1700000000,
+    };
+  }
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    harness?.wrapper.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(payload: RepullingTransactionPayload = basePayload()): ModelFormHarness<RepullingTransactionPayload> {
+    return mountModelForm(RepullingExchangeForm, {
+      errors: {},
+      global: {
+        plugins: [pinia],
+        stubs: {
+          DateTimeRangePicker: stub('DateTimeRangePicker', ['start', 'end', 'startErrorMessages', 'endErrorMessages']),
+          RuiAlert: stub('RuiAlert', ['type']),
+          RuiAutoComplete: stub('RuiAutoComplete', ['modelValue', 'options', 'errorMessages']),
+        },
+      },
+      payload,
+    });
+  }
+
+  async function chooseExchange(): Promise<void> {
+    const select: VueWrapper<ComponentPublicInstance> = harness.wrapper.findComponent({ name: 'RuiAutoComplete' });
+    select.vm.$emit('update:modelValue', KRAKEN);
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should reject a form with no exchange chosen', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await harness.validate()).toBe(false);
+  });
+
+  it('should accept a form once an exchange is chosen', async () => {
+    harness = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await chooseExchange();
+
+    expect(await harness.validate()).toBe(true);
+  });
+
+  /*
+   * The payload is shared with the blockchain form above this one, where clearing the chain is
+   * allowed. This form renders no chain field, so a chain rule here rejects the form with nothing
+   * to show for it: the submit button stops working and no message says why.
+   */
+  it('should accept a form whose shared payload carries no chain', async () => {
+    harness = createWrapper({ ...basePayload(), chain: undefined });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await chooseExchange();
+
+    expect(await harness.validate()).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.vue
+++ b/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.vue
@@ -18,7 +18,6 @@ const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, requ
 
 const { t } = useI18n({ useScope: 'global' });
 
-const chain = useRefPropVModel(modelValue, 'chain');
 const fromTimestamp = useRefPropVModel(modelValue, 'fromTimestamp');
 const toTimestamp = useRefPropVModel(modelValue, 'toTimestamp');
 
@@ -32,7 +31,6 @@ const showDateRangePicker = computed<boolean>(() => shouldShowDateRangePicker(fa
 const rules = computed(() => {
   const timestampRules = get(showDateRangePicker) ? { required } : {};
   return {
-    chain: { required },
     exchange: { required },
     fromTimestamp: timestampRules,
     toTimestamp: timestampRules,
@@ -40,7 +38,6 @@ const rules = computed(() => {
 });
 
 const states = {
-  chain,
   exchange,
   fromTimestamp,
   toTimestamp,

--- a/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.vue
+++ b/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.vue
@@ -54,9 +54,12 @@ watchImmediate(errors, (value) => {
   form.setServerErrors(toServerErrors(value));
 }, { deep: true });
 
-watch(form.dirty, (dirty) => {
-  set(stateUpdated, dirty);
-});
+/*
+ * Immediate, like `useModelForm` does it. The flag belongs to the dialog and is shared with the two
+ * sibling tabs, so a form arriving after an edited one has to hand it back disarmed; a plain watch
+ * only ever raises it, and this form's own state never changes to trigger one.
+ */
+syncRefs(form.dirty, stateUpdated);
 
 // An exchange that reports no range has no picker, so anything already in it is dropped rather than
 // sent.
@@ -69,10 +72,6 @@ watch(showDateRangePicker, (show) => {
 
 onBeforeUnmount(() => {
   set(errors, {});
-});
-
-onUnmounted(() => {
-  set(stateUpdated, false);
 });
 
 defineExpose({

--- a/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.vue
+++ b/frontend/app/src/modules/history/events/tx/RepullingExchangeForm.vue
@@ -1,13 +1,12 @@
 <script lang="ts" setup>
+import type { ZodType } from 'zod';
 import type { Exchange } from '@/modules/balances/types/exchanges';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { RepullingTransactionPayload } from '@/modules/history/events/event-payloads';
-import useVuelidate from '@vuelidate/core';
-import { required } from '@vuelidate/validators';
 import { useExchangeData } from '@/modules/balances/exchanges/use-exchange-data';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { toServerErrors } from '@/modules/core/form/server-errors';
+import { type FormApi, useForm } from '@/modules/core/form/use-form';
+import { type RepullingExchangeFormState, repullingExchangeSchema } from '@/modules/history/events/tx/repulling-forms';
 import { shouldShowDateRangePicker } from '@/modules/history/events/tx/use-repulling-transaction-form';
 import LocationIcon from '@/modules/shell/components/display/LocationIcon.vue';
 import DateTimeRangePicker from '@/modules/shell/components/inputs/DateTimeRangePicker.vue';
@@ -18,59 +17,67 @@ const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, requ
 
 const { t } = useI18n({ useScope: 'global' });
 
-const fromTimestamp = useRefPropVModel(modelValue, 'fromTimestamp');
-const toTimestamp = useRefPropVModel(modelValue, 'toTimestamp');
-
-const exchange = ref<Exchange>();
 const { syncingExchanges } = useExchangeData();
 
 const hasNoExchanges = computed<boolean>(() => get(syncingExchanges).length === 0);
 
-const showDateRangePicker = computed<boolean>(() => shouldShowDateRangePicker(false, get(exchange)));
-
-const rules = computed(() => {
-  const timestampRules = get(showDateRangePicker) ? { required } : {};
-  return {
-    exchange: { required },
-    fromTimestamp: timestampRules,
-    toTimestamp: timestampRules,
-  };
+/*
+ * `useForm` rather than `useModelForm`: the chosen exchange is the form's main field and is not part
+ * of the shared payload, so the state is wider than the model. Only the range is mirrored back.
+ */
+const form: FormApi<RepullingExchangeFormState, RepullingExchangeFormState> = useForm({
+  initial: (): RepullingExchangeFormState => ({
+    // Spelled out, not left off: a key the state does not carry fails the schema on its absence
+    // rather than on the rule, and reports zod's own message instead of the one below.
+    exchange: undefined,
+    fromTimestamp: get(modelValue).fromTimestamp,
+    toTimestamp: get(modelValue).toTimestamp,
+  }),
+  // A getter, not a computed over `showDateRangePicker`: that reads the state this form owns, so
+  // the two would be defined in terms of each other.
+  schema: (): ZodType => repullingExchangeSchema({
+    exchangeRequired: t('transactions.repulling.validation.exchange_non_empty'),
+    rangeRequired: t('transactions.repulling.validation.date_non_empty'),
+  }, shouldShowDateRangePicker(false, form.state.exchange)),
+  // The dialog owns the persist and reads the range off the model.
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): RepullingExchangeFormState => ({ ...state }),
 });
 
-const states = {
-  exchange,
-  fromTimestamp,
-  toTimestamp,
-};
+const showDateRangePicker = computed<boolean>(() => shouldShowDateRangePicker(false, form.state.exchange));
 
-const v$ = useVuelidate(
-  rules,
-  states,
-  {
-    $autoDirty: true,
-    $externalResults: errors,
-  },
-);
+watch(() => [form.state.fromTimestamp, form.state.toTimestamp], ([fromTimestamp, toTimestamp]) => {
+  set(modelValue, { ...get(modelValue), fromTimestamp, toTimestamp });
+});
 
-useFormStateWatcher(states, stateUpdated);
+watchImmediate(errors, (value) => {
+  form.setServerErrors(toServerErrors(value));
+}, { deep: true });
+
+watch(form.dirty, (dirty) => {
+  set(stateUpdated, dirty);
+});
+
+// An exchange that reports no range has no picker, so anything already in it is dropped rather than
+// sent.
+watch(showDateRangePicker, (show) => {
+  if (!show) {
+    form.state.fromTimestamp = undefined;
+    form.state.toTimestamp = undefined;
+  }
+});
 
 onBeforeUnmount(() => {
   set(errors, {});
 });
 
-watch(showDateRangePicker, (show) => {
-  if (!show) {
-    set(modelValue, {
-      ...get(modelValue),
-      fromTimestamp: undefined,
-      toTimestamp: undefined,
-    });
-  }
+onUnmounted(() => {
+  set(stateUpdated, false);
 });
 
 defineExpose({
-  getExchangeData: () => get(exchange),
-  validate: () => get(v$).$validate(),
+  getExchangeData: (): Exchange | undefined => form.state.exchange,
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -101,14 +108,15 @@ defineExpose({
 
     <template v-else>
       <RuiAutoComplete
-        v-model="exchange"
+        v-model="form.state.exchange"
         :options="syncingExchanges"
         :label="t('common.exchange')"
         variant="outlined"
         auto-select-first
         :item-height="48"
         text-attr="name"
-        :error-messages="toMessages(v$.exchange)"
+        :error-messages="form.errors('exchange')"
+        @update:model-value="form.touch('exchange')"
       >
         <template #selection="{ item }">
           <div class="flex items-center gap-2 pl-1">
@@ -133,12 +141,14 @@ defineExpose({
 
       <DateTimeRangePicker
         v-if="showDateRangePicker"
-        v-model:start="fromTimestamp"
-        v-model:end="toTimestamp"
+        v-model:start="form.state.fromTimestamp"
+        v-model:end="form.state.toTimestamp"
         allow-empty
         max-end-date="now"
-        :start-error-messages="toMessages(v$.fromTimestamp)"
-        :end-error-messages="toMessages(v$.toTimestamp)"
+        :start-error-messages="form.errors('fromTimestamp')"
+        :end-error-messages="form.errors('toTimestamp')"
+        @update:start="form.touch('fromTimestamp')"
+        @update:end="form.touch('toTimestamp')"
       />
     </template>
   </div>

--- a/frontend/app/src/modules/history/events/tx/RepullingTransactionForm.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/RepullingTransactionForm.spec.ts
@@ -1,0 +1,163 @@
+import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import type { RepullingEthStakingPayload, RepullingTransactionPayload } from '@/modules/history/events/event-payloads';
+import { Blockchain } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComponentPublicInstance, defineComponent, useTemplateRef } from 'vue';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
+import RepullingTransactionForm, { type AccountType } from '@/modules/history/events/tx/RepullingTransactionForm.vue';
+import '@test/i18n';
+
+const ADDRESS = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12';
+
+vi.mock('@/modules/balances/exchanges/use-exchange-data', () => ({
+  useExchangeData: (): Record<string, unknown> => ({
+    syncingExchanges: computed(() => [{ location: 'kraken', name: 'my kraken' }]),
+  }),
+}));
+
+vi.mock('@/modules/history/events/tx/use-repulling-transaction-form', () => ({
+  shouldShowDateRangePicker: (): boolean => true,
+  useRepullingTransactionForm: (): Record<string, unknown> => ({
+    chainOptions: computed<string[]>(() => ['all', Blockchain.ETH]),
+    getUsableChains: (): string[] => [Blockchain.ETH],
+  }),
+}));
+
+function stub(name: string, props: string[]): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'update:start', 'update:end'],
+    name,
+    props,
+    template: '<div />',
+  };
+}
+
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function addressAccount(chain: string, address: string): BlockchainAccount {
+  return {
+    chain,
+    data: { address, type: 'address' },
+    nativeAsset: 'ETH',
+  };
+}
+
+/** The three forms share one payload and one unsaved-changes flag, which is what the tabs switch. */
+const Harness = defineComponent({
+  components: { RepullingTransactionForm },
+  setup() {
+    const model = ref<RepullingTransactionPayload>({
+      address: '',
+      chain: 'all',
+      fromTimestamp: 1600000000,
+      toTimestamp: 1700000000,
+    });
+    const ethStakingData = ref<RepullingEthStakingPayload>({
+      entryType: OnlineHistoryEventsQueryType.ETH_WITHDRAWALS,
+      fromTimestamp: 1600000000,
+      toTimestamp: 1700000000,
+    });
+    const errors = ref<ValidationErrors>({});
+    const stateUpdated = ref<boolean>(false);
+    const accountType = ref<AccountType>('blockchain');
+    const form = useTemplateRef<InstanceType<typeof RepullingTransactionForm>>('form');
+    return { accountType, errors, ethStakingData, form, model, stateUpdated };
+  },
+  template: `<RepullingTransactionForm
+    ref="form"
+    v-model="model"
+    v-model:account-type="accountType"
+    v-model:error-messages="errors"
+    v-model:eth-staking-data="ethStakingData"
+    v-model:state-updated="stateUpdated"
+  />`,
+});
+
+describe('history/events/tx/RepullingTransactionForm.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<InstanceType<typeof Harness>>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    useBlockchainAccountsStore().updateAccounts(Blockchain.ETH, [addressAccount(Blockchain.ETH, ADDRESS)]);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(): VueWrapper<InstanceType<typeof Harness>> {
+    return mount(Harness, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          AccountDisplay: stub('AccountDisplay', ['account']),
+          BlockchainAccountSelector: stub('BlockchainAccountSelector', ['modelValue', 'errorMessages', 'chains']),
+          ChainSelect: stub('ChainSelect', ['modelValue', 'errorMessages', 'items']),
+          DateTimeRangePicker: stub('DateTimeRangePicker', ['start', 'end', 'startErrorMessages', 'endErrorMessages']),
+          RuiAlert: stub('RuiAlert', ['type']),
+          RuiAutoComplete: stub('RuiAutoComplete', ['modelValue', 'options', 'errorMessages']),
+          RuiTab: stub('RuiTab', ['value']),
+          RuiTabs: stub('RuiTabs', ['modelValue']),
+          ValidatorFilterInput: stub('ValidatorFilterInput', ['modelValue', 'items', 'hint']),
+        },
+      },
+    });
+  }
+
+  async function switchTo(type: AccountType): Promise<void> {
+    wrapper.vm.accountType = type;
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  async function editChain(): Promise<void> {
+    wrapper.findComponent<StubInstance>({ name: 'ChainSelect' }).vm.$emit('update:modelValue', Blockchain.ETH);
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should delegate validation to the tab on screen', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The exchange tab opens with nothing chosen, so it rejects where the blockchain tab accepts.
+    expect(await wrapper.vm.form?.validate()).toBe(true);
+
+    await switchTo('exchange');
+
+    expect(await wrapper.vm.form?.validate()).toBe(false);
+  });
+
+  /*
+   * The flag belongs to the dialog and outlives the form that armed it. Leaving a tab has to hand
+   * it back disarmed, or the tab arrived at prompts about changes the user made somewhere else -
+   * and cannot clear it, because its own state is pristine and never changes.
+   */
+  it('should disarm the close prompt when an edited tab is left', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await editChain();
+    expect(wrapper.vm.stateUpdated).toBe(true);
+
+    await switchTo('exchange');
+
+    expect(wrapper.vm.stateUpdated).toBe(false);
+  });
+
+  it('should disarm the close prompt on the way to eth staking too', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await editChain();
+    await switchTo('eth_staking');
+
+    expect(wrapper.vm.stateUpdated).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/history/events/tx/TransactionForm.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/TransactionForm.spec.ts
@@ -1,12 +1,13 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComponentPublicInstance } from 'vue';
 import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { AddTransactionHashPayload } from '@/modules/history/events/event-payloads';
 import { Blockchain } from '@rotki/common';
+import { type ModelFormHarness, mountModelForm } from '@test/utils/model-form-harness';
 import { libraryDefaults } from '@test/utils/provide-defaults';
-import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, type Pinia, setActivePinia } from 'pinia';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ComponentPublicInstance, defineComponent, useTemplateRef } from 'vue';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import TransactionForm from '@/modules/history/events/tx/TransactionForm.vue';
 import '@test/i18n';
@@ -47,28 +48,10 @@ function addressAccount(chain: string, address: string): BlockchainAccount {
  * The form edits a payload its dialog owns, so the round trip is part of what is under test: a
  * harness that holds the model in a real ref exercises it, while re-feeding props by hand does not.
  */
-let seed: { errors: ValidationErrors; payload: AddTransactionHashPayload };
-
-const Harness = defineComponent({
-  components: { TransactionForm },
-  setup() {
-    const model = ref<AddTransactionHashPayload>(seed.payload);
-    const errors = ref<ValidationErrors>(seed.errors);
-    const stateUpdated = ref<boolean>(false);
-    const form = useTemplateRef<InstanceType<typeof TransactionForm>>('form');
-    return { errors, form, model, stateUpdated };
-  },
-  template: `<TransactionForm
-    ref="form"
-    v-model="model"
-    v-model:error-messages="errors"
-    v-model:state-updated="stateUpdated"
-  />`,
-});
 
 describe('history/events/tx/TransactionForm.vue', () => {
   let pinia: Pinia;
-  let wrapper: VueWrapper<InstanceType<typeof Harness>>;
+  let harness: ModelFormHarness<AddTransactionHashPayload>;
 
   function basePayload(): AddTransactionHashPayload {
     return {
@@ -89,16 +72,16 @@ describe('history/events/tx/TransactionForm.vue', () => {
   });
 
   afterEach(() => {
-    wrapper?.unmount();
+    harness?.wrapper.unmount();
     vi.useRealTimers();
   });
 
   function createWrapper(
     modelValue: AddTransactionHashPayload = basePayload(),
     errorMessages: ValidationErrors = {},
-  ): VueWrapper<InstanceType<typeof Harness>> {
-    seed = { errors: errorMessages, payload: modelValue };
-    return mount(Harness, {
+  ): ModelFormHarness<AddTransactionHashPayload> {
+    return mountModelForm(TransactionForm, {
+      errors: errorMessages,
       global: {
         plugins: [pinia],
         provide: libraryDefaults,
@@ -107,17 +90,12 @@ describe('history/events/tx/TransactionForm.vue', () => {
           ChainSelect: selectStub('ChainSelect'),
         },
       },
+      payload: modelValue,
     });
   }
 
-  function form(): InstanceType<typeof TransactionForm> {
-    const instance = wrapper.vm.form;
-    assert(instance);
-    return instance;
-  }
-
   function field(testId: string): VueWrapper<StubInstance> {
-    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+    return harness.wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
   }
 
   function messages(testId: string): string[] {
@@ -132,52 +110,52 @@ describe('history/events/tx/TransactionForm.vue', () => {
   }
 
   it('should accept a fully filled payload', async () => {
-    wrapper = createWrapper();
+    harness = createWrapper();
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(await form().validate()).toBe(true);
+    expect(await harness.validate()).toBe(true);
   });
 
   it.each([
     ['associatedAddress'],
     ['txRef'],
   ] as const)('should reject a payload with an empty %s', async (key) => {
-    wrapper = createWrapper({ ...basePayload(), [key]: '' });
+    harness = createWrapper({ ...basePayload(), [key]: '' });
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(await form().validate()).toBe(false);
+    expect(await harness.validate()).toBe(false);
   });
 
   // The form seeds a chain on open, so an empty `blockchain` is only reachable by clearing the
   // select, never by opening the dialog on a payload that has none.
   it('should reject the payload once the chain is cleared', async () => {
-    wrapper = createWrapper();
+    harness = createWrapper();
     await vi.advanceTimersToNextTimerAsync();
 
     field('tx-blockchain').vm.$emit('update:modelValue', '');
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(await form().validate()).toBe(false);
+    expect(await harness.validate()).toBe(false);
     await vi.advanceTimersToNextTimerAsync();
     expect(messages('tx-blockchain')).not.toEqual([]);
   });
 
   it('should reject a tx reference that is not a hash or a signature', async () => {
-    wrapper = createWrapper({ ...basePayload(), txRef: '0xnope' });
+    harness = createWrapper({ ...basePayload(), txRef: '0xnope' });
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(await form().validate()).toBe(false);
+    expect(await harness.validate()).toBe(false);
   });
 
   it('should reject a whitespace-only tx reference', async () => {
-    wrapper = createWrapper({ ...basePayload(), txRef: '   ' });
+    harness = createWrapper({ ...basePayload(), txRef: '   ' });
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(await form().validate()).toBe(false);
+    expect(await harness.validate()).toBe(false);
   });
 
   it('should show no message before anything is edited', async () => {
-    wrapper = createWrapper({ associatedAddress: '', blockchain: '', txRef: '' });
+    harness = createWrapper({ associatedAddress: '', blockchain: '', txRef: '' });
     await vi.advanceTimersToNextTimerAsync();
 
     expect(messages('tx-account')).toEqual([]);
@@ -185,10 +163,10 @@ describe('history/events/tx/TransactionForm.vue', () => {
   });
 
   it('should reveal every message once validate runs', async () => {
-    wrapper = createWrapper({ associatedAddress: '', blockchain: '', txRef: '' });
+    harness = createWrapper({ associatedAddress: '', blockchain: '', txRef: '' });
     await vi.advanceTimersToNextTimerAsync();
 
-    await form().validate();
+    await harness.validate();
     await vi.advanceTimersToNextTimerAsync();
 
     expect(messages('tx-account')).toEqual(['transactions.form.account.validation.non_empty']);
@@ -196,7 +174,7 @@ describe('history/events/tx/TransactionForm.vue', () => {
   });
 
   it('should show the tx reference message once the field is emptied', async () => {
-    wrapper = createWrapper();
+    harness = createWrapper();
     await vi.advanceTimersToNextTimerAsync();
 
     await editTxRef('');
@@ -207,19 +185,19 @@ describe('history/events/tx/TransactionForm.vue', () => {
   });
 
   it('should write an edit back into the model', async () => {
-    wrapper = createWrapper();
+    harness = createWrapper();
     await vi.advanceTimersToNextTimerAsync();
 
     await editTxRef(OTHER_TX_HASH);
 
-    expect(wrapper.vm.model.txRef).toBe(OTHER_TX_HASH);
+    expect(harness.model().txRef).toBe(OTHER_TX_HASH);
   });
 
   it('should surface a server error under the field it names', async () => {
-    wrapper = createWrapper(basePayload(), { txRef: ['already added'] });
+    harness = createWrapper(basePayload(), { txRef: ['already added'] });
     await vi.advanceTimersToNextTimerAsync();
 
-    await form().validate();
+    await harness.validate();
     await vi.advanceTimersToNextTimerAsync();
 
     expect(field('tx-ref').text()).toContain('already added');
@@ -227,37 +205,37 @@ describe('history/events/tx/TransactionForm.vue', () => {
 
   it('should seed the chain remembered from the last add', async () => {
     localStorage.setItem('rotki.history_event.add_by_tx_hash.chain', Blockchain.OPTIMISM);
-    wrapper = createWrapper({ ...basePayload(), blockchain: '' });
+    harness = createWrapper({ ...basePayload(), blockchain: '' });
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(wrapper.vm.model.blockchain).toBe(Blockchain.OPTIMISM);
+    expect(harness.model().blockchain).toBe(Blockchain.OPTIMISM);
   });
 
   it('should not arm the close prompt for the chain it seeds itself', async () => {
-    wrapper = createWrapper({ ...basePayload(), blockchain: '' });
+    harness = createWrapper({ ...basePayload(), blockchain: '' });
     // Past the point where an edit would be picked up, so only the seeding is in play.
     await vi.advanceTimersByTimeAsync(600);
 
-    expect(wrapper.vm.stateUpdated).toBe(false);
+    expect(harness.stateUpdated()).toBe(false);
   });
 
   it('should arm the close prompt once a field is edited', async () => {
-    wrapper = createWrapper();
+    harness = createWrapper();
     await vi.advanceTimersByTimeAsync(600);
 
     await editTxRef(OTHER_TX_HASH);
 
-    expect(wrapper.vm.stateUpdated).toBe(true);
+    expect(harness.stateUpdated()).toBe(true);
   });
 
   it('should render nothing to fill in when no chain has an account', async () => {
     const store = useBlockchainAccountsStore();
     store.updateAccounts(Blockchain.ETH, []);
     store.updateAccounts(Blockchain.OPTIMISM, []);
-    wrapper = createWrapper();
+    harness = createWrapper();
     await vi.advanceTimersToNextTimerAsync();
 
     expect(field('tx-blockchain').exists()).toBe(false);
-    expect(wrapper.text()).toContain('transactions.form.no_accounts');
+    expect(harness.wrapper.text()).toContain('transactions.form.no_accounts');
   });
 });

--- a/frontend/app/src/modules/history/events/tx/TransactionForm.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/TransactionForm.spec.ts
@@ -1,0 +1,263 @@
+import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import type { AddTransactionHashPayload } from '@/modules/history/events/event-payloads';
+import { Blockchain } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, type Pinia, setActivePinia } from 'pinia';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComponentPublicInstance, defineComponent, useTemplateRef } from 'vue';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import TransactionForm from '@/modules/history/events/tx/TransactionForm.vue';
+import '@test/i18n';
+
+const ADDRESS = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12';
+const TX_HASH = '0x8d0e0f0e0a4b1e1c9c8d6c5b4a39281706f5e4d3c2b1a09f8e7d6c5b4a392817';
+const OTHER_TX_HASH = '0x1a2b3c4d5e6f78901234567890abcdef1234567890abcdef1234567890abcdef';
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({
+    evmAndEvmLikeTxChainsInfo: computed(() => [{ id: Blockchain.ETH }, { id: Blockchain.OPTIMISM }]),
+    getChain: (chain: string): string => chain,
+    solanaChainsData: computed(() => []),
+  }),
+}));
+
+/** The two selects are heavy third-party wrappers, stubbed down to what the form reads. */
+function selectStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue'],
+    name,
+    props: ['modelValue', 'errorMessages', 'items', 'chains'],
+    template: '<div />',
+  };
+}
+
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function addressAccount(chain: string, address: string): BlockchainAccount {
+  return {
+    chain,
+    data: { address, type: 'address' },
+    nativeAsset: 'ETH',
+  };
+}
+
+/**
+ * The form edits a payload its dialog owns, so the round trip is part of what is under test: a
+ * harness that holds the model in a real ref exercises it, while re-feeding props by hand does not.
+ */
+let seed: { errors: ValidationErrors; payload: AddTransactionHashPayload };
+
+const Harness = defineComponent({
+  components: { TransactionForm },
+  setup() {
+    const model = ref<AddTransactionHashPayload>(seed.payload);
+    const errors = ref<ValidationErrors>(seed.errors);
+    const stateUpdated = ref<boolean>(false);
+    const form = useTemplateRef<InstanceType<typeof TransactionForm>>('form');
+    return { errors, form, model, stateUpdated };
+  },
+  template: `<TransactionForm
+    ref="form"
+    v-model="model"
+    v-model:error-messages="errors"
+    v-model:state-updated="stateUpdated"
+  />`,
+});
+
+describe('history/events/tx/TransactionForm.vue', () => {
+  let pinia: Pinia;
+  let wrapper: VueWrapper<InstanceType<typeof Harness>>;
+
+  function basePayload(): AddTransactionHashPayload {
+    return {
+      associatedAddress: ADDRESS,
+      blockchain: Blockchain.ETH,
+      txRef: TX_HASH,
+    };
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    pinia = createPinia();
+    setActivePinia(pinia);
+    const store = useBlockchainAccountsStore();
+    store.updateAccounts(Blockchain.ETH, [addressAccount(Blockchain.ETH, ADDRESS)]);
+    store.updateAccounts(Blockchain.OPTIMISM, [addressAccount(Blockchain.OPTIMISM, ADDRESS)]);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    modelValue: AddTransactionHashPayload = basePayload(),
+    errorMessages: ValidationErrors = {},
+  ): VueWrapper<InstanceType<typeof Harness>> {
+    seed = { errors: errorMessages, payload: modelValue };
+    return mount(Harness, {
+      global: {
+        plugins: [pinia],
+        provide: libraryDefaults,
+        stubs: {
+          BlockchainAccountSelector: selectStub('BlockchainAccountSelector'),
+          ChainSelect: selectStub('ChainSelect'),
+        },
+      },
+    });
+  }
+
+  function form(): InstanceType<typeof TransactionForm> {
+    const instance = wrapper.vm.form;
+    assert(instance);
+    return instance;
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function editTxRef(value: string): Promise<void> {
+    await field('tx-ref').find('input').setValue(value);
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should accept a fully filled payload', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await form().validate()).toBe(true);
+  });
+
+  it.each([
+    ['associatedAddress'],
+    ['txRef'],
+  ] as const)('should reject a payload with an empty %s', async (key) => {
+    wrapper = createWrapper({ ...basePayload(), [key]: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await form().validate()).toBe(false);
+  });
+
+  // The form seeds a chain on open, so an empty `blockchain` is only reachable by clearing the
+  // select, never by opening the dialog on a payload that has none.
+  it('should reject the payload once the chain is cleared', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    field('tx-blockchain').vm.$emit('update:modelValue', '');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await form().validate()).toBe(false);
+    await vi.advanceTimersToNextTimerAsync();
+    expect(messages('tx-blockchain')).not.toEqual([]);
+  });
+
+  it('should reject a tx reference that is not a hash or a signature', async () => {
+    wrapper = createWrapper({ ...basePayload(), txRef: '0xnope' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await form().validate()).toBe(false);
+  });
+
+  it('should reject a whitespace-only tx reference', async () => {
+    wrapper = createWrapper({ ...basePayload(), txRef: '   ' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await form().validate()).toBe(false);
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper({ associatedAddress: '', blockchain: '', txRef: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('tx-account')).toEqual([]);
+    expect(messages('tx-blockchain')).toEqual([]);
+  });
+
+  it('should reveal every message once validate runs', async () => {
+    wrapper = createWrapper({ associatedAddress: '', blockchain: '', txRef: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await form().validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('tx-account')).toEqual(['transactions.form.account.validation.non_empty']);
+    expect(field('tx-ref').find('.text-rui-error').exists()).toBe(true);
+  });
+
+  it('should show the tx reference message once the field is emptied', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await editTxRef('');
+
+    expect(field('tx-ref').find('.text-rui-error').exists()).toBe(true);
+    // The untouched fields stay quiet.
+    expect(messages('tx-account')).toEqual([]);
+  });
+
+  it('should write an edit back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await editTxRef(OTHER_TX_HASH);
+
+    expect(wrapper.vm.model.txRef).toBe(OTHER_TX_HASH);
+  });
+
+  it('should surface a server error under the field it names', async () => {
+    wrapper = createWrapper(basePayload(), { txRef: ['already added'] });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await form().validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('tx-ref').text()).toContain('already added');
+  });
+
+  it('should seed the chain remembered from the last add', async () => {
+    localStorage.setItem('rotki.history_event.add_by_tx_hash.chain', Blockchain.OPTIMISM);
+    wrapper = createWrapper({ ...basePayload(), blockchain: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.vm.model.blockchain).toBe(Blockchain.OPTIMISM);
+  });
+
+  it('should not arm the close prompt for the chain it seeds itself', async () => {
+    wrapper = createWrapper({ ...basePayload(), blockchain: '' });
+    // Past the point where an edit would be picked up, so only the seeding is in play.
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.vm.stateUpdated).toBe(false);
+  });
+
+  it('should arm the close prompt once a field is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    await editTxRef(OTHER_TX_HASH);
+
+    expect(wrapper.vm.stateUpdated).toBe(true);
+  });
+
+  it('should render nothing to fill in when no chain has an account', async () => {
+    const store = useBlockchainAccountsStore();
+    store.updateAccounts(Blockchain.ETH, []);
+    store.updateAccounts(Blockchain.OPTIMISM, []);
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('tx-blockchain').exists()).toBe(false);
+    expect(wrapper.text()).toContain('transactions.form.no_accounts');
+  });
+});

--- a/frontend/app/src/modules/history/events/tx/TransactionForm.vue
+++ b/frontend/app/src/modules/history/events/tx/TransactionForm.vue
@@ -1,19 +1,18 @@
 <script lang="ts" setup>
+import type { ZodType } from 'zod';
 import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { AddTransactionHashPayload } from '@/modules/history/events/event-payloads';
-import { Blockchain, isValidTxHashOrSignature } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import { Blockchain } from '@rotki/common';
 import { hasAccountAddress } from '@/modules/accounts/account-helpers';
 import { getAccountAddress } from '@/modules/accounts/account-utils';
 import ChainSelect from '@/modules/accounts/blockchain/ChainSelect.vue';
 import BlockchainAccountSelector from '@/modules/accounts/BlockchainAccountSelector.vue';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { toServerErrors } from '@/modules/core/form/server-errors';
+import { useModelForm } from '@/modules/core/form/use-model-form';
+import { transactionFormSchema, type TransactionFormState } from '@/modules/history/events/tx/transaction-form';
 
 const modelValue = defineModel<AddTransactionHashPayload>({ required: true });
 const errors = defineModel<ValidationErrors>('errorMessages', { required: true });
@@ -22,16 +21,13 @@ const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, requ
 const { t } = useI18n({ useScope: 'global' });
 
 const lastChain = useLocalStorage<string>('rotki.history_event.add_by_tx_hash.chain', Blockchain.ETH);
-const txRef = useRefPropVModel(modelValue, 'txRef');
-const blockchain = useRefPropVModel(modelValue, 'blockchain');
-const associatedAddress = useRefPropVModel(modelValue, 'associatedAddress');
 
 const { accounts: accountsPerChain } = storeToRefs(useBlockchainAccountsStore());
 const { evmAndEvmLikeTxChainsInfo, getChain, solanaChainsData } = useSupportedChains();
 const txChains = useArrayMap(evmAndEvmLikeTxChainsInfo, x => x.id);
 const solanaChains = useArrayMap(solanaChainsData, x => x.id);
 
-const chainOptions = computed(() => {
+const chainOptions = computed<string[]>(() => {
   const accountChains = Object.entries(get(accountsPerChain))
     .filter(([_, accounts]) => accounts.length > 0)
     .map(([chain]) => chain);
@@ -39,40 +35,49 @@ const chainOptions = computed(() => {
   return [...get(txChains), ...get(solanaChains)].filter(chain => accountChains.includes(chain));
 });
 
+const schema = computed<ZodType>(() => transactionFormSchema({
+  accountRequired: t('transactions.form.account.validation.non_empty'),
+  chainRequired: t('transactions.form.chain.validation.non_empty'),
+  txRefRequired: t('transactions.form.tx_hash.validation.non_empty'),
+  txRefValid: t('transactions.form.tx_hash.validation.valid'),
+}));
+
+const form = useModelForm<TransactionFormState>({
+  model: modelValue,
+  schema,
+  stateUpdated,
+});
+
+/*
+ * The dialog opens on the chain the last add used. It is seeded through `reset`, so it becomes part
+ * of the baseline the form compares against: written as a plain edit it would arm the dialog's
+ * close prompt before the user has typed anything.
+ */
+const options = get(chainOptions);
+if (!options.includes(get<string>(lastChain)) && options.length > 0) {
+  set(lastChain, options[0]);
+}
+form.reset({ ...form.state, blockchain: get<string>(lastChain) });
+
 const usableChains = computed<string[]>(() => {
-  const blockchainVal = get(blockchain);
-  if (!blockchainVal) {
+  const blockchain = form.state.blockchain;
+  if (!blockchain) {
     return get(chainOptions);
   }
 
-  return [getChain(blockchainVal)];
-});
-
-watch(blockchain, (chain) => {
-  if (chain) {
-    set(lastChain, chain);
-  }
-});
-
-onMounted(() => {
-  const last = get<string>(lastChain);
-  const options = get(chainOptions);
-  if (!options.includes(last) && options.length > 0) {
-    set(lastChain, options[0]);
-  }
-  set(blockchain, get<string>(lastChain));
+  return [getChain(blockchain)];
 });
 
 const accounts = computed<BlockchainAccount<AddressData>[]>({
   get: () => {
-    const model = get(modelValue);
+    const { associatedAddress, blockchain } = form.state;
     const accountFound = Object.values(get(accountsPerChain))
       .flatMap(x => x)
       .filter(hasAccountAddress)
       .find(
         item =>
-          getAccountAddress(item) === model.associatedAddress
-          && (!model.blockchain || model.blockchain === item.chain),
+          getAccountAddress(item) === associatedAddress
+          && (!blockchain || blockchain === item.chain),
       );
 
     if (accountFound) {
@@ -83,54 +88,28 @@ const accounts = computed<BlockchainAccount<AddressData>[]>({
   },
   set: (value: BlockchainAccount<AddressData>[]) => {
     const account = value[0];
-    const associatedAddress = account
-      ? getAccountAddress(account)
-      : '';
-
-    set(modelValue, {
-      ...get(modelValue),
-      associatedAddress,
-    });
+    form.state.associatedAddress = account ? getAccountAddress(account) : '';
+    form.touch('associatedAddress');
   },
 });
 
-const rules = {
-  associatedAddress: {
-    required: helpers.withMessage(
-      t('transactions.form.account.validation.non_empty'),
-      (accounts: BlockchainAccount<AddressData>[]) => accounts.length > 0,
-    ),
-  },
-  blockchain: { required },
-  txRef: {
-    isValidTxHashOrSignature: helpers.withMessage(t('transactions.form.tx_hash.validation.valid'), isValidTxHashOrSignature),
-    required: helpers.withMessage(t('transactions.form.tx_hash.validation.non_empty'), required),
-  },
-};
+watch(() => form.state.blockchain, (chain) => {
+  if (chain) {
+    set(lastChain, chain);
+  }
+});
 
-const states = {
-  associatedAddress,
-  blockchain,
-  txRef,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  {
-    $autoDirty: true,
-    $externalResults: errors,
-  },
-);
-
-useFormStateWatcher(states, stateUpdated);
+// Immediate: the dialog can hand the form errors from a save that failed before it reopened.
+watchImmediate(errors, (value) => {
+  form.setServerErrors(toServerErrors(value));
+}, { deep: true });
 
 onBeforeUnmount(() => {
   set(errors, {});
 });
 
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -147,14 +126,17 @@ defineExpose({
   >
     <div class="flex gap-2">
       <ChainSelect
-        v-model="blockchain"
+        v-model="form.state.blockchain"
         class="max-w-[20rem]"
+        data-testid="tx-blockchain"
         :items="chainOptions"
-        :error-messages="toMessages(v$.blockchain)"
+        :error-messages="form.errors('blockchain')"
+        @update:model-value="form.touch('blockchain')"
       />
       <BlockchainAccountSelector
         v-model="accounts"
         class="flex-1"
+        data-testid="tx-account"
         :chains="usableChains"
         hide-chain-icon
         outlined
@@ -163,17 +145,19 @@ defineExpose({
         required
         unique
         :label="t('common.address')"
-        :error-messages="toMessages(v$.associatedAddress)"
+        :error-messages="form.errors('associatedAddress')"
         :no-data-text="t('transactions.form.account.no_address_found')"
       />
     </div>
 
     <RuiTextField
-      v-model="txRef"
+      v-model="form.state.txRef"
+      data-testid="tx-ref"
       :label="`${t('common.tx_hash')} / ${t('common.signature')}`"
       variant="outlined"
       color="primary"
-      :error-messages="toMessages(v$.txRef)"
+      :error-messages="form.errors('txRef')"
+      @update:model-value="form.touch('txRef')"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/history/events/tx/TransactionForm.vue
+++ b/frontend/app/src/modules/history/events/tx/TransactionForm.vue
@@ -10,7 +10,6 @@ import ChainSelect from '@/modules/accounts/blockchain/ChainSelect.vue';
 import BlockchainAccountSelector from '@/modules/accounts/BlockchainAccountSelector.vue';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { toServerErrors } from '@/modules/core/form/server-errors';
 import { useModelForm } from '@/modules/core/form/use-model-form';
 import { transactionFormSchema, type TransactionFormState } from '@/modules/history/events/tx/transaction-form';
 
@@ -42,22 +41,22 @@ const schema = computed<ZodType>(() => transactionFormSchema({
   txRefValid: t('transactions.form.tx_hash.validation.valid'),
 }));
 
+/** The dialog opens on the chain the last add used, or on the first one with an account. */
+function rememberedChain(): string {
+  const options = get(chainOptions);
+  if (!options.includes(get<string>(lastChain)) && options.length > 0) {
+    set(lastChain, options[0]);
+  }
+  return get<string>(lastChain);
+}
+
 const form = useModelForm<TransactionFormState>({
   model: modelValue,
   schema,
+  seed: state => ({ ...state, blockchain: rememberedChain() }),
+  serverErrors: errors,
   stateUpdated,
 });
-
-/*
- * The dialog opens on the chain the last add used. It is seeded through `reset`, so it becomes part
- * of the baseline the form compares against: written as a plain edit it would arm the dialog's
- * close prompt before the user has typed anything.
- */
-const options = get(chainOptions);
-if (!options.includes(get<string>(lastChain)) && options.length > 0) {
-  set(lastChain, options[0]);
-}
-form.reset({ ...form.state, blockchain: get<string>(lastChain) });
 
 const usableChains = computed<string[]>(() => {
   const blockchain = form.state.blockchain;
@@ -98,11 +97,6 @@ watch(() => form.state.blockchain, (chain) => {
     set(lastChain, chain);
   }
 });
-
-// Immediate: the dialog can hand the form errors from a save that failed before it reopened.
-watchImmediate(errors, (value) => {
-  form.setServerErrors(toServerErrors(value));
-}, { deep: true });
 
 onBeforeUnmount(() => {
   set(errors, {});

--- a/frontend/app/src/modules/history/events/tx/repulling-forms.ts
+++ b/frontend/app/src/modules/history/events/tx/repulling-forms.ts
@@ -1,0 +1,93 @@
+import type { Eth2ValidatorEntry } from '@rotki/common';
+import type { RepullingEthStakingPayload } from '@/modules/history/events/event-payloads';
+import { z, type ZodType } from 'zod';
+import { Exchange } from '@/modules/balances/types/exchanges';
+import { requiredField } from '@/modules/core/form/fields';
+
+/**
+ * The three repulling forms are not one schema with a flag. They share the optional time range and
+ * nothing else: the blockchain one edits a chain and an address, the exchange one an exchange that
+ * never reaches the payload, and eth staking an entry type. Only the range is factored out.
+ *
+ * The range is required whenever its picker is on screen, and the epoch is a date like any other:
+ * `required` reported on a cleared picker, which arrives as undefined, never on 0.
+ */
+function timeRange(required: boolean, message: string): {
+  fromTimestamp: ZodType<number | undefined>;
+  toTimestamp: ZodType<number | undefined>;
+} {
+  const field = required ? z.number({ error: message }) : z.number().optional();
+  return { fromTimestamp: field, toTimestamp: field };
+}
+
+export interface RepullingBlockchainFormState {
+  address?: string;
+  chain?: string;
+  fromTimestamp?: number;
+  toTimestamp?: number;
+}
+
+export interface RepullingExchangeFormState {
+  /** Local to the form: the request carries the exchange itself, not through the shared payload. */
+  exchange?: Exchange;
+  fromTimestamp?: number;
+  toTimestamp?: number;
+}
+
+export type RepullingFilterMode = 'addresses' | 'validator_indices';
+
+export interface RepullingEthStakingFormState {
+  entryType: string;
+  /** Which of the two selections below is sent. Never part of the request itself. */
+  filterMode: RepullingFilterMode;
+  fromTimestamp?: number;
+  toTimestamp?: number;
+  selectedAddresses: string[];
+  selectedValidators: Eth2ValidatorEntry[];
+}
+
+export function repullingBlockchainSchema(rangeRequired: string): ZodType {
+  return z.object({
+    /*
+     * Neither carries a rule. The address is here so an error the api reports against it has
+     * somewhere to land, which vuelidate needed a no-op validator to do at all.
+     */
+    address: z.string().optional(),
+    chain: z.string().optional(),
+    ...timeRange(true, rangeRequired),
+  });
+}
+
+export function repullingExchangeSchema(messages: { exchangeRequired: string; rangeRequired: string }, hasDateRange: boolean): ZodType {
+  return z.object({
+    exchange: Exchange.or(z.undefined()).refine(value => value !== undefined, { error: messages.exchangeRequired }),
+    ...timeRange(hasDateRange, messages.rangeRequired),
+  });
+}
+
+/** The request the eth staking form's state projects to: one selection or the other, never both. */
+export function toEthStakingPayload(state: RepullingEthStakingFormState): RepullingEthStakingPayload {
+  const base: RepullingEthStakingPayload = {
+    entryType: state.entryType,
+    fromTimestamp: state.fromTimestamp,
+    toTimestamp: state.toTimestamp,
+  };
+
+  return state.filterMode === 'validator_indices'
+    ? { ...base, validatorIndices: state.selectedValidators.map(validator => validator.index) }
+    : { ...base, addresses: state.selectedAddresses };
+}
+
+/**
+ * The two selections carry no rule: either may be empty, which the request reads as "all of them".
+ * They are still in the state, because changing one is an edit the dialog has to prompt about.
+ */
+export function repullingEthStakingSchema(messages: { entryTypeRequired: string; rangeRequired: string }, hasDateRange: boolean): ZodType {
+  return z.object({
+    entryType: requiredField(messages.entryTypeRequired),
+    filterMode: z.string(),
+    selectedAddresses: z.array(z.string()),
+    selectedValidators: z.array(z.custom<Eth2ValidatorEntry>()),
+    ...timeRange(hasDateRange, messages.rangeRequired),
+  });
+}

--- a/frontend/app/src/modules/history/events/tx/transaction-form.ts
+++ b/frontend/app/src/modules/history/events/tx/transaction-form.ts
@@ -1,0 +1,36 @@
+import { isValidTxHashOrSignature } from '@rotki/common';
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+/** The payload's own fields are readonly, and the form has to be able to write them. */
+export interface TransactionFormState {
+  associatedAddress: string;
+  blockchain: string;
+  txRef: string;
+}
+
+export interface TransactionFormMessages {
+  accountRequired: string;
+  chainRequired: string;
+  txRefRequired: string;
+  txRefValid: string;
+}
+
+export function transactionFormSchema(messages: TransactionFormMessages): ZodType {
+  return z.object({
+    /*
+     * Not trimmed, unlike the other two. The address is picked from a selector rather than typed,
+     * so the rule only ever separates "an account is chosen" from "none is", and trimming here
+     * would be a new rule rather than a port of the old one.
+     */
+    associatedAddress: z.string().min(1, { error: messages.accountRequired }),
+    blockchain: requiredField(messages.chainRequired),
+    /*
+     * Both messages, because the format check runs on an empty string too and reports alongside
+     * the missing-value one, which is what the form showed before.
+     */
+    txRef: requiredField(messages.txRefRequired).refine(isValidTxHashOrSignature, {
+      error: messages.txRefValid,
+    }),
+  });
+}

--- a/frontend/app/src/modules/history/events/tx/transaction-form.ts
+++ b/frontend/app/src/modules/history/events/tx/transaction-form.ts
@@ -23,7 +23,7 @@ export function transactionFormSchema(messages: TransactionFormMessages): ZodTyp
      * so the rule only ever separates "an account is chosen" from "none is", and trimming here
      * would be a new rule rather than a port of the old one.
      */
-    associatedAddress: z.string().min(1, { error: messages.accountRequired }),
+    associatedAddress: z.string({ error: messages.accountRequired }).min(1, { error: messages.accountRequired }),
     blockchain: requiredField(messages.chainRequired),
     /*
      * Both messages, because the format check runs on an empty string too and reports alongside

--- a/frontend/app/tests/unit/utils/model-form-harness.ts
+++ b/frontend/app/tests/unit/utils/model-form-harness.ts
@@ -1,0 +1,97 @@
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { type ComponentMountingOptions, mount, type VueWrapper } from '@vue/test-utils';
+import { type Component, type ComponentPublicInstance, defineComponent, h, ref, shallowRef } from 'vue';
+
+interface ExposedForm {
+  validate: () => boolean | Promise<boolean>;
+}
+
+function isExposedForm(value: unknown): value is ExposedForm {
+  return typeof value === 'object' && value !== null && typeof Reflect.get(value, 'validate') === 'function';
+}
+
+export interface ModelFormHarness<TPayload extends object> {
+  wrapper: VueWrapper;
+  /** The payload as the dialog above the form holds it, after every write the form has made. */
+  model: () => TPayload;
+  /** The dialog's prompt-on-close flag. False on open is the contract; see `mountModelForm`. */
+  stateUpdated: () => boolean;
+  /** Field errors as reported by the api, which the form both reads and clears. */
+  errors: () => ValidationErrors;
+  validate: () => boolean | Promise<boolean>;
+}
+
+export interface ModelFormOptions<TPayload extends object> {
+  payload: TPayload;
+  /** Only bound when given, so a form that declares no `errorMessages` model gets no stray attr. */
+  errors?: ValidationErrors;
+  props?: Record<string, unknown>;
+  global?: ComponentMountingOptions<Component>['global'];
+}
+
+/**
+ * Mounts a form whose payload belongs to the dialog above it, with a parent that holds that payload
+ * in a real ref.
+ *
+ * The round trip is part of what these forms do, so it has to be real: re-feeding `modelValue` with
+ * `wrapper.setProps` never reaches the form's own state, which leaves the edit-driven assertions
+ * passing for the wrong reason and the ones about `stateUpdated` failing for no reason.
+ *
+ * Two contracts are worth asserting for every one of these forms, because neither is visible
+ * without a test and both have been broken in practice:
+ *
+ * - `expect(harness.stateUpdated()).toBe(false)` after mount settles. A form that decides part of
+ *   its own opening state - a remembered chain, a suggested name - must seed it into the baseline
+ *   (`useModelForm`'s `seed`), or the dialog prompts about unsaved changes before the user has
+ *   touched anything.
+ * - an edit reaching `harness.model()`, since the dialog saves what it reads off the model rather
+ *   than what the form holds.
+ */
+export function mountModelForm<TPayload extends object>(
+  component: Component,
+  options: ModelFormOptions<TPayload>,
+): ModelFormHarness<TPayload> {
+  const model = ref<TPayload>(options.payload);
+  const errors = ref<ValidationErrors>(options.errors ?? {});
+  const stateUpdated = ref<boolean>(false);
+  const form = shallowRef<ExposedForm>();
+
+  const bindsErrors = options.errors !== undefined;
+
+  const parent = defineComponent({
+    setup() {
+      return () => h(component, {
+        ...options.props,
+        'modelValue': get(model),
+        'onUpdate:modelValue': (value: TPayload): void => set(model, value),
+        'ref': (instance: Element | ComponentPublicInstance | null): void => {
+          if (isExposedForm(instance))
+            set(form, instance);
+        },
+        'stateUpdated': get(stateUpdated),
+        'onUpdate:stateUpdated': (value: boolean): void => set(stateUpdated, value),
+        ...(bindsErrors
+          ? {
+              'errorMessages': get(errors),
+              'onUpdate:errorMessages': (value: ValidationErrors): void => set(errors, value),
+            }
+          : {}),
+      });
+    },
+  });
+
+  const wrapper = mount(parent, { global: options.global });
+
+  return {
+    errors: (): ValidationErrors => get(errors),
+    model: (): TPayload => get(model),
+    stateUpdated: (): boolean => get(stateUpdated),
+    validate: (): boolean | Promise<boolean> => {
+      const instance = get(form);
+      if (!instance)
+        throw new Error('the form did not expose a validate method');
+      return instance.validate();
+    },
+    wrapper,
+  };
+}


### PR DESCRIPTION
Continues the vuelidate to zod migration with the four forms under `modules/history/events/tx/`:
`TransactionForm`, `RepullingBlockchainForm`, `RepullingExchangeForm` and
`RepullingEthStakingForm`. That directory no longer imports vuelidate.

`AssetMovementMatchingSettingsMenu` is deliberately left out. It is a per-keystroke settings
popover with no submit boundary, so there is nothing for a form core to attach to.

### Two additions to the form core

Both come from wiring the first form by hand and finding the obvious way wrong.

`useModelForm` gained `seed`, for a form that decides part of its own opening state. Writing
that state into the model and re-taking the baseline does not work: a `defineModel` ref reads
back the value from before the write, so the baseline comes from the stale payload and the form
opens dirty, prompting about unsaved changes before the user has touched anything.
`ExchangeKeysForm` had already discovered this and solved it for itself, in a comment.

It also gained `serverErrors`, replacing the three-line watch each form repeated. It is
immediate, since a dialog can already hold errors from a failed save when the form mounts.

### Three shapes, not one

The forms are not variations of each other, and the migration does not pretend they are.
`repulling-forms.ts` factors out the optional time range and nothing else.

- `TransactionForm` and `RepullingBlockchainForm`: state is the payload, so `useModelForm`.
- `RepullingExchangeForm`: state is wider than the payload, since the chosen exchange never
  travels in it, so `useForm` mirroring only the range back.
- `RepullingEthStakingForm`: the payload is a projection of the state, since the filter mode
  picks which of the two selections is sent and never travels itself, so `useForm` and a
  transform.

### Fixes found along the way

- The exchange repull validated a `chain` it never renders. The payload is shared with the
  blockchain form, where clearing the chain is allowed, so switching tabs afterwards left the
  form rejecting itself with no field to show a message on: the button stopped working and
  nothing said why. The endpoint takes no chain at all. Fixed in its own commit, before the
  migration, so that diff stays a port.
- The three repull tabs share one unsaved-changes flag, and leaving an edited tab left it armed,
  so an untouched tab prompted about changes made elsewhere and could not clear it.
- Several bare `required` rules reported vuelidate's untranslated default and now have messages.

### Tests

None of the four forms had a spec, and neither did the tab switcher. Every rule is pinned by a
test that was checked by removing the rule and confirming that test fails.

Two of those checks changed the code. A test that could not fail turned out to be validating a
missing state key rather than the rule, which reported zod's wording rather than ours. And the
`externalServerValidation: () => true` no-op on the blockchain form's address is load-bearing
under vuelidate: dropping it takes the api's error message with it. The new core keys server
errors independently of schema rules, so the no-op is gone and the message still shows.

`getValidationErrors` also gets its first test. It decides for every form in the app whether an
api error lands under its field or in a message box, and it had none.

The epoch is pinned as a valid timestamp everywhere it appears. `required` reported on a cleared
picker, which arrives as undefined, so a port reaching for a truthiness check would silently
start rejecting 1970.

### Checks

Full unit suite (8014), typecheck, eslint, stylelint, linked keys and `typos` all clean. Both
dialogs were walked in the app: seeded chain, validation messages, and the close prompt arming
only after a real edit.

Depends on the form core from #12882.
