### PR TITLE
Validate the remaining singleton forms with zod

### DIFF
--- a/frontend/app/src/modules/assets/admin/MergeDialog.spec.ts
+++ b/frontend/app/src/modules/assets/admin/MergeDialog.spec.ts
@@ -1,0 +1,273 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import type { ActionStatus } from '@/modules/core/common/action';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@test/i18n';
+
+interface MergePayload {
+  sourceIdentifier: string;
+  targetIdentifier: string;
+}
+
+const mergeAssets = vi.fn<(payload: MergePayload) => Promise<ActionStatus<string | ValidationErrors>>>();
+
+vi.mock('@/modules/assets/use-assets', () => ({
+  useAssets: vi.fn().mockImplementation(() => ({ mergeAssets })),
+}));
+
+const MergeDialog = (await import('@/modules/assets/admin/MergeDialog.vue')).default;
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'update:asset', 'blur', 'focus'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled', 'excludes'],
+    template: '<div />',
+  };
+}
+
+describe('mergeDialog', () => {
+  let wrapper: VueWrapper<InstanceType<typeof MergeDialog>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mergeAssets.mockResolvedValue({ success: true });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(props: Record<string, unknown> = {}): VueWrapper<InstanceType<typeof MergeDialog>> {
+    return mount(MergeDialog, {
+      global: {
+        stubs: {
+          AssetSelect: inputStub('AssetSelect'),
+          RuiCard: {
+            name: 'RuiCard',
+            template: '<div><slot name="header" /><slot name="subheader" /><slot /><slot name="footer" /></div>',
+          },
+          RuiDialog: {
+            name: 'RuiDialog',
+            props: ['modelValue'],
+            template: '<div><slot v-if="modelValue" /></div>',
+          },
+          RuiTextField: inputStub('RuiTextField'),
+        },
+      },
+      props: { modelValue: true, ...props },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  function submitDisabled(): unknown {
+    return wrapper.findComponent<StubInstance>('[data-testid=merge-submit]').props('disabled');
+  }
+
+  async function edit(testId: string, value: string): Promise<void> {
+    const input = field(testId);
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  async function fillBoth(): Promise<void> {
+    await edit('merge-source', 'eip155:1/erc20:0xsource');
+    await edit('merge-target', 'ETH');
+  }
+
+  async function submit(): Promise<void> {
+    await wrapper.find('form').trigger('submit');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should show no message before anything is touched', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('merge-source')).toEqual([]);
+    expect(messages('merge-target')).toEqual([]);
+  });
+
+  it('should block the merge while both identifiers are empty', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(submitDisabled()).toBe(true);
+  });
+
+  it('should block the merge while only the source is filled', async () => {
+    wrapper = createWrapper();
+    await edit('merge-source', 'eip155:1/erc20:0xsource');
+
+    expect(submitDisabled()).toBe(true);
+  });
+
+  it('should block the merge while only the target is filled', async () => {
+    wrapper = createWrapper();
+    await edit('merge-target', 'ETH');
+
+    expect(submitDisabled()).toBe(true);
+  });
+
+  it('should allow the merge once both identifiers are filled', async () => {
+    wrapper = createWrapper();
+    await fillBoth();
+
+    expect(submitDisabled()).toBe(false);
+    // Both fields stay editable while nothing is in flight.
+    expect(field('merge-source').props('disabled')).toBe(false);
+    expect(field('merge-target').props('disabled')).toBe(false);
+  });
+
+  it('should keep the merge blocked for whitespace-only identifiers', async () => {
+    wrapper = createWrapper();
+    await edit('merge-source', '   ');
+    await edit('merge-target', '   ');
+
+    expect(submitDisabled()).toBe(true);
+  });
+
+  it('should report the source message while typing, before the field is left', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    // No blur: the submit button is gated on validity, and a disabled button cannot be clicked to
+    // blur the field, so waiting for blur would leave the user with no message at all.
+    field('merge-source').vm.$emit('update:modelValue', '');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('merge-source')).toEqual(['merge_dialog.source.non_empty']);
+  });
+
+  it('should report the source message once it is emptied', async () => {
+    wrapper = createWrapper();
+    await fillBoth();
+
+    await edit('merge-source', '');
+
+    expect(messages('merge-source')).toEqual(['merge_dialog.source.non_empty']);
+    expect(messages('merge-target')).toEqual([]);
+  });
+
+  it('should report the target message once it is emptied', async () => {
+    wrapper = createWrapper();
+    await fillBoth();
+
+    await edit('merge-target', '');
+
+    expect(messages('merge-target')).toEqual(['merge_dialog.target.non_empty']);
+  });
+
+  it('should seed both fields from the props when the dialog opens', async () => {
+    wrapper = createWrapper({
+      modelValue: false,
+      sourceIdentifier: 'eip155:1/erc20:0xseeded',
+      targetIdentifier: 'BTC',
+    });
+    await wrapper.setProps({ modelValue: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('merge-source').props('modelValue')).toBe('eip155:1/erc20:0xseeded');
+    expect(field('merge-target').props('modelValue')).toBe('BTC');
+  });
+
+  it('should merge the two identifiers and announce the result', async () => {
+    wrapper = createWrapper();
+    await fillBoth();
+
+    await submit();
+
+    expect(mergeAssets).toHaveBeenCalledWith({
+      sourceIdentifier: 'eip155:1/erc20:0xsource',
+      targetIdentifier: 'ETH',
+    });
+    expect(wrapper.emitted<[MergePayload]>('merged')?.at(-1)).toEqual([{
+      sourceIdentifier: 'eip155:1/erc20:0xsource',
+      targetIdentifier: 'ETH',
+    }]);
+  });
+
+  it('should clear both fields after a successful merge', async () => {
+    wrapper = createWrapper();
+    await fillBoth();
+
+    await submit();
+
+    expect(field('merge-source').props('modelValue')).toBe('');
+    expect(field('merge-target').props('modelValue')).toBe('');
+  });
+
+  it('should show a plain failure message under the source field', async () => {
+    mergeAssets.mockResolvedValue({ message: 'assets are not compatible', success: false });
+    wrapper = createWrapper();
+    await fillBoth();
+
+    await submit();
+
+    expect(messages('merge-source')).toEqual(['assets are not compatible']);
+  });
+
+  it('should fan a per-field failure onto the field it names', async () => {
+    mergeAssets.mockResolvedValue({
+      message: { targetIdentifier: ['unknown asset'] } satisfies ValidationErrors,
+      success: false,
+    });
+    wrapper = createWrapper();
+    await fillBoth();
+
+    await submit();
+
+    expect(messages('merge-target')).toEqual(['unknown asset']);
+  });
+
+  it('should keep the merge blocked while a server error stands', async () => {
+    mergeAssets.mockResolvedValue({ message: 'assets are not compatible', success: false });
+    wrapper = createWrapper();
+    await fillBoth();
+
+    await submit();
+
+    expect(submitDisabled()).toBe(true);
+  });
+
+  it('should drop the server message when the field is focused again', async () => {
+    mergeAssets.mockResolvedValue({ message: 'assets are not compatible', success: false });
+    wrapper = createWrapper();
+    await fillBoth();
+    await submit();
+
+    field('merge-source').vm.$emit('focus');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('merge-source')).toEqual([]);
+  });
+
+  it('should clear the fields when the dialog closes', async () => {
+    wrapper = createWrapper();
+    await fillBoth();
+
+    await wrapper.setProps({ modelValue: false });
+    await vi.advanceTimersByTimeAsync(200);
+    await wrapper.setProps({ modelValue: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('merge-source').props('modelValue')).toBe('');
+    expect(field('merge-target').props('modelValue')).toBe('');
+  });
+});

--- a/frontend/app/src/modules/assets/admin/MergeDialog.vue
+++ b/frontend/app/src/modules/assets/admin/MergeDialog.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
 import type { AssetInfoWithId } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { z, type ZodType } from 'zod';
 import { useAssets } from '@/modules/assets/use-assets';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { requiredField } from '@/modules/core/form/fields';
+import { toServerErrors } from '@/modules/core/form/server-errors';
+import { useForm } from '@/modules/core/form/use-form';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 
-type Errors = Partial<Record<'targetIdentifier' | 'sourceIdentifier', string[]>>;
+interface MergePayload {
+  sourceIdentifier: string;
+  targetIdentifier: string;
+}
 
 const display = defineModel<boolean>({ required: true });
 
@@ -16,103 +21,83 @@ const { sourceIdentifier: propSourceIdentifier, targetIdentifier: propTargetIden
 }>();
 
 const emit = defineEmits<{
-  merged: [events: { sourceIdentifier: string; targetIdentifier: string }];
+  merged: [events: MergePayload];
 }>();
 
-const done = ref(false);
-const errorMessages = ref<Errors>({});
-const targetIdentifier = ref('');
-const target = ref<AssetInfoWithId>();
-const sourceIdentifier = ref('');
-const pending = ref(false);
-
-const { mergeAssets } = useAssets();
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  sourceIdentifier: {
-    required: helpers.withMessage(t('merge_dialog.source.non_empty'), required),
-  },
-  targetIdentifier: {
-    required: helpers.withMessage(t('merge_dialog.target.non_empty'), required),
-  },
-};
+const { mergeAssets } = useAssets();
 
-const v$ = useVuelidate(
-  rules,
-  {
-    sourceIdentifier,
-    targetIdentifier,
-  },
-  {
-    $autoDirty: true,
-    $externalResults: errorMessages,
-  },
-);
+const done = ref<boolean>(false);
+const target = ref<AssetInfoWithId>();
 
