### PR TITLE
Silence the vite 8 config import warnings

### DIFF
--- a/frontend/app/tsconfig.node.json
+++ b/frontend/app/tsconfig.node.json
@@ -7,6 +7,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "types": ["node", "vite/client"],
+    "allowImportingTsExtensions": true,
     "noEmit": true
   },
   "include": [

--- a/frontend/app/vite.config.ts
+++ b/frontend/app/vite.config.ts
@@ -14,10 +14,14 @@ import vueDevTools from 'vite-plugin-vue-devtools';
 import { defineConfig } from 'vitest/config';
 import { VueRouterAutoImports } from 'vue-router/unplugin';
 import VueRouter from 'vue-router/vite';
-import { backendIcons } from './backend-icons.generated';
-import { sharedHelperModules, vendorGroupEntries } from './scripts/chunk-groups';
-import { backendIconsCachePlugin } from './scripts/extract-backend-icons';
+import { backendIcons } from './backend-icons.generated.ts';
+import { sharedHelperModules, vendorGroupEntries } from './scripts/chunk-groups.ts';
+import { backendIconsCachePlugin } from './scripts/extract-backend-icons.ts';
 
+// The three relative imports above keep their `.ts` extension on purpose: vite 8 loads this config
+// natively instead of bundling it, and warns about every extensionless relative import. The
+// `@rotki/no-dot-ts-imports` autofix would strip them back off, so it is disabled for config files
+// in eslint.config.js, and tsconfig.node.json sets `allowImportingTsExtensions` for vue-tsc.
 const PACKAGE_ROOT = import.meta.dirname;
 const PROJECT_ROOT = resolve(PACKAGE_ROOT, '../..');
 

--- a/frontend/app/vitest.config.ts
+++ b/frontend/app/vitest.config.ts
@@ -1,14 +1,14 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { configDefaults, defineConfig, mergeConfig } from 'vitest/config';
-import viteConfig from './vite.config';
+import viteConfig from './vite.config.ts';
 
 export default mergeConfig(
   mergeConfig(viteConfig, {
     resolve: {
       alias: {
-        '@test': `${path.join(__dirname, 'tests', 'unit')}/`,
-        '@electron': `${path.join(__dirname, 'electron')}/`,
+        '@test': `${path.join(import.meta.dirname, 'tests', 'unit')}/`,
+        '@electron': `${path.join(import.meta.dirname, 'electron')}/`,
       },
     },
   }),

--- a/frontend/app/vitest.contract.config.ts
+++ b/frontend/app/vitest.contract.config.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { merge } from 'es-toolkit';
 import { defineConfig, mergeConfig } from 'vitest/config';
-import viteConfig from './vite.config';
+import viteConfig from './vite.config.ts';
 
 /**
  * Contract test mode (measurement framework §5.1).
@@ -21,7 +21,7 @@ export default mergeConfig(
   merge(viteConfig, {
     resolve: {
       alias: {
-        '@test': `${path.join(__dirname, 'tests', 'unit')}/`,
+        '@test': `${path.join(import.meta.dirname, 'tests', 'unit')}/`,
       },
     },
   }),

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -93,6 +93,15 @@ export default rotki({
     }],
   },
 }, {
+  // Vite 8 loads the config file natively rather than bundling it, so a relative import without an
+  // extension is a warning on every startup. `@rotki/no-dot-ts-imports` wants the opposite and would
+  // autofix the extensions straight back off, so it is off for the config files themselves. It stays
+  // on everywhere else, including the `scripts/` modules the config imports.
+  files: ['**/vite.config.ts', '**/vite.config.*.ts', '**/vitest.config.ts', '**/vitest.*.config.ts'],
+  rules: {
+    '@rotki/no-dot-ts-imports': 'off',
+  },
+}, {
   files: ['**/src/**/*.ts'],
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'error',


### PR DESCRIPTION
Vite 8 loads `frontend/app/vite.config.ts` natively instead of bundling it, so every extensionless relative import in it prints a warning on each dev/build start:

```
import "./scripts/chunk-groups" without a file extension (vite.config.ts:N:M). Add the file extension
```

Changes:

- `app/vite.config.ts`: add `.ts` to the three local imports (`backend-icons.generated`, `scripts/chunk-groups`, `scripts/extract-backend-icons`).
- `eslint.config.js`: turn `@rotki/no-dot-ts-imports` off for config entry files only (`vite.config*.ts`, `vitest*.config.ts`). The rule is autofixable, so without this `lint:fix` silently strips the extensions back off. It stays on everywhere else, including the `scripts/` modules the config imports.
- `app/tsconfig.node.json`: `allowImportingTsExtensions` so `vue-tsc` accepts them (legal here, `noEmit` is already set).
- `app/vitest.config.ts` / `app/vitest.contract.config.ts`: same treatment for their `./vite.config` import, plus `__dirname` -> `import.meta.dirname`.

Verified with `pnpm run typecheck`, `pnpm run lint:file:check`, `pnpm run build` and a unit-test slice; negative control confirms reverting an extension brings the warning back.