### PR TITLE
feat(premium): introduce components v16

### DIFF
--- a/frontend/app/scripts/extract-premium-keys.ts
+++ b/frontend/app/scripts/extract-premium-keys.ts
@@ -15,7 +15,7 @@
  * rotki pins a components *major* (`COMPONENTS_VERSION` in rotkehlchen/premium/premium.py, and the
  * bundle filename derives from the premium package major), so the keys of the current major are the
  * complete set any supported rotki can request. Verified across every 15.x tag: the union is
- * identical to the tip, and identical again to 14.x.
+ * identical to the tip, and identical again to 14.x. Re-verify when 16.x accumulates tags.
  */
 
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';

--- a/frontend/app/src/modules/dashboard/liquidity-pools/use-pool-data-fetching.spec.ts
+++ b/frontend/app/src/modules/dashboard/liquidity-pools/use-pool-data-fetching.spec.ts
@@ -91,7 +91,7 @@ describe('usePoolDataFetching', () => {
     });
 
     it('should store parsed balances on success', async () => {
-      const balances = { '0x123': [{ address: '0x456', assets: [], totalAmount: '1', usdPrice: '2', userBalance: { amount: '1', usdValue: '2' } }] };
+      const balances = { '0x123': [{ address: '0x456', assets: [], totalAmount: '1', usdPrice: '2', userBalance: { amount: '1', value: '2' } }] };
       mockRunTaskResult.mockResolvedValue(ok(balances));
 
       const { usePoolBalancesStore } = await import('./use-pool-balances-store');

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { Account, Blockchain, HistoryEventEntryType } from '@rotki/common';
 import type { PullLocationTransactionPayload } from '@/modules/history/events/event-payloads';
+import type { HistoryEventsRestrictions } from '@/modules/history/events/history-events-restrictions';
 import type { HistoryEventRow } from '@/modules/history/events/schemas';
 import type { Filters } from '@/modules/history/events/use-events-filter';
 import { isAccountingUpdateEnabled } from '@/modules/core/common/feature-flags';
@@ -35,36 +35,13 @@ import RefreshButton from '@/modules/shell/components/RefreshButton.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
 
-type Period = { fromTimestamp?: string; toTimestamp?: string } | { fromTimestamp?: number; toTimestamp?: number };
-
 defineOptions({ inheritAttrs: false });
 
-const {
-  entryTypes,
-  eventSubTypes = [],
-  eventTypes = [],
-  externalAccountFilter = [],
-  location,
-  mainPage,
-  onlyChains = [],
-  period,
-  protocols = [],
-  sectionTitle = '',
-  useExternalAccountFilter,
-  validators,
-} = defineProps<{
-  location?: string;
-  protocols?: string[];
-  eventTypes?: string[];
-  eventSubTypes?: string[];
-  entryTypes?: HistoryEventEntryType[];
-  period?: Period;
-  validators?: number[];
-  externalAccountFilter?: Account[];
-  useExternalAccountFilter?: boolean;
+const { mainPage = false, restrictions = {}, sectionTitle = '' } = defineProps<{
+  /** What this view fixes for the user. See HistoryEventsRestrictions. */
+  restrictions?: HistoryEventsRestrictions;
   sectionTitle?: string;
   mainPage?: boolean;
-  onlyChains?: Blockchain[];
 }>();
 
 const SyncProgressPanel = defineAsyncComponent(() => import('@/modules/shell/sync-progress/components/SyncProgressPanel.vue'));
@@ -102,25 +79,10 @@ const {
 
 const usedTitle = computed<string>(() => sectionTitle || t('transactions.title'));
 
-// What this view fixes for the user, read by both the table's filters and the pill-bar fields, so
-// the restrictions are stated once.
-const filterOptions = {
-  entryTypes: () => entryTypes,
-  eventSubTypes: () => eventSubTypes,
-  eventTypes: () => eventTypes,
-  externalAccountFilter: () => externalAccountFilter,
-  location: () => location,
-  mainPage: () => mainPage,
-  period: () => period,
-  protocols: () => protocols,
-  useExternalAccountFilter: () => useExternalAccountFilter,
-  validators: () => validators,
-};
-
 // The filter bag, and the fields bound to it, in that order: the fields read the bag to scope
 // their option lists, and the table below reads the url shape of the bag off the fields.
 const modelFilters = ref<Filters>({});
-const fields = useHistoryEventFields({ ...filterOptions, modelFilters });
+const fields = useHistoryEventFields({ modelFilters, restrictions: () => restrictions });
 
 const {
   clearFilters,
@@ -144,7 +106,12 @@ const {
   requestPayload,
   setPage,
   sort,
-} = useHistoryEventsFilters({ ...filterOptions, fields, filters: modelFilters }, toggles, overlayMode);
+} = useHistoryEventsFilters({
+  fields,
+  filters: modelFilters,
+  mainPage: () => mainPage,
+  restrictions: () => restrictions,
+}, toggles, overlayMode);
 
 // Accounting overlay: shows the known balance after each event. Keys off each event's own
 // (account, asset) pair, so no extra filter is required. Gated by VITE_ACCOUNTING_UPDATE,
@@ -188,11 +155,11 @@ watch(syncCompleted, async () => {
 });
 
 const actions = useHistoryEventsActions({
-  entryTypes: () => entryTypes,
+  entryTypes: () => restrictions.entryTypes,
   refetch,
   groups,
   mainPage: () => mainPage,
-  onlyChains: () => onlyChains,
+  onlyChains: () => restrictions.onlyChains ?? [],
   shouldFetchEventsRegularly,
 });
 

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
+import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
 import type { PullLocationTransactionPayload } from '@/modules/history/events/event-payloads';
 import type { HistoryEventsRestrictions } from '@/modules/history/events/history-events-restrictions';
 import type { HistoryEventRow } from '@/modules/history/events/schemas';
 import type { Filters } from '@/modules/history/events/use-events-filter';
-import { isAccountingUpdateEnabled } from '@/modules/core/common/feature-flags';
 import { AccountingOverlayToggle, BalanceDivergenceToggle } from '@/modules/history/balances/components';
-import { OverlayMode, type OverlayPair, useAccountingOverlay } from '@/modules/history/balances/use-accounting-overlay';
-import { provideAccountingOverlay } from '@/modules/history/balances/use-accounting-overlay-context';
+import { OverlayMode } from '@/modules/history/balances/use-accounting-overlay';
 import HistoryEventsVirtualTable from '@/modules/history/events/components/HistoryEventsVirtualTable.vue';
 import {
   getDefaultToggles,
@@ -14,14 +13,16 @@ import {
   useHistoryEventNavigationConsumer,
   useHistoryEventsActions,
   useHistoryEventsDeletion,
+  useHistoryEventsDialogRouting,
   useHistoryEventsFilters,
+  useHistoryEventsOverlay,
   useHistoryEventsSelectionActions,
   useHistoryEventsSelectionMode,
   useHistoryEventsStatus,
+  useHistoryEventsTableHeight,
   useUnmatchedAssetMovements,
   useUnmatchedBridgeTransactions,
 } from '@/modules/history/events/composables';
-import { DIALOG_TYPES, type DialogShowOptions, type HistoryEventsToggles } from '@/modules/history/events/dialog-types';
 import HistoryEventsDialogContainer from '@/modules/history/events/HistoryEventsDialogContainer.vue';
 import HistoryEventsFiltersChips from '@/modules/history/events/HistoryEventsFiltersChips.vue';
 import HistoryEventsTableActions from '@/modules/history/events/HistoryEventsTableActions.vue';
@@ -33,7 +34,6 @@ import {
 } from '@/modules/history/events/prices/use-event-price-update-trigger';
 import RefreshButton from '@/modules/shell/components/RefreshButton.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
-import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
 
 defineOptions({ inheritAttrs: false });
 
@@ -47,7 +47,6 @@ const { mainPage = false, restrictions = {}, sectionTitle = '' } = defineProps<{
 const SyncProgressPanel = defineAsyncComponent(() => import('@/modules/shell/sync-progress/components/SyncProgressPanel.vue'));
 
 const { t } = useI18n({ useScope: 'global' });
-const router = useRouter();
 const route = useRoute();
 
 const toggles = ref<HistoryEventsToggles>(getDefaultToggles());
@@ -56,18 +55,13 @@ const overlayMode = ref<OverlayMode>(OverlayMode.NONE);
 
 const eventPriceUpdatePayload = ref<EventPriceUpdatePayload>();
 
-const syncProgressPanelEl = useTemplateRef<ComponentPublicInstance>('syncProgressPanel');
-const tableActionsEl = useTemplateRef<ComponentPublicInstance>('tableActions');
-const filtersChipsEl = useTemplateRef<ComponentPublicInstance>('filtersChips');
 const dialogContainer = useTemplateRef<InstanceType<typeof HistoryEventsDialogContainer>>('dialogContainer');
 
-const { height: syncProgressHeight } = useElementSize(syncProgressPanelEl);
-const { height: tableActionsHeight } = useElementSize(tableActionsEl);
-const { height: filtersChipsHeight } = useElementSize(filtersChipsEl);
-
-const BASE_TABLE_HEIGHT_OFFSET = 252;
-
-const tableHeightOffset = computed<number>(() => get(syncProgressHeight) + get(tableActionsHeight) + get(filtersChipsHeight) + BASE_TABLE_HEIGHT_OFFSET);
+const tableHeightOffset = useHistoryEventsTableHeight(
+  useTemplateRef<ComponentPublicInstance>('syncProgressPanel'),
+  useTemplateRef<ComponentPublicInstance>('tableActions'),
+  useTemplateRef<ComponentPublicInstance>('filtersChips'),
+);
 
 const {
   anyEventsDecoding,
@@ -113,46 +107,7 @@ const {
   restrictions: () => restrictions,
 }, toggles, overlayMode);
 
-// Accounting overlay: shows the known balance after each event. Keys off each event's own
-// (account, asset) pair, so no extra filter is required. Gated by VITE_ACCOUNTING_UPDATE,
-// which is derived at build/dev time from the backend's ROTKI_ACCOUNTING_UPDATE env var (see
-// vite.config.ts), so the overlay only appears in builds where the backend serves it.
-// The mode is synced through the router query (via useHistoryEventsFilters' queryParamsOnly):
-// it rides along with pagination instead of being clobbered by it, and is NOT persisted across
-// sessions. Fresh navigation to history resets it to 'none' (empty query), while browser/in-app
-// back restores it from the history entry's query. Only the main page syncs (history: 'router').
-const overlayAvailable = isAccountingUpdateEnabled();
-
-// Require the build flag too, so the 'balance' choice can't enable it where the
-// backend would reject every call.
-const overlayEnabled = computed<boolean>(() => overlayAvailable && get(overlayMode) === OverlayMode.BALANCE);
-
-const overlayPairs = computed<OverlayPair[]>(() => {
-  const events = get(groups).data.flatMap(row => Array.isArray(row) ? row : [row]);
-  // Map keyed by `${account} ${asset}` dedupes for free; last write wins (identical payload).
-  const byKey = new Map<string, OverlayPair>();
-  for (const { asset, locationLabel } of events) {
-    if (locationLabel)
-      byKey.set(`${locationLabel} ${asset}`, { asset, locationLabel });
-  }
-  return [...byKey.values()];
-});
-
-const accountingOverlay = useAccountingOverlay({
-  enabled: overlayEnabled,
-  pairs: overlayPairs,
-});
-
-provideAccountingOverlay({ enabled: overlayEnabled, overlay: accountingOverlay });
-
-// When the history sync (tx query + exchange events + decoding) completes, new events have
-// landed and their historical balances may have shifted, so the whole overlay is refreshed to
-// re-resolve every visible row against the updated series. Guarded so a hidden overlay stays idle.
-const { syncCompleted } = useSyncCompleted();
-watch(syncCompleted, async () => {
-  if (get(overlayEnabled))
-    await accountingOverlay.refresh();
-});
+const { available: overlayAvailable } = useHistoryEventsOverlay(overlayMode, groups);
 
 const actions = useHistoryEventsActions({
   entryTypes: () => restrictions.entryTypes,
@@ -237,21 +192,7 @@ watchImmediate(groups, (newGroups) => {
   selectionMode.setTotalMatchingCount(newGroups.found);
 });
 
-const queryToDialogMap: Record<string, DialogShowOptions> = {
-  openDecodingStatusDialog: { type: DIALOG_TYPES.DECODING_STATUS },
-  openMatchAssetMovementsDialog: { type: DIALOG_TYPES.MATCH_ASSET_MOVEMENTS },
-  openMatchBridgesDialog: { type: DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS },
-};
-
-watchImmediate(route, async ({ query }) => {
-  const dialogOptions = Object.keys(queryToDialogMap).find(key => query[key]);
-  if (!dialogOptions)
-    return;
-
-  await nextTick();
-  get(dialogContainer)?.show(queryToDialogMap[dialogOptions]);
-  await router.replace({ query: {} });
-});
+useHistoryEventsDialogRouting(dialogContainer);
 
 watch(backgroundLoading, async (isLoading, wasLoading) => {
   if (!isLoading && wasLoading)

--- a/frontend/app/src/modules/history/events/composables.ts
+++ b/frontend/app/src/modules/history/events/composables.ts
@@ -13,14 +13,20 @@ export { useHistoryEventsActions } from './use-history-events-actions';
 
 export { useHistoryEventsDeletion } from './use-history-events-deletion';
 
+export { useHistoryEventsDialogRouting } from './use-history-events-dialog-routing';
+
 export {
   getDefaultToggles,
   useHistoryEventsFilters,
 } from './use-history-events-filters';
 
+export { useHistoryEventsOverlay } from './use-history-events-overlay';
+
 export { useHistoryEventsSelectionActions } from './use-history-events-selection-actions';
 
 export { useHistoryEventsStatus } from './use-history-events-status';
+
+export { useHistoryEventsTableHeight } from './use-history-events-table-height';
 
 export { useHistoryEventsSelectionMode } from './use-selection-mode';
 

--- a/frontend/app/src/modules/history/events/history-event-query.ts
+++ b/frontend/app/src/modules/history/events/history-event-query.ts
@@ -14,7 +14,6 @@ type Period = { fromTimestamp?: string; toTimestamp?: string } | { fromTimestamp
 interface HistoryEventSourceDeps {
   duplicateHandlingStatusFromQuery: ComputedRef<DuplicateHandlingStatus | undefined>;
   entryTypes: MaybeRefOrGetter<HistoryEventEntryType[] | undefined>;
-  eventSubTypes: MaybeRefOrGetter<string[]>;
   eventTypes: MaybeRefOrGetter<string[]>;
   groupIdentifiersFromQuery: ComputedRef<string[] | undefined>;
   location: MaybeRefOrGetter<string | undefined>;
@@ -51,7 +50,6 @@ export function buildHistoryEventSources({
   action,
   duplicateHandlingStatusFromQuery,
   entryTypes,
-  eventSubTypes,
   eventTypes,
   groupIdentifiersFromQuery,
   location,
@@ -123,7 +121,6 @@ export function buildHistoryEventSources({
         const params: Writeable<Partial<HistoryEventRequestPayload>> = {
           aggregateByGroupIds: true,
           counterparties: toValue(protocols),
-          eventSubtypes: toValue(eventSubTypes),
           eventTypes: toValue(eventTypes),
           identifiers: get(missingAcquisitionFromQuery),
         };

--- a/frontend/app/src/modules/history/events/history-events-restrictions.ts
+++ b/frontend/app/src/modules/history/events/history-events-restrictions.ts
@@ -1,0 +1,72 @@
+import type { Account, Blockchain, HistoryEventEntryType } from '@rotki/common';
+import type { MaybeRefOrGetter } from 'vue';
+
+type HistoryEventsPeriod =
+  | { fromTimestamp?: string; toTimestamp?: string }
+  | { fromTimestamp?: number; toTimestamp?: number };
+
+/**
+ * What a view has already decided for the user, stated once.
+ *
+ * Every consumer reads the same bag: the pill bar drops a field the view has pinned, the request
+ * sources fold it into the payload, and the events fetch narrows to the chains it names. These
+ * used to be a dozen sibling props threaded separately through three layers, which meant a new
+ * restriction had to be added in each of them and could silently reach only some.
+ *
+ * An absent key means unrestricted. Restricting to nothing is not expressible, and would not be
+ * meaningful: an empty array reads as "no restriction on this axis", the same as omitting it.
+ * `externalAccounts` is the one exception, for the reason given on it.
+ */
+export interface HistoryEventsRestrictions {
+  entryTypes?: HistoryEventEntryType[];
+  eventTypes?: string[];
+  /**
+   * Accounts the view selects for the user, replacing the bar's account pill.
+   *
+   * Presence is the switch, so an empty array is meaningful here and not the same as omitting the
+   * key: Kraken owns the account axis without pinning any address, and reads as `[]`. This was two
+   * props, a boolean beside the list, which made "pinned to these accounts but the pill is still
+   * offered" and "pill suppressed but the list is ignored" both expressible and neither meaningful.
+   */
+  externalAccounts?: Account[];
+  location?: string;
+  onlyChains?: Blockchain[];
+  period?: HistoryEventsPeriod;
+  protocols?: string[];
+  validators?: number[];
+}
+
+interface RestrictionGetters {
+  entryTypes: () => HistoryEventEntryType[] | undefined;
+  eventTypes: () => string[];
+  externalAccounts: () => Account[] | undefined;
+  location: () => string | undefined;
+  onlyChains: () => Blockchain[];
+  period: () => HistoryEventsPeriod | undefined;
+  protocols: () => string[];
+  validators: () => number[] | undefined;
+}
+
+/**
+ * Splits the bag into the per-axis getters the composables below it read.
+ *
+ * The list-valued axes default to `[]` here, in one place, because the consumers test them with
+ * `.length` and treat absent and empty alike. The nullable ones stay nullable: `entryTypes`
+ * distinguishes "every type" from a chosen set, `validators`/`location` gate a pill on presence
+ * rather than on emptiness, and `externalAccounts` must not be defaulted at all — `[]` is a
+ * meaningful value there and `undefined` is the off state.
+ */
+export function toRestrictionGetters(
+  restrictions: MaybeRefOrGetter<HistoryEventsRestrictions>,
+): RestrictionGetters {
+  return {
+    entryTypes: (): HistoryEventEntryType[] | undefined => toValue(restrictions).entryTypes,
+    eventTypes: (): string[] => toValue(restrictions).eventTypes ?? [],
+    externalAccounts: (): Account[] | undefined => toValue(restrictions).externalAccounts,
+    location: (): string | undefined => toValue(restrictions).location,
+    onlyChains: (): Blockchain[] => toValue(restrictions).onlyChains ?? [],
+    period: (): HistoryEventsPeriod | undefined => toValue(restrictions).period,
+    protocols: (): string[] => toValue(restrictions).protocols ?? [],
+    validators: (): number[] | undefined => toValue(restrictions).validators,
+  };
+}

--- a/frontend/app/src/modules/history/events/use-history-event-fields.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-fields.ts
@@ -1,4 +1,3 @@
-import type { HistoryEventEntryType } from '@rotki/common';
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { AssetsWithId } from '@/modules/assets/types';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
@@ -8,6 +7,7 @@ import { assetSuggestions } from '@/modules/core/common/display/assets';
 import { useSharedFieldResolvers } from '@/modules/core/table/filters/shared/use-shared-field-resolvers';
 import { useEventActionPicker } from '@/modules/history/events/action-picker/use-event-action-picker';
 import { type ActionFieldOption, toHistoryAccountField, toHistoryActionField, toHistoryEventFields, toHistoryIgnoredField, toHistoryStateField } from '@/modules/history/events/history-event-fields';
+import { type HistoryEventsRestrictions, toRestrictionGetters } from '@/modules/history/events/history-events-restrictions';
 import { subtypesForTypes } from '@/modules/history/events/mapping/event-type-subtypes';
 import { useHistoryEventCounterpartyMappings } from '@/modules/history/events/mapping/use-history-event-counterparty-mappings';
 import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
@@ -16,26 +16,18 @@ import { HistoryEventState } from '@/modules/history/events/schemas';
 import { useAccountFilterOptions } from '@/modules/history/use-account-filter-options';
 import { useHistoryStore } from '@/modules/history/use-history-store';
 
-/**
- * What the view has already decided for the user. It is the same object the table's own filters
- * take, so a page states its restrictions once and both read them: a page pinned to one protocol,
- * location, period, validator set or event type has nothing left to offer a pill for.
- */
 export interface HistoryEventFieldsOptions {
-  entryTypes: MaybeRefOrGetter<HistoryEventEntryType[] | undefined>;
+  /**
+   * What the view has already decided for the user. The table's own filters take the same bag, so a
+   * page states its restrictions once and both read them: a page pinned to one protocol, location,
+   * period, validator set or event type has nothing left to offer a pill for.
+   */
+  restrictions: MaybeRefOrGetter<HistoryEventsRestrictions>;
   /**
    * The table's filter bag, writable: what is picked scopes the asset search and the offered
    * subtypes, and a narrowing subtype set prunes what it no longer admits.
    */
   modelFilters: Ref<Filters>;
-  eventSubTypes: MaybeRefOrGetter<string[]>;
-  eventTypes: MaybeRefOrGetter<string[]>;
-  location: MaybeRefOrGetter<string | undefined>;
-  period: MaybeRefOrGetter<unknown>;
-  protocols: MaybeRefOrGetter<string[]>;
-  /** True when the view is pinned to an external account set, which replaces the account pill. */
-  useExternalAccountFilter: MaybeRefOrGetter<boolean | undefined>;
-  validators: MaybeRefOrGetter<number[] | undefined>;
 }
 
 /**
@@ -44,16 +36,24 @@ export interface HistoryEventFieldsOptions {
  * The account pill is omitted when the view is already pinned to an external account set.
  */
 export function useHistoryEventFields(options: HistoryEventFieldsOptions): ComputedRef<FieldDef[]> {
-  const { entryTypes, modelFilters: filters, useExternalAccountFilter } = options;
+  const { modelFilters: filters } = options;
+  const {
+    entryTypes,
+    eventTypes,
+    externalAccounts,
+    location: pinnedLocation,
+    period,
+    protocols,
+    validators,
+  } = toRestrictionGetters(options.restrictions);
 
   // What the view fixes, and so the bar does not offer.
   const disabled = computed(() => ({
-    eventSubtypes: (toValue(options.eventSubTypes) || []).length > 0,
-    eventTypes: (toValue(options.eventTypes) || []).length > 0,
-    locations: !!toValue(options.location),
-    period: !!toValue(options.period),
-    protocols: (toValue(options.protocols) || []).length > 0,
-    validators: !!toValue(options.validators),
+    eventTypes: eventTypes().length > 0,
+    locations: !!pinnedLocation(),
+    period: !!period(),
+    protocols: protocols().length > 0,
+    validators: !!validators(),
   }));
 
   const { t } = useI18n({ useScope: 'global' });
@@ -146,7 +146,7 @@ export function useHistoryEventFields(options: HistoryEventFieldsOptions): Compu
     }, {
       counterparties: (): string[] => get(counterparties),
       disabled: get(disabled),
-      entryTypes: toValue(entryTypes),
+      entryTypes: entryTypes(),
       eventSubtypes: (): string[] => subtypesFor(get(selectedEventTypes)),
       eventTypes: (): string[] => get(historyEventTypes),
       locations: (): string[] => get(associatedLocations),
@@ -154,6 +154,7 @@ export function useHistoryEventFields(options: HistoryEventFieldsOptions): Compu
       subtypesFor,
     });
     const withParams = [...base, actionField, stateField, ignoredField];
-    return toValue(useExternalAccountFilter) ? withParams : [...withParams, accountField];
+    // The view selects accounts itself, so the bar has no account pill to offer.
+    return externalAccounts() ? withParams : [...withParams, accountField];
   });
 }

--- a/frontend/app/src/modules/history/events/use-history-events-dialog-routing.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-dialog-routing.ts
@@ -1,0 +1,39 @@
+import type { ShallowRef } from 'vue';
+import { DIALOG_TYPES, type DialogShowOptions } from '@/modules/history/events/dialog-types';
+
+/**
+ * Query keys other pages navigate here with to land on a particular dialog, e.g. a decoding-status
+ * link from the task center. They are one-shot instructions rather than view state, which is why
+ * they are cleared below instead of being persisted like the table's own query keys.
+ */
+const QUERY_TO_DIALOG: Record<string, DialogShowOptions> = {
+  openDecodingStatusDialog: { type: DIALOG_TYPES.DECODING_STATUS },
+  openMatchAssetMovementsDialog: { type: DIALOG_TYPES.MATCH_ASSET_MOVEMENTS },
+  openMatchBridgesDialog: { type: DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS },
+};
+
+interface DialogOpener {
+  show: (options: DialogShowOptions) => void;
+}
+
+/**
+ * Opens the dialog an incoming route asked for, then drops the key so a back-navigation or a
+ * reload does not reopen it.
+ *
+ * `nextTick` before showing: on the immediate run the container has not mounted yet, so the ref is
+ * still null.
+ */
+export function useHistoryEventsDialogRouting(container: ShallowRef<DialogOpener | null>): void {
+  const route = useRoute();
+  const router = useRouter();
+
+  watchImmediate(route, async ({ query }) => {
+    const key = Object.keys(QUERY_TO_DIALOG).find(candidate => query[candidate]);
+    if (!key)
+      return;
+
+    await nextTick();
+    get(container)?.show(QUERY_TO_DIALOG[key]);
+    await router.replace({ query: {} });
+  });
+}

--- a/frontend/app/src/modules/history/events/use-history-events-filters.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-filters.spec.ts
@@ -1,7 +1,7 @@
-import type { Account, HistoryEventEntryType } from '@rotki/common';
 import type { ComputedRef, Ref } from 'vue';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
+import type { HistoryEventsRestrictions } from '@/modules/history/events/history-events-restrictions';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { Filters } from '@/modules/history/events/use-events-filter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -88,48 +88,33 @@ vi.mock('@/modules/history/events/action-picker/use-event-action-picker', () => 
 
 interface DefaultOptions {
   options: {
-    entryTypes: Ref<HistoryEventEntryType[] | undefined>;
-    eventSubTypes: Ref<string[]>;
-    eventTypes: Ref<string[]>;
-    externalAccountFilter: Ref<Account[]>;
     fields: Ref<FieldDef[]>;
     filters: Ref<Filters>;
-    location: Ref<string | undefined>;
     mainPage: Ref<boolean>;
-    period: Ref<undefined>;
-    protocols: Ref<string[]>;
-    useExternalAccountFilter: Ref<boolean | undefined>;
-    validators: Ref<number[] | undefined>;
+    restrictions: Ref<HistoryEventsRestrictions>;
   };
   toggles: Ref<HistoryEventsToggles>;
-  locationRef: Ref<string | undefined>;
+  /** The same ref the options carry, exposed so a test can re-state what the view fixes. */
+  restrictions: Ref<HistoryEventsRestrictions>;
 }
 
 function createDefaultOptions(locationValue?: string): DefaultOptions {
-  const locationRef = ref<string | undefined>(locationValue);
+  const restrictions = ref<HistoryEventsRestrictions>({ location: locationValue });
   const toggles = ref<HistoryEventsToggles>({
     matchExactEvents: false,
     showIgnoredAssets: false,
     stateMarkers: [],
   });
   return {
-    locationRef,
     options: {
-      entryTypes: ref(undefined),
-      eventSubTypes: ref<string[]>([]),
-      eventTypes: ref<string[]>([]),
-      externalAccountFilter: ref([]),
       // The view builds both and hands them in: the fields are what the table reads its url shape
       // off, and nothing here exercises the URL.
       fields: ref<FieldDef[]>([]),
       filters: ref<Filters>({}),
-      location: locationRef,
       mainPage: ref(false),
-      period: ref(undefined),
-      protocols: ref<string[]>([]),
-      useExternalAccountFilter: ref(undefined),
-      validators: ref(undefined),
+      restrictions,
     },
+    restrictions,
     toggles,
   };
 }
@@ -157,9 +142,9 @@ describe('useHistoryEventsFilters', () => {
       expect(get(usedLocationLabels)).toEqual(['0xABC']);
     });
 
-    it('should use local locationLabels when useExternalAccountFilter is false', () => {
-      const { options, toggles } = createDefaultOptions();
-      set(options.useExternalAccountFilter, false);
+    it('should use local locationLabels when the view pins no accounts', () => {
+      const { options, restrictions, toggles } = createDefaultOptions();
+      set(restrictions, {});
       const { onLocationLabelsChanged, usedLocationLabels } = useHistoryEventsFilters(options, toggles);
 
       onLocationLabelsChanged(['0xABC']);
@@ -167,13 +152,24 @@ describe('useHistoryEventsFilters', () => {
       expect(get(usedLocationLabels)).toEqual(['0xABC']);
     });
 
-    it('should use external account filter when useExternalAccountFilter is true', () => {
-      const { options, toggles } = createDefaultOptions();
-      set(options.useExternalAccountFilter, true);
-      set(options.externalAccountFilter, [{ address: '0xDEF', chain: 'eth' }]);
+    it('should use the accounts the view pins', () => {
+      const { options, restrictions, toggles } = createDefaultOptions();
+      set(restrictions, { externalAccounts: [{ address: '0xDEF', chain: 'eth' }] });
       const { usedLocationLabels } = useHistoryEventsFilters(options, toggles);
 
       expect(get(usedLocationLabels)).toEqual(['0xDEF']);
+    });
+
+    // Kraken's shape: it owns the account axis without naming an address, which an empty array has
+    // to express. Defaulting the key would collapse this onto the unrestricted case.
+    it('should ignore local locationLabels when the view pins an empty account set', () => {
+      const { options, restrictions, toggles } = createDefaultOptions();
+      set(restrictions, { externalAccounts: [] });
+      const { onLocationLabelsChanged, usedLocationLabels } = useHistoryEventsFilters(options, toggles);
+
+      onLocationLabelsChanged(['0xABC']);
+
+      expect(get(usedLocationLabels)).toEqual([]);
     });
 
     it('should reactively update when locationLabels change', async () => {
@@ -240,13 +236,13 @@ describe('useHistoryEventsFilters', () => {
     });
 
     it('should reactively update requestParams when location prop changes', async () => {
-      const { locationRef, options, toggles } = createDefaultOptions('ethereum');
+      const { options, restrictions, toggles } = createDefaultOptions('ethereum');
 
       useHistoryEventsFilters(options, toggles);
 
       expect(get(capturedRequestParams!).location).toBe('ethereum');
 
-      set(locationRef, 'optimism');
+      set(restrictions, { location: 'optimism' });
       await nextTick();
 
       expect(get(capturedRequestParams!).location).toBe('optimism');

--- a/frontend/app/src/modules/history/events/use-history-events-filters.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-filters.ts
@@ -1,4 +1,3 @@
-import type { Account, HistoryEventEntryType } from '@rotki/common';
 import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
 import type { ComputedRef, MaybeRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { Collection } from '@/modules/core/common/collection';
@@ -19,10 +18,9 @@ import {
 } from '@/modules/history/event-utils';
 import { DuplicateHandlingStatus, type HighlightType } from '@/modules/history/events/action-types';
 import { buildHistoryEventSources } from '@/modules/history/events/history-event-query';
+import { type HistoryEventsRestrictions, toRestrictionGetters } from '@/modules/history/events/history-events-restrictions';
 import { useHistoryEventHighlights, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
 import { useHistoryEvents } from '@/modules/history/events/use-history-events';
-
-type Period = { fromTimestamp?: string; toTimestamp?: string } | { fromTimestamp?: number; toTimestamp?: number };
 
 /**
  * The payload without its sorting, so a re-sort is not read as a change of what is being asked for.
@@ -35,7 +33,6 @@ function withoutSorting(
 }
 
 interface HistoryEventsFiltersOptions {
-  entryTypes: MaybeRefOrGetter<HistoryEventEntryType[] | undefined>;
   /**
    * The pill-bar fields, and the filter bag they are bound to. Both are built by the view: the
    * fields read the bag to scope their option lists, and the table reads the url shape of the bag
@@ -44,15 +41,9 @@ interface HistoryEventsFiltersOptions {
    */
   fields: MaybeRefOrGetter<FieldDef[]>;
   filters: Ref<Filters>;
-  eventSubTypes: MaybeRefOrGetter<string[]>;
-  eventTypes: MaybeRefOrGetter<string[]>;
-  externalAccountFilter: MaybeRefOrGetter<Account[]>;
-  location: MaybeRefOrGetter<string | undefined>;
   mainPage: MaybeRefOrGetter<boolean>;
-  period: MaybeRefOrGetter<Period | undefined>;
-  protocols: MaybeRefOrGetter<string[]>;
-  useExternalAccountFilter: MaybeRefOrGetter<boolean | undefined>;
-  validators: MaybeRefOrGetter<number[] | undefined>;
+  /** What the view fixes; the same bag the pill bar reads. */
+  restrictions: MaybeRefOrGetter<HistoryEventsRestrictions>;
 }
 
 export function getDefaultToggles(): HistoryEventsToggles {
@@ -98,20 +89,16 @@ export function useHistoryEventsFilters(
   // restored from the route, so it cannot be widened to MaybeRefOrGetter.
   overlayMode: WritableRef<OverlayMode> = ref<OverlayMode>(OverlayMode.NONE),
 ): UseHistoryEventsFiltersReturn {
+  const { fields, filters: modelFilters, mainPage } = options;
   const {
     entryTypes,
-    eventSubTypes,
     eventTypes,
-    externalAccountFilter,
-    fields,
-    filters: modelFilters,
+    externalAccounts,
     location,
-    mainPage,
     period,
     protocols,
-    useExternalAccountFilter,
     validators,
-  } = options;
+  } = toRestrictionGetters(options.restrictions);
 
   const locationLabels = ref<string[]>([]);
 
@@ -159,11 +146,11 @@ export function useHistoryEventsFilters(
     return undefined;
   });
 
+  // A view that selects accounts for the user owns this axis outright, so its (possibly empty) set
+  // replaces the bar's, rather than being merged with it.
   const usedLocationLabels = computed<string[]>(() => {
-    if (toValue(useExternalAccountFilter))
-      return toValue(externalAccountFilter).map(account => account.address);
-
-    return get(locationLabels);
+    const pinned = externalAccounts();
+    return pinned ? pinned.map(account => account.address) : get(locationLabels);
   });
 
   // Owned here rather than by the caller: it is written back from the route like locationLabels,
@@ -174,7 +161,6 @@ export function useHistoryEventsFilters(
     action,
     duplicateHandlingStatusFromQuery,
     entryTypes,
-    eventSubTypes,
     eventTypes,
     groupIdentifiersFromQuery,
     location,
@@ -250,7 +236,7 @@ export function useHistoryEventsFilters(
   const { highlightedGroupIdentifier, highlightedIdentifiers, highlightTypes } = useHistoryEventHighlights();
 
   const includes = computed<{ evmEvents: boolean; onlineEvents: boolean }>(() => {
-    const entryTypesValue = toValue(entryTypes);
+    const entryTypesValue = entryTypes();
     return {
       evmEvents: entryTypesValue ? entryTypesValue.some(type => isEvmEventType(type)) : true,
       onlineEvents: entryTypesValue ? entryTypesValue.some(type => isOnlineHistoryEventType(type)) : true,

--- a/frontend/app/src/modules/history/events/use-history-events-overlay.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-overlay.ts
@@ -1,0 +1,64 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { Collection } from '@/modules/core/common/collection';
+import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import { isAccountingUpdateEnabled } from '@/modules/core/common/feature-flags';
+import { OverlayMode, type OverlayPair, useAccountingOverlay } from '@/modules/history/balances/use-accounting-overlay';
+import { provideAccountingOverlay } from '@/modules/history/balances/use-accounting-overlay-context';
+import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
+
+interface UseHistoryEventsOverlayReturn {
+  /** Whether the build serves the overlay at all, i.e. whether to render its toggles. */
+  available: boolean;
+  enabled: ComputedRef<boolean>;
+}
+
+/**
+ * The accounting overlay: the known balance after each event.
+ *
+ * It keys off each event's own (account, asset) pair, so it needs no filter of its own. Gated by
+ * VITE_ACCOUNTING_UPDATE, derived at build/dev time from the backend's ROTKI_ACCOUNTING_UPDATE (see
+ * vite.config.ts), so it only appears where the backend serves it.
+ *
+ * `mode` is synced through the router query by useHistoryEventsFilters' queryParamsOnly: it rides
+ * along with pagination instead of being clobbered by it, and is NOT persisted across sessions.
+ * Fresh navigation to history resets it to 'none' (empty query), while browser/in-app back restores
+ * it from the history entry's query. Only the main page syncs (history: 'router').
+ *
+ * Provides itself to the rows that read it, so the caller only wires the toggles.
+ */
+export function useHistoryEventsOverlay(
+  mode: MaybeRefOrGetter<OverlayMode>,
+  groups: MaybeRefOrGetter<Collection<HistoryEventRow>>,
+): UseHistoryEventsOverlayReturn {
+  const available = isAccountingUpdateEnabled();
+
+  // The build flag is required too, so the 'balance' choice cannot enable it where the backend
+  // would reject every call.
+  const enabled = computed<boolean>(() => available && toValue(mode) === OverlayMode.BALANCE);
+
+  const pairs = computed<OverlayPair[]>(() => {
+    const events = toValue(groups).data.flatMap(row => Array.isArray(row) ? row : [row]);
+    // Map keyed by `${account} ${asset}` dedupes for free; last write wins (identical payload).
+    const byKey = new Map<string, OverlayPair>();
+    for (const { asset, locationLabel } of events) {
+      if (locationLabel)
+        byKey.set(`${locationLabel} ${asset}`, { asset, locationLabel });
+    }
+    return [...byKey.values()];
+  });
+
+  const overlay = useAccountingOverlay({ enabled, pairs });
+
+  provideAccountingOverlay({ enabled, overlay });
+
+  // When the history sync (tx query + exchange events + decoding) completes, new events have landed
+  // and their historical balances may have shifted, so the whole overlay is refreshed to re-resolve
+  // every visible row against the updated series. Guarded so a hidden overlay stays idle.
+  const { syncCompleted } = useSyncCompleted();
+  watch(syncCompleted, async () => {
+    if (get(enabled))
+      await overlay.refresh();
+  });
+
+  return { available, enabled };
+}

--- a/frontend/app/src/modules/history/events/use-history-events-table-height.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-table-height.ts
@@ -1,0 +1,24 @@
+import type { ComponentPublicInstance, ComputedRef, ShallowRef } from 'vue';
+
+/** Chrome that does not change height: page header, card padding, the table's own header row. */
+const BASE_TABLE_HEIGHT_OFFSET = 252;
+
+/**
+ * How much vertical space the virtual table must leave for what sits above it.
+ *
+ * The regions passed in are the ones that change height while the page is open: the sync panel,
+ * the action row and the filter chips. The virtual table needs a pixel offset rather than flex, so
+ * they are measured rather than derived from layout.
+ *
+ * The refs are created by the caller rather than here, even though `useTemplateRef` would resolve
+ * against the calling instance either way: a ref this file created would be invisible to the
+ * template that declares it, and `vue/no-unused-refs` would report every one of them.
+ */
+export function useHistoryEventsTableHeight(
+  ...regions: ShallowRef<ComponentPublicInstance | null>[]
+): ComputedRef<number> {
+  const heights = regions.map(region => useElementSize(region).height);
+
+  return computed<number>(() =>
+    heights.reduce((total, height) => total + get(height), BASE_TABLE_HEIGHT_OFFSET));
+}

--- a/frontend/app/src/modules/premium/premium-apis.ts
+++ b/frontend/app/src/modules/premium/premium-apis.ts
@@ -11,7 +11,6 @@ import {
   type TimedAssetHistoricalBalances,
   type TimedBalances,
   type UserSettingsApi,
-  type UtilsApi,
 } from '@rotki/common';
 import { useAssetManagementApi } from '@/modules/assets/api/use-asset-management-api';
 import { isNft } from '@/modules/assets/nft-utils';
@@ -22,7 +21,6 @@ import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval
 import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import { usePriceApi } from '@/modules/balances/api/use-price-api';
 import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
-import { truncateAddress } from '@/modules/core/common/display/truncate';
 import { useSetting } from '@/modules/settings/use-setting';
 import { useStatisticsApi } from '@/modules/statistics/api/use-statistics-api';
 import { useStatisticsDataFetching } from '@/modules/statistics/use-statistics-data-fetching';
@@ -121,7 +119,6 @@ export function userSettings(): UserSettingsApi {
 export function balancesApi(): BalancesApi {
   const { getAssetPrice, getExchangeRate } = usePriceUtils();
   const { balancesByLocation, useBalances } = useAggregatedBalances();
-  const { createKey, isPending } = useHistoricPriceCache();
   const { queryOnlyCacheHistoricalRates } = usePriceApi();
   const currencySymbol = useSetting('currencySymbol');
 
@@ -130,7 +127,6 @@ export function balancesApi(): BalancesApi {
     balances: (groupMultiChain = false, exclude = []) => useBalances(false, groupMultiChain, exclude),
     byLocation: balancesByLocation,
     exchangeRate: (currency: string) => computed(() => getExchangeRate(currency, One)),
-    isHistoricPricePending: (asset: string, timestamp: number) => isPending(createKey(asset, timestamp)),
     queryOnlyCacheHistoricalRates: async (asset: string, timestamp: number[]): Promise<Record<string, BigNumber>> => {
       const data = await queryOnlyCacheHistoricalRates({
         assetsTimestamp: timestamp.map(item => [asset, item.toString()]),
@@ -140,11 +136,5 @@ export function balancesApi(): BalancesApi {
 
       return data.assets[asset] ?? {};
     },
-  };
-}
-
-export function utilsApi(): UtilsApi {
-  return {
-    truncate: truncateAddress,
   };
 }

--- a/frontend/app/src/modules/premium/premium.ts
+++ b/frontend/app/src/modules/premium/premium.ts
@@ -5,7 +5,10 @@ import { app } from '@/main';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useStatisticsApi } from '@/modules/statistics/api/use-statistics-api';
 
-const PREMIUM_COMPONENTS_VERSION = 28;
+// Bumped whenever the surface premium builds against changes. v29 (components major 16): the
+// statistics schemas read usdValue, and HistoryEventsView takes a single `restrictions` prop.
+// A v16 bundle refuses to render below this, rather than failing halfway.
+const PREMIUM_COMPONENTS_VERSION = 29;
 
 type PremiumLibrary = {
   install: (app: App) => void;

--- a/frontend/app/src/modules/premium/register-components.ts
+++ b/frontend/app/src/modules/premium/register-components.ts
@@ -52,73 +52,30 @@ function ruiRegister(app: App): void {
   app.component('RuiColorPicker', RuiColorPicker);
   app.component('RuiProgress', RuiProgress);
   app.component('RuiDateTimePicker', RuiDateTimePicker);
-  // RuiAccordion(s) removed at 1.44
 }
 
+/**
+ * Components registered here are also handed to the premium bundle, which renders them by name.
+ *
+ * Every entry below is used by components major 16. The per-component "first available in version
+ * N" trail this list used to carry went back to version 1 (rotki 1.19) and is gone: a bundle now
+ * refuses to render below host version 29, so no supported bundle can ask for anything older, and
+ * git history holds the record for anyone who needs it.
+ */
 export function registerComponents(app: App): void {
-  // Globally registered components are also provided to the premium components.
-  // AmountDisplay was removed at 1.42;
-  // version: 1
   app.component('HashLink', HashLink);
-  // AssetDetails removed at 1.44
-  // DefiProtocolIcon was removed in 1.37;
-  // version: 2
-  //  CryptoIcon was replaced with AssetIcon on v11
   app.component('BalanceDisplay', BalanceDisplay);
-  // version: 3
   app.component('PercentageDisplay', PercentageDisplay);
-  // version: 4
-  // BlockchainAccountSelector removed at 1.44
   app.component('DateDisplay', DateDisplay);
-  // LocationDisplay removed at 1.44
-  // version 5
   app.component('AssetSelect', AssetSelect);
-  // version 6
-  // DateTimePicker removed at 1.44
-  // version 8
-  // CardTitle removed at 1.44
-  // version 9
-  // LiquidityPoolSelector removed at 1.37
-  // TableFilter removed at 1.44
-  // version 11
-  // AssetIcon removed at 1.44
-  // version 12 - 1.19
-  // RangeSelector and ConfirmDialog removed at 1.44
-  // Version 13 - 1.20
-  // UniswapPoolDetails was removed at 1.37
-  // Version 14 - 1.21
-  // PaginatedCards and AssetLink removed at 1.44
-  // Version 15 - 1.21.2
   app.component('StatisticsGraphSettings', StatisticsGraphSettings);
-  // Version 16 - 1.23
-  // AmountInput removed at 1.44
-  // Version 17 - 1.24
   app.component('ExportSnapshotDialog', ExportSnapshotDialog);
-  // Version 18 - 1.25
   app.component('MenuTooltipButton', MenuTooltipButton);
-  // 'GraphTooltipWrapper' removed at 1.40
-  // Version 19 - 1.26
-  // LpPoolIcon was removed at 1.37
-  // Version 20 - 1.27
-  // BadgeDisplay removed at 1.44
-  // Version 21 - 1.28
   app.component('HistoryEventsView', HistoryEventsView);
-  // Version 24 - 1.31
-  // LpPoolHeader was removed at 1.37
-  // RowAppend removed at 1.44
-  // Version 25 - 1.32
-  // UniswapPoolAssetBalance was removed at 1.37
-  // Version 26 - 1.34
-  // RefreshButton removed at 1.44
   app.component('AssetBalanceStatisticSourceSetting', AssetBalanceStatisticSourceSetting);
-
   app.component('MissingDailyPrices', MissingDailyPrices);
-
   app.component('NewGraphTooltipWrapper', NewGraphTooltipWrapper);
-
-  // Version 27 - Amount display components
   app.component('FiatDisplay', FiatDisplay);
-  // AssetValueDisplay and AssetAmountDisplay removed at 1.44
   app.component('ValueDisplay', ValueDisplay);
 
   ruiRegister(app);

--- a/frontend/app/src/modules/premium/register-components.ts
+++ b/frontend/app/src/modules/premium/register-components.ts
@@ -11,9 +11,7 @@ import {
   RuiDialog,
   RuiDivider,
   RuiIcon,
-  RuiMenu,
   RuiProgress,
-  RuiSlider,
   RuiTextField,
   RuiTooltip,
 } from '@rotki/ui-library';
@@ -31,7 +29,6 @@ import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import PercentageDisplay from '@/modules/shell/components/display/PercentageDisplay.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
-import MenuTooltipButton from '@/modules/shell/components/MenuTooltipButton.vue';
 import MissingDailyPrices from '@/modules/statistics/MissingDailyPrices.vue';
 import NewGraphTooltipWrapper from '@/modules/statistics/NewGraphTooltipWrapper.vue';
 
@@ -46,8 +43,6 @@ function ruiRegister(app: App): void {
   app.component('RuiDataTable', RuiDataTable);
   app.component('RuiDivider', RuiDivider);
   app.component('RuiChip', RuiChip);
-  app.component('RuiMenu', RuiMenu);
-  app.component('RuiSlider', RuiSlider);
   app.component('RuiDialog', RuiDialog);
   app.component('RuiColorPicker', RuiColorPicker);
   app.component('RuiProgress', RuiProgress);
@@ -70,7 +65,6 @@ export function registerComponents(app: App): void {
   app.component('AssetSelect', AssetSelect);
   app.component('StatisticsGraphSettings', StatisticsGraphSettings);
   app.component('ExportSnapshotDialog', ExportSnapshotDialog);
-  app.component('MenuTooltipButton', MenuTooltipButton);
   app.component('HistoryEventsView', HistoryEventsView);
   app.component('AssetBalanceStatisticSourceSetting', AssetBalanceStatisticSourceSetting);
   app.component('MissingDailyPrices', MissingDailyPrices);

--- a/frontend/app/src/modules/premium/setup-interface.ts
+++ b/frontend/app/src/modules/premium/setup-interface.ts
@@ -12,7 +12,7 @@ import { convertToTimestamp } from '@/modules/core/common/data/date';
 import { DateFormat } from '@/modules/core/common/date-format';
 import { isOfEnum } from '@/modules/core/common/helpers/is-of-enum';
 import { logger } from '@/modules/core/common/logging/logging';
-import { assetsApi, balancesApi, statisticsApi, userSettings, utilsApi } from '@/modules/premium/premium-apis';
+import { assetsApi, balancesApi, statisticsApi, userSettings } from '@/modules/premium/premium-apis';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
 import { useThemeSettings } from '@/modules/shell/theme/use-theme-settings';
 import { useGraph } from '@/modules/statistics/use-graph';
@@ -76,7 +76,6 @@ export function createPremiumApi(): PremiumApi {
       assets: assetsApi(),
       balances: balancesApi(),
       statistics: statisticsApi(),
-      utils: utilsApi(),
     },
     date,
     graphs(): NewGraphApi {

--- a/frontend/app/src/modules/staking/api/use-kraken-api.spec.ts
+++ b/frontend/app/src/modules/staking/api/use-kraken-api.spec.ts
@@ -69,8 +69,8 @@ describe('composables/api/staking/kraken', () => {
               entries_limit: 100,
               entries_total: 50,
               received: [
-                { asset: 'ETH', amount: '1.5', usd_value: '3000' },
-                { asset: 'DOT', amount: '100', usd_value: '500' },
+                { asset: 'ETH', amount: '1.5', value: '3000' },
+                { asset: 'DOT', amount: '100', value: '500' },
               ],
               total_value: '3500',
             },
@@ -99,6 +99,9 @@ describe('composables/api/staking/kraken', () => {
       expect(result.entriesFound).toBe(10);
       expect(result.entriesTotal).toBe(50);
       expect(result.received).toHaveLength(2);
+      // The endpoint sends `value`; a length check alone passed while the schema defaulted a
+      // missing one to zero, which is how the fixture kept the pre-1.42 `usd_value` name.
+      expect(result.received[0].value.toString()).toBe('3000');
       expect(result.totalValue).toBeInstanceOf(BigNumber);
       expect(result.totalValue.toString()).toBe('3500');
     });
@@ -116,7 +119,7 @@ describe('composables/api/staking/kraken', () => {
               entries_limit: 50,
               entries_total: 20,
               received: [
-                { asset: 'ETH', amount: '0.5', usd_value: '1000' },
+                { asset: 'ETH', amount: '0.5', value: '1000' },
               ],
               total_value: '1000',
             },

--- a/frontend/app/src/modules/staking/kraken/KrakenStaking.vue
+++ b/frontend/app/src/modules/staking/kraken/KrakenStaking.vue
@@ -94,11 +94,14 @@ const earnedAssetsData = computed<EarnedAssetsData>(() => {
     <!-- as an exception here we specify event-types to only include staking events  -->
     <!-- if an alternative way becomes possible we can use that -->
     <HistoryEventsView
-      use-external-account-filter
-      location="kraken"
-      :period="modelValue"
-      :event-types="['staking']"
-      :entry-types="[HistoryEventEntryType.HISTORY_EVENT]"
+      :restrictions="{
+        entryTypes: [HistoryEventEntryType.HISTORY_EVENT],
+        eventTypes: ['staking'],
+        // Kraken has no per-account axis to offer, but it owns the one there is.
+        externalAccounts: [],
+        location: 'kraken',
+        period: modelValue,
+      }"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/staking/liquity/LiquityStakingDetails.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityStakingDetails.vue
@@ -328,12 +328,13 @@ function refresh() {
     />
 
     <HistoryEventsView
-      use-external-account-filter
       :section-title="t('liquity_staking_events.title')"
-      :protocols="['liquity']"
-      :external-account-filter="accountFilter"
-      :only-chains="chains"
-      :entry-types="[HistoryEventEntryType.EVM_EVENT]"
+      :restrictions="{
+        entryTypes: [HistoryEventEntryType.EVM_EVENT],
+        externalAccounts: accountFilter,
+        onlyChains: chains,
+        protocols: ['liquity'],
+      }"
     />
   </TablePageLayout>
 </template>

--- a/frontend/app/src/modules/statistics/api/use-statistics-api.spec.ts
+++ b/frontend/app/src/modules/statistics/api/use-statistics-api.spec.ts
@@ -90,6 +90,10 @@ describe('composables/api/statistics/statistics-api', () => {
         asset: 'ETH',
       });
       expect(result).toHaveLength(1);
+      // The endpoint sends usd_value, not value. Asserting the parsed number is what discriminates:
+      // the schema used to drop it and default to zero, and a length check could not see that (#12822).
+      expect(result[0].usdValue.toString()).toBe('1050');
+      expect(result[0].amount.toString()).toBe('10.5');
     });
 
     it('should send POST request with collection_id when provided', async () => {

--- a/frontend/common/src/balances/index.ts
+++ b/frontend/common/src/balances/index.ts
@@ -1,9 +1,15 @@
 import z from 'zod';
-import { bigNumberify, NumericString } from '../numbers';
+import { NumericString } from '../numbers';
 
+/**
+ * Mirrors the backend's `Balance.serialize()`, which always emits both fields. `value` used to
+ * default to zero when absent, which turned a schema that did not match its endpoint into a silent
+ * zero instead of a parse error, and hid the same bug twice (#11766, #12822). A missing `value` now
+ * fails loudly: an endpoint that sends something else needs its own schema, not this one.
+ */
 export const Balance = z.object({
   amount: NumericString,
-  value: NumericString.optional().default(bigNumberify(0)),
+  value: NumericString,
 });
 
 export type Balance = z.infer<typeof Balance>;

--- a/frontend/common/src/premium/index.ts
+++ b/frontend/common/src/premium/index.ts
@@ -48,7 +48,6 @@ export interface BalancesApi {
   exchangeRate: (currency: string) => Ref<BigNumber>;
   queryOnlyCacheHistoricalRates: (asset: string, timestamp: number[]) => Promise<Record<number, BigNumber>>;
   assetPrice: (asset: string) => ComputedRef<BigNumber>;
-  isHistoricPricePending: (asset: string, timestamp: number) => ComputedRef<boolean>;
 }
 
 export interface AssetsApi {
@@ -57,13 +56,8 @@ export interface AssetsApi {
   tokenAddress: (identifier: MaybeRef<string>) => ComputedRef<string>;
 }
 
-export interface UtilsApi {
-  truncate: (text: string, length: number) => string;
-}
-
 export interface DataUtilities {
   readonly assets: AssetsApi;
-  readonly utils: UtilsApi;
   readonly statistics: StatisticsApi;
   readonly balances: BalancesApi;
 }

--- a/frontend/common/src/statistics/index.ts
+++ b/frontend/common/src/statistics/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { AssetBalance, AssetEntry, Balance } from '../balances';
+import { AssetEntry } from '../balances';
 import { NumericString } from '../numbers';
 
 const TimedEntry = z.object({ time: z.number().positive() });
@@ -9,9 +9,15 @@ const AssetDistribution = z.object({
   usdValue: NumericString,
 });
 
+/**
+ * A row of `/statistics/balance`, which serializes a `SingleDBAssetBalance` (a timed_balances row)
+ * rather than a `Balance`, so it sends `usd_value` and no `value`. This was built on the shared
+ * `Balance` schema until 1.44: zod dropped the undeclared `usdValue` and `value` fell back to its
+ * default of zero, so every point parsed as zero-valued. See #12822.
+ */
 const TimedBalance = z.object({
-  ...Balance.shape,
-  ...TimedEntry.shape,
+  amount: NumericString,
+  ...AssetDistribution.shape,
 });
 
 export type TimedBalance = z.infer<typeof TimedBalance>;
@@ -33,23 +39,12 @@ export const LocationData = z.array(LocationDataItem);
 
 export type LocationData = z.infer<typeof LocationData>;
 
-/**
- * Legacy schema (PREMIUM_COMPONENTS_VERSION <= 27): had AssetBalance (asset, amount, value) + time.
- * This was incorrect as the API returns {asset, time, usdValue} without amount/value.
- * Kept for backward compatibility with premium components using version 27.
- * TODO: Remove LegacyTimedAssetBalance and the union when we bump components to v16.
- */
-const LegacyTimedAssetBalance = z.object({
-  ...AssetBalance.shape,
-  ...TimedEntry.shape,
-});
-
 const TimedAssetBalance = z.object({
   ...AssetEntry.shape,
   ...AssetDistribution.shape,
 });
 
-export const TimedAssetBalances = z.union([z.array(TimedAssetBalance), z.array(LegacyTimedAssetBalance)]);
+export const TimedAssetBalances = z.array(TimedAssetBalance);
 
 export type TimedAssetBalances = z.infer<typeof TimedAssetBalances>;
 

--- a/rotkehlchen/premium/premium.py
+++ b/rotkehlchen/premium/premium.py
@@ -150,7 +150,7 @@ class UserLimitType(Enum):
         raise NotImplementedError(f'Unknown limit type: {self}. This indicates a bug in the code.')
 
 
-COMPONENTS_VERSION: Final = 15
+COMPONENTS_VERSION: Final = 16
 DEFAULT_ERROR_MSG: Final = 'Failed to contact rotki server. Check logs for more details'
 KNOWN_STATUS_CODES: Final = (
     HTTPStatus.OK,


### PR DESCRIPTION
Moves the app to premium components v16. Fixes #12822.

## What the bundle is asked for, and what it is handed

- `COMPONENTS_VERSION` 15 to 16 (`rotkehlchen/premium/premium.py`), so the server returns `premium_components_v16.js`
- `PREMIUM_COMPONENTS_VERSION` 28 to 29 (`modules/premium/premium.ts`), the host API version handed to the bundle. The bundle gates on `hostVersion >= 29`, which is the only check that catches a mismatch, since neither side's type-check crosses the bundle boundary

## Schema

`TimedBalance` now reads `usdValue`. `/statistics/balance` returns a `SingleDBAssetBalance`, not a `Balance`, so the field was being read under the wrong name (#12822). `Balance.value` also loses its `.optional().default(0)`: the zero default is what let the mismatch go unnoticed, because a missing value parsed to zero instead of failing.

Removing the default immediately surfaced two stale fixtures (`use-kraken-api.spec.ts`, `use-pool-data-fetching.spec.ts`) that sent the pre-1.42 `usd_value` and passed anyway by asserting only array length. Those are corrected here.

`LegacyTimedAssetBalance` and its union are dropped.

## History events view

`HistoryEventsView` went from 12 props to 3: the restrictions a caller places on the view are now stated in one `restrictions` object, and the view wiring moves into composables. The premium bundle passes a single object in place of the loose props.

## Surface no v16 component uses

`data.utils.truncate` and `isHistoricPricePending` are dropped, verified against the bundle as having zero callers, along with three component registrations the v16 bundle never renders.

## Release

Targets 1.44.0. The bundle's `MINIMUM_APP_VERSION` is display-only text for the upgrade prompt; the real gate is numeric, so a dev build still reporting 1.43.2 works as long as it hands over host version 29.

Release order is forced: this lands first, the v16 bundle second. An older host with a v16 bundle is blanked by the gate, so the bundle cannot ship ahead of the app.

## Verification

Rebased onto `upstream/develop` today, no conflicts, and checked that the 24 files here have zero overlap with the 96 files develop changed in the meantime, so nothing is silently reverted. Type-check clean, 8101 tests across 823 files pass, lint reports no errors.

The premium side is built and green against this branch: type-check 0, lint clean, 179 tests, `premium_components_v16.js` builds at 105.24 kB (28.99 kB gzip).
