### PR TITLE
test(frontend): characterize the auth forms before the zod migration

### DIFF
--- a/frontend/app/src/modules/auth/create-account/credentials/CreateAccountCredentials.spec.ts
+++ b/frontend/app/src/modules/auth/create-account/credentials/CreateAccountCredentials.spec.ts
@@ -1,0 +1,182 @@
+import type { LoginCredentials } from '@/modules/auth/login';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+import { type ComponentPublicInstance, defineComponent, h, ref, type VNode } from 'vue';
+import CreateAccountCredentials from '@/modules/auth/create-account/credentials/CreateAccountCredentials.vue';
+import '@test/i18n';
+
+/**
+ * Guards the step's Continue button, with the REAL form mounted underneath.
+ *
+ * `CreateAccountCredentialsForm.spec.ts` pins the rules and the `valid` model the form writes; this
+ * one pins the other half of that contract - the wizard step actually gating on it. Two regressions
+ * live in the gap between them and neither spec alone can see either:
+ *
+ * - the form stops writing `valid` (the zod swap has no `watchImmediate(v$, ...)` to port), so
+ *   Continue never enables and the account wizard dead-locks at this step;
+ * - the step binds something truthy-but-not-a-boolean, which is what `form.valid` not unwrapping in
+ *   a template produces, so Continue is enabled no matter what the user typed.
+ */
+
+/** The stubs declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+const ButtonStub = {
+  name: 'RuiButton',
+  props: ['disabled', 'loading'],
+  template: '<button :disabled="disabled"><slot /></button>',
+};
+
+const USERNAME = 'create-account__fields__username';
+const PASSWORD = 'create-account__fields__password';
+const PASSWORD_REPEAT = 'create-account__fields__password-repeat';
+const USER_PROMPTED = 'create-account__boxes__user-prompted';
+const CONTINUE = 'create-account__credentials__button__continue';
+
+interface State {
+  credentials: LoginCredentials;
+  passwordConfirm: string;
+  userPrompted: boolean;
+}
+
+function filled(): State {
+  return {
+    credentials: { password: 'password', username: 'user' },
+    passwordConfirm: 'password',
+    userPrompted: true,
+  };
+}
+
+function blank(): State {
+  return {
+    credentials: { password: '', username: '' },
+    passwordConfirm: '',
+    userPrompted: false,
+  };
+}
+
+describe('createAccountCredentials', () => {
+  let wrapper: VueWrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(initial: State = filled(), props: Record<string, unknown> = {}): VueWrapper {
+    const form = ref<LoginCredentials>(initial.credentials);
+    const passwordConfirm = ref<string>(initial.passwordConfirm);
+    const userPrompted = ref<boolean>(initial.userPrompted);
+
+    const parent = defineComponent({
+      setup(): () => VNode {
+        return () => h(CreateAccountCredentials, {
+          'form': get(form),
+          'loading': false,
+          'onUpdate:form': (value: LoginCredentials): void => set(form, value),
+          'onUpdate:passwordConfirm': (value: string): void => set(passwordConfirm, value),
+          'onUpdate:userPrompted': (value: boolean): void => set(userPrompted, value),
+          'passwordConfirm': get(passwordConfirm),
+          'userPrompted': get(userPrompted),
+          ...props,
+        });
+      },
+    });
+
+    return mount(parent, {
+      global: {
+        stubs: {
+          RuiButton: ButtonStub,
+          RuiCheckbox: inputStub('RuiCheckbox'),
+          RuiRevealableTextField: inputStub('RuiRevealableTextField'),
+          RuiTextField: inputStub('RuiTextField'),
+        },
+      },
+    });
+  }
+
+  function continueDisabled(): boolean {
+    return wrapper.get(`[data-testid=${CONTINUE}]`).attributes('disabled') !== undefined;
+  }
+
+  async function edit(testId: string, value: string | boolean): Promise<void> {
+    // `findComponent(string)` alone types the wrapper as `WrapperLike`, which has no `vm`.
+    const field = wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+    assert(field.exists(), `no field with test id ${testId} is rendered`);
+    field.vm.$emit('update:modelValue', value);
+    await nextTick();
+  }
+
+  it('should enable continue for a complete set of credentials', async () => {
+    wrapper = createWrapper();
+    await nextTick();
+
+    expect(continueDisabled()).toBe(false);
+  });
+
+  it('should keep continue disabled on a blank step', async () => {
+    wrapper = createWrapper(blank());
+    await nextTick();
+
+    expect(continueDisabled()).toBe(true);
+  });
+
+  it.each([
+    [USERNAME, ''],
+    [PASSWORD, ''],
+    [PASSWORD_REPEAT, ''],
+    [USER_PROMPTED, false],
+  ] as const)('should disable continue once %s is cleared', async (testId, cleared) => {
+    wrapper = createWrapper();
+    await edit(testId, cleared);
+
+    expect(continueDisabled()).toBe(true);
+  });
+
+  it('should disable continue for an invalid username', async () => {
+    wrapper = createWrapper();
+    await edit(USERNAME, 'user name');
+
+    expect(continueDisabled()).toBe(true);
+  });
+
+  it('should disable continue when the confirmation stops matching', async () => {
+    wrapper = createWrapper();
+    await edit(PASSWORD_REPEAT, 'different');
+
+    expect(continueDisabled()).toBe(true);
+  });
+
+  it('should re-enable continue once the credentials are corrected', async () => {
+    wrapper = createWrapper(blank());
+    await edit(USERNAME, 'user');
+    await edit(PASSWORD, 'password');
+    await edit(PASSWORD_REPEAT, 'password');
+    await edit(USER_PROMPTED, true);
+
+    expect(continueDisabled()).toBe(false);
+  });
+
+  it('should disable continue while the step is loading', async () => {
+    wrapper = createWrapper(filled(), { loading: true });
+    await nextTick();
+
+    expect(continueDisabled()).toBe(true);
+  });
+
+  it('should advance the wizard when continue is pressed', async () => {
+    wrapper = createWrapper();
+    await nextTick();
+    await wrapper.get(`[data-testid=${CONTINUE}]`).trigger('click');
+
+    expect(wrapper.findComponent(CreateAccountCredentials).emitted('next')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/auth/create-account/credentials/CreateAccountCredentialsForm.spec.ts
+++ b/frontend/app/src/modules/auth/create-account/credentials/CreateAccountCredentialsForm.spec.ts
@@ -1,0 +1,287 @@
+import type { LoginCredentials } from '@/modules/auth/login';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+import { type ComponentPublicInstance, defineComponent, h, ref, type VNode } from 'vue';
+import CreateAccountCredentialsForm from '@/modules/auth/create-account/credentials/CreateAccountCredentialsForm.vue';
+import '@test/i18n';
+
+/**
+ * Characterization of the vuelidate rules, written before the zod migration.
+ *
+ * The seam is the four models the wizard binds - `form`, `passwordConfirm`, `userPrompted` and the
+ * `valid` flag that gates Continue - plus the `error-messages` each field receives. The form exposes
+ * no `validate()`, so `valid` is the whole contract: the wizard's step dead-locks if it stops being
+ * written, and every e2e spec that creates an account rides on this form.
+ */
+
+/** The stubs declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+const USERNAME = 'create-account__fields__username';
+const PASSWORD = 'create-account__fields__password';
+const PASSWORD_REPEAT = 'create-account__fields__password-repeat';
+const USER_PROMPTED = 'create-account__boxes__user-prompted';
+
+interface State {
+  credentials: LoginCredentials;
+  passwordConfirm: string;
+  userPrompted: boolean;
+}
+
+interface Harness {
+  wrapper: VueWrapper;
+  /** The credentials as the wizard holds them, after every write the form has made. */
+  credentials: () => LoginCredentials;
+  /** The flag that gates the wizard's Continue button. */
+  valid: () => boolean;
+}
+
+function filled(): State {
+  return {
+    credentials: { password: 'password', username: 'user' },
+    passwordConfirm: 'password',
+    userPrompted: true,
+  };
+}
+
+function blank(): State {
+  return {
+    credentials: { password: '', username: '' },
+    passwordConfirm: '',
+    userPrompted: false,
+  };
+}
+
+describe('createAccountCredentialsForm', () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    harness?.wrapper.unmount();
+  });
+
+  function createHarness(initial: State = filled()): Harness {
+    const form = ref<LoginCredentials>(initial.credentials);
+    const passwordConfirm = ref<string>(initial.passwordConfirm);
+    const userPrompted = ref<boolean>(initial.userPrompted);
+    // `valid` starts true so a test asserting it turns false cannot pass on the initial value alone.
+    const valid = ref<boolean>(true);
+
+    const parent = defineComponent({
+      setup(): () => VNode {
+        return () => h(CreateAccountCredentialsForm, {
+          'form': get(form),
+          'loading': false,
+          'onUpdate:form': (value: LoginCredentials): void => set(form, value),
+          'onUpdate:passwordConfirm': (value: string): void => set(passwordConfirm, value),
+          'onUpdate:userPrompted': (value: boolean): void => set(userPrompted, value),
+          'onUpdate:valid': (value: boolean): void => set(valid, value),
+          'passwordConfirm': get(passwordConfirm),
+          'userPrompted': get(userPrompted),
+          'valid': get(valid),
+        });
+      },
+    });
+
+    const wrapper = mount(parent, {
+      global: {
+        stubs: {
+          RuiCheckbox: inputStub('RuiCheckbox'),
+          RuiRevealableTextField: inputStub('RuiRevealableTextField'),
+          RuiTextField: inputStub('RuiTextField'),
+        },
+      },
+    });
+
+    return {
+      credentials: (): LoginCredentials => get(form),
+      valid: (): boolean => get(valid),
+      wrapper,
+    };
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    const match = harness.wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+    assert(match.exists(), `no field with test id ${testId} is rendered`);
+    return match;
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(testId: string, value: string | boolean): Promise<void> {
+    field(testId).vm.$emit('update:modelValue', value);
+    await nextTick();
+  }
+
+  it('should report valid when every field is filled and the prompt is checked', async () => {
+    harness = createHarness();
+    await nextTick();
+
+    expect(harness.valid()).toBe(true);
+  });
+
+  it('should report invalid on an untouched blank form', async () => {
+    harness = createHarness(blank());
+    await nextTick();
+
+    expect(harness.valid()).toBe(false);
+  });
+
+  it.each([
+    [USERNAME, ''],
+    [PASSWORD, ''],
+    [PASSWORD_REPEAT, ''],
+    [USER_PROMPTED, false],
+  ] as const)('should report invalid once %s is cleared', async (testId, cleared) => {
+    harness = createHarness();
+    await edit(testId, cleared);
+
+    expect(harness.valid()).toBe(false);
+  });
+
+  it('should show no message on an untouched field', async () => {
+    harness = createHarness(blank());
+    await nextTick();
+
+    expect(messages(USERNAME)).toStrictEqual([]);
+    expect(messages(PASSWORD)).toStrictEqual([]);
+    expect(messages(PASSWORD_REPEAT)).toStrictEqual([]);
+    expect(messages(USER_PROMPTED)).toStrictEqual([]);
+  });
+
+  describe('username', () => {
+    it.each([
+      ['user name'],
+      ['user@name'],
+      ['user/name'],
+    ])('should reject %s', async (username) => {
+      harness = createHarness();
+      await edit(USERNAME, username);
+
+      expect(harness.valid()).toBe(false);
+      expect(messages(USERNAME)).toStrictEqual(['create_account.credentials.validation.valid_username']);
+    });
+
+    it.each([
+      ['user_name'],
+      ['user.name'],
+      ['user-name'],
+      ['User1'],
+    ])('should accept %s', async (username) => {
+      harness = createHarness();
+      await edit(USERNAME, username);
+
+      expect(harness.valid()).toBe(true);
+      expect(messages(USERNAME)).toStrictEqual([]);
+    });
+
+    // Vuelidate reports every failing rule, so an emptied username fails the regex as well.
+    it('should report both of its messages when cleared', async () => {
+      harness = createHarness();
+      await edit(USERNAME, '');
+
+      expect(messages(USERNAME)).toStrictEqual([
+        'create_account.credentials.validation.valid_username',
+        'create_account.credentials.validation.non_empty_username',
+      ]);
+    });
+
+    it('should write an edit back to the wizard model', async () => {
+      harness = createHarness();
+      await edit(USERNAME, 'typed');
+
+      expect(harness.credentials().username).toBe('typed');
+    });
+  });
+
+  describe('password confirmation', () => {
+    it('should report invalid while the confirmation differs', async () => {
+      harness = createHarness();
+      await edit(PASSWORD_REPEAT, 'different');
+
+      expect(harness.valid()).toBe(false);
+      expect(messages(PASSWORD_REPEAT)).toStrictEqual([
+        'create_account.credentials.validation.password_confirmation_mismatch',
+      ]);
+    });
+
+    // The rule reads the password off the form model, so editing the password has to move the
+    // confirmation's verdict too. This is the cross-field pair the zod schema must reproduce.
+    it('should clear the mismatch when the password is edited to match', async () => {
+      harness = createHarness();
+      await edit(PASSWORD_REPEAT, 'different');
+      expect(harness.valid()).toBe(false);
+
+      await edit(PASSWORD, 'different');
+
+      expect(messages(PASSWORD_REPEAT)).toStrictEqual([]);
+      expect(harness.valid()).toBe(true);
+    });
+
+    // Characterizing, NOT endorsing. `$errors` is `$dirty ? $silentErrors : []`, and editing the
+    // password does not make the *confirmation* field dirty. So Continue goes dead with no message
+    // anywhere on screen, and the user has to touch the confirmation to find out why.
+    // Pinned as-is so the migration reproduces it deliberately rather than changing it by accident;
+    // flipping it is a one-line decision once the swap lands.
+    it('should turn valid off with no message when the password is edited away from the confirmation', async () => {
+      harness = createHarness();
+      await edit(PASSWORD, 'changed');
+
+      expect(harness.valid()).toBe(false);
+      expect(messages(PASSWORD_REPEAT)).toStrictEqual([]);
+      expect(messages(PASSWORD)).toStrictEqual([]);
+    });
+
+    it('should surface the mismatch as soon as the confirmation itself is touched', async () => {
+      harness = createHarness();
+      await edit(PASSWORD, 'changed');
+      // Re-emitting the value it already holds would not make it dirty, so the user has to actually
+      // change something for the message to appear.
+      await edit(PASSWORD_REPEAT, 'chang');
+
+      expect(messages(PASSWORD_REPEAT)).toStrictEqual([
+        'create_account.credentials.validation.password_confirmation_mismatch',
+      ]);
+    });
+
+    it('should report both messages when the confirmation is cleared', async () => {
+      harness = createHarness();
+      await edit(PASSWORD_REPEAT, '');
+
+      expect(messages(PASSWORD_REPEAT)).toStrictEqual([
+        'create_account.credentials.validation.password_confirmation_mismatch',
+        'create_account.credentials.validation.non_empty_password_confirmation',
+      ]);
+    });
+  });
+
+  describe('the backup prompt', () => {
+    it('should show its message once unchecked', async () => {
+      harness = createHarness();
+      await edit(USER_PROMPTED, false);
+
+      expect(messages(USER_PROMPTED)).toStrictEqual(['create_account.credentials.validation.check_prompt']);
+    });
+
+    it('should report valid again once re-checked', async () => {
+      harness = createHarness();
+      await edit(USER_PROMPTED, false);
+      await edit(USER_PROMPTED, true);
+
+      expect(harness.valid()).toBe(true);
+      expect(messages(USER_PROMPTED)).toStrictEqual([]);
+    });
+  });
+});