-function reset() {
+const schema = computed<ZodType>(() => z.object({
+  sourceIdentifier: requiredField(t('merge_dialog.source.non_empty')),
+  targetIdentifier: requiredField(t('merge_dialog.target.non_empty')),
+}));
+
+const form = useForm<MergePayload, MergePayload, string | ValidationErrors>({
+  initial: (): MergePayload => ({ sourceIdentifier: '', targetIdentifier: '' }),
+  schema,
+  submit: async (payload: MergePayload) => mergeAssets(payload),
+  transform: (state): MergePayload => ({
+    sourceIdentifier: state.sourceIdentifier,
+    targetIdentifier: state.targetIdentifier,
+  }),
+});
+
+// Destructured, because a ref reached through `form.` in the template is not unwrapped and
+// would read as permanently truthy.
+const { errorCount, submitting, valid } = form;
+
+// The button is also blocked while a server error stands, which vuelidate did through
+// $externalResults feeding $invalid. The core keeps the two apart, so the count is read here.
+const blocked = computed<boolean>(() => !get(valid) || get(errorCount) > 0 || get(submitting));
+
+const excluded = computed<string[]>(() => {
+  const source = form.state.sourceIdentifier;
+  return source ? [source] : [];
+});
+
+function reset(): void {
   set(done, false);
-  set(targetIdentifier, '');
-  set(sourceIdentifier, '');
-  set(pending, false);
-  set(errorMessages, {});
-  get(v$).$reset();
+  form.reset();
   set(target, undefined);
 }
 
-function clearErrors() {
+function clearErrors(): void {
   set(done, false);
-  set(errorMessages, {});
+  form.setServerErrors({});
 }
 
-async function merge() {
-  set(pending, true);
-  const source = get(sourceIdentifier);
-  const target = get(targetIdentifier);
+async function merge(): Promise<void> {
+  const result = await form.submit();
 
-  const result = await mergeAssets({
-    sourceIdentifier: source,
-    targetIdentifier: target,
-  });
-
-  if (result.success) {
-    emit('merged', { sourceIdentifier: source, targetIdentifier: target });
+  if (result.outcome === 'success') {
+    emit('merged', result.payload);
     reset();
     set(done, true);
   }
-  else {
-    set(
-      errorMessages,
-      typeof result.message === 'string'
-        ? ({
-            sourceIdentifier: [result.message || t('merge_dialog.error')],
-          } satisfies Errors)
-        : result.message,
-    );
-    await get(v$).$validate();
+  else if (result.outcome === 'error') {
+    const { message } = result;
+    form.setServerErrors(typeof message === 'object'
+      ? toServerErrors(message)
+      : { sourceIdentifier: [message || t('merge_dialog.error')] });
   }
-  set(pending, false);
 }
 
-function input(value: boolean) {
+function input(value: boolean): void {
   set(display, value);
   setTimeout(reset, 100);
 }
 
-const excluded = computed(() => {
-  const source = get(sourceIdentifier);
-  if (!source)
-    return [];
-  return [source];
-});
-
 watch([display, () => propSourceIdentifier, () => propTargetIdentifier], ([isDisplayed, propSource, propTarget]) => {
   if (isDisplayed) {
     if (propSource) {
-      set(sourceIdentifier, propSource);
+      form.state.sourceIdentifier = propSource;
     }
     if (propTarget) {
-      set(targetIdentifier, propTarget);
+      form.state.targetIdentifier = propTarget;
     }
   }
 });
@@ -147,30 +132,32 @@ watch(display, (isDisplayed) => {
         <!-- We use `RuiTextField` here instead `asset-select` -->
         <!-- because the source can be filled with unknown identifier -->
         <RuiTextField
-          v-model="sourceIdentifier"
+          v-model="form.state.sourceIdentifier"
           :label="t('merge_dialog.source.label')"
-          :error-messages="toMessages(v$.sourceIdentifier)"
+          :error-messages="form.errors('sourceIdentifier')"
           variant="outlined"
           color="primary"
-          :disabled="pending"
+          :disabled="submitting"
           :hint="t('merge_dialog.source_hint')"
+          data-testid="merge-source"
           @focus="clearErrors()"
-          @blur="v$.sourceIdentifier.$touch()"
+          @update:model-value="form.touch('sourceIdentifier')"
         />
         <div class="my-4 flex justify-center">
           <RuiIcon name="lu-arrow-down" />
         </div>
         <AssetSelect
-          v-model="targetIdentifier"
+          v-model="form.state.targetIdentifier"
           v-model:asset="target"
           outlined
-          :error-messages="toMessages(v$.targetIdentifier)"
+          :error-messages="form.errors('targetIdentifier')"
           :label="t('merge_dialog.target.label')"
-          :disabled="pending"
+          :disabled="submitting"
           :excludes="excluded"
           :hint="target ? t('merge_dialog.target_hint', { identifier: target.identifier }) : ''"
+          data-testid="merge-target"
           @focus="clearErrors()"
-          @blur="v$.targetIdentifier.$touch()"
+          @update:model-value="form.touch('targetIdentifier')"
         />
 
         <RuiAlert
@@ -191,9 +178,10 @@ watch(display, (isDisplayed) => {
           </RuiButton>
           <RuiButton
             color="primary"
-            :disabled="v$.$invalid || pending"
-            :loading="pending"
+            :disabled="blocked"
+            :loading="submitting"
             type="submit"
+            data-testid="merge-submit"
           >
             {{ t('merge_dialog.merge') }}
           </RuiButton>

--- a/frontend/app/src/modules/assets/admin/UnderlyingTokenManager.spec.ts
+++ b/frontend/app/src/modules/assets/admin/UnderlyingTokenManager.spec.ts
@@ -1,0 +1,270 @@
+import { EvmTokenKind, type UnderlyingToken } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import useVuelidate from '@vuelidate/core';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComponentPublicInstance, defineComponent, h } from 'vue';
+import UnderlyingTokenManager from '@/modules/assets/admin/UnderlyingTokenManager.vue';
+import '@test/i18n';
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+const ADDRESS = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+const OTHER_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div><slot name="append" /></div>',
+  };
+}
+
+const stubs = {
+  RowActions: {
+    emits: ['delete-click', 'edit-click'],
+    name: 'RowActions',
+    template: '<div />',
+  },
+  RuiMenuSelect: inputStub('RuiMenuSelect'),
+  RuiTextField: inputStub('RuiTextField'),
+  SimpleTable: { name: 'SimpleTable', template: '<table><slot /></table>' },
+  UnderlyingTokenWeightHint: true,
+};
+
+describe('underlyingTokenManager', () => {
+  let wrapper: VueWrapper<InstanceType<typeof UnderlyingTokenManager>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(modelValue: UnderlyingToken[] = []): VueWrapper<InstanceType<typeof UnderlyingTokenManager>> {
+    return mount(UnderlyingTokenManager, {
+      global: { stubs },
+      props: { modelValue },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  function addDisabled(): unknown {
+    return wrapper.findComponent<StubInstance>('[data-testid=underlying-token-add]').props('disabled');
+  }
+
+  async function edit(testId: string, value: string): Promise<void> {
+    const input = field(testId);
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  async function fillRow(address = ADDRESS, weight = '50'): Promise<void> {
+    await edit('underlying-token-address', address);
+    await edit('underlying-token-weight', weight);
+  }
+
+  async function add(): Promise<void> {
+    await wrapper.find('form').trigger('submit');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  function lastModel(): UnderlyingToken[] | undefined {
+    return wrapper.emitted<[UnderlyingToken[]]>('update:modelValue')?.at(-1)?.[0];
+  }
+
+  it('should show no message before the staging row is touched', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('underlying-token-address')).toEqual([]);
+    expect(messages('underlying-token-weight')).toEqual([]);
+  });
+
+  it('should block the add button while the staging row is empty', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(addDisabled()).toBe(true);
+  });
+
+  it('should allow the add once the row is valid', async () => {
+    wrapper = createWrapper();
+    await fillRow();
+
+    expect(addDisabled()).toBe(false);
+    expect(messages('underlying-token-address')).toEqual([]);
+    expect(messages('underlying-token-weight')).toEqual([]);
+  });
+
+  it('should report an emptied address as both missing and malformed', async () => {
+    wrapper = createWrapper();
+    await fillRow();
+
+    await edit('underlying-token-address', '');
+
+    expect(messages('underlying-token-address')).toEqual([
+      'underlying_token_manager.validation.valid',
+      'underlying_token_manager.validation.address_non_empty',
+    ]);
+  });
+
+  it('should report a malformed address on its own', async () => {
+    wrapper = createWrapper();
+    await fillRow('0x123');
+
+    expect(messages('underlying-token-address')).toEqual(['underlying_token_manager.validation.valid']);
+    expect(addDisabled()).toBe(true);
+  });
+
+  it('should report an emptied weight as missing only', async () => {
+    wrapper = createWrapper();
+    await fillRow();
+
+    await edit('underlying-token-weight', '');
+
+    // The range and numeric rules skip an empty value, so only the missing-value rule fires.
+    expect(messages('underlying-token-weight')).toEqual(['underlying_token_manager.validation.non_empty']);
+  });
+
+  it('should report an out-of-range weight while typing, before the field is left', async () => {
+    wrapper = createWrapper();
+    await edit('underlying-token-address', ADDRESS);
+
+    // No blur: the add button is gated on validity, and a disabled button cannot be clicked to
+    // blur the field, so waiting for blur would leave the user with no message at all.
+    field('underlying-token-weight').vm.$emit('update:modelValue', '150');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('underlying-token-weight')).toEqual(['underlying_token_manager.validation.out_of_range']);
+  });
+
+  it.each([
+    ['0'],
+    ['101'],
+  ])('should reject %s as out of range', async (weight) => {
+    wrapper = createWrapper();
+    await fillRow(ADDRESS, weight);
+
+    expect(messages('underlying-token-weight')).toEqual(['underlying_token_manager.validation.out_of_range']);
+    expect(addDisabled()).toBe(true);
+  });
+
+  it('should report a non-numeric weight as both out of range and not a number', async () => {
+    wrapper = createWrapper();
+    await fillRow(ADDRESS, 'abc');
+
+    expect(messages('underlying-token-weight')).toEqual([
+      'underlying_token_manager.validation.out_of_range',
+      'underlying_token_manager.validation.not_valid',
+    ]);
+  });
+
+  it('should accept a fractional weight inside the range', async () => {
+    wrapper = createWrapper();
+    await fillRow(ADDRESS, '12.5');
+
+    expect(messages('underlying-token-weight')).toEqual([]);
+    expect(addDisabled()).toBe(false);
+  });
+
+  it('should reject a weight padded with whitespace', async () => {
+    wrapper = createWrapper();
+    await fillRow(ADDRESS, ' 50');
+
+    expect(messages('underlying-token-weight')).toEqual([
+      'underlying_token_manager.validation.out_of_range',
+      'underlying_token_manager.validation.not_valid',
+    ]);
+  });
+
+  it('should append the staged token and clear the row', async () => {
+    wrapper = createWrapper();
+    await fillRow();
+
+    await add();
+
+    expect(lastModel()).toEqual([{ address: ADDRESS, tokenKind: EvmTokenKind.ERC20, weight: '50' }]);
+    expect(field('underlying-token-address').props('modelValue')).toBe('');
+    expect(field('underlying-token-weight').props('modelValue')).toBe('');
+    expect(messages('underlying-token-address')).toEqual([]);
+  });
+
+  it('should replace an entry whose address is staged again', async () => {
+    wrapper = createWrapper([{ address: ADDRESS, tokenKind: EvmTokenKind.ERC20, weight: '20' }]);
+    await fillRow(ADDRESS, '70');
+
+    await add();
+
+    expect(lastModel()).toEqual([{ address: ADDRESS, tokenKind: EvmTokenKind.ERC20, weight: '70' }]);
+  });
+
+  it('should keep both entries when a second address is staged', async () => {
+    wrapper = createWrapper([{ address: ADDRESS, tokenKind: EvmTokenKind.ERC20, weight: '20' }]);
+    await fillRow(OTHER_ADDRESS, '70');
+
+    await add();
+
+    expect(lastModel()).toHaveLength(2);
+    expect(lastModel()?.at(-1)?.address).toBe(OTHER_ADDRESS);
+  });
+
+  it('should move a row back into the staging fields when it is edited', async () => {
+    wrapper = createWrapper([{ address: ADDRESS, tokenKind: EvmTokenKind.ERC20, weight: '20' }]);
+    await vi.advanceTimersToNextTimerAsync();
+
+    wrapper.findComponent<StubInstance>({ name: 'RowActions' }).vm.$emit('edit-click', {
+      address: ADDRESS,
+      tokenKind: EvmTokenKind.ERC20,
+      weight: '20',
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('underlying-token-address').props('modelValue')).toBe(ADDRESS);
+    expect(field('underlying-token-weight').props('modelValue')).toBe('20');
+    expect(lastModel()).toEqual([]);
+  });
+
+  it('should drop a row when it is deleted', async () => {
+    wrapper = createWrapper([{ address: ADDRESS, tokenKind: EvmTokenKind.ERC20, weight: '20' }]);
+    await vi.advanceTimersToNextTimerAsync();
+
+    wrapper.findComponent<StubInstance>({ name: 'RowActions' }).vm.$emit('delete-click');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(lastModel()).toEqual([]);
+  });
+
+  it('should keep its permanently invalid staging row out of a parent validator', async () => {
+    const Parent = defineComponent({
+      setup() {
+        const v$ = useVuelidate();
+        // Read in the render so the collector stays subscribed.
+        return (): unknown => h('div', { 'data-invalid': String(get(v$).$invalid) }, [
+          h(UnderlyingTokenManager, { 'modelValue': [], 'onUpdate:modelValue': (): void => {} }),
+        ]);
+      },
+    });
+
+    const parent = mount(Parent, { global: { stubs } });
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The staging row is empty, so the child is invalid; the parent must not see it.
+    expect(parent.find('[data-invalid]').attributes('data-invalid')).toBe('false');
+    parent.unmount();
+  });
+});

--- a/frontend/app/src/modules/assets/admin/UnderlyingTokenManager.vue
+++ b/frontend/app/src/modules/assets/admin/UnderlyingTokenManager.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { EvmTokenKind, isValidEthAddress, type UnderlyingToken } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { between, helpers, numeric, required } from '@vuelidate/validators';
+import { z, type ZodType } from 'zod';
 import UnderlyingTokenWeightHint from '@/modules/assets/admin/UnderlyingTokenWeightHint.vue';
 import { evmTokenKindsData } from '@/modules/core/common/chains';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import RowActions from '@/modules/shell/components/RowActions.vue';
 import SimpleTable from '@/modules/shell/components/SimpleTable.vue';
 
@@ -12,69 +11,88 @@ const modelValue = defineModel<UnderlyingToken[]>({ required: true });
 
 const { t } = useI18n({ useScope: 'global' });
 
-const underlyingAddress = ref<string>('');
-const tokenKind = ref<EvmTokenKind>(EvmTokenKind.ERC20);
-const underlyingWeight = ref<string>('');
-
-const rules = {
-  address: {
-    isValidEthAddress: helpers.withMessage(t('underlying_token_manager.validation.valid'), isValidEthAddress),
-    required: helpers.withMessage(t('underlying_token_manager.validation.address_non_empty'), required),
-  },
-  weight: {
-    minMax: helpers.withMessage(t('underlying_token_manager.validation.out_of_range'), between(1, 100)),
-    notNaN: helpers.withMessage(t('underlying_token_manager.validation.not_valid'), numeric),
-    required: helpers.withMessage(t('underlying_token_manager.validation.non_empty'), required),
-  },
-};
-
-const v$ = useVuelidate(
-  rules,
-  {
-    address: underlyingAddress,
-    weight: underlyingWeight,
-  },
-  { $autoDirty: true, $stopPropagation: true },
-);
-
-function addToken() {
-  const underlyingTokens = [...get(modelValue)];
-  const index = underlyingTokens.findIndex(({ address }) => address === get(underlyingAddress));
-
-  const token = {
-    address: get(underlyingAddress),
-    tokenKind: get(tokenKind),
-    weight: get(underlyingWeight),
-  };
-
-  if (index >= 0)
-    underlyingTokens[index] = token;
-  else underlyingTokens.push(token);
-
-  resetForm();
-  get(v$).$reset();
-  set(modelValue, underlyingTokens);
+/** Vuelidate's `req`, which reports presence without trimming, so `'  '` counts as present. */
+function isPresent(value: string): boolean {
+  return value.length > 0;
 }
 
-function editToken(token: UnderlyingToken) {
-  set(underlyingAddress, token.address);
-  set(tokenKind, token.tokenKind);
-  set(underlyingWeight, token.weight);
-  deleteToken(token.address);
-}
+/**
+ * The staging row, not the list it feeds. Both fields report every rule they break, in the order
+ * vuelidate evaluated them, so an emptied address is still both malformed and missing.
+ *
+ * The range rule rejects any value carrying whitespace, which is what `between` did before
+ * comparing, so `' 50'` is out of range rather than merely oddly typed.
+ */
+const schema = computed<ZodType>(() => z.object({
+  address: z.string().superRefine((value, ctx) => {
+    if (!isValidEthAddress(value))
+      ctx.addIssue({ code: 'custom', message: t('underlying_token_manager.validation.valid') });
 
-function deleteToken(address: string) {
-  const underlyingTokens = [...get(modelValue)];
+    if (value.trim() === '')
+      ctx.addIssue({ code: 'custom', message: t('underlying_token_manager.validation.address_non_empty') });
+  }),
+  tokenKind: z.enum(EvmTokenKind),
+  weight: z.string().superRefine((value, ctx) => {
+    const weight = Number(value);
+    if (isPresent(value) && (/\s/.test(value) || !(weight >= 1 && weight <= 100)))
+      ctx.addIssue({ code: 'custom', message: t('underlying_token_manager.validation.out_of_range') });
+
+    if (isPresent(value) && !/^\d*(?:\.\d+)?$/.test(value))
+      ctx.addIssue({ code: 'custom', message: t('underlying_token_manager.validation.not_valid') });
+
+    if (value.trim() === '')
+      ctx.addIssue({ code: 'custom', message: t('underlying_token_manager.validation.non_empty') });
+  }),
+}));
+
+/**
+ * The row is invalid whenever it is empty, which is most of the time, and it must never block the
+ * asset form that owns the list. Vuelidate needed $stopPropagation for that; a zod form joins no
+ * parent tree, so the isolation comes for free.
+ */
+const form = useForm<UnderlyingToken, UnderlyingToken>({
+  initial: (): UnderlyingToken => ({ address: '', tokenKind: EvmTokenKind.ERC20, weight: '' }),
+  schema,
+  submit: async (token: UnderlyingToken): Promise<{ success: boolean }> => {
+    const underlyingTokens = [...get(modelValue)];
+    const index = underlyingTokens.findIndex(({ address }) => address === token.address);
+
+    if (index >= 0)
+      underlyingTokens[index] = token;
+    else underlyingTokens.push(token);
+
+    set(modelValue, underlyingTokens);
+    return Promise.resolve({ success: true });
+  },
+  transform: (state): UnderlyingToken => ({
+    address: state.address,
+    tokenKind: state.tokenKind,
+    weight: state.weight,
+  }),
+});
+
+// Destructured, because a ref reached through `form.` in the template is not unwrapped and would
+// read as permanently truthy.
+const { valid } = form;
+
+function deleteToken(address: string): void {
   set(
     modelValue,
-    underlyingTokens.filter(({ address: tokenAddress }) => tokenAddress !== address),
+    [...get(modelValue)].filter(({ address: tokenAddress }) => tokenAddress !== address),
   );
 }
 
-function resetForm() {
-  set(underlyingAddress, '');
-  set(underlyingWeight, '');
-  set(tokenKind, EvmTokenKind.ERC20);
+async function addToken(): Promise<void> {
+  const result = await form.submit();
+  if (result.outcome === 'success')
+    form.reset();
+}
+
+function editToken(token: UnderlyingToken): void {
+  form.state.address = token.address;
+  form.state.tokenKind = token.tokenKind;
+  form.state.weight = token.weight;
+  deleteToken(token.address);
 }
 </script>
 
@@ -91,17 +109,19 @@ function resetForm() {
     >
       <div class="md:col-span-2">
         <RuiTextField
-          v-model="underlyingAddress"
-          :error-messages="toMessages(v$.address)"
+          v-model="form.state.address"
+          :error-messages="form.errors('address')"
+          data-testid="underlying-token-address"
           variant="outlined"
           color="primary"
           :label="t('common.address')"
+          @update:model-value="form.touch('address')"
         />
       </div>
 
       <div class="col-span-1">
         <RuiMenuSelect
-          v-model="tokenKind"
+          v-model="form.state.tokenKind"
           :label="t('asset_form.labels.token_kind')"
           :options="evmTokenKindsData"
           key-attr="identifier"
@@ -112,14 +132,16 @@ function resetForm() {
 
       <div class="col-span-1">
         <RuiTextField
-          v-model="underlyingWeight"
+          v-model="form.state.weight"
           variant="outlined"
           color="primary"
           type="number"
           max="100"
           min="1"
-          :error-messages="toMessages(v$.weight)"
+          :error-messages="form.errors('weight')"
+          data-testid="underlying-token-weight"
           :label="t('underlying_token_manager.labels.weight')"
+          @update:model-value="form.touch('weight')"
         >
           <template #append>
             <UnderlyingTokenWeightHint />
@@ -130,8 +152,9 @@ function resetForm() {
       <RuiButton
         color="primary"
         class="col-span-2 lg:col-span-4"
-        :disabled="v$.$invalid"
+        :disabled="!valid"
         type="submit"
+        data-testid="underlying-token-add"
       >
         <template #prepend>
           <RuiIcon name="lu-plus" />

--- a/frontend/app/src/modules/core/common/use-ref-truthy.ts
+++ b/frontend/app/src/modules/core/common/use-ref-truthy.ts
@@ -1,5 +1,0 @@
-import type { ComputedRef, MaybeRef } from 'vue';
-
-export function refIsTruthy<T>(ref: MaybeRef<T>): ComputedRef<boolean> {
-  return computed(() => !!get(ref));
-}

--- a/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.spec.ts
+++ b/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.spec.ts
@@ -1,8 +1,8 @@
-import type { ComponentPublicInstance } from 'vue';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { PremiumDevice } from '@/modules/premium/devices/premium';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComponentPublicInstance, defineComponent, h, type VNode } from 'vue';
 import PremiumDeviceForm from '@/modules/premium/devices/components/PremiumDeviceForm.vue';
 import '@test/i18n';
 
@@ -163,6 +163,66 @@ describe('premiumDeviceForm', () => {
     await vi.advanceTimersToNextTimerAsync();
 
     expect(messages()).toEqual(['taken already']);
+  });
+
+  /*
+   * A parent that holds the name in a real ref, so the write out and the echo back are both real.
+   * `mountModelForm` does not fit here: it is typed for an object payload, and this form's model is
+   * a bare string bridged through a writable computed.
+   */
+  function mountUnderParent(initial = 'desktop'): { name: () => string; parent: VueWrapper } {
+    const name = ref<string>(initial);
+    const parent = defineComponent({
+      setup(): () => VNode {
+        return () => h(PremiumDeviceForm, {
+          'device': device(),
+          'errorMessages': {} satisfies ValidationErrors,
+          'modelValue': get(name),
+          'onUpdate:modelValue': (value: string): void => set(name, value),
+        });
+      },
+    });
+
+    return {
+      name: (): string => get(name),
+      parent: mount(parent, {
+        global: {
+          stubs: {
+            DateDisplay: true,
+            RuiCard: { name: 'RuiCard', template: '<div><slot /></div>' },
+            RuiTextField: textFieldStub,
+          },
+        },
+      }),
+    };
+  }
+
+  it('should land an edit in the model the dialog holds', async () => {
+    const { name, parent } = mountUnderParent();
+    await vi.advanceTimersToNextTimerAsync();
+
+    parent.findComponent<StubInstance>('[data-testid=premium-device-name]').vm.$emit('update:modelValue', 'workstation');
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The dialog saves what it reads off the model, not what the form holds.
+    expect(name()).toBe('workstation');
+
+    parent.unmount();
+  });
+
+  it('should not re-enter the value the model echoes back', async () => {
+    const { name, parent } = mountUnderParent();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const field = parent.findComponent<StubInstance>('[data-testid=premium-device-name]');
+    field.vm.$emit('update:modelValue', 'workstation');
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The echo travels model -> state, which is the loop the core guards with isEqual.
+    expect(field.props('modelValue')).toBe('workstation');
+    expect(name()).toBe('workstation');
+
+    parent.unmount();
   });
 
   it('should write an edit back into the model', async () => {

--- a/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.spec.ts
+++ b/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.spec.ts
@@ -1,0 +1,193 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import type { PremiumDevice } from '@/modules/premium/devices/premium';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import PremiumDeviceForm from '@/modules/premium/devices/components/PremiumDeviceForm.vue';
+import '@test/i18n';
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+const textFieldStub = {
+  emits: ['update:modelValue', 'blur'],
+  name: 'RuiTextField',
+  props: ['modelValue', 'errorMessages', 'disabled'],
+  template: '<div />',
+};
+
+describe('premiumDeviceForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof PremiumDeviceForm>>;
+
+  const device = (deviceName = 'laptop'): PremiumDevice => ({
+    deviceIdentifier: 'device-1',
+    deviceName,
+    lastSeenAt: 1700000000,
+    platform: 'linux',
+    user: 'someone',
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    modelValue = 'desktop',
+    props: Record<string, unknown> = {},
+  ): VueWrapper<InstanceType<typeof PremiumDeviceForm>> {
+    return mount(PremiumDeviceForm, {
+      global: {
+        stubs: {
+          DateDisplay: true,
+          RuiCard: { name: 'RuiCard', template: '<div><slot /></div>' },
+          RuiTextField: textFieldStub,
+        },
+      },
+      props: {
+        device: device(),
+        errorMessages: {} satisfies ValidationErrors,
+        modelValue,
+        ...props,
+      },
+    });
+  }
+
+  function field(): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>('[data-testid=premium-device-name]');
+  }
+
+  function messages(): string[] {
+    const value: unknown = field().props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(value: string): Promise<void> {
+    const input = field();
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should pass validation for a non-empty name that differs from the current one', async () => {
+    wrapper = createWrapper('desktop');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should fail validation when the name is empty', async () => {
+    wrapper = createWrapper('');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should treat a whitespace-only name as empty', async () => {
+    wrapper = createWrapper('   ');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should fail validation when the name equals the current device name', async () => {
+    wrapper = createWrapper('laptop');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should compare against the device name captured at setup, not the current prop', async () => {
+    wrapper = createWrapper('desktop', { device: device('laptop') });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.setProps({ device: device('renamed') });
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The snapshot is still 'laptop', so the new prop value is accepted...
+    await edit('renamed');
+    expect(await wrapper.vm.validate()).toBe(true);
+
+    // ...and the value the prop no longer holds is still rejected.
+    await edit('laptop');
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper('');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages()).toEqual([]);
+  });
+
+  it('should report the required message once validate runs', async () => {
+    wrapper = createWrapper('');
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages()).toEqual(['premium_devices.form.device_name.error.required']);
+  });
+
+  it('should report the not-equal message once validate runs', async () => {
+    wrapper = createWrapper('laptop');
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages()).toEqual(['premium_devices.form.device_name.error.not_equal']);
+  });
+
+  it('should show the required message once the field is emptied', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('');
+
+    expect(messages()).toEqual(['premium_devices.form.device_name.error.required']);
+  });
+
+  it('should surface a server error reported for the field', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+    await wrapper.vm.validate();
+
+    await wrapper.setProps({ errorMessages: { deviceName: ['taken already'] } satisfies ValidationErrors });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages()).toEqual(['taken already']);
+  });
+
+  it('should write an edit back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('workstation');
+
+    expect(wrapper.emitted<[string]>('update:modelValue')?.at(-1)).toEqual(['workstation']);
+  });
+
+  it('should flag stateUpdated once a field is edited', async () => {
+    wrapper = createWrapper();
+    // Settle the mounted work first, so what follows is the only edit in play.
+    await vi.advanceTimersByTimeAsync(600);
+
+    await edit('workstation');
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
+  });
+
+  it('should not flag stateUpdated before anything is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).not.toEqual([true]);
+  });
+});

--- a/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.vue
+++ b/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { PremiumDevice } from '@/modules/premium/devices/premium';
-import useVuelidate from '@vuelidate/core';
-import { helpers, not, required, sameAs } from '@vuelidate/validators';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { toServerErrors } from '@/modules/core/form/server-errors';
+import { useModelForm } from '@/modules/core/form/use-model-form';
+import { deviceNameSchema, type DeviceNameState } from '@/modules/premium/devices/device-form-schema';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 
 const modelValue = defineModel<string>({ required: true });
@@ -19,31 +18,49 @@ const { device } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  deviceName: {
-    notEqual: helpers.withMessage(t('premium_devices.form.device_name.error.not_equal'), not(sameAs(device.deviceName))),
-    required: helpers.withMessage(t('premium_devices.form.device_name.error.required'), required),
+// Read once, so the rule keeps comparing against the name the device had when the dialog opened.
+const currentName = device.deviceName;
+
+const schema = deviceNameSchema(currentName, {
+  notEqual: t('premium_devices.form.device_name.error.not_equal'),
+  required: t('premium_devices.form.device_name.error.required'),
+});
+
+// The dialog owns the name as a bare string, while the form core works on a state object, so the
+// two are bridged here rather than by a pair of hand-written watchers.
+const model = computed<DeviceNameState>({
+  get: (): DeviceNameState => ({ deviceName: get(modelValue) }),
+  set: (value: DeviceNameState): void => {
+    set(modelValue, value.deviceName);
   },
-};
+});
 
-const v$ = useVuelidate(rules, { deviceName: modelValue }, { $autoDirty: true, $externalResults: errors });
+const form = useModelForm<DeviceNameState>({
+  model,
+  schema,
+  stateUpdated,
+});
 
-useFormStateWatcher({ deviceName: modelValue }, stateUpdated);
+watchImmediate(errors, (value) => {
+  form.setServerErrors(toServerErrors(value));
+});
 
 defineExpose({
-  validate: async () => await get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
 <template>
   <div class="mt-4">
     <RuiTextField
-      v-model="modelValue"
+      v-model="form.state.deviceName"
       variant="outlined"
       color="primary"
       :label="t('premium_devices.form.device_name.label')"
       :hint="t('premium_devices.form.device_name.hint')"
-      :error-messages="toMessages(v$.deviceName)"
+      :error-messages="form.errors('deviceName')"
+      data-testid="premium-device-name"
+      @blur="form.touch('deviceName')"
     />
 
     <div>

--- a/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.vue
+++ b/frontend/app/src/modules/premium/devices/components/PremiumDeviceForm.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { PremiumDevice } from '@/modules/premium/devices/premium';
-import { toServerErrors } from '@/modules/core/form/server-errors';
 import { useModelForm } from '@/modules/core/form/use-model-form';
 import { deviceNameSchema, type DeviceNameState } from '@/modules/premium/devices/device-form-schema';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
@@ -38,11 +37,8 @@ const model = computed<DeviceNameState>({
 const form = useModelForm<DeviceNameState>({
   model,
   schema,
+  serverErrors: errors,
   stateUpdated,
-});
-
-watchImmediate(errors, (value) => {
-  form.setServerErrors(toServerErrors(value));
 });
 
 defineExpose({

--- a/frontend/app/src/modules/premium/devices/device-form-schema.ts
+++ b/frontend/app/src/modules/premium/devices/device-form-schema.ts
@@ -1,0 +1,34 @@
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface DeviceNameMessages {
+  /** The name is blank. */
+  required: string;
+  /** The name is the one the device already carries, so renaming would be a no-op. */
+  notEqual: string;
+}
+
+/** The state the rename form edits. The dialog owns it as a bare string. */
+export interface DeviceNameState {
+  deviceName: string;
+}
+
+/**
+ * Schema for the device rename field.
+ *
+ * `currentName` is read once, by the caller, and passed in: vuelidate's `not(sameAs(...))` snapshotted
+ * the prop at setup, so a device renamed underneath an open dialog kept being compared against the
+ * name it had when the dialog opened. That is preserved rather than fixed, since making it reactive
+ * would change which values a mounted form accepts.
+ *
+ * The no-op check skips a blank name, as vuelidate's `not` did through its `req` guard, so an empty
+ * field reports only the missing-value message.
+ */
+export function deviceNameSchema(currentName: string, messages: DeviceNameMessages): ZodType {
+  return z.object({
+    deviceName: requiredField(messages.required).superRefine((value, ctx) => {
+      if (value !== '' && value === currentName)
+        ctx.addIssue({ code: 'custom', message: messages.notEqual });
+    }),
+  });
+}

--- a/frontend/app/src/modules/reports/RangeSelector.spec.ts
+++ b/frontend/app/src/modules/reports/RangeSelector.spec.ts
@@ -1,7 +1,7 @@
-import type { ComponentPublicInstance, Ref } from 'vue';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import dayjs from 'dayjs';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComponentPublicInstance, defineComponent, h, type Ref, type VNode } from 'vue';
 import { Quarter } from '@/modules/settings/types/frontend-settings';
 import '@test/i18n';
 
@@ -192,5 +192,75 @@ describe('rangeSelector', () => {
       start: undefined,
     });
     expect(updateFrontendSetting).toHaveBeenCalledWith({ profitLossReportPeriod: selection });
+  });
+
+  /*
+   * A parent holding the range in a real ref, so both directions are exercised. The shared
+   * `mountModelForm` does not fit: it binds a `stateUpdated` prop this form does not declare, and
+   * the validity this form reports leaves by an emit rather than through the model.
+   */
+  function mountUnderParent(initial: Range): { range: () => Range; setRange: (value: Range) => void; parent: VueWrapper } {
+    const range = ref<Range>(initial);
+    const parent = defineComponent({
+      setup(): () => VNode {
+        return () => h(RangeSelector, {
+          'modelValue': get(range),
+          'onUpdate:modelValue': (value: Range): void => set(range, value),
+        });
+      },
+    });
+
+    return {
+      parent: mount(parent, {
+        global: {
+          stubs: {
+            DateTimeRangePicker: {
+              emits: ['update:start', 'update:end'],
+              name: 'DateTimeRangePicker',
+              props: ['start', 'end', 'startErrorMessages', 'endErrorMessages'],
+              template: '<div />',
+            },
+            ReportPeriodSelector: {
+              emits: ['update:period', 'update:selection'],
+              name: 'ReportPeriodSelector',
+              props: ['year', 'quarter'],
+              template: '<div />',
+            },
+          },
+        },
+      }),
+      range: (): Range => get(range),
+      setRange: (value: Range): void => set(range, value),
+    };
+  }
+
+  it('should land a picked date in the model the page holds', async () => {
+    set(period, { quarter: Quarter.Q1, year: 'custom' });
+    const { parent, range } = mountUnderParent({ end: 1700000000, start: 1600000000 });
+    await vi.advanceTimersToNextTimerAsync();
+
+    parent.findComponent<StubInstance>({ name: 'DateTimeRangePicker' }).vm.$emit('update:start', 1650000000);
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The report is generated from what the page holds, not from what the form holds.
+    expect(range().start).toBe(1650000000);
+
+    parent.unmount();
+  });
+
+  it('should take a range changed outside the form', async () => {
+    set(period, { quarter: Quarter.Q1, year: 'custom' });
+    const { parent, setRange } = mountUnderParent({ end: 1700000000, start: 1600000000 });
+    await vi.advanceTimersToNextTimerAsync();
+
+    setRange({ end: 1800000000, start: 1750000000 });
+    await vi.advanceTimersToNextTimerAsync();
+
+    // model -> state, the direction an edit made by the page above takes.
+    const picker = parent.findComponent<StubInstance>({ name: 'DateTimeRangePicker' });
+    expect(picker.props('start')).toBe(1750000000);
+    expect(picker.props('end')).toBe(1800000000);
+
+    parent.unmount();
   });
 });

--- a/frontend/app/src/modules/reports/RangeSelector.spec.ts
+++ b/frontend/app/src/modules/reports/RangeSelector.spec.ts
@@ -1,0 +1,196 @@
+import type { ComponentPublicInstance, Ref } from 'vue';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import dayjs from 'dayjs';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Quarter } from '@/modules/settings/types/frontend-settings';
+import '@test/i18n';
+
+interface ReportPeriod {
+  quarter: Quarter;
+  year: string;
+}
+
+const period = ref<ReportPeriod>({ quarter: Quarter.Q1, year: '2024' });
+const updateFrontendSetting = vi.fn();
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: vi.fn().mockImplementation((): Ref<ReportPeriod> => period),
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: vi.fn().mockImplementation(() => ({ updateFrontendSetting })),
+}));
+
+const RangeSelector = (await import('@/modules/reports/RangeSelector.vue')).default;
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+interface Range {
+  end: number;
+  start: number | undefined;
+}
+
+describe('rangeSelector', () => {
+  let wrapper: VueWrapper<InstanceType<typeof RangeSelector>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(period, { quarter: Quarter.Q1, year: '2024' });
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-14T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(modelValue: Range = { end: 1700000000, start: 1600000000 }): VueWrapper<InstanceType<typeof RangeSelector>> {
+    return mount(RangeSelector, {
+      global: {
+        stubs: {
+          DateTimeRangePicker: {
+            emits: ['update:start', 'update:end'],
+            name: 'DateTimeRangePicker',
+            props: ['start', 'end', 'startErrorMessages', 'endErrorMessages'],
+            template: '<div />',
+          },
+          ReportPeriodSelector: {
+            emits: ['update:period', 'update:selection'],
+            name: 'ReportPeriodSelector',
+            props: ['year', 'quarter'],
+            template: '<div />',
+          },
+        },
+      },
+      props: { modelValue },
+    });
+  }
+
+  function picker(): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>({ name: 'DateTimeRangePicker' });
+  }
+
+  function messages(prop: 'startErrorMessages' | 'endErrorMessages'): string[] {
+    const value: unknown = picker().props(prop);
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  function lastValid(): boolean | undefined {
+    return wrapper.emitted<[boolean]>('update:valid')?.at(-1)?.[0];
+  }
+
+  async function selectCustom(): Promise<void> {
+    set(period, { quarter: Quarter.Q1, year: 'custom' });
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should hide the range picker outside the custom period', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(picker().exists()).toBe(false);
+  });
+
+  it('should report a preset period as valid even with no start date', async () => {
+    wrapper = createWrapper({ end: 1700000000, start: undefined });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(lastValid()).toBe(true);
+  });
+
+  it('should report a custom period with no start date as invalid', async () => {
+    wrapper = createWrapper({ end: 1700000000, start: undefined });
+    await selectCustom();
+
+    expect(lastValid()).toBe(false);
+  });
+
+  it('should report a custom period with no end date as invalid', async () => {
+    wrapper = createWrapper();
+    await selectCustom();
+
+    // The picker allows an empty end date, so it is reached the way the app reaches it rather
+    // than by seeding a value the model type does not admit.
+    picker().vm.$emit('update:end', undefined);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(lastValid()).toBe(false);
+  });
+
+  it('should report a fully filled custom period as valid', async () => {
+    wrapper = createWrapper();
+    await selectCustom();
+
+    expect(lastValid()).toBe(true);
+  });
+
+  it('should accept a zero start date as present', async () => {
+    wrapper = createWrapper({ end: 1700000000, start: 0 });
+    await selectCustom();
+
+    expect(lastValid()).toBe(true);
+  });
+
+  it('should never render a message on either date field', async () => {
+    wrapper = createWrapper();
+    await selectCustom();
+
+    // Edit both fields into an invalid state. Under $autoDirty that is exactly what makes a
+    // message appear; here it must not, because the picker is configured with it off and nothing
+    // touches the fields. These two messages have never been reachable.
+    picker().vm.$emit('update:start', undefined);
+    picker().vm.$emit('update:end', undefined);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(lastValid()).toBe(false);
+    expect(messages('startErrorMessages')).toEqual([]);
+    expect(messages('endErrorMessages')).toEqual([]);
+  });
+
+  it('should blank the range when a custom period is picked', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    wrapper.findComponent<StubInstance>({ name: 'ReportPeriodSelector' }).vm.$emit('update:period', null);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted<[Range]>('update:modelValue')?.at(-1)?.[0]).toEqual({
+      end: dayjs().unix(),
+      start: undefined,
+    });
+  });
+
+  it('should clamp a preset period that reaches past now', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const future = dayjs().unix() + 10_000;
+    wrapper.findComponent<StubInstance>({ name: 'ReportPeriodSelector' })
+      .vm
+      .$emit('update:period', { end: future, start: 1600000000 });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted<[Range]>('update:modelValue')?.at(-1)?.[0]).toEqual({
+      end: dayjs().unix(),
+      start: 1600000000,
+    });
+  });
+
+  it('should reset the range before persisting a switch to custom', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    const selection = { quarter: Quarter.Q1, year: 'custom' };
+    wrapper.findComponent<StubInstance>({ name: 'ReportPeriodSelector' }).vm.$emit('update:selection', selection);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted<[Range]>('update:modelValue')?.at(-1)?.[0]).toEqual({
+      end: dayjs().unix(),
+      start: undefined,
+    });
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ profitLossReportPeriod: selection });
+  });
+});

--- a/frontend/app/src/modules/reports/RangeSelector.vue
+++ b/frontend/app/src/modules/reports/RangeSelector.vue
@@ -1,21 +1,26 @@
 <script setup lang="ts">
 import type { PeriodChangedEvent, SelectionChangedEvent } from '@/modules/reports/report-types';
 import type { Quarter } from '@/modules/settings/types/frontend-settings';
-import useVuelidate from '@vuelidate/core';
-import { helpers, requiredIf } from '@vuelidate/validators';
 import dayjs from 'dayjs';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { z, type ZodType } from 'zod';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import ReportPeriodSelector from '@/modules/reports/ReportPeriodSelector.vue';
 import { useSetting } from '@/modules/settings/use-setting';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
 import DateTimeRangePicker from '@/modules/shell/components/inputs/DateTimeRangePicker.vue';
 
-const modelValue = defineModel<{ start: number | undefined; end: number }>({ required: true });
+interface ReportRange {
+  start: number | undefined;
+  end: number;
+}
+
+const modelValue = defineModel<ReportRange>({ required: true });
 
 const emit = defineEmits<{
   'update:valid': [valid: boolean];
 }>();
+
+const { t } = useI18n({ useScope: 'global' });
 
 const profitLossReportPeriod = useSetting('profitLossReportPeriod');
 const { updateFrontendSetting } = useSettingsOperations();