--- a/frontend/app/src/modules/auth/create-account/premium/CreateAccountPremium.spec.ts
+++ b/frontend/app/src/modules/auth/create-account/premium/CreateAccountPremium.spec.ts
@@ -1,0 +1,137 @@
+import type { PremiumSetup } from '@/modules/auth/login';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+import { defineComponent, h, ref, type VNode } from 'vue';
+import CreateAccountPremium from '@/modules/auth/create-account/premium/CreateAccountPremium.vue';
+import '@test/i18n';
+
+/**
+ * Guards the step's Continue button, with the REAL form mounted underneath.
+ *
+ * Same contract as [[CreateAccountCredentials.spec.ts]]: the form spec pins the rules and the `valid`
+ * model, this one pins the step gating on it. Premium adds a case the credentials step does not
+ * have - declining premium has to leave Continue enabled with both credential fields empty, so a
+ * schema that forgets to stay conditional locks the user out of the wizard entirely.
+ */
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+const ButtonStub = {
+  name: 'RuiButton',
+  props: ['disabled', 'loading'],
+  template: '<button :disabled="disabled"><slot /></button>',
+};
+
+const CONTINUE = 'create-account__premium__button__continue';
+
+describe('createAccountPremium', () => {
+  let wrapper: VueWrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function emptySetup(): PremiumSetup {
+    return { apiKey: '', apiSecret: '', syncDatabase: false };
+  }
+
+  function createWrapper(options: {
+    premiumEnabled: boolean;
+    setup?: PremiumSetup;
+    props?: Record<string, unknown>;
+  }): VueWrapper {
+    const form = ref<PremiumSetup>(options.setup ?? emptySetup());
+    const premiumEnabled = ref<boolean>(options.premiumEnabled);
+
+    const parent = defineComponent({
+      setup(): () => VNode {
+        return () => h(CreateAccountPremium, {
+          'form': get(form),
+          'loading': false,
+          'mode': 'create',
+          'onUpdate:form': (value: PremiumSetup): void => set(form, value),
+          'onUpdate:premiumEnabled': (value: boolean): void => set(premiumEnabled, value),
+          'premiumEnabled': get(premiumEnabled),
+          ...options.props,
+        });
+      },
+    });
+
+    return mount(parent, {
+      global: {
+        stubs: {
+          ExternalLink: true,
+          RuiButton: ButtonStub,
+          RuiRevealableTextField: inputStub('RuiRevealableTextField'),
+        },
+      },
+    });
+  }
+
+  function continueDisabled(): boolean {
+    return wrapper.get(`[data-testid=${CONTINUE}]`).attributes('disabled') !== undefined;
+  }
+
+  async function editCredential(label: string, value: string): Promise<void> {
+    const field = wrapper
+      .findAllComponents({ name: 'RuiRevealableTextField' })
+      .find(component => component.attributes('label') === label);
+    assert(field, `no field labelled ${label} is rendered`);
+    field.vm.$emit('update:modelValue', value);
+    await nextTick();
+  }
+
+  // The case that locks a user out of the wizard if the schema stops being conditional.
+  it('should enable continue when premium is declined, with empty credentials', async () => {
+    wrapper = createWrapper({ premiumEnabled: false });
+    await nextTick();
+
+    expect(continueDisabled()).toBe(false);
+  });
+
+  it('should disable continue when premium is accepted with empty credentials', async () => {
+    wrapper = createWrapper({ premiumEnabled: true });
+    await nextTick();
+
+    expect(continueDisabled()).toBe(true);
+  });
+
+  it('should enable continue once both premium credentials are filled', async () => {
+    wrapper = createWrapper({
+      premiumEnabled: true,
+      setup: { apiKey: 'key', apiSecret: 'secret', syncDatabase: false },
+    });
+    await nextTick();
+
+    expect(continueDisabled()).toBe(false);
+  });
+
+  it('should disable continue again when a premium credential is cleared', async () => {
+    wrapper = createWrapper({
+      premiumEnabled: true,
+      setup: { apiKey: 'key', apiSecret: 'secret', syncDatabase: false },
+    });
+    await editCredential('premium_credentials.label_api_key', '');
+
+    expect(continueDisabled()).toBe(true);
+  });
+
+  // No loading assertion here, unlike the credentials step: this step's Continue binds only
+  // `:disabled="!valid"` and passes `loading` through to RuiButton, so whether it is clickable
+  // during a submit is RuiButton's business and the stub does not model it.
+
+  it('should advance the wizard when continue is pressed', async () => {
+    wrapper = createWrapper({ premiumEnabled: false });
+    await nextTick();
+    await wrapper.get(`[data-testid=${CONTINUE}]`).trigger('click');
+
+    expect(wrapper.findComponent(CreateAccountPremium).emitted('next')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/auth/create-account/premium/CreateAccountPremiumForm.spec.ts
+++ b/frontend/app/src/modules/auth/create-account/premium/CreateAccountPremiumForm.spec.ts
@@ -1,0 +1,216 @@
+import type { PremiumSetup } from '@/modules/auth/login';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+import { type ComponentPublicInstance, defineComponent, h, ref, type VNode } from 'vue';
+import CreateAccountPremiumForm from '@/modules/auth/create-account/premium/CreateAccountPremiumForm.vue';
+import '@test/i18n';
+
+/**
+ * Characterization of the vuelidate rules, written before the zod migration.
+ *
+ * The seam is what the form exposes to the step above it: the `valid` model that gates Continue in
+ * `CreateAccountPremium.vue`, the `form` model the wizard submits, and the `error-messages` prop each
+ * field receives. None of it is markup, so these tests survive the swap unchanged.
+ */
+
+/** The stubs declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+interface Harness {
+  wrapper: VueWrapper;
+  /** The credentials as the wizard step above holds them, after every write the form has made. */
+  form: () => PremiumSetup;
+  /** The flag that gates the Continue button. */
+  valid: () => boolean;
+  setEnabled: (value: boolean) => void;
+}
+
+const KEY_FIELD = 'premium_credentials.label_api_key';
+const SECRET_FIELD = 'premium_credentials.label_api_secret';
+
+describe('createAccountPremiumForm', () => {
+  let harness: Harness;
+
+  afterEach(() => {
+    harness?.wrapper.unmount();
+  });
+
+  function emptySetup(): PremiumSetup {
+    return { apiKey: '', apiSecret: '', syncDatabase: false };
+  }
+
+  function createHarness(options: { enabled: boolean; setup?: PremiumSetup }): Harness {
+    const form = ref<PremiumSetup>(options.setup ?? emptySetup());
+    // `valid` starts true so a test that asserts it turns false cannot pass on the initial value.
+    const valid = ref<boolean>(true);
+    const enabled = ref<boolean>(options.enabled);
+
+    const parent = defineComponent({
+      setup(): () => VNode {
+        return () => h(CreateAccountPremiumForm, {
+          'enabled': get(enabled),
+          'form': get(form),
+          'loading': false,
+          'onUpdate:form': (value: PremiumSetup): void => set(form, value),
+          'onUpdate:valid': (value: boolean): void => set(valid, value),
+          'valid': get(valid),
+        });
+      },
+    });
+
+    const wrapper = mount(parent, {
+      global: {
+        stubs: {
+          RuiRevealableTextField: inputStub('RuiRevealableTextField'),
+        },
+      },
+    });
+
+    return {
+      form: (): PremiumSetup => get(form),
+      setEnabled: (value: boolean): void => set(enabled, value),
+      valid: (): boolean => get(valid),
+      wrapper,
+    };
+  }
+
+  function field(label: string): VueWrapper<StubInstance> {
+    const match = harness.wrapper
+      .findAllComponents<StubInstance>({ name: 'RuiRevealableTextField' })
+      .find(component => component.attributes('label') === label);
+    assert(match, `no field labelled ${label} is rendered`);
+    return match;
+  }
+
+  function messages(label: string): string[] {
+    const value: unknown = field(label).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(label: string, value: string): Promise<void> {
+    field(label).vm.$emit('update:modelValue', value);
+    await nextTick();
+  }
+
+  describe('when premium is not enabled', () => {
+    it('should report valid immediately, with both credentials empty', async () => {
+      harness = createHarness({ enabled: false });
+      await nextTick();
+
+      expect(harness.valid()).toBe(true);
+    });
+
+    it('should render no credential fields at all', async () => {
+      harness = createHarness({ enabled: false });
+      await nextTick();
+
+      expect(harness.wrapper.findAllComponents({ name: 'RuiRevealableTextField' })).toHaveLength(0);
+    });
+  });
+
+  describe('when premium is enabled', () => {
+    it('should report invalid while both credentials are empty', async () => {
+      harness = createHarness({ enabled: true });
+      await nextTick();
+
+      expect(harness.valid()).toBe(false);
+    });
+
+    it('should report valid once both credentials are filled', async () => {
+      harness = createHarness({ enabled: true, setup: { apiKey: 'key', apiSecret: 'secret', syncDatabase: false } });
+      await nextTick();
+
+      expect(harness.valid()).toBe(true);
+    });
+
+    it.each([
+      [KEY_FIELD, SECRET_FIELD],
+      [SECRET_FIELD, KEY_FIELD],
+    ])('should report invalid while only %s is filled', async (filled, empty) => {
+      harness = createHarness({ enabled: true });
+      await edit(filled, 'value');
+      await edit(empty, '');
+
+      expect(harness.valid()).toBe(false);
+    });
+
+    it.each([
+      [KEY_FIELD, 'premium_credentials.validation.non_empty_key'],
+      [SECRET_FIELD, 'premium_credentials.validation.non_empty_secret'],
+    ])('should show %s its own message once cleared', async (label, message) => {
+      harness = createHarness({ enabled: true, setup: { apiKey: 'key', apiSecret: 'secret', syncDatabase: false } });
+      await edit(label, '');
+
+      expect(messages(label)).toStrictEqual([message]);
+    });
+
+    it('should show no message on a field the user has not touched', async () => {
+      harness = createHarness({ enabled: true });
+      await nextTick();
+
+      expect(messages(KEY_FIELD)).toStrictEqual([]);
+      expect(messages(SECRET_FIELD)).toStrictEqual([]);
+    });
+
+    // Vuelidate's `required` trims, so whitespace is the input that separates "present" from
+    // "non-empty". The `.trim` modifier on the template binding does not cover a value that
+    // arrives on the model from anywhere else.
+    it('should reject a whitespace-only api key', async () => {
+      harness = createHarness({ enabled: true, setup: { apiKey: '   ', apiSecret: 'secret', syncDatabase: false } });
+      await edit(KEY_FIELD, '   ');
+
+      expect(harness.valid()).toBe(false);
+      expect(messages(KEY_FIELD)).toStrictEqual(['premium_credentials.validation.non_empty_key']);
+    });
+
+    it('should write an edit back to the wizard model', async () => {
+      harness = createHarness({ enabled: true });
+      await edit(KEY_FIELD, 'typed-key');
+
+      expect(harness.form().apiKey).toBe('typed-key');
+    });
+
+    it('should carry the untouched syncDatabase flag through an edit', async () => {
+      harness = createHarness({ enabled: true, setup: { apiKey: '', apiSecret: '', syncDatabase: true } });
+      await edit(KEY_FIELD, 'typed-key');
+
+      expect(harness.form().syncDatabase).toBe(true);
+    });
+  });
+
+  // The rules read `enabled` through `requiredIf`, so they have to re-evaluate when the user
+  // changes their mind. Under zod this becomes a schema that must stay reactive.
+  describe('when premium is toggled', () => {
+    it('should turn valid on as soon as premium is declined', async () => {
+      harness = createHarness({ enabled: true });
+      await nextTick();
+      expect(harness.valid()).toBe(false);
+
+      harness.setEnabled(false);
+      await nextTick();
+
+      expect(harness.valid()).toBe(true);
+    });
+
+    it('should turn valid off as soon as premium is accepted with empty credentials', async () => {
+      harness = createHarness({ enabled: false });
+      await nextTick();
+      expect(harness.valid()).toBe(true);
+
+      harness.setEnabled(true);
+      await nextTick();
+
+      expect(harness.valid()).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/auth/login/LoginForm.spec.ts
+++ b/frontend/app/src/modules/auth/login/LoginForm.spec.ts
@@ -1,0 +1,418 @@
+import type { LoginCredentials } from '@/modules/auth/login';
+import type { useCustomBackend } from '@/modules/auth/login/use-custom-backend';
+import type { useLoginRememberOptions } from '@/modules/auth/login/use-login-remember-options';
+import type { useLogout } from '@/modules/auth/use-logout';
+import type { useSavedProfiles } from '@/modules/auth/use-saved-profiles';
+import type { ActionStatus } from '@/modules/core/common/action';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComponentPublicInstance, ref } from 'vue';
+import '@test/i18n';
+
+/**
+ * Characterization of the vuelidate rules, written before the zod migration.
+ *
+ * The seam is what the form exposes to `LoginScreen`: the `login` emit and its payload, the state of
+ * the submit button, and the `error-messages` each field receives. The form has no `valid` model and
+ * exposes no `validate()` - it gates its own submit button on `v$.$invalid` - so the button's
+ * disabled state IS the validity contract here.
+ *
+ * `:disabled="v$.$invalid || ..."` is exactly the binding that breaks under the zod core, where
+ * `form.valid` does not unwrap in a template. These tests fail loudly if that happens.
+ */
+
+const backendDisplay = ref<boolean>(false);
+const backendUrl = ref<string>('');
+const savedUsernames = ref<string[]>(['saved-user']);
+const storedUsername = ref<string>('');
+
+/** Typed off the real composables so a drift in any of them fails the typecheck rather than a test. */
+type SavedProfilesMock = ReturnType<typeof useSavedProfiles>;
+
+type RememberOptionsMock = ReturnType<typeof useLoginRememberOptions>;
+
+type CustomBackendMock = ReturnType<typeof useCustomBackend>;
+
+type LogoutMock = Pick<ReturnType<typeof useLogout>, 'logoutRemoteSession'>;
+
+vi.mock('@/modules/auth/use-saved-profiles', () => ({
+  useSavedProfiles: (): SavedProfilesMock => ({
+    hasProfiles: computed<boolean>(() => get(savedUsernames).length > 0),
+    loadProfiles: vi.fn(async () => Promise.resolve()),
+    resolveStoredUsername: (): string => get(storedUsername),
+    savedUsernames,
+  }),
+}));
+
+vi.mock('@/modules/auth/login/use-login-remember-options', () => ({
+  useLoginRememberOptions: (): RememberOptionsMock => ({
+    loadRememberSettings: vi.fn(),
+    modelRememberPassword: ref(false),
+    modelRememberUsername: ref(false),
+    rememberCredentials: vi.fn(async () => Promise.resolve()),
+    storedUsername,
+  }),
+}));
+
+vi.mock('@/modules/auth/login/use-custom-backend', () => ({
+  useCustomBackend: (): CustomBackendMock => ({
+    clearBackend: vi.fn(),
+    display: backendDisplay,
+    loadBackendSettings: vi.fn(),
+    modelSessionOnly: ref(false),
+    modelUrl: backendUrl,
+    saveBackend: vi.fn(),
+    saved: ref(false),
+    serverColor: computed(() => undefined),
+    toggleDisplay: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/auth/use-logout', () => ({
+  useLogout: (): LogoutMock => ({
+    logoutRemoteSession: vi.fn<() => Promise<ActionStatus>>(async () => Promise.resolve({ success: true })),
+  }),
+}));
+
+const LoginForm = (await import('@/modules/auth/login/LoginForm.vue')).default;
+
+/** The stubs declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+const ButtonStub = {
+  name: 'RuiButton',
+  props: ['disabled', 'loading'],
+  template: '<button :disabled="disabled"><slot /></button>',
+};
+
+const USERNAME = 'LoginUsernameField';
+const PASSWORD = 'password-input';
+
+describe('loginForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LoginForm>>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    set(backendDisplay, false);
+    set(backendUrl, '');
+    set(savedUsernames, ['saved-user']);
+    set(storedUsername, '');
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  function createWrapper(props: Record<string, unknown> = {}): VueWrapper<InstanceType<typeof LoginForm>> {
+    return mount(LoginForm, {
+      global: {
+        stubs: {
+          ExternalLink: true,
+          IncompleteUpgradeAlert: true,
+          LoginBackendToggle: true,
+          LoginCustomBackendFields: inputStub('LoginCustomBackendFields'),
+          LoginRememberOptions: true,
+          // The form focuses this one through its template ref on mount.
+          LoginUsernameField: { ...inputStub('LoginUsernameField'), methods: { focus: (): void => {} } },
+          LoginWelcomeMessageDialog: true,
+          PremiumSyncConflictAlert: true,
+          RuiButton: ButtonStub,
+          RuiRevealableTextField: inputStub('RuiRevealableTextField'),
+        },
+      },
+      props: { loading: false, ...props },
+    });
+  }
+
+  function usernameField(): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>({ name: USERNAME });
+  }
+
+  function passwordField(): VueWrapper<StubInstance> {
+    const match = wrapper.findComponent<StubInstance>(`[data-testid=${PASSWORD}]`);
+    assert(match.exists(), 'the password field is not rendered');
+    return match;
+  }
+
+  function messagesOf(field: VueWrapper<StubInstance>): string[] {
+    const value: unknown = field.props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  function submitDisabled(): boolean {
+    return wrapper.get('[data-testid=login-submit]').attributes('disabled') !== undefined;
+  }
+
+  async function fill(username: string, password: string): Promise<void> {
+    usernameField().vm.$emit('update:modelValue', username);
+    passwordField().vm.$emit('update:modelValue', password);
+    await nextTick();
+  }
+
+  async function submit(): Promise<void> {
+    await wrapper.get('form').trigger('submit');
+    await nextTick();
+  }
+
+  function loginPayloads(): LoginCredentials[] {
+    const emitted = wrapper.emitted('login') ?? [];
+    return emitted.map(([credentials]) => {
+      assert(credentials && typeof credentials === 'object');
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the emit is typed at the source; VTU erases it to unknown
+      return credentials as LoginCredentials;
+    });
+  }
+
+  it('should keep submit disabled on an empty form', async () => {
+    wrapper = createWrapper();
+    await nextTick();
+
+    expect(submitDisabled()).toBe(true);
+  });
+
+  it('should enable submit once username and password are filled', async () => {
+    wrapper = createWrapper();
+    await fill('user', 'password');
+
+    expect(submitDisabled()).toBe(false);
+  });
+
+  it('should emit the typed credentials on submit', async () => {
+    wrapper = createWrapper();
+    await fill('user', 'password');
+    await submit();
+
+    expect(loginPayloads()).toStrictEqual([{ password: 'password', username: 'user' }]);
+  });
+
+  it.each([
+    ['', 'password'],
+    ['user', ''],
+    ['', ''],
+  ])('should keep submit disabled for username %s and password %s', async (username, password) => {
+    wrapper = createWrapper();
+    await fill(username, password);
+
+    expect(submitDisabled()).toBe(true);
+  });
+
+  describe('username rules', () => {
+    it.each([
+      ['user name'],
+      ['user@name'],
+      ['user/name'],
+    ])('should reject %s', async (username) => {
+      wrapper = createWrapper();
+      await fill(username, 'password');
+
+      expect(submitDisabled()).toBe(true);
+      expect(messagesOf(usernameField())).toStrictEqual(['login.validation.valid_username']);
+    });
+
+    it.each([
+      ['user_name'],
+      ['user.name'],
+      ['user-name'],
+    ])('should accept %s', async (username) => {
+      wrapper = createWrapper();
+      await fill(username, 'password');
+
+      expect(submitDisabled()).toBe(false);
+      expect(messagesOf(usernameField())).toStrictEqual([]);
+    });
+
+    it('should report both messages when cleared after being filled', async () => {
+      wrapper = createWrapper();
+      await fill('user', 'password');
+      await fill('', 'password');
+
+      expect(messagesOf(usernameField())).toStrictEqual([
+        'login.validation.valid_username',
+        'login.validation.non_empty_username',
+      ]);
+    });
+  });
+
+  describe('password rules', () => {
+    it('should show the empty message once cleared', async () => {
+      wrapper = createWrapper();
+      await fill('user', 'password');
+      await fill('user', '');
+
+      expect(messagesOf(passwordField())).toStrictEqual(['login.validation.non_empty_password']);
+    });
+
+    // `required` trims, so a password of only spaces is treated as absent.
+    it('should reject a whitespace-only password', async () => {
+      wrapper = createWrapper();
+      await fill('user', '   ');
+
+      expect(submitDisabled()).toBe(true);
+      expect(messagesOf(passwordField())).toStrictEqual(['login.validation.non_empty_password']);
+    });
+  });
+
+  describe('the custom backend panel', () => {
+    it('should keep submit disabled while it is open, even on a valid form', async () => {
+      wrapper = createWrapper();
+      await fill('user', 'password');
+      set(backendDisplay, true);
+      await nextTick();
+
+      expect(submitDisabled()).toBe(true);
+    });
+
+    // The url rules are `$autoDirty`, so an untouched empty field shows nothing at all: the message
+    // only appears once a value has been entered and taken away again.
+    it('should show nothing on an untouched empty url', async () => {
+      wrapper = createWrapper();
+      set(backendDisplay, true);
+      await nextTick();
+
+      const field = wrapper.findComponent<StubInstance>({ name: 'LoginCustomBackendFields' });
+      expect(messagesOf(field)).toStrictEqual([]);
+    });
+
+    it('should require a url once one has been entered and cleared', async () => {
+      wrapper = createWrapper();
+      set(backendDisplay, true);
+      set(backendUrl, 'http://rotki.com');
+      await nextTick();
+      set(backendUrl, '');
+      await nextTick();
+
+      const field = wrapper.findComponent<StubInstance>({ name: 'LoginCustomBackendFields' });
+      expect(messagesOf(field)).toStrictEqual([
+        'login.custom_backend.validation.url',
+        'login.custom_backend.validation.non_empty',
+      ]);
+    });
+
+    it('should reject a malformed url', async () => {
+      wrapper = createWrapper();
+      set(backendDisplay, true);
+      set(backendUrl, 'not a url');
+      await nextTick();
+
+      const field = wrapper.findComponent<StubInstance>({ name: 'LoginCustomBackendFields' });
+      expect(messagesOf(field)).toStrictEqual(['login.custom_backend.validation.url']);
+    });
+
+    it('should accept a well-formed url', async () => {
+      wrapper = createWrapper();
+      set(backendDisplay, true);
+      set(backendUrl, 'http://127.0.0.1:4242');
+      await nextTick();
+
+      const field = wrapper.findComponent<StubInstance>({ name: 'LoginCustomBackendFields' });
+      expect(messagesOf(field)).toStrictEqual([]);
+    });
+
+    // Characterizing, NOT endorsing: `isValidUrl` requires a dotted host, so the most obvious local
+    // backend address a user would type is rejected. Pinned so the migration reproduces today's
+    // behaviour rather than silently changing it; fixing it is a separate decision.
+    it('should reject http://localhost:4242', async () => {
+      wrapper = createWrapper();
+      set(backendDisplay, true);
+      set(backendUrl, 'http://localhost:4242');
+      await nextTick();
+
+      const field = wrapper.findComponent<StubInstance>({ name: 'LoginCustomBackendFields' });
+      expect(messagesOf(field)).toStrictEqual(['login.custom_backend.validation.url']);
+    });
+
+    // The length bound sits in the same rule as the url check, so it reports the same message.
+    it('should reject a url of 300 characters or more', async () => {
+      wrapper = createWrapper();
+      set(backendDisplay, true);
+      set(backendUrl, `http://localhost/${'a'.repeat(300)}`);
+      await nextTick();
+
+      const field = wrapper.findComponent<StubInstance>({ name: 'LoginCustomBackendFields' });
+      expect(messagesOf(field)).toStrictEqual(['login.custom_backend.validation.url']);
+    });
+
+    it('should ignore the url rules while it is closed', async () => {
+      wrapper = createWrapper();
+      set(backendUrl, 'not a url');
+      await fill('user', 'password');
+
+      expect(submitDisabled()).toBe(false);
+    });
+  });
+
+  // The server errors arrive as a flat string list and are routed to a field by prefix. Both the
+  // prefixes and the ordering (local messages first) are contract.
+  describe('server errors', () => {
+    it('should append a username error to that field', async () => {
+      wrapper = createWrapper({ errors: ['User user does not exist'] });
+      await nextTick();
+
+      expect(messagesOf(usernameField())).toStrictEqual(['User user does not exist']);
+    });
+
+    it('should append a password error to that field', async () => {
+      wrapper = createWrapper({ errors: ['Wrong password for user'] });
+      await nextTick();
+
+      expect(messagesOf(passwordField())).toStrictEqual(['Wrong password for user']);
+    });
+
+    it('should keep the local message first when both are present', async () => {
+      wrapper = createWrapper({ errors: ['Wrong password for user'] });
+      await fill('user', 'password');
+      await fill('user', '');
+
+      expect(messagesOf(passwordField())).toStrictEqual([
+        'login.validation.non_empty_password',
+        'Wrong password for user',
+      ]);
+    });
+
+    it('should route an unrecognised error to neither field', async () => {
+      wrapper = createWrapper({ errors: ['Something else went wrong'] });
+      await nextTick();
+
+      expect(messagesOf(usernameField())).toStrictEqual([]);
+      expect(messagesOf(passwordField())).toStrictEqual([]);
+    });
+  });
+
+  describe('the touched signal', () => {
+    it('should emit once the user edits the username', async () => {
+      wrapper = createWrapper();
+      await fill('user', '');
+
+      expect(wrapper.emitted('touched')).toHaveLength(1);
+    });
+
+    // Restoring a remembered username is not a user edit, so it must stay silent.
+    it('should stay silent when the username is restored from storage', async () => {
+      set(storedUsername, 'saved-user');
+      wrapper = createWrapper();
+      await nextTick();
+      await nextTick();
+
+      expect(wrapper.emitted('touched')).toBeUndefined();
+    });
+  });
+
+  it('should ask for a new account when no profile is saved', async () => {
+    set(savedUsernames, []);
+    wrapper = createWrapper();
+    await flushPromises();
+
+    expect(wrapper.emitted('new-account')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/auth/login/PasswordConfirmationDialog.spec.ts
+++ b/frontend/app/src/modules/auth/login/PasswordConfirmationDialog.spec.ts
@@ -1,0 +1,234 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComponentPublicInstance, defineComponent, h, ref, type VNode } from 'vue';
+import PasswordConfirmationDialog from '@/modules/auth/login/PasswordConfirmationDialog.vue';
+import '@test/i18n';
+
+/**
+ * Characterization of the vuelidate rules, written before the zod migration.
+ *
+ * This dialog had no coverage of any kind - no unit spec, no e2e - and it guards the password
+ * re-entry that unlocks a session, so the contract is pinned before anything moves.
+ *
+ * The seam is what the dialog exposes to `AppMessages.vue`: the `confirm` emit carrying the typed
+ * password, the `display` model, and the `error-messages` the input receives. No markup assertions.
+ *
+ * NOT covered: the `@keydown.enter` submit path. The listener falls through onto the stubbed input,
+ * where neither `trigger('keydown.enter')` nor a real dispatched `KeyboardEvent` reaches it, so the
+ * only test that could be written for it is one that cannot fail. It runs the same
+ * `confirmPassword()` as the button, so the validation contract below still covers the logic - but
+ * the binding itself is unpinned and stays that way through the migration.
+ */
+
+const getPassword = vi.fn<(username: string) => Promise<string>>();
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): { getPassword: typeof getPassword } => ({ getPassword }),
+}));
+
+/** The stub declares its props at runtime, so its instance is typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+const TextFieldStub = {
+  emits: ['update:modelValue'],
+  name: 'RuiTextField',
+  props: ['modelValue', 'errorMessages', 'disabled'],
+  template: '<div />',
+};
+
+const PassthroughStub = {
+  name: 'Passthrough',
+  template: '<div><slot name="header" /><slot /><slot name="footer" /></div>',
+};
+
+interface Harness {
+  wrapper: VueWrapper;
+  /** Passwords the dialog has confirmed, in order. */
+  confirmed: () => string[];
+  /** The dialog's own visibility model. */
+  display: () => boolean;
+  setDisplay: (value: boolean) => void;
+}
+
+describe('passwordConfirmationDialog', () => {
+  let harness: Harness;
+
+  beforeEach(() => {
+    getPassword.mockReset();
+    getPassword.mockResolvedValue('');
+  });
+
+  afterEach(() => {
+    harness?.wrapper.unmount();
+  });
+
+  function createHarness(props: { username?: string; errorMessage?: string } = {}): Harness {
+    const display = ref<boolean>(true);
+    const confirmed = ref<string[]>([]);
+
+    const parent = defineComponent({
+      setup(): () => VNode {
+        return () => h(PasswordConfirmationDialog, {
+          'modelValue': get(display),
+          'onConfirm': (password: string): void => {
+            set(confirmed, [...get(confirmed), password]);
+          },
+          'onUpdate:modelValue': (value: boolean): void => set(display, value),
+          'username': 'user',
+          ...props,
+        });
+      },
+    });
+
+    const wrapper = mount(parent, {
+      global: {
+        stubs: {
+          RuiButton: PassthroughStub,
+          RuiCard: PassthroughStub,
+          RuiDialog: PassthroughStub,
+          RuiTextField: TextFieldStub,
+        },
+      },
+    });
+
+    return {
+      confirmed: (): string[] => get(confirmed),
+      display: (): boolean => get(display),
+      setDisplay: (value: boolean): void => set(display, value),
+      wrapper,
+    };
+  }
+
+  function input(): VueWrapper<StubInstance> {
+    const match = harness.wrapper.findComponent<StubInstance>('[data-testid=password-confirmation-input]');
+    assert(match.exists(), 'the password input is not rendered');
+    return match;
+  }
+
+  function messages(): string[] {
+    const value: unknown = input().props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function type(password: string): Promise<void> {
+    input().vm.$emit('update:modelValue', password);
+    await nextTick();
+  }
+
+  async function confirm(): Promise<void> {
+    await harness.wrapper.get('[data-testid=password-confirmation-confirm]').trigger('click');
+    await nextTick();
+  }
+
+  it('should confirm with the typed password', async () => {
+    harness = createHarness();
+    await type('secret');
+    await confirm();
+
+    expect(harness.confirmed()).toStrictEqual(['secret']);
+  });
+
+  it('should not confirm while the password is empty', async () => {
+    harness = createHarness();
+    await confirm();
+
+    expect(harness.confirmed()).toStrictEqual([]);
+  });
+
+  it('should show the empty-password message once confirm is attempted', async () => {
+    harness = createHarness();
+    await confirm();
+
+    expect(messages()).toStrictEqual(['password_confirmation_dialog.validation.non_empty_password']);
+  });
+
+  it('should show no message before the user has done anything', async () => {
+    harness = createHarness();
+    await nextTick();
+
+    expect(messages()).toStrictEqual([]);
+  });
+
+  // Vuelidate's `required` trims, so a password of only spaces never reaches the backend.
+  it('should not confirm a whitespace-only password', async () => {
+    harness = createHarness();
+    await type('   ');
+    await confirm();
+
+    expect(harness.confirmed()).toStrictEqual([]);
+    expect(messages()).toStrictEqual(['password_confirmation_dialog.validation.non_empty_password']);
+  });
+
+  it('should clear a shown message once a password is typed', async () => {
+    harness = createHarness();
+    await confirm();
+    expect(messages()).not.toStrictEqual([]);
+
+    await type('secret');
+
+    expect(messages()).toStrictEqual([]);
+  });
+
+  // The dialog stays mounted across a rejected attempt, so a second submission must be possible.
+  it('should confirm again after a rejected attempt', async () => {
+    harness = createHarness();
+    await type('wrong');
+    await confirm();
+    await type('right');
+    await confirm();
+
+    expect(harness.confirmed()).toStrictEqual(['wrong', 'right']);
+  });
+
+  describe('when the backend has reported an error', () => {
+    it('should show that error instead of the local message', async () => {
+      harness = createHarness({ errorMessage: 'Wrong password' });
+      await confirm();
+
+      expect(messages()).toStrictEqual(['Wrong password']);
+    });
+
+    // The server error wins unconditionally, so it keeps showing over an untouched empty field.
+    it('should show that error even before the user types', async () => {
+      harness = createHarness({ errorMessage: 'Wrong password' });
+      await nextTick();
+
+      expect(messages()).toStrictEqual(['Wrong password']);
+    });
+
+    it('should still refuse to confirm an empty password', async () => {
+      harness = createHarness({ errorMessage: 'Wrong password' });
+      await confirm();
+
+      expect(harness.confirmed()).toStrictEqual([]);
+    });
+  });
+
+  describe('when the dialog is reopened', () => {
+    it('should clear the previously typed password', async () => {
+      harness = createHarness();
+      await type('secret');
+
+      harness.setDisplay(false);
+      await nextTick();
+      harness.setDisplay(true);
+      await nextTick();
+
+      expect(input().props('modelValue')).toBe('');
+    });
+
+    it('should clear a message left over from the previous attempt', async () => {
+      harness = createHarness();
+      await confirm();
+      expect(messages()).not.toStrictEqual([]);
+
+      harness.setDisplay(false);
+      await nextTick();
+      harness.setDisplay(true);
+      await nextTick();
+
+      expect(messages()).toStrictEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Characterization tests for the four auth forms, ahead of their vuelidate → zod migration. **No rule is changed and no production file is touched** — the diff is six new spec files.

The auth group is scheduled last in the migration because it has the widest blast radius and, until now, the least coverage: none of the four forms had a spec, and `PasswordConfirmationDialog` had no coverage of any kind, unit or e2e.

## What is pinned

| Spec | Tests | What it covers |
|---|---|---|
| `PasswordConfirmationDialog` | 12 | the confirm gate, message text, server-error precedence, reset on reopen |
| `CreateAccountPremiumForm` | 14 | the `requiredIf(enabled)` conditionality and its re-evaluation when the user changes their mind |
| `LoginForm` | 30 | the submit gate, username regex, custom-backend url rules, prefix routing of server errors |
| `CreateAccountCredentialsForm` | 23 | the `sameAs` confirmation pair in both directions, the backup-prompt checkbox, the `valid` model |
| `CreateAccountCredentials` + `CreateAccountPremium` | 16 | the wizard steps' Continue buttons, with the real forms mounted underneath |

Every test was mutation-proved: each one was shown to fail when the rule it pins is removed. For example, dropping `v$.$invalid` from `LoginForm`'s submit gate reddens 8 tests, and making the credentials form stop writing its `valid` model reddens 23 — including both "advance the wizard" assertions, which is the wizard dead-locking.

The specs assert through the seam rather than through markup — the exposed models, the emitted events, and the `error-messages` prop each field receives — so they are intended to survive the zod swap unchanged and act as the safety net for it.

## Two behaviours recorded as-is, not fixed

Both are pinned with a comment saying they are being characterized rather than endorsed, so that the migration reproduces current behaviour instead of changing it by accident. Fixing either is a separate decision.

- **Editing the password after confirming it disables Continue with no message shown.** `$errors` is `$dirty ? $silentErrors : []`, and editing the password field never marks the *confirmation* field dirty, so the user has to touch the confirmation to find out why the wizard stopped.
- **`http://localhost:4242` is rejected as a custom backend url.** `isValidUrl` requires a dotted host, so the most obvious local address fails; `http://127.0.0.1:4242` passes.

## Known gaps

- The `@keydown.enter` submit path on `PasswordConfirmationDialog` is **not** covered. The fallthrough listener does not reach a stubbed input, so the only test that could be written there could not fail. This is stated in the spec's doc comment rather than papered over.
- Fields are stubbed, so nothing here proves a message actually renders. That remains e2e's job.

## Checks

`typecheck`, full `test:unit` (8254 passing), `lint` (0 errors, 19 warnings — unchanged from develop), `knip` and `typos` all clean on the rebased tip.