@@ -24,15 +29,30 @@ const year = computed<string>(() => get(profitLossReportPeriod).year);
 const quarter = computed<Quarter>(() => get(profitLossReportPeriod).quarter);
 const custom = computed<boolean>(() => get(year) === 'custom');
 
-const start = useRefPropVModel(modelValue, 'start');
-const end = useRefPropVModel(modelValue, 'end');
+/**
+ * Both dates are only required while the period is custom, which is a persisted setting rather than
+ * part of the state, so the schema is rebuilt when it changes.
+ *
+ * They are numbers, so the rule catches a cleared picker and nothing else: the epoch is a date like
+ * any other, which is what vuelidate's `required` reported too.
+ */
+const schema = computed<ZodType>(() => {
+  if (!get(custom))
+    return z.object({ end: z.number().optional(), start: z.number().optional() });
 
-function input(data: { start: number | undefined; end: number }): void {
+  return z.object({
+    end: z.number({ error: t('generate.validation.empty_end_date') }),
+    start: z.number({ error: t('generate.validation.empty_start_date') }),
+  });
+});
+
+const form = useModelForm<ReportRange>({
+  model: modelValue,
+  schema,
+});
+
+function input(data: ReportRange): void {
   set(modelValue, data);
-}
-
-function updateValid(valid: boolean): void {
-  emit('update:valid', valid);
 }
 
 async function onChanged(event: SelectionChangedEvent): Promise<void> {
@@ -40,7 +60,7 @@ async function onChanged(event: SelectionChangedEvent): Promise<void> {
   // clicks inside the Custom picker land on a sane `end=now, start=undefined`
   // baseline. Doing it after `await updateFrontendSetting` opens a race where
   // a fast click on a preset gets the old year/quarter's end as the
-  // max-date constraint — see DateTimeRangePicker.applyQuickOption.
+  // max-date constraint - see DateTimeRangePicker.applyQuickOption.
   if (event.year === 'custom') {
     input({ end: dayjs().unix(), start: undefined });
   }
@@ -53,42 +73,21 @@ async function onChanged(event: SelectionChangedEvent): Promise<void> {
 function onPeriodChange(period: PeriodChangedEvent | null): void {
   const now = dayjs().unix();
   if (period === null) {
-    // Custom period — leave start undefined so the picker renders empty
-    // instead of defaulting the field to 1970-01-01 (epoch). The
-    // `requiredIf(custom)` rule in v$ catches this as a validation error
-    // until the user picks a date or hits a quick-option preset.
+    // Custom period - leave start undefined so the picker renders empty
+    // instead of defaulting the field to 1970-01-01 (epoch). The schema
+    // catches this as a validation error until the user picks a date or hits
+    // a quick-option preset.
     input({ end: now, start: undefined });
     return;
   }
 
-  const start = period.start;
-  let end = period.end;
-  end = Math.min(end, now);
-  input({ end, start });
+  input({ end: Math.min(period.end, now), start: period.start });
 }
 
-const { t } = useI18n({ useScope: 'global' });
-
-const rules = {
-  end: {
-    required: helpers.withMessage(t('generate.validation.empty_end_date'), requiredIf(custom)),
-  },
-  start: {
-    required: helpers.withMessage(t('generate.validation.empty_start_date'), requiredIf(custom)),
-  },
-};
-
-const v$ = useVuelidate(
-  rules,
-  {
-    end,
-    start,
-  },
-  { $autoDirty: false },
-);
-
-watchImmediate(v$, ({ $invalid }) => {
-  updateValid(!$invalid);
+// The validity is the only thing anything consumes: no field ever renders a message, because
+// nothing touches them, which reproduces vuelidate's $autoDirty: false exactly.
+watchImmediate(form.valid, (valid) => {
+  emit('update:valid', valid);
 });
 </script>
 
@@ -102,13 +101,13 @@ watchImmediate(v$, ({ $invalid }) => {
     />
     <DateTimeRangePicker
       v-if="custom"
-      v-model:start="start"
-      v-model:end="end"
+      v-model:start="form.state.start"
+      v-model:end="form.state.end"
       class="mt-1.5"
       allow-empty
       max-end-date="now"
-      :start-error-messages="toMessages(v$.start)"
-      :end-error-messages="toMessages(v$.end)"
+      :start-error-messages="form.errors('start')"
+      :end-error-messages="form.errors('end')"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/reports/ReportProfitLossEventAction.spec.ts
+++ b/frontend/app/src/modules/reports/ReportProfitLossEventAction.spec.ts
@@ -1,0 +1,222 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
+import type { ProfitLossEvent } from '@/modules/reports/report-types';
+import { bigNumberify, Zero } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@test/i18n';
+
+const addHistoricalPrice = vi.fn<(payload: HistoricalPriceFormPayload) => Promise<boolean>>();
+const resetHistoricalPricesData = vi.fn();
+const getHistoricPrice = vi.fn();
+const setMessage = vi.fn();
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: vi.fn().mockImplementation(() => ({ addHistoricalPrice })),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: vi.fn().mockImplementation(() => ({ resetHistoricalPricesData })),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
+  usePriceTaskManager: vi.fn().mockImplementation(() => ({ getHistoricPrice })),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: vi.fn().mockImplementation(() => ({ setMessage })),
+}));
+
+const ReportProfitLossEventAction = (await import('@/modules/reports/ReportProfitLossEventAction.vue')).default;
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled', 'loading'],
+    template: '<div />',
+  };
+}
+
+describe('reportProfitLossEventAction', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ReportProfitLossEventAction>>;
+
+  const event = (): ProfitLossEvent => ({
+    assetIdentifier: 'ETH',
+    costBasis: null,
+    freeAmount: Zero,
+    location: 'blockchain',
+    notes: null,
+    pnlFree: Zero,
+    pnlTaxable: Zero,
+    price: Zero,
+    taxableAmount: Zero,
+    timestamp: 1700000000,
+    type: 'sell',
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // A value nothing else in the fixture holds, so a write-back that never happens is visible.
+    getHistoricPrice.mockResolvedValue(bigNumberify('1234.5'));
+    addHistoricalPrice.mockResolvedValue(true);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(): VueWrapper<InstanceType<typeof ReportProfitLossEventAction>> {
+    return mount(ReportProfitLossEventAction, {
+      global: {
+        stubs: {
+          AmountInput: inputStub('AmountInput'),
+          AssetSelect: inputStub('AssetSelect'),
+          DateTimePicker: inputStub('DateTimePicker'),
+          RuiCard: { name: 'RuiCard', template: '<div><slot name="header" /><slot /><slot name="footer" /></div>' },
+          // Rendered eagerly, so the dialog contents are reachable without driving the popper.
+          RuiDialog: {
+            name: 'RuiDialog',
+            props: ['modelValue'],
+            template: '<div><slot v-if="modelValue" /></div>',
+          },
+          RuiMenu: {
+            name: 'RuiMenu',
+            template: '<div><slot name="activator" :attrs="{}" /><slot /></div>',
+          },
+        },
+      },
+      props: { currency: 'USD', event: event() },
+    });
+  }
+
+  function field(): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>('[data-testid=edit-historic-price-value]');
+  }
+
+  function messages(): string[] {
+    const value: unknown = field().props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function openDialog(): Promise<void> {
+    await wrapper.find('[data-testid=edit-historic-price-open]').trigger('click');
+    await vi.advanceTimersToNextTimerAsync();
+    await nextTick();
+  }
+
+  async function edit(value: string): Promise<void> {
+    const input = field();
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  async function submit(): Promise<void> {
+    await wrapper.find('form').trigger('submit');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should seed the price field from the fetched historic price', async () => {
+    wrapper = createWrapper();
+
+    await openDialog();
+
+    expect(getHistoricPrice).toHaveBeenCalledWith({
+      fromAsset: 'ETH',
+      timestamp: 1700000000,
+      toAsset: 'USD',
+    });
+    expect(field().props('modelValue')).toBe('1234.5');
+  });
+
+  it('should seed zero when no historic price is known', async () => {
+    getHistoricPrice.mockResolvedValue(Zero);
+    wrapper = createWrapper();
+
+    await openDialog();
+
+    expect(field().props('modelValue')).toBe('0');
+  });
+
+  it('should show no message before the field is edited', async () => {
+    wrapper = createWrapper();
+    await openDialog();
+
+    expect(messages()).toEqual([]);
+  });
+
+  it('should show the required message once the price is emptied', async () => {
+    wrapper = createWrapper();
+    await openDialog();
+
+    await edit('');
+
+    expect(messages()).toEqual(['price_form.price_non_empty']);
+  });
+
+  it('should treat a whitespace-only price as empty', async () => {
+    wrapper = createWrapper();
+    await openDialog();
+
+    await edit('   ');
+
+    expect(messages()).toEqual(['price_form.price_non_empty']);
+  });
+
+  it('should clear the message once a price is typed again', async () => {
+    wrapper = createWrapper();
+    await openDialog();
+
+    await edit('');
+    await edit('42');
+
+    expect(messages()).toEqual([]);
+  });
+
+  it('should save the price and reset the cached entry', async () => {
+    wrapper = createWrapper();
+    await openDialog();
+
+    await edit('42');
+    await submit();
+
+    const payload: HistoricalPriceFormPayload = {
+      fromAsset: 'ETH',
+      price: '42',
+      sourceType: 'manual',
+      timestamp: 1700000000,
+      toAsset: 'USD',
+    };
+    expect(addHistoricalPrice).toHaveBeenCalledWith(payload);
+    expect(resetHistoricalPricesData).toHaveBeenCalledWith([payload]);
+  });
+
+  it('should not save an empty price', async () => {
+    wrapper = createWrapper();
+    await openDialog();
+
+    await edit('');
+    await submit();
+
+    expect(addHistoricalPrice).not.toHaveBeenCalled();
+    expect(messages()).toEqual(['price_form.price_non_empty']);
+  });
+
+  it('should report a failed save', async () => {
+    addHistoricalPrice.mockRejectedValue(new Error('nope'));
+    wrapper = createWrapper();
+    await openDialog();
+
+    await edit('42');
+    await submit();
+
+    expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+  });
+});

--- a/frontend/app/src/modules/reports/ReportProfitLossEventAction.vue
+++ b/frontend/app/src/modules/reports/ReportProfitLossEventAction.vue
@@ -1,33 +1,65 @@
 <script setup lang="ts">
 import type { HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
 import type { ProfitLossEvent } from '@/modules/reports/report-types';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import { z, type ZodType } from 'zod';
 import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
 import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
 import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { requiredField } from '@/modules/core/form/fields';
+import { useForm } from '@/modules/core/form/use-form';
 import { PriceOracle } from '@/modules/settings/types/price-oracle';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 import DateTimePicker from '@/modules/shell/components/inputs/DateTimePicker.vue';
+
+interface PriceState {
+  price: string;
+}
 
 const { event, currency } = defineProps<{
   event: ProfitLossEvent;
   currency: string;
 }>();
 
+const { t } = useI18n({ useScope: 'global' });
+
 const { resetHistoricalPricesData } = useHistoricPriceCache();
 const { getHistoricPrice } = usePriceTaskManager();
 const { addHistoricalPrice } = useAssetPricesApi();
+const { setMessage } = useMessageStore();
 
 const fetchingPrice = ref<boolean>(false);
 const showDialog = ref<boolean>(false);
-const price = ref<string>('');
 
-async function openEditHistoricPriceDialog() {
+const schema = computed<ZodType>(() => z.object({
+  price: requiredField(t('price_form.price_non_empty')),
+}));
+
+const form = useForm<PriceState, HistoricalPriceFormPayload>({
+  initial: (): PriceState => ({ price: '' }),
+  schema,
+  submit: async (payload: HistoricalPriceFormPayload): Promise<{ message?: string; success: boolean }> => {
+    try {
+      await addHistoricalPrice(payload);
+      resetHistoricalPricesData([payload]);
+      return { success: true };
+    }
+    catch (error: unknown) {
+      return { message: getErrorMessage(error), success: false };
+    }
+  },
+  transform: (state): HistoricalPriceFormPayload => ({
+    fromAsset: event.assetIdentifier,
+    price: state.price,
+    sourceType: PriceOracle.MANUAL,
+    timestamp: event.timestamp,
+    toAsset: currency,
+  }),
+});
+
+async function openEditHistoricPriceDialog(): Promise<void> {
   set(showDialog, true);
   set(fetchingPrice, true);
   const { assetIdentifier, timestamp } = event;
@@ -36,57 +68,20 @@ async function openEditHistoricPriceDialog() {
     timestamp,
     toAsset: currency,
   });
-  set(price, historicPrice.isPositive() ? historicPrice.toFixed() : '0');
+  form.state.price = historicPrice.isPositive() ? historicPrice.toFixed() : '0';
   set(fetchingPrice, false);
 }
 
-const { t } = useI18n({ useScope: 'global' });
-
-const rules = {
-  price: {
-    required: helpers.withMessage(t('price_form.price_non_empty'), required),
-  },
-};
-
-const v$ = useVuelidate(
-  rules,
-  {
-    price,
-  },
-  { $autoDirty: true },
-);
-
-const { setMessage } = useMessageStore();
-
-async function savePrice(payload: HistoricalPriceFormPayload) {
-  await addHistoricalPrice(payload);
-  resetHistoricalPricesData([payload]);
-}
-
-async function updatePrice() {
-  if (!(await get(v$).$validate()))
-    return;
-
-  const payload: HistoricalPriceFormPayload = {
-    fromAsset: event.assetIdentifier,
-    price: get(price),
-    sourceType: PriceOracle.MANUAL,
-    timestamp: event.timestamp,
-    toAsset: currency,
-  };
-
-  try {
-    await savePrice(payload);
+async function updatePrice(): Promise<void> {
+  const result = await form.submit();
+  if (result.outcome === 'success') {
     set(showDialog, false);
   }
-  catch (error: unknown) {
-    const values = { message: getErrorMessage(error) };
-    const title = t('price_management.add.error.title');
-    const description = t('price_management.add.error.description', values);
+  else if (result.outcome === 'error') {
     setMessage({
-      description,
+      description: t('price_management.add.error.description', { message: result.message ?? '' }),
       success: false,
-      title,
+      title: t('price_management.add.error.title'),
     });
   }
 }
@@ -154,13 +149,14 @@ async function updatePrice() {
               :label="t('common.datetime')"
             />
             <AmountInput
-              v-model="price"
+              v-model="form.state.price"
               variant="outlined"
               :loading="fetchingPrice"
               :disabled="fetchingPrice"
               :label="t('common.price')"
-              :error-messages="toMessages(v$.price)"
+              :error-messages="form.errors('price')"
               data-testid="edit-historic-price-value"
+              @blur="form.touch('price')"
             />
           </div>
 

--- a/frontend/app/src/modules/reports/ReportProfitLossEventAction.vue
+++ b/frontend/app/src/modules/reports/ReportProfitLossEventAction.vue
@@ -64,6 +64,9 @@ async function savePrice(payload: HistoricalPriceFormPayload) {
 }
 
 async function updatePrice() {
+  if (!(await get(v$).$validate()))
+    return;
+
   const payload: HistoricalPriceFormPayload = {
     fromAsset: event.assetIdentifier,
     price: get(price),
@@ -104,6 +107,7 @@ async function updatePrice() {
       </template>
       <RuiButton
         variant="list"
+        data-testid="edit-historic-price-open"
         @click="openEditHistoricPriceDialog()"
       >
         <template #prepend>
@@ -156,6 +160,7 @@ async function updatePrice() {
               :disabled="fetchingPrice"
               :label="t('common.price')"
               :error-messages="toMessages(v$.price)"
+              data-testid="edit-historic-price-value"
             />
           </div>
 

--- a/frontend/app/src/modules/staking/lido-csm/LidoCsmAddDialog.spec.ts
+++ b/frontend/app/src/modules/staking/lido-csm/LidoCsmAddDialog.spec.ts
@@ -1,0 +1,257 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import { Blockchain } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@test/i18n';
+
+interface NodeOperatorPayload {
+  address: string;
+  nodeOperatorId: number;
+}
+
+const addNodeOperator = vi.fn<(payload: NodeOperatorPayload) => Promise<{ message?: string }>>();
+const setMessage = vi.fn();
+
+vi.mock('@/modules/staking/api/use-lido-csm-api', () => ({
+  useLidoCsmApi: vi.fn().mockImplementation(() => ({ addNodeOperator })),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: vi.fn().mockImplementation(() => ({ setMessage })),
+}));
+
+const LidoCsmAddDialog = (await import('@/modules/staking/lido-csm/LidoCsmAddDialog.vue')).default;
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+const ADDRESS = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+
+function account(address = ADDRESS): BlockchainAccount<AddressData> {
+  return {
+    chain: Blockchain.ETH,
+    data: { address, type: 'address' },
+    nativeAsset: 'ETH',
+  };
+}
+
+describe('lidoCsmAddDialog', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LidoCsmAddDialog>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addNodeOperator.mockResolvedValue({});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(): VueWrapper<InstanceType<typeof LidoCsmAddDialog>> {
+    return mount(LidoCsmAddDialog, {
+      global: {
+        stubs: {
+          BlockchainAccountSelector: inputStub('BlockchainAccountSelector'),
+          RuiCard: {
+            name: 'RuiCard',
+            template: '<div><slot name="header" /><slot /><slot name="footer" /></div>',
+          },
+          RuiDialog: {
+            name: 'RuiDialog',
+            props: ['modelValue'],
+            template: '<div><slot v-if="modelValue" /></div>',
+          },
+          RuiTextField: inputStub('RuiTextField'),
+        },
+      },
+      props: { modelValue: true },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  function submitDisabled(): unknown {
+    return wrapper.findComponent<StubInstance>('[data-testid=lido-csm-submit]').props('disabled');
+  }
+
+  async function selectAccount(accounts: BlockchainAccount<AddressData>[] = [account()]): Promise<void> {
+    const input = field('lido-csm-address');
+    input.vm.$emit('update:modelValue', accounts);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  async function typeId(value: string): Promise<void> {
+    const input = field('lido-csm-node-operator');
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  async function submit(): Promise<void> {
+    await wrapper.find('[data-testid=lido-csm-submit]').trigger('click');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should show no message before anything is touched', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('lido-csm-address')).toEqual([]);
+    expect(messages('lido-csm-node-operator')).toEqual([]);
+  });
+
+  it('should block the submit until both fields are filled', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(submitDisabled()).toBe(true);
+
+    await selectAccount();
+    expect(submitDisabled()).toBe(true);
+
+    await typeId('5');
+    expect(submitDisabled()).toBe(false);
+  });
+
+  it('should block the submit on the address alone', async () => {
+    wrapper = createWrapper();
+    await typeId('5');
+
+    expect(submitDisabled()).toBe(true);
+
+    await selectAccount();
+    expect(submitDisabled()).toBe(false);
+  });
+
+  it('should accept a zero node operator id', async () => {
+    wrapper = createWrapper();
+    await selectAccount();
+
+    await typeId('0');
+
+    expect(submitDisabled()).toBe(false);
+  });
+
+  it('should report the missing address once the selection is cleared', async () => {
+    wrapper = createWrapper();
+    await selectAccount();
+
+    await selectAccount([]);
+
+    expect(messages('lido-csm-address')).toEqual(['staking_page.lido_csm.form.validation.non_empty_address']);
+  });
+
+  it('should report the missing id once the field is emptied', async () => {
+    wrapper = createWrapper();
+    await selectAccount();
+    await typeId('5');
+
+    await typeId('');
+
+    expect(messages('lido-csm-node-operator')).toEqual(['staking_page.lido_csm.form.validation.non_empty_id']);
+  });
+
+  it('should treat a whitespace-only id as missing, and not as a bad number', async () => {
+    wrapper = createWrapper();
+    await selectAccount();
+
+    await typeId('   ');
+
+    // Number('   ') is 0, so the numeric rule is satisfied; only the missing-value rule fires.
+    expect(messages('lido-csm-node-operator')).toEqual(['staking_page.lido_csm.form.validation.non_empty_id']);
+  });
+
+  it('should report an invalid id while typing, before the field is left', async () => {
+    wrapper = createWrapper();
+    await selectAccount();
+
+    // No blur: the submit button is gated on validity, and a disabled button cannot be clicked to
+    // blur the field, so waiting for blur would leave the user with no message at all.
+    field('lido-csm-node-operator').vm.$emit('update:modelValue', 'abc');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('lido-csm-node-operator')).toEqual(['staking_page.lido_csm.form.validation.invalid_id']);
+  });
+
+  it.each([
+    ['abc'],
+    ['1.5'],
+    ['-1'],
+  ])('should reject %s as a node operator id', async (value) => {
+    wrapper = createWrapper();
+    await selectAccount();
+
+    await typeId(value);
+
+    expect(messages('lido-csm-node-operator')).toEqual(['staking_page.lido_csm.form.validation.invalid_id']);
+    expect(submitDisabled()).toBe(true);
+  });
+
+  it('should send the selected address and the id as a number', async () => {
+    wrapper = createWrapper();
+    await selectAccount();
+    await typeId('7');
+
+    await submit();
+
+    expect(addNodeOperator).toHaveBeenCalledWith({ address: ADDRESS, nodeOperatorId: 7 });
+    expect(wrapper.emitted('refresh')).toBeTruthy();
+    expect(wrapper.emitted<[boolean]>('update:modelValue')?.at(-1)).toEqual([false]);
+  });
+
+  it('should send nothing while the form is invalid', async () => {
+    wrapper = createWrapper();
+    await selectAccount();
+
+    // The button is the gate, so a click on it does not even reach the handler.
+    await submit();
+
+    expect(submitDisabled()).toBe(true);
+    expect(addNodeOperator).not.toHaveBeenCalled();
+  });
+
+  it('should surface a message returned by the api', async () => {
+    addNodeOperator.mockResolvedValue({ message: 'already tracked' });
+    wrapper = createWrapper();
+    await selectAccount();
+    await typeId('7');
+
+    await submit();
+
+    expect(setMessage).toHaveBeenCalledWith({ description: 'already tracked' });
+  });
+
+  it('should surface a thrown error', async () => {
+    addNodeOperator.mockRejectedValue(new Error('offline'));
+    wrapper = createWrapper();
+    await selectAccount();
+    await typeId('7');
+
+    await submit();
+
+    expect(setMessage).toHaveBeenCalledWith({
+      description: 'staking_page.lido_csm.messages.add_failed::offline',
+    });
+  });
+});

--- a/frontend/app/src/modules/staking/lido-csm/LidoCsmAddDialog.vue
+++ b/frontend/app/src/modules/staking/lido-csm/LidoCsmAddDialog.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
 import { Blockchain } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import { z, type ZodType } from 'zod';
 import { getAccountAddress } from '@/modules/accounts/account-utils';
 import BlockchainAccountSelector from '@/modules/accounts/BlockchainAccountSelector.vue';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { requiredField } from '@/modules/core/form/fields';
+import { useForm } from '@/modules/core/form/use-form';
 import { useLidoCsmApi } from '@/modules/staking/api/use-lido-csm-api';
 
 defineOptions({
@@ -19,78 +19,89 @@ const emit = defineEmits<{
   refresh: [];
 }>();
 
+interface NodeOperatorState {
+  nodeOperatorId: string;
+  selectedAccount: BlockchainAccount<AddressData>[];
+}
+
+interface NodeOperatorPayload {
+  address: string;
+  nodeOperatorId: number;
+}
+
 const { t } = useI18n({ useScope: 'global' });
-
-const selectedAccount = ref<BlockchainAccount<AddressData>[]>([]);
-const nodeOperatorId = ref<string>('');
-const submitting = ref<boolean>(false);
-
-const rules = {
-  nodeOperatorId: {
-    required: helpers.withMessage(
-      t('staking_page.lido_csm.form.validation.non_empty_id'),
-      required,
-    ),
-    validId: helpers.withMessage(
-      t('staking_page.lido_csm.form.validation.invalid_id'),
-      (value: string) => {
-        const parsed = Number(value);
-        return Number.isInteger(parsed) && parsed >= 0;
-      },
-    ),
-  },
-  selectedAddress: {
-    required: helpers.withMessage(
-      t('staking_page.lido_csm.form.validation.non_empty_address'),
-      required,
-    ),
-  },
-};
 
 const api = useLidoCsmApi();
 const { setMessage } = useMessageStore();
 
-const selectedAddress = computed<string>(() => {
-  const account = get(selectedAccount)[0];
-  return account ? getAccountAddress(account) : '';
+/**
+ * Vuelidate validated the derived address string rather than the selection, so the rule is written
+ * over the same value: an account whose address reads blank is still a missing address.
+ */
+const schema = computed<ZodType>(() => z.object({
+  nodeOperatorId: requiredField(t('staking_page.lido_csm.form.validation.non_empty_id')).superRefine((value, ctx) => {
+    const parsed = Number(value);
+    if (!(Number.isInteger(parsed) && parsed >= 0))
+      ctx.addIssue({ code: 'custom', message: t('staking_page.lido_csm.form.validation.invalid_id') });
+  }),
+  selectedAccount: z.array(z.custom<BlockchainAccount<AddressData>>()).superRefine((accounts, ctx) => {
+    const account = accounts[0];
+    if (!account || getAccountAddress(account).trim() === '')
+      ctx.addIssue({ code: 'custom', message: t('staking_page.lido_csm.form.validation.non_empty_address') });
+  }),
+}));
+
+const form = useForm<NodeOperatorState, NodeOperatorPayload>({
+  initial: (): NodeOperatorState => ({ nodeOperatorId: '', selectedAccount: [] }),
+  schema,
+  submit: async (payload: NodeOperatorPayload): Promise<{ success: boolean }> => {
+    try {
+      const { message } = await api.addNodeOperator(payload);
+
+      if (message) {
+        setMessage({
+          description: message,
+        });
+      }
+
+      return { success: true };
+    }
+    catch (error: unknown) {
+      setMessage({
+        description: t('staking_page.lido_csm.messages.add_failed', {
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      });
+      return { success: false };
+    }
+  },
+  transform: (state): NodeOperatorPayload => {
+    const account = state.selectedAccount[0];
+    return {
+      address: account ? getAccountAddress(account) : '',
+      nodeOperatorId: Number(state.nodeOperatorId),
+    };
+  },
 });
 
-const v$ = useVuelidate(rules, { nodeOperatorId, selectedAddress }, { $autoDirty: true });
+// Destructured, because a ref reached through `form.` in the template is not unwrapped and would
+// read as permanently truthy.
+const { submitting, valid } = form;
 
 function closeDialog(): void {
   set(dialogOpen, false);
 }
 
 async function submitForm(): Promise<void> {
-  if (!(await get(v$).$validate()) || get(submitting))
+  if (get(submitting))
     return;
 
-  set(submitting, true);
-  try {
-    const { message } = await api.addNodeOperator({
-      address: get(selectedAddress),
-      nodeOperatorId: Number(get(nodeOperatorId)),
-    });
+  const result = await form.submit();
+  if (result.outcome !== 'success')
+    return;
 
-    if (message) {
-      setMessage({
-        description: message,
-      });
-    }
-
-    closeDialog();
-    emit('refresh');
-  }
-  catch (error: unknown) {
-    setMessage({
-      description: t('staking_page.lido_csm.messages.add_failed', {
-        message: error instanceof Error ? error.message : String(error),
-      }),
-    });
-  }
-  finally {
-    set(submitting, false);
-  }
+  closeDialog();
+  emit('refresh');
 }
 </script>
 
@@ -124,24 +135,28 @@ async function submitForm(): Promise<void> {
         </p>
         <div class="grid gap-4 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
           <BlockchainAccountSelector
-            v-model="selectedAccount"
+            v-model="form.state.selectedAccount"
             :chains="[Blockchain.ETH]"
             outlined
             show-details
             :label="t('staking_page.lido_csm.form.address_label')"
             :custom-hint="t('staking_page.lido_csm.form.address_hint')"
-            :error-messages="toMessages(v$.selectedAddress)"
+            :error-messages="form.errors('selectedAccount')"
+            data-testid="lido-csm-address"
+            @update:model-value="form.touch('selectedAccount')"
           />
           <RuiTextField
-            v-model="nodeOperatorId"
+            v-model="form.state.nodeOperatorId"
             type="number"
             min="0"
             step="1"
             color="primary"
             :label="t('staking_page.lido_csm.form.node_operator_label')"
             :hint="t('staking_page.lido_csm.form.node_operator_hint')"
-            :error-messages="toMessages(v$.nodeOperatorId)"
+            :error-messages="form.errors('nodeOperatorId')"
             variant="outlined"
+            data-testid="lido-csm-node-operator"
+            @update:model-value="form.touch('nodeOperatorId')"
           />
         </div>
       </div>
@@ -156,7 +171,8 @@ async function submitForm(): Promise<void> {
           <RuiButton
             color="primary"
             :loading="submitting"
-            :disabled="v$.$invalid"
+            :disabled="!valid"
+            data-testid="lido-csm-submit"
             @click="submitForm()"
           >
             {{ t('staking_page.lido_csm.form.submit') }}

--- a/frontend/app/src/modules/user-data/ImportSource.spec.ts
+++ b/frontend/app/src/modules/user-data/ImportSource.spec.ts
@@ -1,0 +1,284 @@
+import type { ComponentPublicInstance } from 'vue';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { err, ok } from 'plainfp/result';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DateFormat } from '@/modules/core/common/date-format';
+import { TaskFailed } from '@/modules/core/tasks/task-result';
+import '@test/i18n';
+
+const submitTask = vi.fn();
+const useIsActive = vi.fn();
+const getPath = vi.fn();
+
+vi.mock('@/modules/task-center/use-native-task', () => ({
+  useNativeTask: vi.fn().mockImplementation(() => ({ submitTask })),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', () => ({
+  useTaskCenter: vi.fn().mockImplementation(() => ({ useIsActive })),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: vi.fn().mockImplementation(() => ({ getPath })),
+}));
+
+vi.mock('@/modules/user-data/use-import-data-api', () => ({
+  useImportDataApi: vi.fn().mockImplementation(() => ({
+    importDataFrom: vi.fn(),
+    importFile: vi.fn(),
+  })),
+}));
+
+const ImportSource = (await import('@/modules/user-data/ImportSource.vue')).default;
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+/** Declares the two props the upload outcome is read through, which `inputStub` does not carry. */
+const fileUploadStub: Record<string, unknown> = {
+  emits: ['update:modelValue', 'update:errorMessage', 'update:uploaded'],
+  name: 'FileUpload',
+  props: ['modelValue', 'errorMessage', 'uploaded', 'loading', 'source'],
+  template: '<div />',
+};
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+describe('importSource', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ImportSource>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useIsActive.mockReturnValue(computed<boolean>(() => false));
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(): VueWrapper<InstanceType<typeof ImportSource>> {
+    return mount(ImportSource, {
+      global: {
+        stubs: {
+          DateFormatHelp: true,
+          FileUpload: fileUploadStub,
+          RuiSwitch: {
+            emits: ['update:modelValue'],
+            name: 'RuiSwitch',
+            props: ['modelValue'],
+            template: '<div><slot /></div>',
+          },
+          RuiTextField: inputStub('RuiTextField'),
+          RuiTimezoneSelect: inputStub('RuiTimezoneSelect'),
+        },
+      },
+      props: { source: 'cointracking' },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(): string[] {
+    const value: unknown = field('import-date-format').props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  function importDisabled(): unknown {
+    return wrapper.findComponent<StubInstance>('[data-testid=button-import]').props('disabled');
+  }
+
+  async function attachFile(): Promise<void> {
+    wrapper.findComponent<StubInstance>({ name: 'FileUpload' }).vm.$emit('update:modelValue', new File(['a'], 'a.csv'));
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  async function enableCustomFormat(): Promise<void> {
+    field('import-date-format-switch').vm.$emit('update:modelValue', true);
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  async function typeFormat(value: string): Promise<void> {
+    const input = field('import-date-format');
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  it('should keep the import blocked until a file is chosen', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(importDisabled()).toBe(true);
+
+    await attachFile();
+
+    expect(importDisabled()).toBe(false);
+  });
+
+  it('should hide the format field until the switch is turned on', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('import-date-format').exists()).toBe(false);
+
+    await enableCustomFormat();
+
+    expect(field('import-date-format').props('modelValue')).toBe(DateFormat.DateMonthYearHourMinuteSecond);
+  });
+
+  it('should accept the default format the switch seeds', async () => {
+    wrapper = createWrapper();
+    await attachFile();
+    await enableCustomFormat();
+
+    expect(messages()).toEqual([]);
+    expect(importDisabled()).toBe(false);
+  });
+
+  it('should reject a pattern with no recognised directive', async () => {
+    wrapper = createWrapper();
+    await attachFile();
+    await enableCustomFormat();
+
+    await typeFormat('not a date');
+
+    expect(messages()).toEqual(['general_settings.date_display.validation.invalid']);
+    expect(importDisabled()).toBe(true);
+  });
+
+  it('should report a blank pattern as invalid, never as empty', async () => {
+    wrapper = createWrapper();
+    await attachFile();
+    await enableCustomFormat();
+
+    await typeFormat('');
+
+    // The empty-value rule is `requiredIf(refIsTruthy(dateInputFormat))`: required only while the
+    // field already holds something, so it cannot fire. A blank pattern is caught as invalid.
+    expect(messages()).toEqual(['general_settings.date_display.validation.invalid']);
+    expect(importDisabled()).toBe(true);
+  });
+
+  it('should report a whitespace-only pattern as both empty and invalid', async () => {
+    wrapper = createWrapper();
+    await attachFile();
+    await enableCustomFormat();
+
+    // The only input the empty-value rule can fire on: truthy enough to arm its own
+    // `requiredIf`, blank once trimmed.
+    await typeFormat('   ');
+
+    expect(messages()).toEqual([
+      'general_settings.date_display.validation.empty',
+      'general_settings.date_display.validation.invalid',
+    ]);
+  });
+
+  it('should reject a pattern while typing, before the field is left', async () => {
+    wrapper = createWrapper();
+    await attachFile();
+    await enableCustomFormat();
+
+    // No blur: the import button is gated on validity, and a disabled button cannot be clicked to
+    // blur the field, so waiting for blur would leave the user with no message at all.
+    field('import-date-format').vm.$emit('update:modelValue', 'not a date');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages()).toEqual(['general_settings.date_display.validation.invalid']);
+  });
+
+  it('should accept a pattern once a directive is typed back in', async () => {
+    wrapper = createWrapper();
+    await attachFile();
+    await enableCustomFormat();
+
+    await typeFormat('not a date');
+    await typeFormat('%d/%m/%Y');
+
+    expect(messages()).toEqual([]);
+    expect(importDisabled()).toBe(false);
+  });
+
+  it('should stop validating once the switch is turned back off', async () => {
+    wrapper = createWrapper();
+    await attachFile();
+    await enableCustomFormat();
+    await typeFormat('not a date');
+
+    field('import-date-format-switch').vm.$emit('update:modelValue', false);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('import-date-format').exists()).toBe(false);
+    expect(importDisabled()).toBe(false);
+  });
+
+  it('should mark the upload done only when the task reports a completed import', async () => {
+    submitTask.mockResolvedValue(ok(true));
+    wrapper = createWrapper();
+    await attachFile();
+
+    await wrapper.find('form').trigger('submit');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.findComponent<StubInstance>({ name: 'FileUpload' }).props('uploaded')).toBe(true);
+  });
+
+  it('should leave the upload undone when the task settles on a failed import', async () => {
+    submitTask.mockResolvedValue(ok(false));
+    wrapper = createWrapper();
+    await attachFile();
+
+    await wrapper.find('form').trigger('submit');
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.findComponent<StubInstance>({ name: 'FileUpload' }).props('uploaded')).toBe(false);
+  });
+
+  it('should surface an actionable task error on the upload field', async () => {
+    submitTask.mockResolvedValue(err(TaskFailed({ message: 'bad csv' })));
+    wrapper = createWrapper();
+    await attachFile();
+
+    await wrapper.find('form').trigger('submit');
+    await vi.advanceTimersToNextTimerAsync();
+
+    const upload = wrapper.findComponent<StubInstance>({ name: 'FileUpload' });
+    expect(upload.props('uploaded')).toBe(false);
+    expect(upload.props('errorMessage')).toBe('bad csv');
+  });
+
+  it('should hide both switches for a rotki custom import', async () => {
+    wrapper = mount(ImportSource, {
+      global: {
+        stubs: {
+          DateFormatHelp: true,
+          FileUpload: fileUploadStub,
+          RuiSwitch: {
+            emits: ['update:modelValue'],
+            name: 'RuiSwitch',
+            props: ['modelValue'],
+            template: '<div><slot /></div>',
+          },
+          RuiTextField: inputStub('RuiTextField'),
+        },
+      },
+      props: { source: 'rotki_events' },
+    });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('import-date-format-switch').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=import-timezone-switch]').exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/user-data/ImportSource.vue
+++ b/frontend/app/src/modules/user-data/ImportSource.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import type { ImportSourceType } from '@/modules/core/common/upload-types';
-import useVuelidate from '@vuelidate/core';
-import { helpers, requiredIf } from '@vuelidate/validators';
 import { isErr, map as mapResult, type Result } from 'plainfp/result';
+import { z, type ZodType } from 'zod';
 import { msg } from '@/message-key';
 import { DateFormat } from '@/modules/core/common/date-format';
 import { displayDateFormatter } from '@/modules/core/common/date-formatter';
-import { refIsTruthy } from '@/modules/core/common/use-ref-truthy';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
 import DateFormatHelp from '@/modules/settings/controls/DateFormatHelp.vue';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
@@ -26,7 +24,10 @@ defineSlots<{
   'upload-title': () => any;
 }>();
 
-const dateInputFormat = ref<string>();
+interface ImportState {
+  dateInputFormat: string | undefined;
+}
+
 const useCustomTimezone = ref<boolean>(false);
 const timezone = ref<string>();
 const uploaded = ref(false);
@@ -37,33 +38,41 @@ const file = ref<File>();
 const { t } = useI18n({ useScope: 'global' });
 const { getPath } = useInterop();
 
-const rules = {
-  dateInputFormat: {
-    required: helpers.withMessage(
-      t('general_settings.date_display.validation.empty'),
-      requiredIf(refIsTruthy(dateInputFormat)),
-    ),
-    validDate: helpers.withMessage(
-      t('general_settings.date_display.validation.invalid'),
-      (v: string | undefined): boolean => v === undefined || displayDateFormatter.containsValidDirectives(v),
-    ),
-  },
-};
+/**
+ * The empty-value rule only ever fires on a pattern that is truthy but blank once trimmed, because
+ * vuelidate armed it with `requiredIf(refIsTruthy(self))` and then trimmed before checking. A field
+ * cleared to '' therefore reports only the invalid-pattern message, which is preserved here.
+ */
+const schema = computed<ZodType>(() => z.object({
+  dateInputFormat: z.string().optional().superRefine((value, ctx) => {
+    if (value === undefined)
+      return;
 
-const v$ = useVuelidate(
-  rules,
-  {
-    dateInputFormat,
-  },
-  { $autoDirty: true },
-);
+    if (value !== '' && value.trim() === '')
+      ctx.addIssue({ code: 'custom', message: t('general_settings.date_display.validation.empty') });
 
-const dateInputFormatExample = computed(() => {
-  const now = new Date();
-  if (!get(dateInputFormat))
+    if (!displayDateFormatter.containsValidDirectives(value))
+      ctx.addIssue({ code: 'custom', message: t('general_settings.date_display.validation.invalid') });
+  }),
+}));
+
+const form = useForm<ImportState, ImportState>({
+  initial: (): ImportState => ({ dateInputFormat: undefined }),
+  schema,
+  submit: async (): Promise<{ success: boolean }> => ({ success: await uploadFile() }),
+  transform: (state): ImportState => ({ dateInputFormat: state.dateInputFormat }),
+});
+
+// Destructured, because a ref reached through `form.` in the template is not unwrapped and would
+// read as permanently truthy.
+const { valid } = form;
+
+const dateInputFormatExample = computed<string>(() => {
+  const format = form.state.dateInputFormat;
+  if (!format)
     return '';
 
-  return displayDateFormatter.format(now, get(dateInputFormat)!);
+  return displayDateFormatter.format(new Date(), format);
 });
 
 const { submitTask } = useNativeTask();
@@ -72,7 +81,22 @@ const { useIsActive } = useTaskCenter();
 const loading = useIsActive(ActivityKind.CSV_IMPORT, source);
 const { importDataFrom, importFile } = useImportDataApi();
 
-async function uploadPackaged(file: string): Promise<void> {
+/** An import only counts as done when the task both settled and reported a completed import. */
+function applyOutcome(outcome: Result<boolean, TaskError>): boolean {
+  if (!isErr(outcome)) {
+    if (outcome.value)
+      set(uploaded, true);
+
+    return outcome.value;
+  }
+
+  if (isActionable(outcome.error))
+    set(errorMessage, outcome.error.message);
+
+  return false;
+}
+
+async function uploadPackaged(file: string): Promise<boolean> {
   const outcome = await submitTask<boolean>({
     id: makeActivityId(ActivityKind.CSV_IMPORT, source),
     kind: ActivityKind.CSV_IMPORT,
@@ -82,7 +106,7 @@ async function uploadPackaged(file: string): Promise<void> {
         () => importDataFrom({
           file,
           source,
-          timestampFormat: get(dateInputFormat) || null,
+          timestampFormat: form.state.dateInputFormat || null,
           timezone: get(timezone) || null,
         }),
       ),
@@ -92,63 +116,50 @@ async function uploadPackaged(file: string): Promise<void> {
     title: t('task_center.group.csv_import'),
   });
 
-  if (!isErr(outcome)) {
-    if (outcome.value)
-      set(uploaded, true);
-  }
-  else if (isActionable(outcome.error)) {
-    set(errorMessage, outcome.error.message);
-  }
+  return applyOutcome(outcome);
 }
 
-async function uploadFile(): Promise<void> {
+async function uploadFile(): Promise<boolean> {
   const fileVal = get(file);
-  if (fileVal) {
-    const path = getPath(fileVal);
-    if (path) {
-      await uploadPackaged(path);
-    }
-    else {
-      const formData = new FormData();
-      formData.append('source', source);
-      formData.append('file', fileVal);
-      formData.append('async_query', 'true');
-      const dateInputFormatVal = get(dateInputFormat);
-      if (dateInputFormatVal)
-        formData.append('timestamp_format', dateInputFormatVal);
-      const timezoneVal = get(timezone);
-      if (timezoneVal)
-        formData.append('timezone', timezoneVal);
+  if (!fileVal)
+    return false;
 
-      const outcome = await submitTask<boolean>({
-        id: makeActivityId(ActivityKind.CSV_IMPORT, source),
-        kind: ActivityKind.CSV_IMPORT,
-        rerunnable: false,
-        run: async ({ runTask }): Promise<Result<boolean, TaskError>> => mapResult(
-          await runTask<boolean>(
-            () => importFile(formData),
-          ),
-          value => value,
-        ),
-        subtitle: activityLabelFor(msg.$t('task_center.activity.csv_import.source'), { source }),
-        title: t('task_center.group.csv_import'),
-      });
+  const path = getPath(fileVal);
+  if (path)
+    return uploadPackaged(path);
 
-      if (!isErr(outcome)) {
-        if (outcome.value)
-          set(uploaded, true);
-      }
-      else if (isActionable(outcome.error)) {
-        set(errorMessage, outcome.error.message);
-      }
-    }
-  }
+  const formData = new FormData();
+  formData.append('source', source);
+  formData.append('file', fileVal);
+  formData.append('async_query', 'true');
+  const dateInputFormatVal = form.state.dateInputFormat;
+  if (dateInputFormatVal)
+    formData.append('timestamp_format', dateInputFormatVal);
+  const timezoneVal = get(timezone);
+  if (timezoneVal)
+    formData.append('timezone', timezoneVal);
+
+  const outcome = await submitTask<boolean>({
+    id: makeActivityId(ActivityKind.CSV_IMPORT, source),
+    kind: ActivityKind.CSV_IMPORT,
+    rerunnable: false,
+    run: async ({ runTask }): Promise<Result<boolean, TaskError>> => mapResult(
+      await runTask<boolean>(
+        () => importFile(formData),
+      ),
+      value => value,
+    ),
+    subtitle: activityLabelFor(msg.$t('task_center.activity.csv_import.source'), { source }),
+    title: t('task_center.group.csv_import'),
+  });
+
+  return applyOutcome(outcome);
 }
 
-function changeShouldCustomDateFormat() {
-  if (!isDefined(dateInputFormat))
-    set(dateInputFormat, DateFormat.DateMonthYearHourMinuteSecond);
-  else set(dateInputFormat, undefined);
+function changeShouldCustomDateFormat(): void {
+  form.state.dateInputFormat = form.state.dateInputFormat === undefined
+    ? DateFormat.DateMonthYearHourMinuteSecond
+    : undefined;
 }
 
 function toggleCustomTimezone(enabled: boolean): void {
@@ -170,7 +181,7 @@ const isRotkiCustomImport = computed<boolean>(() => source.startsWith('rotki_'))
     </div>
     <form
       novalidate
-      @submit.stop.prevent="uploadFile()"
+      @submit.stop.prevent="form.submit()"
     >
       <FileUpload
         v-model="file"
@@ -184,24 +195,27 @@ const isRotkiCustomImport = computed<boolean>(() => source.startsWith('rotki_'))
         v-if="!isRotkiCustomImport"
         color="primary"
         class="mt-4"
-        :model-value="dateInputFormat !== undefined"
+        :model-value="form.state.dateInputFormat !== undefined"
+        data-testid="import-date-format-switch"
         @update:model-value="changeShouldCustomDateFormat()"
       >
         {{ t('file_upload.date_input_format.switch_label') }}
       </RuiSwitch>
       <RuiTextField
-        v-if="dateInputFormat !== undefined"
-        v-model="dateInputFormat"
+        v-if="form.state.dateInputFormat !== undefined"
+        v-model="form.state.dateInputFormat"
         class="mt-2"
         variant="outlined"
         color="primary"
-        :error-messages="toMessages(v$.dateInputFormat)"
+        :error-messages="form.errors('dateInputFormat')"
+        data-testid="import-date-format"
         :label="t('file_upload.date_input_format.placeholder')"
         :hint="
           t('file_upload.date_input_format.hint', {
             format: dateInputFormatExample,
           })
         "
+        @update:model-value="form.touch('dateInputFormat')"
       >
         <template #append>
           <RuiButton
@@ -255,7 +269,7 @@ const isRotkiCustomImport = computed<boolean>(() => source.startsWith('rotki_'))
           data-testid="button-import"
           size="lg"
           type="submit"
-          :disabled="v$.$invalid || !file || loading"
+          :disabled="!valid || !file || loading"
         >
           <template #prepend>
             <RuiIcon


### PR DESCRIPTION
Moves the seven "quick singleton" forms off vuelidate: the device rename, the historic price edit, the asset merge dialog, the lido csm add dialog, the csv import format, the underlying token staging row and the report range selector. One commit per form, each carrying its component, its schema and its spec.

Only two of these had any spec before, so every form starts with characterization tests written against the vuelidate behaviour and mutation-proved on both sides of the swap: the rule is neutered, the expected tests go red, the rule is restored, and the same proof is re-run against the zod schema.

## Behaviour changes

Three, each deliberate rather than a side effect of the port:

- **The historic price edit did not use its own validation.** It validated the price, rendered the message and then never consulted it, so `updatePrice` sent an empty price to `addHistoricalPrice`. Fixed in its own commit ahead of the migration, so the port itself stays mechanical.
- **A failed csv import reported success.** `uploadFile` does not throw on a failure, it funnels an actionable task error onto the upload field, so the new submit callback would have told the form core that every import worked. It now reports the real verdict.
- **Messages appear on input rather than on blur** wherever the submit button is gated on validity. Blur is a dead end there: a disabled button is not focusable, so clicking it neither submits nor blurs, and the user sees a disabled button with no explanation until they happen to click elsewhere. This is also what `$autoDirty` did, and matches the asset price forms.

## Two things the migration disproved

- **The report range selector's two messages have never rendered.** Vuelidate's `$errors` is `$dirty ? $silentErrors : []`, and with `$autoDirty: false` and no `$touch` call anywhere, `$dirty` was permanently false. Only the emitted validity boolean was ever consumed. The keys are kept and are now reachable.
- **The csv import's `required` is not the tautology it looks like.** Vuelidate's `required` trims before checking while `refIsTruthy` does not, so a whitespace-only pattern arms its own predicate and then fails. That is the one input separating the empty message from the invalid one, and it is pinned.

## Worth a reviewer's attention

- The device rename keeps comparing against the name the device had when the dialog opened, because `not(sameAs(...))` read the prop once at setup rather than reactively. Preserved rather than fixed, since making it reactive changes which values a mounted form accepts, and a test renames the prop mid-flight to pin it.
- `$stopPropagation` on the underlying token row has nothing to port to: a zod form joins no parent validator tree, so the permanently invalid staging row can no longer block the parent save by construction. Its spec still mounts the component inside a real vuelidate parent to assert that, which is why it still imports `@vuelidate/core`; that goes with the last root.
- The lido dialog validates a read-only computed with no setter, so the selection array is the state and the rule still resolves the address through `getAccountAddress` rather than substituting a length check.
- `refIsTruthy` is deleted: the csv import form was its only caller, and knip fails on it otherwise.

## Testing

Full frontend gates green: typecheck, 823 files / 8100 unit tests, lint at the 0 errors / 20 warnings baseline, knip and typos clean. 88 tests are new.

Not verified in the app beyond the csv import form, where the on-input message was confirmed by hand. The device rename and the lido dialog sit behind premium.