### PR TITLE
Validate the account forms with zod

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -4576,7 +4576,8 @@
       "amount": "The amount cannot be empty",
       "asset": "The asset cannot be empty",
       "label_empty": "The label cannot be empty",
-      "label_exists": "Label {label} already exists"
+      "label_exists": "Label {label} already exists",
+      "location": "The location cannot be empty"
     }
   },
   "manual_balances_table": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2944,6 +2944,9 @@
     },
     "ownership_percentage": "Ownership Percentage",
     "public_key": "Public Key",
+    "validation": {
+      "required": "The value is required"
+    },
     "validator_index": {
       "validation": "Validator index can be filled with numeric value only."
     }

--- a/frontend/app/src/modules/accounts/address-book/AddressBookForm.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookForm.spec.ts
@@ -1,0 +1,172 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComponentPublicInstance } from 'vue';
+import type { AddressBookPayload } from '@/modules/accounts/address-book/eth-names';
+import { type ModelFormHarness, mountModelForm } from '@test/utils/model-form-harness';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
+  useAddressNameResolution: vi.fn().mockReturnValue({
+    getAddressName: vi.fn(),
+    useAddressesWithoutNames: vi.fn().mockImplementation(() => computed<string[]>(() => [])),
+  }),
+}));
+
+const AddressBookForm = (await import('@/modules/accounts/address-book/AddressBookForm.vue')).default;
+
+/** The stubs declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function fieldStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue'],
+    name,
+    props: ['modelValue', 'errorMessages', 'items', 'options', 'disabled'],
+    template: '<div />',
+  };
+}
+
+const STUBS = {
+  AppImage: true,
+  AutoCompleteWithSearchSync: fieldStub('AutoCompleteWithSearchSync'),
+  ChainSelect: fieldStub('ChainSelect'),
+  RuiMenuSelect: fieldStub('RuiMenuSelect'),
+  RuiTextField: fieldStub('RuiTextField'),
+};
+
+function payload(overrides: Partial<AddressBookPayload> = {}): AddressBookPayload {
+  return {
+    address: '',
+    blockchain: 'all',
+    location: 'private',
+    name: '',
+    ...overrides,
+  };
+}
+
+describe('modules/accounts/address-book/AddressBookForm', () => {
+  let harness: ModelFormHarness<AddressBookPayload>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    harness?.wrapper.unmount();
+  });
+
+  function createHarness(value: AddressBookPayload = payload()): ModelFormHarness<AddressBookPayload> {
+    return mountModelForm<AddressBookPayload>(AddressBookForm, {
+      errors: {},
+      global: { stubs: STUBS },
+      payload: value,
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return harness.wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(testId: string, value: unknown): Promise<void> {
+    field(testId).vm.$emit('update:modelValue', value);
+    await nextTick();
+  }
+
+  it('should reject an empty form and name each missing field', async () => {
+    harness = createHarness(payload({ blockchain: null }));
+
+    expect(await harness.validate()).toBe(false);
+    await nextTick();
+
+    expect(messages('address-book-form-chain')).toEqual(['address_book.form.validation.chain']);
+    expect(messages('address-book-form-address')).toEqual(['address_book.form.validation.address']);
+    expect(messages('address-book-form-name')).toEqual(['address_book.form.validation.name']);
+  });
+
+  it('should accept a filled entry', async () => {
+    harness = createHarness(payload({
+      address: '0x9531C059098e3d194fF87FebB587aB07B30B1306',
+      name: 'my wallet',
+    }));
+
+    expect(await harness.validate()).toBe(true);
+    await nextTick();
+
+    expect(messages('address-book-form-name')).toEqual([]);
+  });
+
+  it('should treat a whitespace-only entry as missing', async () => {
+    harness = createHarness(payload({ address: '  ', name: '  ' }));
+
+    expect(await harness.validate()).toBe(false);
+    await nextTick();
+
+    expect(messages('address-book-form-address')).toEqual(['address_book.form.validation.address']);
+    expect(messages('address-book-form-name')).toEqual(['address_book.form.validation.name']);
+  });
+
+  it('should write an edit back to the payload the dialog saves', async () => {
+    harness = createHarness();
+
+    await edit('address-book-form-name', 'my wallet');
+
+    expect(harness.model().name).toBe('my wallet');
+  });
+
+  it('should open without arming the unsaved-changes prompt', async () => {
+    harness = createHarness();
+    await nextTick();
+
+    expect(harness.stateUpdated()).toBe(false);
+  });
+
+  it('should arm the unsaved-changes prompt on an edit, however early', async () => {
+    harness = createHarness();
+
+    // FLIP: `useFormStateWatcher` installed its watcher behind a 500 ms timer, so an edit made
+    // before it arrived was never seen and the dialog closed without prompting. `dirty` compares
+    // against a baseline taken at construction, so there is no window to miss.
+    await edit('address-book-form-name', 'my wallet');
+
+    expect(harness.stateUpdated()).toBe(true);
+  });
+
+  it('should disarm the unsaved-changes prompt when the edit is undone', async () => {
+    harness = createHarness();
+
+    await edit('address-book-form-name', 'my wallet');
+    await edit('address-book-form-name', '');
+
+    // FLIP: the old watcher latched on the first change and never looked again.
+    expect(harness.stateUpdated()).toBe(false);
+  });
+
+  it('should not arm the unsaved-changes prompt when only the location changes', async () => {
+    harness = createHarness();
+
+    // The location is not one of the watched keys, so switching between the global and private
+    // books is not an edit of the entry itself.
+    await edit('address-book-form-location', 'global');
+
+    expect(harness.model().location).toBe('global');
+    expect(harness.stateUpdated()).toBe(false);
+  });
+
+  it('should show a server error that is already present at mount', async () => {
+    harness = mountModelForm<AddressBookPayload>(AddressBookForm, {
+      errors: { name: ['Name is already taken'] },
+      global: { stubs: STUBS },
+      payload: payload({ address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', name: 'taken' }),
+    });
+    await nextTick();
+
+    // FLIP: external results reached `$errors` only once the field was dirty, so a failed save the
+    // dialog was already holding stayed invisible until the user edited the field it named.
+    expect(messages('address-book-form-name')).toEqual(['Name is already taken']);
+  });
+});

--- a/frontend/app/src/modules/accounts/address-book/AddressBookForm.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookForm.vue
@@ -1,19 +1,15 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { AddressBookLocation, AddressBookPayload } from '@/modules/accounts/address-book/eth-names';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { SelectOptions } from '@/modules/core/common/common-types';
 import { Blockchain } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
-import { each } from 'es-toolkit/compat';
-import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
+import { addressBookEntrySchema } from '@/modules/accounts/address-book/address-book-form';
+import { useAddressSuggestions } from '@/modules/accounts/address-book/use-address-suggestions';
 import ChainSelect from '@/modules/accounts/blockchain/ChainSelect.vue';
 import { useBlockie } from '@/modules/accounts/use-blockie';
-import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { nullDefined, useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import AppImage from '@/modules/shell/components/AppImage.vue';
 import AutoCompleteWithSearchSync from '@/modules/shell/components/inputs/AutoCompleteWithSearchSync.vue';
 
@@ -29,83 +25,61 @@ const { t } = useI18n({ useScope: 'global' });
 
 const { supportedChains } = useSupportedChains();
 
-const name = useRefPropVModel(modelValue, 'name');
-const location = useRefPropVModel(modelValue, 'location');
-const address = useRefPropVModel(modelValue, 'address');
-const blockchain = useRefPropVModel(modelValue, 'blockchain');
-const blockchainModel = nullDefined(blockchain);
-const { addresses } = useAccountAddresses();
-const addressNameResolution = useAddressNameResolution();
-const { getAddressName, useAddressesWithoutNames } = addressNameResolution;
-
-const addressSuggestions = useAddressesWithoutNames(blockchain);
 const locations = computed<SelectOptions<AddressBookLocation>>(() => [
   { key: 'global', label: t('address_book.hint.global') },
   { key: 'private', label: t('address_book.hint.private') },
 ]);
 
-const rules = {
-  address: {
-    required: helpers.withMessage(t('address_book.form.validation.address'), required),
-  },
-  blockchain: {
-    required: helpers.withMessage(t('address_book.form.validation.chain'), required),
-  },
-  name: {
-    required: helpers.withMessage(t('address_book.form.validation.name'), required),
-  },
-};
+const schema = computed<ZodType>(() => addressBookEntrySchema({
+  address: t('address_book.form.validation.address'),
+  chain: t('address_book.form.validation.chain'),
+  name: t('address_book.form.validation.name'),
+}));
 
-const states = {
-  address,
-  blockchain,
-  name,
-};
+const { errors: fieldErrors, state, touch, validate } = useModelForm<AddressBookPayload>({
+  model: modelValue,
+  schema,
+  serverErrors: errors,
+  stateUpdated,
+  // The location picks which book the entry is written to rather than describing the entry, and it
+  // was outside the watched keys before, so switching books is not an unsaved change.
+  transientKeys: ['location'],
+});
 
-const v$ = useVuelidate(
-  rules,
-  states,
-  { $autoDirty: true, $externalResults: errors },
-);
-
-useFormStateWatcher(states, stateUpdated);
+const addressSuggestions = useAddressSuggestions(() => state.blockchain, {
+  clear: (): void => {
+    state.address = '';
+  },
+  selected: () => state.address,
+});
 
 const { getBlockie } = useBlockie();
-
-function fetchNames() {
-  const addressMap = get(addresses);
-
-  each(Blockchain, (chain) => {
-    addressMap[chain]?.forEach(address => getAddressName(address, chain));
-  });
-}
 
 const chainOptions = computed<string[]>(() => [
   'all',
   ...get(supportedChains).map(item => item.id).filter(item => item !== Blockchain.ETH2),
 ]);
 
-/**
- * if new suggestions does not include last suggested and selected address, reset address
- */
-watch(addressSuggestions, (suggestions, oldSuggestions) => {
-  const chainAddress = get(address);
-  if (get(blockchain) && oldSuggestions.includes(chainAddress) && !suggestions.includes(chainAddress))
-    set(address, '');
+/** `ChainSelect` has no null in its model, while the payload uses it for "every chain". */
+const blockchainModel = computed<string | undefined>({
+  get() {
+    return state.blockchain ?? undefined;
+  },
+  set(value?: string) {
+    state.blockchain = value ?? null;
+    touch('blockchain');
+  },
 });
 
-watchEffect(fetchNames);
-onMounted(fetchNames);
-
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate,
 });
 </script>
 
 <template>
   <div class="flex flex-col gap-4">
     <RuiMenuSelect
-      v-model="location"
+      v-model="state.location"
       :label="t('common.location')"
       :options="locations"
       :disabled="editMode"
@@ -118,7 +92,7 @@ defineExpose({
       v-model="blockchainModel"
       :disabled="editMode"
       :items="chainOptions"
-      :error-messages="toMessages(v$.blockchain)"
+      :error-messages="fieldErrors('blockchain')"
       data-testid="address-book-form-chain"
     />
     <div class="flex gap-2">
@@ -130,15 +104,16 @@ defineExpose({
         />
       </div>
       <AutoCompleteWithSearchSync
-        v-model.trim="address"
+        v-model.trim="state.address"
         class="flex-1"
         :label="t('address_book.form.labels.address')"
         :items="addressSuggestions"
         :no-data-text="t('address_book.form.no_suggestions_available')"
         :disabled="editMode"
-        :error-messages="toMessages(v$.address)"
+        :error-messages="fieldErrors('address')"
         clearable
         data-testid="address-book-form-address"
+        @update:model-value="touch('address')"
       >
         <template #item.prepend="{ item }">
           <div
@@ -155,13 +130,14 @@ defineExpose({
       </AutoCompleteWithSearchSync>
     </div>
     <RuiTextField
-      v-model="name"
+      v-model="state.name"
       class="mt-2"
       variant="outlined"
       color="primary"
       :label="t('common.name')"
-      :error-messages="toMessages(v$.name)"
+      :error-messages="fieldErrors('name')"
       data-testid="address-book-form-name"
+      @update:model-value="touch('name')"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/accounts/address-book/address-book-form.ts
+++ b/frontend/app/src/modules/accounts/address-book/address-book-form.ts
@@ -1,0 +1,32 @@
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface AddressBookFormMessages {
+  address: string;
+  chain: string;
+  name: string;
+}
+
+/**
+ * The chain is held as null for "every chain", so it needs the nullable twin of `requiredField`:
+ * the old rule rejected null and whitespace alike, under the one message.
+ */
+function requiredChain(message: string): ZodType {
+  return z.string({ error: message }).nullable().superRefine((value, ctx) => {
+    if ((value ?? '').trim() === '')
+      ctx.addIssue({ code: 'custom', message });
+  });
+}
+
+/**
+ * The location is deliberately absent: it picks which book the entry is written to rather than
+ * describing the entry, and it was never validated. Zod drops the keys a schema does not name, so
+ * it travels untouched.
+ */
+export function addressBookEntrySchema(messages: AddressBookFormMessages): ZodType {
+  return z.object({
+    address: requiredField(messages.address),
+    blockchain: requiredChain(messages.chain),
+    name: requiredField(messages.name),
+  });
+}

--- a/frontend/app/src/modules/accounts/address-book/use-address-suggestions.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-suggestions.spec.ts
@@ -1,0 +1,92 @@
+import type { Ref } from 'vue';
+import { withSetup } from '@test/utils/with-setup';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const suggestions = ref<string[]>([]);
+const getAddressName = vi.fn();
+
+vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
+  useAddressNameResolution: vi.fn().mockReturnValue({
+    getAddressName: vi.fn().mockImplementation((...args: unknown[]) => getAddressName(...args)),
+    useAddressesWithoutNames: vi.fn().mockImplementation(() => suggestions),
+  }),
+}));
+
+vi.mock('@/modules/balances/blockchain/use-account-addresses', () => ({
+  useAccountAddresses: vi.fn().mockReturnValue({
+    addresses: computed<Record<string, string[]>>(() => ({ eth: ['0xabc'] })),
+  }),
+}));
+
+const { useAddressSuggestions } = await import('@/modules/accounts/address-book/use-address-suggestions');
+
+interface Selection {
+  address: Ref<string>;
+  cleared: () => number;
+}
+
+function mountWith(chain: string | null, address: string): { selection: Selection; unmount: () => void } {
+  const selected = ref<string>(address);
+  const clear = vi.fn().mockImplementation(() => set(selected, ''));
+
+  const { wrapper } = withSetup(() => useAddressSuggestions(() => chain, {
+    clear,
+    selected: () => get(selected),
+  }));
+
+  return {
+    selection: {
+      address: selected,
+      cleared: (): number => clear.mock.calls.length,
+    },
+    unmount: (): void => wrapper.unmount(),
+  };
+}
+
+describe('modules/accounts/address-book/useAddressSuggestions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    set(suggestions, ['0xabc', '0xdef']);
+    getAddressName.mockClear();
+  });
+
+  it('should clear an address that stops being offered for the chosen chain', async () => {
+    const { selection, unmount } = mountWith('eth', '0xabc');
+
+    set(suggestions, ['0xdef']);
+    await nextTick();
+
+    expect(selection.cleared()).toBe(1);
+    expect(get(selection.address)).toBe('');
+    unmount();
+  });
+
+  it('should keep an address the user typed themselves', async () => {
+    // It was never offered, so it dropping out of a list it was never on means nothing.
+    const { selection, unmount } = mountWith('eth', '0x999');
+
+    set(suggestions, ['0xdef']);
+    await nextTick();
+
+    expect(selection.cleared()).toBe(0);
+    expect(get(selection.address)).toBe('0x999');
+    unmount();
+  });
+
+  it('should keep the address while no chain is chosen', async () => {
+    const { selection, unmount } = mountWith(null, '0xabc');
+
+    set(suggestions, ['0xdef']);
+    await nextTick();
+
+    expect(selection.cleared()).toBe(0);
+    unmount();
+  });
+
+  it('should resolve the tracked addresses so the unnamed ones can be offered', () => {
+    const { unmount } = mountWith('eth', '');
+
+    expect(getAddressName).toHaveBeenCalledWith('0xabc', 'eth');
+    unmount();
+  });
+});

--- a/frontend/app/src/modules/accounts/address-book/use-address-suggestions.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-suggestions.ts
@@ -1,0 +1,50 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import { Blockchain } from '@rotki/common';
+import { each } from 'es-toolkit/compat';
+import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
+import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
+
+interface AddressSelection {
+  /** The address the form currently holds. */
+  readonly selected: MaybeRefOrGetter<string>;
+  /** Called when the selected address stops being offered for the chosen chain. */
+  readonly clear: () => void;
+}
+
+/**
+ * The addresses offered for a chain, which are the tracked ones that have no name yet.
+ *
+ * The list is driven by the chosen chain, so an address picked for one chain can disappear from it
+ * when the chain changes. Leaving it selected would name an address the entry no longer offers, so
+ * it is cleared: only when it was on the previous list, since an address the user typed themselves
+ * was never offered and must survive.
+ */
+export function useAddressSuggestions(
+  blockchain: MaybeRefOrGetter<string | null>,
+  address: AddressSelection,
+): ComputedRef<string[]> {
+  const { addresses } = useAccountAddresses();
+  const { getAddressName, useAddressesWithoutNames } = useAddressNameResolution();
+
+  const suggestions = useAddressesWithoutNames(blockchain);
+
+  /** Resolving every tracked address is what decides which of them are still unnamed. */
+  function fetchNames(): void {
+    const addressMap = get(addresses);
+
+    each(Blockchain, (chain) => {
+      addressMap[chain]?.forEach(address => getAddressName(address, chain));
+    });
+  }
+
+  watch(suggestions, (suggestions, oldSuggestions) => {
+    const selected = toValue(address.selected);
+    if (toValue(blockchain) && oldSuggestions.includes(selected) && !suggestions.includes(selected))
+      address.clear();
+  });
+
+  watchEffect(fetchNames);
+  onMounted(fetchNames);
+
+  return suggestions;
+}

--- a/frontend/app/src/modules/accounts/blockchain/AddressInput.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/AddressInput.spec.ts
@@ -1,0 +1,169 @@
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
+import AddressInput from '@/modules/accounts/blockchain/AddressInput.vue';
+
+const ADDRESS = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+const OTHER_ADDRESS = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65';
+
+/** Records what each field is handed, and lets the spec write to it as the user would. */
+function fieldStub(tag: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'paste', 'blur'],
+    props: ['modelValue', 'disabled', 'errorMessages'],
+    template: `<${tag} :value="modelValue" :data-errors="[errorMessages ?? []].flat().join('|')" @input="$emit('update:modelValue', $event.target.value)" />`,
+  };
+}
+
+function createWrapper(props: Record<string, unknown> = {}): VueWrapper<InstanceType<typeof AddressInput>> {
+  return mount(AddressInput, {
+    global: {
+      stubs: {
+        RuiCheckbox: {
+          emits: ['update:modelValue'],
+          props: ['modelValue', 'disabled'],
+          template: '<input type="checkbox" data-testid="multiple-toggle" @change="$emit(\'update:modelValue\', $event.target.checked)" />',
+        },
+        RuiTextArea: fieldStub('textarea'),
+        RuiTextField: fieldStub('input'),
+        WalletAddressesImport: true,
+      },
+    },
+    props: {
+      addresses: [],
+      disabled: false,
+      errorMessages: {},
+      multi: true,
+      ...props,
+    },
+  });
+}
+
+describe('modules/accounts/blockchain/AddressInput', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AddressInput>>;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  /** The messages the visible field shows, read off the stub that receives them. */
+  function messages(): string[] {
+    const value = wrapper.find('[data-testid=account-address-field]').attributes('data-errors') ?? '';
+    return value === '' ? [] : value.split('|');
+  }
+
+  async function type(value: string): Promise<void> {
+    await wrapper.find('[data-testid=account-address-field]').setValue(value);
+    await nextTick();
+  }
+
+  async function useMultiple(): Promise<void> {
+    await wrapper.find('[data-testid=multiple-toggle]').setValue(true);
+    await nextTick();
+  }
+
+  /** Bound as a property rather than an attribute, so it is read off the element. */
+  function shownValue(): string {
+    return wrapper.find<HTMLInputElement>('[data-testid=account-address-field]').element.value;
+  }
+
+  function lastAddresses(): string[] | undefined {
+    return wrapper.emitted<[string[]]>('update:addresses')?.at(-1)?.[0];
+  }
+
+  it('should reject an empty address', async () => {
+    wrapper = createWrapper();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+    await nextTick();
+
+    expect(messages()).toEqual(['account_form.validation.address_non_empty']);
+  });
+
+  it('should accept an entered address', async () => {
+    wrapper = createWrapper();
+    await type(ADDRESS);
+
+    expect(await wrapper.vm.validate()).toBe(true);
+    await nextTick();
+
+    expect(messages()).toEqual([]);
+    expect(lastAddresses()).toEqual([ADDRESS]);
+  });
+
+  it('should reject an empty list once several addresses are being entered', async () => {
+    wrapper = createWrapper();
+    await useMultiple();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+    await nextTick();
+
+    // The same message, reported against whichever of the two fields is on screen.
+    expect(messages()).toEqual(['account_form.validation.address_non_empty']);
+  });
+
+  it('should not require the single address while several are being entered', async () => {
+    wrapper = createWrapper();
+    await useMultiple();
+    await type(ADDRESS);
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should split a list on commas and newlines', async () => {
+    wrapper = createWrapper();
+    await useMultiple();
+    await type(`${ADDRESS},\n${OTHER_ADDRESS}`);
+
+    expect(lastAddresses()).toEqual([ADDRESS, OTHER_ADDRESS]);
+  });
+
+  it('should drop a repeated address, whatever its case', async () => {
+    wrapper = createWrapper();
+    await useMultiple();
+    await type(`${ADDRESS}\n${ADDRESS.toLowerCase()}`);
+
+    // The first spelling wins, so the address is offered back as the user first wrote it.
+    expect(lastAddresses()).toEqual([ADDRESS]);
+  });
+
+  it('should show the entry it was opened with', async () => {
+    wrapper = createWrapper({ addresses: [ADDRESS] });
+    await nextTick();
+
+    expect(shownValue()).toBe(ADDRESS);
+  });
+
+  it('should leave an entered address behind when the entry mode changes', async () => {
+    wrapper = createWrapper();
+    await type(ADDRESS);
+    await useMultiple();
+
+    // The list starts empty on the way in, while the address that was already entered stays in the
+    // payload the parent holds: the field on screen and what would be saved disagree until the
+    // list is edited.
+    expect(shownValue()).toBe('');
+    expect(lastAddresses()).toEqual([ADDRESS]);
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should show the address error the backend reports against the single field', async () => {
+    const errorMessages: ValidationErrors = { address: ['Account already exists'] };
+    // Seeded with no address: writing one clears the errors the parent is holding, which is what
+    // an edit is supposed to do, so an address and a stale error cannot coexist here.
+    wrapper = createWrapper({ errorMessages });
+    await nextTick();
+
+    expect(messages()).toEqual(['Account already exists']);
+  });
+
+  it('should show the same error against the list, which the backend does not name', async () => {
+    const errorMessages: ValidationErrors = { address: ['Account already exists'] };
+    wrapper = createWrapper({ errorMessages, forceMultiple: true });
+    await nextTick();
+
+    // One flat key comes back for both fields, so it has to be fanned onto whichever is on screen.
+    expect(messages()).toEqual(['Account already exists']);
+  });
+});

--- a/frontend/app/src/modules/accounts/blockchain/AddressInput.vue
+++ b/frontend/app/src/modules/accounts/blockchain/AddressInput.vue
@@ -228,7 +228,7 @@ defineExpose({
         data-testid="account-address-field"
         variant="outlined"
         color="primary"
-        class="account-form__address flex-1"
+        class="flex-1"
         :label="t('common.account')"
         :rules="rules"
         autocomplete="off"

--- a/frontend/app/src/modules/accounts/blockchain/AddressInput.vue
+++ b/frontend/app/src/modules/accounts/blockchain/AddressInput.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import useVuelidate from '@vuelidate/core';
-import { helpers, requiredIf } from '@vuelidate/validators';
-import { isEmpty } from 'es-toolkit/compat';
+import {
+  addressEntrySchema,
+  type AddressFormState,
+  isXpubPrefix,
+  parseAddressEntries,
+  replaceSelection,
+} from '@/modules/accounts/blockchain/address-entries';
 import WalletAddressesImport from '@/modules/accounts/blockchain/WalletAddressesImport.vue';
 import { trimOnPaste } from '@/modules/core/common/helpers/event';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { toServerErrors } from '@/modules/core/form/server-errors';
+import { useForm } from '@/modules/core/form/use-form';
 
 const addresses = defineModel<string[]>('addresses', { required: true });
 const errorMessages = defineModel<ValidationErrors>('errorMessages', { required: true });
@@ -23,26 +29,22 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const address = ref<string>('');
-const userAddresses = ref<string>('');
 const multiple = ref<boolean>(forceMultiple);
 
-const entries = computed(() => {
-  const allAddresses = get(userAddresses)
-    .split(/[\n,]+/)
-    .map(value => value.trim())
-    .filter(entry => entry.length > 0);
+const schema = computed<ZodType>(() => addressEntrySchema(
+  t('account_form.validation.address_non_empty'),
+  get(multiple),
+));
 
-  const entries: Record<string, string> = {};
-  for (const address of allAddresses) {
-    const lowerCase = address.toLocaleLowerCase();
-    if (entries[lowerCase])
-      continue;
-
-    entries[lowerCase] = address;
-  }
-  return Object.values(entries);
+const { errors: fieldErrors, setServerErrors, state, touch, validate } = useForm<AddressFormState, AddressFormState>({
+  initial: (): AddressFormState => ({ address: '', userAddresses: '' }),
+  schema,
+  // The addresses are handed to the parent as they are entered; there is nothing to submit here.
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): AddressFormState => ({ ...state }),
 });
+
+const entries = computed<string[]>(() => parseAddressEntries(state.userAddresses));
 
 function onPasteMulti(event: ClipboardEvent): void {
   if (disabled)
@@ -59,21 +61,12 @@ function onPasteMulti(event: ClipboardEvent): void {
   }
 
   const { target } = event;
-  const current = get(userAddresses);
+  const current = state.userAddresses;
   const replacement = paste.replace(/,(0x)/g, ',\n0x');
 
-  if (target instanceof HTMLTextAreaElement && target.selectionStart !== target.selectionEnd) {
-    const before = current.slice(0, target.selectionStart);
-    const after = current.slice(target.selectionEnd);
-    set(userAddresses, before + replacement + after);
-  }
-  else {
-    set(userAddresses, current + replacement);
-  }
-}
-
-function isXpubPrefix(value: string): boolean {
-  return value.startsWith('xpub') || value.startsWith('ypub') || value.startsWith('zpub');
+  state.userAddresses = target instanceof HTMLTextAreaElement && target.selectionStart !== target.selectionEnd
+    ? replaceSelection(current, replacement, target.selectionStart, target.selectionEnd)
+    : current + replacement;
 }
 
 function onPasteAddress(event: ClipboardEvent): void {
@@ -90,116 +83,68 @@ function onPasteAddress(event: ClipboardEvent): void {
     return;
   }
 
-  set(address, paste);
+  state.address = paste;
 }
 
-function updateErrorMessages(newErrors: ValidationErrors): void {
-  set(errorMessages, newErrors);
+/**
+ * An edit answers whatever the backend last said about the addresses, so the errors the parent is
+ * holding go with it. The core drops the message under the field on its own; this is what stops a
+ * stale one being handed back to the next form the dialog opens.
+ */
+function updateAddresses(newAddresses: string[]): void {
+  set(errorMessages, {});
+  set(addresses, newAddresses);
 }
-
-watch(entries, addresses => updateAddresses(addresses));
-watch(address, (address) => {
-  updateAddresses(address ? [address.trim()] : []);
-});
 
 function setAddress(addresses: string[]): void {
   if (addresses.length === 1) {
     if (get(multiple)) {
-      if (!get(userAddresses))
-        set(userAddresses, addresses[0]);
+      if (!state.userAddresses)
+        state.userAddresses = addresses[0];
     }
     else {
-      set(address, addresses[0]);
+      state.address = addresses[0];
     }
   }
   else if (addresses.length === 0) {
-    set(address, '');
-    set(userAddresses, '');
+    state.address = '';
+    state.userAddresses = '';
   }
 }
+
+// The backend reports one flat `address` key for both, so its message is shown against whichever
+// field is on screen rather than being keyed to the one the state happens to call it.
+watchImmediate(errorMessages, (value) => {
+  const messages = toServerErrors(value).address ?? [];
+  setServerErrors({ address: messages, userAddresses: messages });
+}, { deep: true });
+
+watch(entries, addresses => updateAddresses(addresses));
+
+watch(() => state.address, (address) => {
+  updateAddresses(address ? [address.trim()] : []);
+});
 
 watch(addresses, addresses => setAddress(addresses));
 onMounted(() => setAddress(get(addresses)));
 
-const rules = {
-  address: {
-    required: helpers.withMessage(
-      t('account_form.validation.address_non_empty'),
-      requiredIf(logicNot(multiple)),
-    ),
-  },
-  userAddresses: {
-    required: helpers.withMessage(
-      t('account_form.validation.address_non_empty'),
-      requiredIf(logicAnd(multiple)),
-    ),
-  },
-};
-
-const errorMessagesModel = computed({
-  get() {
-    const errors = get(errorMessages);
-    return {
-      address: errors.address || '',
-      userAddresses: errors.address || '',
-    };
-  },
-  set(newErrors) {
-    const error = newErrors.address;
-    if (error) {
-      updateErrorMessages({
-        address: error,
-      });
-    }
-    else {
-      updateErrorMessages({});
-    }
-  },
-});
-
-const v$ = useVuelidate(
-  rules,
-  {
-    address,
-    userAddresses,
-  },
-  {
-    $autoDirty: true,
-    $externalResults: errorMessagesModel,
-    $stopPropagation: true,
-  },
-);
-
-function updateAddresses(newAddresses: string[]): void {
-  get(v$).$clearExternalResults();
-  set(addresses, newAddresses);
-}
-
-function validate(): Promise<boolean> {
-  return get(v$).$validate();
-}
-
-watch(errorMessages, (errors) => {
-  if (!isEmpty(errors))
-    get(v$).$validate();
-});
-
 watch(multiple, () => {
-  get(v$).$clearExternalResults();
-  set(userAddresses, '');
+  set(errorMessages, {});
+  state.userAddresses = '';
 });
 
-function updateAddressesFromWalletImport(addresses: string[]) {
+/** Waits a tick, because switching mode empties the field the imported addresses are written to. */
+function updateAddressesFromWalletImport(addresses: string[]): void {
   if (addresses.length > 1) {
     set(multiple, true);
     nextTick(() => {
-      set(userAddresses, addresses.join(',\n'));
+      state.userAddresses = addresses.join(',\n');
     });
   }
   else if (addresses.length === 1) {
     set(multiple, false);
     nextTick(() => {
-      set(address, addresses[0]);
+      state.address = addresses[0];
     });
   }
 }
@@ -224,33 +169,32 @@ defineExpose({
     <div class="flex items-start gap-2">
       <RuiTextField
         v-if="!multiple"
-        v-model="address"
+        v-model="state.address"
         data-testid="account-address-field"
         variant="outlined"
         color="primary"
         class="flex-1"
         :label="t('common.account')"
-        :rules="rules"
         autocomplete="off"
         :disabled="disabled"
-        :error-messages="toMessages(v$.address)"
+        :error-messages="fieldErrors('address')"
         @paste="onPasteAddress($event)"
-        @blur="v$.address.$touch()"
+        @update:model-value="touch('address')"
       />
       <RuiTextArea
         v-else
-        v-model="userAddresses"
+        v-model="state.userAddresses"
         data-testid="account-address-field"
         variant="outlined"
         color="primary"
         class="flex-1"
         :min-rows="forceMultiple ? (entries.length > 1 ? 4 : 2) : 5"
         :disabled="disabled"
-        :error-messages="toMessages(v$.userAddresses)"
+        :error-messages="fieldErrors('userAddresses')"
         :hint="t('account_form.labels.addresses_hint')"
         :placeholder="forceMultiple ? t('account_form.labels.btc.placeholder') : undefined"
         :label="forceMultiple ? t('account_form.labels.btc.addresses') : t('account_form.labels.addresses')"
-        @blur="v$.userAddresses.$touch()"
+        @update:model-value="touch('userAddresses')"
         @paste="onPasteMulti($event)"
       />
       <WalletAddressesImport

--- a/frontend/app/src/modules/accounts/blockchain/BtcAddressInput.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/BtcAddressInput.spec.ts
@@ -1,7 +1,7 @@
 import { Blockchain } from '@rotki/common';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
-import { nextTick } from 'vue';
+import { type ComponentPublicInstance, nextTick } from 'vue';
 import { XpubKeyType, type XpubPayload } from '@/modules/accounts/blockchain-accounts';
 import BtcAddressInput from '@/modules/accounts/blockchain/BtcAddressInput.vue';
 import { XpubPrefix } from '@/modules/accounts/xpub';
@@ -11,7 +11,7 @@ const YPUB_KEY = 'ypub6Ww3ibxVfGzLrAH1PNcjyAWPKPPjLzQ7T9Mmfa18oF5dKaPSLDB6FghfZ1
 const XPUB_KEY = 'xpub6CUGRUonZSQ4TWtTMmzXdrXDtyPWKiMJ7abWaX2ZFGvV3Gg7FbqXdRxivu1nQFCWEPa4UUgJGPkExPNm5';
 const BTC_ADDRESS = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
 
-function createWrapper(blockchain: Blockchain.BTC | Blockchain.BCH = Blockchain.BTC): VueWrapper {
+function createWrapper(blockchain: Blockchain.BTC | Blockchain.BCH = Blockchain.BTC): VueWrapper<InstanceType<typeof BtcAddressInput>> {
   return mount(BtcAddressInput, {
     global: {
       stubs: {
@@ -29,10 +29,11 @@ function createWrapper(blockchain: Blockchain.BTC | Blockchain.BCH = Blockchain.
         },
         RuiTextField: {
           emits: ['update:modelValue', 'paste', 'blur'],
-          props: ['modelValue', 'disabled'],
-          template: '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+          props: ['modelValue', 'disabled', 'errorMessages'],
+          template: '<input :value="modelValue" :data-errors="(errorMessages ?? []).join(\'|\')" @input="$emit(\'update:modelValue\', $event.target.value)" />',
         },
-        RuiTooltip: true,
+        // Renders its activator, which is where the toggle for the advanced fields lives.
+        RuiTooltip: { template: '<div><slot name="activator" /><slot /></div>' },
       },
     },
     props: {
@@ -51,7 +52,7 @@ async function lastEmittedXpub(wrapper: VueWrapper): Promise<XpubPayload | undef
 }
 
 describe('modules/accounts/blockchain/BtcAddressInput', () => {
-  let wrapper: VueWrapper;
+  let wrapper: VueWrapper<InstanceType<typeof BtcAddressInput>>;
 
   afterEach(() => {
     wrapper?.unmount();
@@ -117,6 +118,55 @@ describe('modules/accounts/blockchain/BtcAddressInput', () => {
     expect(wrapper.find('[data-testid="xpub-disambiguation"]').exists()).toBe(false);
     const payload = await lastEmittedXpub(wrapper);
     expect(payload?.xpubType).toBe(XpubKeyType.XPUB);
+  });
+
+  /** The messages the field shows, read off the stub that receives them. */
+  function messages(selector: string): string[] {
+    const value = wrapper.find(selector).attributes('data-errors') ?? '';
+    return value === '' ? [] : value.split('|');
+  }
+
+  it('should reject an empty key', async () => {
+    wrapper = createWrapper(Blockchain.BTC);
+
+    expect(await wrapper.vm.validate()).toBe(false);
+    await nextTick();
+
+    expect(messages('[data-testid=xpub-key]')).toEqual(['account_form.validation.xpub_non_empty']);
+  });
+
+  it('should accept an entered key', async () => {
+    wrapper = createWrapper(Blockchain.BTC);
+    await setXpubValue(ZPUB_KEY);
+
+    expect(await wrapper.vm.validate()).toBe(true);
+    await nextTick();
+
+    expect(messages('[data-testid=xpub-key]')).toEqual([]);
+  });
+
+  it('should reject a whitespace-only key and clear the field', async () => {
+    wrapper = createWrapper(Blockchain.BTC);
+    await setXpubValue('   ');
+
+    // The payload is assembled from the trimmed key and fed straight back into the field, so the
+    // blanks are wiped and what is left is an empty key with no payload behind it.
+    expect(await lastEmittedXpub(wrapper)).toBeUndefined();
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should show a server error reported against the derivation path', async () => {
+    wrapper = createWrapper(Blockchain.BTC);
+    await setXpubValue(ZPUB_KEY);
+    // The derivation path has a rule that always passes, which exists only to give the backend's
+    // errors for that field somewhere to render.
+    await wrapper.setProps({ errorMessages: { derivationPath: ['Invalid derivation path'] } });
+    // Emitted rather than clicked: the toggle sits in the tooltip's activator slot, where a
+    // dispatched DOM event does not reach the listener the parent bound on the stub.
+    wrapper.findComponent<ComponentPublicInstance>('[data-testid=xpub-advanced-toggle] button').vm.$emit('click');
+    await nextTick();
+
+    expect(messages('[data-testid=xpub-derivation-path]')).toEqual(['Invalid derivation path']);
   });
 
   it('should emit detected-address when a plain BTC address is entered', async () => {

--- a/frontend/app/src/modules/accounts/blockchain/BtcAddressInput.vue
+++ b/frontend/app/src/modules/accounts/blockchain/BtcAddressInput.vue
@@ -2,13 +2,13 @@
 import type { XpubPayload } from '@/modules/accounts/blockchain-accounts';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import type { BtcChains } from '@/modules/core/common/chains';
-import { Blockchain } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
-import { isEmpty } from 'es-toolkit/compat';
-import { type DetectionResult, detectXpubType, getKeyType, getPrefix, XpubPrefix } from '@/modules/accounts/xpub';
+import { z, type ZodType } from 'zod';
+import { useXpubInput, type XpubFormState } from '@/modules/accounts/blockchain/use-xpub-input';
+import { XpubPrefix } from '@/modules/accounts/xpub';
 import { trimOnPaste } from '@/modules/core/common/helpers/event';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { requiredField } from '@/modules/core/form/fields';
+import { toServerErrors } from '@/modules/core/form/server-errors';
+import { useForm } from '@/modules/core/form/use-form';
 
 interface DisambiguationOption {
   readonly value: XpubPrefix;
@@ -31,32 +31,36 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const xpubKey = ref<string>('');
-const derivationPath = ref<string>('');
-const xpubKeyPrefix = ref<XpubPrefix>(XpubPrefix.ZPUB);
 const advanced = ref<boolean>(false);
-const detectedType = ref<DetectionResult>();
-const showDisambiguation = ref<boolean>(false);
 
-const v$ = useVuelidate(
-  {
-    derivationPath: {
-      basic: () => true,
-    },
-    xpub: {
-      required: helpers.withMessage(t('account_form.validation.xpub_non_empty'), required),
-    },
+/**
+ * Only the key is validated. The derivation path had a rule that always passed, whose one purpose
+ * was to give the backend's errors for that field somewhere to render; the core keys those by
+ * field rather than by rule, so it needs nothing here.
+ */
+const schema = computed<ZodType>(() => z.object({
+  xpub: requiredField(t('account_form.validation.xpub_non_empty')),
+}));
+
+const { errors: fieldErrors, setServerErrors, state, touch, validate } = useForm<XpubFormState, XpubFormState>({
+  initial: (): XpubFormState => ({ derivationPath: '', xpub: '' }),
+  schema,
+  // The assembled payload is handed to the parent as it is typed; there is nothing to submit here.
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): XpubFormState => ({ ...state }),
+});
+
+const { detectedType, prefix, resolveDisambiguation, showDisambiguation } = useXpubInput(state, xpub, {
+  blockchain: () => blockchain,
+  disabled: () => disabled,
+  onAddressDetected: (address: string): void => {
+    emit('detected-address', address);
   },
-  {
-    derivationPath,
-    xpub,
-  },
-  {
-    $autoDirty: true,
-    $externalResults: errors,
-    $stopPropagation: true,
-  },
-);
+});
+
+watchImmediate(errors, (value) => {
+  setServerErrors(toServerErrors(value));
+}, { deep: true });
 
 const detectedHint = computed<string | undefined>(() => {
   const detected = get(detectedType);
@@ -90,107 +94,14 @@ const disambiguationOptions = computed<DisambiguationOption[]>(() => [
   },
 ]);
 
-function defaultPrefixFor(chain: BtcChains): XpubPrefix {
-  return chain === Blockchain.BCH ? XpubPrefix.XPUB : XpubPrefix.ZPUB;
-}
-
-function normalizeDerivationPath(path: string): string {
-  return path.replace(/'/g, '').replace(/\/$/, '');
-}
-
-function runDetection(value: string): void {
-  const result = detectXpubType(value);
-  set(detectedType, result);
-  set(showDisambiguation, false);
-
-  if (result === 'address') {
-    emit('detected-address', value.trim());
-    return;
-  }
-
-  if (result === XpubPrefix.YPUB || result === XpubPrefix.ZPUB) {
-    set(xpubKeyPrefix, result);
-    return;
-  }
-
-  if (result === 'ambiguous') {
-    set(xpubKeyPrefix, defaultPrefixFor(blockchain));
-    if (blockchain !== Blockchain.BCH)
-      set(showDisambiguation, true);
-  }
-}
-
-function resolveDisambiguation(choice: XpubPrefix): void {
-  set(xpubKeyPrefix, choice);
-  set(detectedType, choice);
-}
-
 function onPasteXpub(event: ClipboardEvent): void {
   if (disabled)
     return;
 
   const paste = trimOnPaste(event);
   if (paste)
-    set(xpubKey, paste);
+    state.xpub = paste;
 }
-
-function samePayload(a: XpubPayload | undefined, b: XpubPayload | undefined): boolean {
-  return a?.xpub === b?.xpub
-    && a?.xpubType === b?.xpubType
-    && a?.derivationPath === b?.derivationPath;
-}
-
-function validate(): Promise<boolean> {
-  return get(v$).$validate();
-}
-
-watch(errors, (errors) => {
-  if (!isEmpty(errors))
-    get(v$).$validate();
-});
-
-watchImmediate(xpub, (xpubVal: XpubPayload | undefined) => {
-  const nextXpub = xpubVal?.xpub ?? '';
-  const nextPath = xpubVal?.derivationPath ?? '';
-  set(xpubKey, nextXpub);
-
-  if (normalizeDerivationPath(get(derivationPath)) !== nextPath)
-    set(derivationPath, nextPath);
-
-  if (!xpubVal?.xpubType)
-    return;
-
-  const prefix = getPrefix(xpubVal.xpubType);
-  set(xpubKeyPrefix, prefix);
-  if (disabled && nextXpub)
-    set(detectedType, prefix);
-});
-
-watch(() => blockchain, (chain) => {
-  set(xpubKeyPrefix, defaultPrefixFor(chain));
-});
-
-watch(xpubKey, (newKey) => {
-  if (!newKey) {
-    set(detectedType, undefined);
-    set(showDisambiguation, false);
-    return;
-  }
-  runDetection(newKey);
-});
-
-watch([xpubKeyPrefix, xpubKey, derivationPath], ([prefix, key, path]) => {
-  const next: XpubPayload | undefined = key
-    ? {
-        derivationPath: normalizeDerivationPath(path),
-        xpub: key.trim(),
-        xpubType: getKeyType(prefix),
-      }
-    : undefined;
-
-  if (!samePayload(get(xpub), next))
-    set(xpub, next);
-});
 
 defineExpose({
   validate,
@@ -201,16 +112,17 @@ defineExpose({
   <div class="mt-2 flex flex-col gap-4">
     <div class="flex gap-4">
       <RuiTextField
-        v-model="xpubKey"
+        v-model="state.xpub"
         variant="outlined"
         color="primary"
-        class="account-form__xpub flex-1"
+        class="flex-1"
+        data-testid="xpub-key"
         :label="t('account_form.labels.btc.xpub')"
         autocomplete="off"
         :hint="detectedHint"
-        :error-messages="toMessages(v$.xpub)"
+        :error-messages="fieldErrors('xpub')"
         :disabled="disabled"
-        @blur="v$.xpub.$touch()"
+        @update:model-value="touch('xpub')"
         @paste="onPasteXpub($event)"
       />
       <div>
@@ -219,7 +131,7 @@ defineExpose({
           :open-delay="400"
         >
           <template #activator>
-            <div class="account-form__advanced">
+            <div data-testid="xpub-advanced-toggle">
               <RuiButton
                 variant="text"
                 icon
@@ -249,7 +161,7 @@ defineExpose({
         <RuiButton
           v-for="option in disambiguationOptions"
           :key="option.value"
-          :variant="xpubKeyPrefix === option.value ? 'default' : 'outlined'"
+          :variant="prefix === option.value ? 'default' : 'outlined'"
           color="primary"
           size="sm"
           :disabled="disabled"
@@ -261,7 +173,7 @@ defineExpose({
             <span>{{ option.label }}</span>
             <span
               class="text-caption"
-              :class="xpubKeyPrefix === option.value ? 'opacity-70' : 'text-rui-text-secondary'"
+              :class="prefix === option.value ? 'opacity-70' : 'text-rui-text-secondary'"
             >
               {{ option.description }}
             </span>
@@ -278,16 +190,15 @@ defineExpose({
 
     <div v-if="advanced">
       <RuiTextField
-        v-model="derivationPath"
+        v-model="state.derivationPath"
         variant="outlined"
         color="primary"
-        class="account-form__derivation-path"
+        data-testid="xpub-derivation-path"
         :label="t('account_form.labels.btc.derivation_path')"
-        :error-messages="toMessages(v$.derivationPath)"
+        :error-messages="fieldErrors('derivationPath')"
         autocomplete="off"
         :disabled="disabled"
         :hint="t('common.optional')"
-        @blur="v$.derivationPath.$touch()"
       />
     </div>
   </div>

--- a/frontend/app/src/modules/accounts/blockchain/Eth2Input.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/Eth2Input.spec.ts
@@ -1,0 +1,188 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { Eth2Validator } from '@/modules/balances/types/balances';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, describe, expect, it } from 'vitest';
+import Eth2Input from '@/modules/accounts/blockchain/Eth2Input.vue';
+
+/**
+ * The index and the public key are a mutually exclusive pair: each is required unless the other is
+ * filled, and the check trims the value it guards but not the companion it reads, so the two sides
+ * do not agree on what whitespace means. Pinned below, since a schema-level refine has to decide.
+ *
+ * Written against the vuelidate rules and carried across the zod swap unchanged apart from three
+ * deliberate flips, each marked where it is asserted.
+ */
+
+/** Was vuelidate's untranslated fallback; now a key of ours, with the same English behind it. */
+const REQUIRED_MESSAGE = 'eth2_input.validation.required';
+
+/** The stubs declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function textFieldStub(): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur'],
+    name: 'RuiTextField',
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+describe('modules/accounts/blockchain/Eth2Input', () => {
+  let wrapper: VueWrapper<InstanceType<typeof Eth2Input>>;
+
+  function createWrapper(validator: Eth2Validator = {}, errorMessages: ValidationErrors = {}): VueWrapper<InstanceType<typeof Eth2Input>> {
+    return mount(Eth2Input, {
+      global: {
+        stubs: {
+          RuiTextField: textFieldStub(),
+        },
+      },
+      props: {
+        disabled: false,
+        editMode: false,
+        errorMessages,
+        validator,
+      },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(testId: string, value: string): Promise<void> {
+    field(testId).vm.$emit('update:modelValue', value);
+    await nextTick();
+  }
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should leave the payload alone until something is typed', async () => {
+    wrapper = createWrapper();
+    await nextTick();
+
+    // The dialog above arms its unsaved-changes prompt on any change to the payload, so a form
+    // that filled in its own blanks at mount would prompt on close without the user typing.
+    expect(wrapper.emitted('update:validator')).toBeUndefined();
+
+    await edit('eth2-validator-index', '123');
+
+    // One edit hands back the whole state, blanks included. The add endpoint strips the empty
+    // fields, and an edit opens with all three already filled, so neither reaches the api.
+    expect(wrapper.emitted('update:validator')?.at(-1)).toEqual([{
+      ownershipPercentage: '',
+      publicKey: '',
+      validatorIndex: '123',
+    }]);
+  });
+
+  it('should reject an empty form and mark both sides of the pair as required', async () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.vm.validate()).toBe(false);
+    await nextTick();
+
+    expect(messages('eth2-validator-index')).toEqual([REQUIRED_MESSAGE]);
+    expect(messages('eth2-public-key')).toEqual([REQUIRED_MESSAGE]);
+    expect(messages('eth2-ownership-percentage')).toEqual([]);
+  });
+
+  it('should accept a validator index alone', async () => {
+    wrapper = createWrapper();
+    await edit('eth2-validator-index', '123');
+
+    expect(wrapper.vm.validate()).toBe(true);
+    await nextTick();
+
+    expect(messages('eth2-validator-index')).toEqual([]);
+    expect(messages('eth2-public-key')).toEqual([]);
+  });
+
+  it('should accept a public key alone', async () => {
+    wrapper = createWrapper();
+    await edit('eth2-public-key', '0xa1d1ad0714035353258038e964ae9675dc0252ee22cea896825c01458e1807bfad2f9969338798548d9858a571f7425c');
+
+    expect(wrapper.vm.validate()).toBe(true);
+    await nextTick();
+
+    expect(messages('eth2-validator-index')).toEqual([]);
+    expect(messages('eth2-public-key')).toEqual([]);
+  });
+
+  it('should reject a non-numeric validator index without also calling it missing', async () => {
+    wrapper = createWrapper();
+    await edit('eth2-validator-index', 'abc');
+
+    expect(wrapper.vm.validate()).toBe(false);
+    await nextTick();
+
+    expect(messages('eth2-validator-index')).toEqual(['eth2_input.validator_index.validation']);
+    expect(messages('eth2-public-key')).toEqual([]);
+  });
+
+  it.each([
+    ['0', false],
+    ['101', false],
+    ['-1', false],
+    ['100', true],
+    ['0.5', true],
+    ['', true],
+  ])('should treat an ownership percentage of "%s" as valid=%s', async (percentage, valid) => {
+    wrapper = createWrapper();
+    await edit('eth2-validator-index', '123');
+    await edit('eth2-ownership-percentage', percentage);
+
+    expect(wrapper.vm.validate()).toBe(valid);
+    await nextTick();
+
+    expect(messages('eth2-ownership-percentage')).toEqual(valid ? [] : ['eth2_input.ownership.validation']);
+  });
+
+  it('should show a server error that is already present at mount', async () => {
+    wrapper = createWrapper({ validatorIndex: '123' }, { validatorIndex: ['Validator 123 is already tracked'] });
+    await nextTick();
+
+    // FLIP: under vuelidate this rendered nothing. External results reached `$errors` only once the
+    // field was dirty, and the watch that revalidated on incoming errors was not immediate, so a
+    // failed save the dialog was already holding stayed invisible until something touched the field.
+    expect(messages('eth2-validator-index')).toEqual(['Validator 123 is already tracked']);
+  });
+
+  it('should show a server error that arrives after mount', async () => {
+    wrapper = createWrapper({ validatorIndex: '123' });
+    await wrapper.setProps({ errorMessages: { validatorIndex: ['Validator 123 is already tracked'] } });
+    await nextTick();
+
+    expect(messages('eth2-validator-index')).toEqual(['Validator 123 is already tracked']);
+    // FLIP: a server error no longer makes the form itself invalid, because the core keys them
+    // separately from the schema. Unobservable through the dialog, which clears the errors it holds
+    // before it validates, so a retry was never blocked by one under vuelidate either.
+    expect(wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should report both rules against a whitespace-only index, in rule order', async () => {
+    wrapper = createWrapper({ validatorIndex: ' ' });
+
+    expect(wrapper.vm.validate()).toBe(false);
+    await nextTick();
+
+    // `consistOfNumbers` guards on `!value`, and `' '` is truthy, so it fails alongside the
+    // required rule. The companion `requiredUnless` on the public key reads the index untrimmed,
+    // so whitespace counts as filled there and the key stays unflagged.
+    expect(messages('eth2-validator-index')).toEqual([
+      'eth2_input.validator_index.validation',
+      REQUIRED_MESSAGE,
+    ]);
+    expect(messages('eth2-public-key')).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/accounts/blockchain/Eth2Input.vue
+++ b/frontend/app/src/modules/accounts/blockchain/Eth2Input.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { Eth2Validator } from '@/modules/balances/types/balances';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import { consistOfNumbers } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { helpers, requiredUnless } from '@vuelidate/validators';
-import { isEmpty } from 'es-toolkit/compat';
-import { refOptional, useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import {
+  type Eth2ValidatorFormState,
+  eth2ValidatorSchema,
+  toFormState,
+} from '@/modules/accounts/blockchain/eth2-validator-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 
 const modelValue = defineModel<Eth2Validator>('validator', { required: true });
 
@@ -17,52 +18,35 @@ defineProps<{
   editMode: boolean;
 }>();
 
-const validatorIndex = refOptional(useRefPropVModel(modelValue, 'validatorIndex'), '');
-const publicKey = refOptional(useRefPropVModel(modelValue, 'publicKey'), '');
-const ownershipPercentage = refOptional(useRefPropVModel(modelValue, 'ownershipPercentage'), '');
-
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  ownershipPercentage: {
-    percentage: helpers.withMessage(
-      t('eth2_input.ownership.validation'),
-      (value: string) => !value || (Number(value) > 0 && Number(value) <= 100),
-    ),
-  },
-  publicKey: {
-    requiredUnlessIndex: requiredUnless(logicAnd(validatorIndex)),
-  },
-  validatorIndex: {
-    consistOfNumbers: helpers.withMessage(
-      t('eth2_input.validator_index.validation'),
-      (value: string) => !value || consistOfNumbers(value),
-    ),
-    requiredUnlessKey: requiredUnless(logicAnd(publicKey)),
-  },
-};
+const schema = computed<ZodType>(() => eth2ValidatorSchema({
+  ownershipPercentage: t('eth2_input.ownership.validation'),
+  required: t('eth2_input.validation.required'),
+  validatorIndex: t('eth2_input.validator_index.validation'),
+}));
 
-const v$ = useVuelidate(
-  rules,
-  {
-    ownershipPercentage,
-    publicKey,
-    validatorIndex,
+/**
+ * The payload is readonly and carries a field only once it has a value, so the form edits its own
+ * copy and hands back a whole one.
+ *
+ * Reading through a bridge rather than seeding the payload is deliberate: the dialog above arms its
+ * unsaved-changes prompt on any change to it, so a form that filled in its own blanks at mount
+ * would prompt on close without the user having typed anything.
+ */
+const formModel = computed<Eth2ValidatorFormState>({
+  get() {
+    return toFormState(get(modelValue));
   },
-  {
-    $autoDirty: true,
-    $externalResults: errorMessages,
-    $stopPropagation: true,
+  set(state: Eth2ValidatorFormState) {
+    set(modelValue, state);
   },
-);
+});
 
-function validate(): Promise<boolean> {
-  return get(v$).$validate();
-}
-
-watch(errorMessages, (errors) => {
-  if (!isEmpty(errors))
-    get(v$).$validate();
+const { errors, state, touch, validate } = useModelForm<Eth2ValidatorFormState>({
+  model: formModel,
+  schema,
+  serverErrors: errorMessages,
 });
 
 defineExpose({
@@ -74,41 +58,44 @@ defineExpose({
   <div class="grid gap-4 grid-cols-3 mt-3">
     <div class="col-span-3 md:col-span-1">
       <RuiTextField
-        v-model.trim="validatorIndex"
+        v-model.trim="state.validatorIndex"
+        data-testid="eth2-validator-index"
         variant="outlined"
         color="primary"
         :disabled="disabled || editMode"
         :label="t('common.validator_index')"
-        :error-messages="toMessages(v$.validatorIndex)"
-        @blur="v$.validatorIndex.$touch()"
+        :error-messages="errors('validatorIndex')"
+        @update:model-value="touch('validatorIndex')"
       />
     </div>
 
     <div class="col-span-3 md:col-span-2 flex gap-4">
       <span class="mt-4">{{ t('common.or') }}</span>
       <RuiTextField
-        v-model.trim="publicKey"
+        v-model.trim="state.publicKey"
+        data-testid="eth2-public-key"
         class="grow"
         variant="outlined"
         color="primary"
         :disabled="disabled || editMode"
         :label="t('eth2_input.public_key')"
-        :error-messages="toMessages(v$.publicKey)"
-        @blur="v$.publicKey.$touch()"
+        :error-messages="errors('publicKey')"
+        @update:model-value="touch('publicKey')"
       />
     </div>
 
     <div class="col-span-3 md:col-span-1">
       <RuiTextField
-        v-model.trim="ownershipPercentage"
+        v-model.trim="state.ownershipPercentage"
+        data-testid="eth2-ownership-percentage"
         variant="outlined"
         placeholder="100"
         :disabled="disabled"
         color="primary"
         :label="t('eth2_input.ownership_percentage')"
         :hint="t('eth2_input.ownership.hint')"
-        :error-messages="toMessages(v$.ownershipPercentage)"
-        @blur="v$.ownershipPercentage.$touch()"
+        :error-messages="errors('ownershipPercentage')"
+        @update:model-value="touch('ownershipPercentage')"
       >
         <template #append>
           {{ t('percentage_display.symbol') }}

--- a/frontend/app/src/modules/accounts/blockchain/address-entries.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/address-entries.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addressEntrySchema,
+  isXpubPrefix,
+  parseAddressEntries,
+  replaceSelection,
+} from '@/modules/accounts/blockchain/address-entries';
+
+const ADDRESS = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+const OTHER_ADDRESS = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65';
+const MESSAGE = 'an address is required';
+
+describe('modules/accounts/blockchain/address-entries', () => {
+  describe('parseAddressEntries', () => {
+    it('should read an empty list as no addresses', () => {
+      expect(parseAddressEntries('')).toEqual([]);
+      expect(parseAddressEntries('  \n , ')).toEqual([]);
+    });
+
+    it.each([
+      ['a comma', `${ADDRESS},${OTHER_ADDRESS}`],
+      ['a newline', `${ADDRESS}\n${OTHER_ADDRESS}`],
+      ['both', `${ADDRESS},\n${OTHER_ADDRESS}`],
+      ['surrounding space', `  ${ADDRESS} ,  ${OTHER_ADDRESS}  `],
+    ])('should split on %s', (_label, text) => {
+      expect(parseAddressEntries(text)).toEqual([ADDRESS, OTHER_ADDRESS]);
+    });
+
+    it('should keep the first spelling of a repeated address', () => {
+      // The same address in another case is the same account, and what the user wrote first is
+      // what they get back.
+      expect(parseAddressEntries(`${ADDRESS}\n${ADDRESS.toLowerCase()}`)).toEqual([ADDRESS]);
+    });
+
+    it('should keep the order the addresses were written in', () => {
+      expect(parseAddressEntries(`${OTHER_ADDRESS},${ADDRESS}`)).toEqual([OTHER_ADDRESS, ADDRESS]);
+    });
+  });
+
+  describe('isXpubPrefix', () => {
+    it.each([
+      ['xpub6CUGRUon', true],
+      ['ypub6Ww3ibxVfGz', true],
+      ['zpub6rFR7y4Q2Aij', true],
+      [ADDRESS, false],
+      ['', false],
+    ])('should read "%s" as an extended key: %s', (value, expected) => {
+      expect(isXpubPrefix(value)).toBe(expected);
+    });
+  });
+
+  describe('replaceSelection', () => {
+    it('should substitute the selected range', () => {
+      expect(replaceSelection('one,two', 'four', 4, 7)).toBe('one,four');
+    });
+
+    it('should insert at a caret with nothing selected', () => {
+      expect(replaceSelection('one,', 'two', 4, 4)).toBe('one,two');
+    });
+  });
+
+  describe('addressEntrySchema', () => {
+    function messagesFor(state: { address: string; userAddresses: string }, multiple: boolean): string[] {
+      const result = addressEntrySchema(MESSAGE, multiple).safeParse(state);
+      if (result.success)
+        return [];
+      return result.error.issues.map(issue => `${issue.path.join('.')}: ${issue.message}`);
+    }
+
+    it('should require the single address while one is being entered', () => {
+      expect(messagesFor({ address: '', userAddresses: '' }, false)).toEqual([`address: ${MESSAGE}`]);
+      expect(messagesFor({ address: ADDRESS, userAddresses: '' }, false)).toEqual([]);
+    });
+
+    it('should require the list while several are being entered', () => {
+      expect(messagesFor({ address: '', userAddresses: '' }, true)).toEqual([`userAddresses: ${MESSAGE}`]);
+      expect(messagesFor({ address: '', userAddresses: ADDRESS }, true)).toEqual([]);
+    });
+
+    it('should ignore the field that is not on screen', () => {
+      // Only one of the two is ever shown, so an empty other field is not something to report.
+      expect(messagesFor({ address: ADDRESS, userAddresses: '' }, false)).toEqual([]);
+      expect(messagesFor({ address: '', userAddresses: ADDRESS }, true)).toEqual([]);
+    });
+
+    it.each([
+      ['one address', false],
+      ['several', true],
+    ])('should treat whitespace as missing when entering %s', (_label, multiple) => {
+      expect(messagesFor({ address: '   ', userAddresses: '   ' }, multiple)).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/blockchain/address-entries.ts
+++ b/frontend/app/src/modules/accounts/blockchain/address-entries.ts
@@ -1,0 +1,55 @@
+import { z, type ZodType } from 'zod';
+
+/** The two fields the addresses are typed into, one of which is on screen at a time. */
+export interface AddressFormState {
+  address: string;
+  userAddresses: string;
+}
+
+/** An extended public key is offered instead of an address, and the parent switches mode for it. */
+export function isXpubPrefix(value: string): boolean {
+  return value.startsWith('xpub') || value.startsWith('ypub') || value.startsWith('zpub');
+}
+
+/**
+ * Reads a pasted or typed list into the addresses it names, separated by commas or newlines.
+ *
+ * A repeat is dropped case-insensitively, since the same address in a different case is the same
+ * account, and the first spelling is the one kept: it is what the user wrote.
+ */
+export function parseAddressEntries(text: string): string[] {
+  const seen = new Map<string, string>();
+
+  for (const entry of text.split(/[\n,]+/)) {
+    const address = entry.trim();
+    if (address.length === 0)
+      continue;
+
+    const key = address.toLocaleLowerCase();
+    if (!seen.has(key))
+      seen.set(key, address);
+  }
+
+  return [...seen.values()];
+}
+
+/** Replaces the selected range, so pasting over a selection substitutes it rather than appending. */
+export function replaceSelection(current: string, replacement: string, start: number, end: number): string {
+  return current.slice(0, start) + replacement + current.slice(end);
+}
+
+/**
+ * One address or a list of them, never both: whichever field is on screen is the one that has to be
+ * filled in, and the other is left alone rather than reported as missing behind the scenes.
+ */
+export function addressEntrySchema(message: string, multiple: boolean): ZodType {
+  return z.object({
+    address: z.string(),
+    userAddresses: z.string(),
+  }).superRefine((state, ctx) => {
+    const field = multiple ? 'userAddresses' : 'address';
+
+    if (state[field].trim() === '')
+      ctx.addIssue({ code: 'custom', message, path: [field] });
+  });
+}

--- a/frontend/app/src/modules/accounts/blockchain/eth2-validator-form.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/eth2-validator-form.spec.ts
@@ -1,0 +1,85 @@
+import type { Eth2Validator } from '@/modules/balances/types/balances';
+import { describe, expect, it } from 'vitest';
+import { eth2ValidatorSchema, isValidOwnershipPercentage } from '@/modules/accounts/blockchain/eth2-validator-form';
+
+const MESSAGES = {
+  ownershipPercentage: 'ownership',
+  required: 'required',
+  validatorIndex: 'numeric',
+};
+
+const schema = eth2ValidatorSchema(MESSAGES);
+
+/** Messages for one field, in the order the schema reports them. */
+function messagesFor(value: Eth2Validator, field: keyof Eth2Validator): string[] {
+  const result = schema.safeParse(value);
+  if (result.success)
+    return [];
+  return result.error.issues.filter(issue => issue.path.join('.') === field).map(issue => issue.message);
+}
+
+describe('modules/accounts/blockchain/eth2-validator-form', () => {
+  describe('isValidOwnershipPercentage', () => {
+    it.each([
+      ['', true],
+      ['100', true],
+      ['0.5', true],
+      ['0', false],
+      ['101', false],
+      ['-1', false],
+      ['abc', false],
+    ])('should treat "%s" as %s', (value, valid) => {
+      expect(isValidOwnershipPercentage(value)).toBe(valid);
+    });
+  });
+
+  describe('the identifier pair', () => {
+    it('should require an identifier when neither is given', () => {
+      expect(messagesFor({}, 'validatorIndex')).toEqual([MESSAGES.required]);
+      expect(messagesFor({}, 'publicKey')).toEqual([MESSAGES.required]);
+    });
+
+    it('should report a field the payload has not got yet as missing, not as mistyped', () => {
+      // An untouched form holds no key at all. Requiring the type here would fail the schema on a
+      // field bound to no message of its own and block the save with nothing on screen.
+      expect(messagesFor({}, 'ownershipPercentage')).toEqual([]);
+      expect(schema.safeParse({ validatorIndex: '42' }).success).toBe(true);
+    });
+
+    it.each([
+      ['an index', { validatorIndex: '42' }],
+      ['a public key', { publicKey: '0xabc' }],
+      ['both', { publicKey: '0xabc', validatorIndex: '42' }],
+    ])('should accept %s', (_label, value) => {
+      expect(schema.safeParse(value).success).toBe(true);
+    });
+
+    it('should report a non-numeric index without also reporting it as missing', () => {
+      expect(messagesFor({ validatorIndex: 'abc' }, 'validatorIndex')).toEqual([MESSAGES.validatorIndex]);
+      expect(messagesFor({ validatorIndex: 'abc' }, 'publicKey')).toEqual([]);
+    });
+
+    it('should report both rules against a whitespace-only index, in rule order', () => {
+      const value = { validatorIndex: ' ' };
+
+      expect(messagesFor(value, 'validatorIndex')).toEqual([MESSAGES.validatorIndex, MESSAGES.required]);
+      // The companion check reads the index as typed, so whitespace counts as filled for the key.
+      expect(messagesFor(value, 'publicKey')).toEqual([]);
+    });
+  });
+
+  describe('ownership percentage', () => {
+    it('should reject a percentage outside the range even when the identifier is fine', () => {
+      expect(messagesFor({ ownershipPercentage: '101', validatorIndex: '42' }, 'ownershipPercentage'))
+        .toEqual([MESSAGES.ownershipPercentage]);
+    });
+
+    it('should report the identifier and the percentage together', () => {
+      const value = { ownershipPercentage: '0' };
+
+      expect(messagesFor(value, 'validatorIndex')).toEqual([MESSAGES.required]);
+      expect(messagesFor(value, 'publicKey')).toEqual([MESSAGES.required]);
+      expect(messagesFor(value, 'ownershipPercentage')).toEqual([MESSAGES.ownershipPercentage]);
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/blockchain/eth2-validator-form.ts
+++ b/frontend/app/src/modules/accounts/blockchain/eth2-validator-form.ts
@@ -1,0 +1,89 @@
+import type { Eth2Validator } from '@/modules/balances/types/balances';
+import { consistOfNumbers } from '@rotki/common';
+import { z, type ZodType } from 'zod';
+
+/**
+ * What the form edits. The payload holds the same three fields, but readonly and only once each has
+ * a value, so the form cannot edit it in place and keeps its own mutable copy.
+ */
+export interface Eth2ValidatorFormState {
+  ownershipPercentage: string;
+  publicKey: string;
+  validatorIndex: string;
+}
+
+/** An absent field edits as empty text. */
+export function toFormState(validator: Eth2Validator): Eth2ValidatorFormState {
+  return {
+    ownershipPercentage: validator.ownershipPercentage ?? '',
+    publicKey: validator.publicKey ?? '',
+    validatorIndex: validator.validatorIndex ?? '',
+  };
+}
+
+export interface Eth2ValidatorMessages {
+  ownershipPercentage: string;
+  required: string;
+  validatorIndex: string;
+}
+
+/** Blank means "the default 100%"; anything else has to land inside the range. */
+export function isValidOwnershipPercentage(value: string): boolean {
+  return !value || (Number(value) > 0 && Number(value) <= 100);
+}
+
+interface FieldIssue {
+  message: string;
+  path: string;
+}
+
+/**
+ * The index and the public key identify the same validator, so each is required only while the
+ * other is blank.
+ *
+ * The old rule trimmed the field it guarded but read its companion as typed, so a whitespace-only
+ * entry counts as filled for the other field while still failing its own check. Kept: the two sides
+ * are not interchangeable, and the fields trim on input, so only a seeded payload can get there.
+ */
+function identifierIssues(validatorIndex: string, publicKey: string, messages: Eth2ValidatorMessages): FieldIssue[] {
+  const issues: FieldIssue[] = [];
+
+  // Reported in the order the vuelidate rules were declared: a field renders every message it
+  // collects, and the order is what the user reads.
+  if (validatorIndex && !consistOfNumbers(validatorIndex))
+    issues.push({ message: messages.validatorIndex, path: 'validatorIndex' });
+
+  if (validatorIndex.trim() === '' && publicKey === '')
+    issues.push({ message: messages.required, path: 'validatorIndex' });
+
+  if (publicKey.trim() === '' && validatorIndex === '')
+    issues.push({ message: messages.required, path: 'publicKey' });
+
+  return issues;
+}
+
+/**
+ * A validator is identified either by its index or by its public key, so neither field can be
+ * required on its own. The pair is checked on the object rather than per field, which is also what
+ * keeps the two checks from depending on each other's validity.
+ *
+ * Each field is optional here because the payload leaves it out until it has a value, and an
+ * untouched form must not be reported as holding the wrong type: a structural failure on a field
+ * bound to no message would block the save with nothing on screen.
+ */
+export function eth2ValidatorSchema(messages: Eth2ValidatorMessages): ZodType {
+  return z.object({
+    ownershipPercentage: z.string().optional(),
+    publicKey: z.string().optional(),
+    validatorIndex: z.string().optional(),
+  }).superRefine((state, ctx) => {
+    const ownershipPercentage = state.ownershipPercentage ?? '';
+    const issues = identifierIssues(state.validatorIndex ?? '', state.publicKey ?? '', messages);
+
+    if (!isValidOwnershipPercentage(ownershipPercentage))
+      issues.push({ message: messages.ownershipPercentage, path: 'ownershipPercentage' });
+
+    for (const { message, path } of issues)
+      ctx.addIssue({ code: 'custom', message, path: [path] });
+  });
+}

--- a/frontend/app/src/modules/accounts/blockchain/use-xpub-input.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-xpub-input.ts
@@ -1,0 +1,144 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { XpubPayload } from '@/modules/accounts/blockchain-accounts';
+import type { BtcChains } from '@/modules/core/common/chains';
+import { Blockchain } from '@rotki/common';
+import { type DetectionResult, detectXpubType, getKeyType, getPrefix, XpubPrefix } from '@/modules/accounts/xpub';
+
+/** The two fields the user types into. The payload is assembled from them and the chosen prefix. */
+export interface XpubFormState {
+  derivationPath: string;
+  xpub: string;
+}
+
+interface XpubInputOptions {
+  readonly blockchain: MaybeRefOrGetter<BtcChains>;
+  /** An existing account is shown read-only, where the type is stated rather than detected. */
+  readonly disabled: MaybeRefOrGetter<boolean>;
+  /** Pasting a plain address rather than a key is handled by the parent, which switches mode. */
+  readonly onAddressDetected: (address: string) => void;
+}
+
+interface XpubInputReturn {
+  readonly prefix: Readonly<Ref<XpubPrefix>>;
+  readonly detectedType: Readonly<Ref<DetectionResult | undefined>>;
+  readonly showDisambiguation: Readonly<Ref<boolean>>;
+  /** Records the address type the user picked when the key alone does not say which it is. */
+  readonly resolveDisambiguation: (choice: XpubPrefix) => void;
+}
+
+/** Bitcoin cash has no segwit, so a bare key there can only be legacy. */
+function defaultPrefixFor(chain: BtcChains): XpubPrefix {
+  return chain === Blockchain.BCH ? XpubPrefix.XPUB : XpubPrefix.ZPUB;
+}
+
+/** The apostrophes and the trailing separator are ours to drop; the backend takes neither. */
+function normalizeDerivationPath(path: string): string {
+  return path.replace(/'/g, '').replace(/\/$/, '');
+}
+
+function samePayload(a: XpubPayload | undefined, b: XpubPayload | undefined): boolean {
+  return a?.xpub === b?.xpub
+    && a?.xpubType === b?.xpubType
+    && a?.derivationPath === b?.derivationPath;
+}
+
+/**
+ * Keeps the xpub payload and the fields it is typed into in step.
+ *
+ * The address type is read off the key where its prefix says which one it is, and asked for where
+ * it does not. It is not part of the form state, because the user picks it from a prompt rather
+ * than typing it, but it does belong to the payload, so a change to it rewrites that.
+ */
+export function useXpubInput(
+  state: XpubFormState,
+  model: Ref<XpubPayload | undefined>,
+  options: XpubInputOptions,
+): XpubInputReturn {
+  const { blockchain, disabled, onAddressDetected } = options;
+
+  const prefix = shallowRef<XpubPrefix>(defaultPrefixFor(toValue(blockchain)));
+  const detectedType = shallowRef<DetectionResult>();
+  const showDisambiguation = shallowRef<boolean>(false);
+
+  function runDetection(value: string): void {
+    const result = detectXpubType(value);
+    set(detectedType, result);
+    set(showDisambiguation, false);
+
+    if (result === 'address') {
+      onAddressDetected(value.trim());
+      return;
+    }
+
+    if (result === XpubPrefix.YPUB || result === XpubPrefix.ZPUB) {
+      set(prefix, result);
+      return;
+    }
+
+    if (result === 'ambiguous') {
+      set(prefix, defaultPrefixFor(toValue(blockchain)));
+      if (toValue(blockchain) !== Blockchain.BCH)
+        set(showDisambiguation, true);
+    }
+  }
+
+  // The payload is the source of truth, so what it holds is written back into the fields. The
+  // derivation path is only overwritten when it means something different, or every apostrophe
+  // would be stripped from under the user as they type.
+  watchImmediate(model, (payload) => {
+    state.xpub = payload?.xpub ?? '';
+
+    const path = payload?.derivationPath ?? '';
+    if (normalizeDerivationPath(state.derivationPath) !== path)
+      state.derivationPath = path;
+
+    if (!payload?.xpubType)
+      return;
+
+    const detected = getPrefix(payload.xpubType);
+    set(prefix, detected);
+    // A read-only field detects nothing, so the type it was saved with is stated instead.
+    if (toValue(disabled) && payload.xpub)
+      set(detectedType, detected);
+  });
+
+  watch(() => toValue(blockchain), (chain) => {
+    set(prefix, defaultPrefixFor(chain));
+  });
+
+  watch(() => state.xpub, (key) => {
+    if (!key) {
+      set(detectedType, undefined);
+      set(showDisambiguation, false);
+      return;
+    }
+    runDetection(key);
+  });
+
+  watch([
+    prefix,
+    (): string => state.xpub,
+    (): string => state.derivationPath,
+  ], ([prefix, key, path]): void => {
+    const next: XpubPayload | undefined = key
+      ? {
+          derivationPath: normalizeDerivationPath(path),
+          xpub: key.trim(),
+          xpubType: getKeyType(prefix),
+        }
+      : undefined;
+
+    if (!samePayload(get(model), next))
+      set(model, next);
+  });
+
+  return {
+    detectedType: readonly(detectedType),
+    prefix: readonly(prefix),
+    resolveDisambiguation: (choice: XpubPrefix): void => {
+      set(prefix, choice);
+      set(detectedType, choice);
+    },
+    showDisambiguation: readonly(showDisambiguation),
+  };
+}

--- a/frontend/app/src/modules/accounts/management/AccountForm.spec.ts
+++ b/frontend/app/src/modules/accounts/management/AccountForm.spec.ts
@@ -1,0 +1,110 @@
+import { Blockchain } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { XpubKeyType } from '@/modules/accounts/blockchain-accounts';
+import { type AccountManageState, createNewBlockchainAccount } from '@/modules/accounts/blockchain/use-account-manage';
+import AccountForm from '@/modules/accounts/management/AccountForm.vue';
+
+/**
+ * `AccountForm.validate()` falls back to `true` when the selected child does not expose a
+ * `validate` method, so a child that stops exposing it under that exact name sends every account
+ * save through unvalidated, with no error and nothing but a debug log. Typecheck does not catch it
+ * either. These tests pin the delegation for all four branches: each asserts the child's `false`
+ * comes back out, which is precisely what the fail-open path cannot produce.
+ */
+
+const inputValidate = vi.fn<() => Promise<boolean>>();
+
+/** The leaf inputs are stubbed down to the one thing the intermediate forms call on them. */
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    methods: { validate: inputValidate },
+    name,
+    template: '<div />',
+  };
+}
+
+function createWrapper(modelValue: AccountManageState): VueWrapper<InstanceType<typeof AccountForm>> {
+  return mount(AccountForm, {
+    global: {
+      stubs: {
+        AccountDataInput: true,
+        AccountSelector: true,
+        AddressInput: inputStub('AddressInput'),
+        BtcAddressInput: inputStub('BtcAddressInput'),
+        Eth2Input: inputStub('Eth2Input'),
+        ModuleActivator: true,
+      },
+    },
+    props: {
+      chainIds: [],
+      errorMessages: {},
+      loading: false,
+      modelValue,
+    },
+  });
+}
+
+function xpubAccount(): AccountManageState {
+  return {
+    chain: Blockchain.BTC,
+    data: {
+      tags: null,
+      xpub: {
+        derivationPath: '',
+        xpub: '',
+        xpubType: XpubKeyType.ZPUB,
+      },
+    },
+    mode: 'edit',
+    type: 'xpub',
+  };
+}
+
+function validatorAccount(): AccountManageState {
+  return {
+    chain: Blockchain.ETH2,
+    data: {},
+    mode: 'edit',
+    type: 'validator',
+  };
+}
+
+function groupAccount(): AccountManageState {
+  return {
+    category: 'evm',
+    chain: undefined,
+    data: {
+      address: '0x9531C059098e3d194fF87FebB587aB07B30B1306',
+      tags: null,
+    },
+    mode: 'edit',
+    type: 'group',
+  };
+}
+
+describe('modules/accounts/management/AccountForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AccountForm>>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    inputValidate.mockReset();
+    inputValidate.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it.each([
+    ['a blockchain account', createNewBlockchainAccount],
+    ['an account group', groupAccount],
+    ['an xpub', xpubAccount],
+    ['a validator', validatorAccount],
+  ])('should report the rejection raised by the form for %s', async (_label, model) => {
+    wrapper = createWrapper(model());
+
+    expect(await wrapper.vm.validate()).toBe(false);
+    expect(inputValidate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/src/modules/accounts/management/inputs/AccountDataInput.vue
+++ b/frontend/app/src/modules/accounts/management/inputs/AccountDataInput.vue
@@ -19,7 +19,6 @@ const { t } = useI18n({ useScope: 'global' });
     data-testid="account-label-field"
     color="primary"
     variant="outlined"
-    class="account-form__label"
     :label="t('common.name')"
     :disabled="disabled"
   />

--- a/frontend/app/src/modules/accounts/management/types/AddressAccountForm.vue
+++ b/frontend/app/src/modules/accounts/management/types/AddressAccountForm.vue
@@ -120,7 +120,8 @@ const showWalletImport = computed<boolean>(() => {
   return isEvm(model.chain) || model.chain === 'all';
 });
 
-function validate(): Promise<boolean> {
+/** The input validates synchronously now; the account form still awaits every child alike. */
+async function validate(): Promise<boolean> {
   assert(isDefined(address));
   return get(address).validate();
 }

--- a/frontend/app/src/modules/accounts/management/types/AgnosticAddressAccountForm.vue
+++ b/frontend/app/src/modules/accounts/management/types/AgnosticAddressAccountForm.vue
@@ -69,7 +69,8 @@ const addresses = computed<string[]>({
   },
 });
 
-function validate(): Promise<boolean> {
+/** The input validates synchronously now; the account form still awaits every child alike. */
+async function validate(): Promise<boolean> {
   assert(isDefined(address));
   return get(address).validate();
 }

--- a/frontend/app/src/modules/accounts/management/types/BtcAccountForm.vue
+++ b/frontend/app/src/modules/accounts/management/types/BtcAccountForm.vue
@@ -71,7 +71,8 @@ const label = computed<string>({
   },
 });
 
-function validate(): Promise<boolean> {
+/** The input validates synchronously now; the account form still awaits every child alike. */
+async function validate(): Promise<boolean> {
   assert(isDefined(input));
   return get(input).validate();
 }

--- a/frontend/app/src/modules/accounts/management/types/ValidatorAccountForm.vue
+++ b/frontend/app/src/modules/accounts/management/types/ValidatorAccountForm.vue
@@ -20,7 +20,8 @@ const validator = useRefPropVModel(modelValue, 'data');
 
 const input = useTemplateRef<ComponentExposed<typeof Eth2Input>>('input');
 
-function validate(): Promise<boolean> {
+/** The input validates synchronously now; the account form still awaits every child alike. */
+async function validate(): Promise<boolean> {
   assert(isDefined(input));
   return get(input).validate();
 }

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalancesDialog.vue
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalancesDialog.vue
@@ -65,10 +65,12 @@ function notifyTabChange(payload: ManualBalance | RawManualBalance): void {
  * Field-level errors go back to the form so it can mark the offending inputs; a plain string has no
  * field to attach to and is surfaced as a message instead.
  */
-async function reportSaveFailure(message: string | ValidationErrors, formRef: ManualBalanceForm): Promise<void> {
+function reportSaveFailure(message: string | ValidationErrors, formRef: ManualBalanceForm): void {
   if (typeof message !== 'string') {
     set(errorMessages, message);
-    await formRef?.validate();
+    // The form renders the errors as they arrive; this only reveals the fields the user has not
+    // touched yet, so a rejected save marks every offending input rather than the visited ones.
+    formRef?.validate();
     return;
   }
 
@@ -85,7 +87,7 @@ async function save(): Promise<boolean> {
     return false;
 
   const formRef = get(form);
-  const valid = await formRef?.validate();
+  const valid = formRef?.validate();
   if (!valid)
     return false;
 
@@ -103,7 +105,7 @@ async function save(): Promise<boolean> {
   }
 
   if (status.message)
-    await reportSaveFailure(status.message, formRef);
+    reportSaveFailure(status.message, formRef);
 
   set(loading, false);
   return false;

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalancesForm.spec.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalancesForm.spec.ts
@@ -1,0 +1,251 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComponentPublicInstance } from 'vue';
+import type { ManualBalance, RawManualBalance } from '@/modules/balances/types/manual-balances';
+import { bigNumberify } from '@rotki/common';
+import { type ModelFormHarness, mountModelForm } from '@test/utils/model-form-harness';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BalanceType } from '@/modules/balances/types/balances';
+
+const manualLabels = ref<string[]>([]);
+const assetInfo = ref<{ evmChain?: string }>({});
+const tradeLocations = ref<{ identifier: string }[]>([]);
+
+vi.mock('@/modules/balances/manual/use-manual-balance-data', () => ({
+  useManualBalanceData: vi.fn().mockReturnValue({
+    manualLabels: computed<string[]>(() => get(manualLabels)),
+  }),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn().mockReturnValue({
+    getAssetInfo: vi.fn().mockImplementation(() => get(assetInfo)),
+  }),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-management-api', () => ({
+  useAssetManagementApi: vi.fn().mockReturnValue({
+    getCustomAssetTypes: vi.fn().mockResolvedValue([]),
+  }),
+}));
+
+// Reactive rather than a plain object: `storeToRefs` only picks up a key whose raw value is a ref,
+// and only hands back the array through a proxy that unwraps it.
+vi.mock('@/modules/core/common/use-location-store', () => ({
+  useLocationStore: vi.fn().mockImplementation(() => reactive({
+    tradeLocations: computed(() => get(tradeLocations)),
+  })),
+}));
+
+const ManualBalancesForm = (await import('@/modules/accounts/manual-balances/ManualBalancesForm.vue')).default;
+
+/** The stubs declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function fieldStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled', 'label', 'chain'],
+    template: '<div />',
+  };
+}
+
+const STUBS = {
+  AmountInput: fieldStub('AmountInput'),
+  AssetSelect: fieldStub('AssetSelect'),
+  BalanceTypeInput: fieldStub('BalanceTypeInput'),
+  CustomAssetFormDialog: true,
+  LocationSelector: fieldStub('LocationSelector'),
+  ManualBalancesPriceForm: true,
+  RuiButton: true,
+  RuiIcon: true,
+  RuiTextField: fieldStub('RuiTextField'),
+  RuiTooltip: true,
+  TagInput: fieldStub('TagInput'),
+};
+
+/** What the balances page hands the dialog for a new entry: a zero amount and a default location. */
+function payload(overrides: Partial<RawManualBalance> = {}): RawManualBalance {
+  return {
+    amount: bigNumberify(0),
+    asset: '',
+    balanceType: BalanceType.ASSET,
+    label: '',
+    location: 'external',
+    tags: null,
+    ...overrides,
+  };
+}
+
+function filled(): RawManualBalance {
+  return payload({
+    amount: bigNumberify(10),
+    asset: 'ETH',
+    label: 'my wallet',
+    location: 'external',
+  });
+}
+
+describe('modules/accounts/manual-balances/ManualBalancesForm', () => {
+  let harness: ModelFormHarness<RawManualBalance | ManualBalance>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    set(manualLabels, []);
+    set(assetInfo, {});
+    set(tradeLocations, []);
+  });
+
+  afterEach(() => {
+    harness?.wrapper.unmount();
+  });
+
+  function createHarness(
+    value: RawManualBalance | ManualBalance = payload(),
+    errors: Record<string, string[]> = {},
+  ): ModelFormHarness<RawManualBalance | ManualBalance> {
+    return mountModelForm<RawManualBalance | ManualBalance>(ManualBalancesForm, {
+      errors,
+      global: { stubs: STUBS },
+      payload: value,
+      props: { submitting: false },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return harness.wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(testId: string, value: unknown): Promise<void> {
+    field(testId).vm.$emit('update:modelValue', value);
+    await nextTick();
+  }
+
+  it('should reject a new balance with nothing filled in', async () => {
+    harness = createHarness();
+
+    expect(await harness.validate()).toBe(false);
+    await nextTick();
+
+    expect(messages('manual-balances-form-label')).toEqual(['manual_balances_form.validation.label_empty']);
+    expect(messages('manual-balances-form-asset')).toEqual(['manual_balances_form.validation.asset']);
+    // The page opens the dialog with a zero amount and a default location, so neither of those two
+    // rules can fire until the user clears the field.
+    expect(messages('manual-balances-form-amount')).toEqual([]);
+    expect(messages('manual-balances-form-location')).toEqual([]);
+  });
+
+  it('should reject a cleared amount and location', async () => {
+    harness = createHarness(filled());
+
+    await edit('manual-balances-form-amount', '');
+    await edit('manual-balances-form-location', '');
+
+    expect(await harness.validate()).toBe(false);
+    await nextTick();
+
+    expect(messages('manual-balances-form-amount')).toEqual(['manual_balances_form.validation.amount']);
+    // FLIP: the rule carried no message of its own, so vuelidate's untranslated "Value is required"
+    // showed here. It has a key of its own now, saying which field is meant.
+    expect(messages('manual-balances-form-location')).toEqual(['manual_balances_form.validation.location']);
+  });
+
+  it('should accept a filled balance', async () => {
+    harness = createHarness(filled());
+
+    expect(await harness.validate()).toBe(true);
+    await nextTick();
+
+    expect(messages('manual-balances-form-label')).toEqual([]);
+  });
+
+  it('should reject a label another balance already uses', async () => {
+    set(manualLabels, ['my wallet']);
+    harness = createHarness(filled());
+
+    expect(await harness.validate()).toBe(false);
+    await nextTick();
+
+    expect(messages('manual-balances-form-label')).toEqual([
+      'manual_balances_form.validation.label_exists::my wallet',
+    ]);
+  });
+
+  it('should let an edited balance keep its own label', async () => {
+    set(manualLabels, ['my wallet']);
+    harness = createHarness({ ...filled(), identifier: 4 });
+
+    // The uniqueness check is skipped entirely while editing, so the label it already holds - and
+    // any other taken one - passes.
+    expect(await harness.validate()).toBe(true);
+    await nextTick();
+
+    expect(messages('manual-balances-form-label')).toEqual([]);
+  });
+
+  it('should suggest the location that matches the asset chain', async () => {
+    set(assetInfo, { evmChain: 'arbitrum_one' });
+    set(tradeLocations, [{ identifier: 'arbitrum one' }]);
+    harness = createHarness();
+
+    await edit('manual-balances-form-asset', 'ARB');
+
+    expect(harness.model().location).toBe('arbitrum one');
+  });
+
+  it('should not overrule a location the user chose', async () => {
+    set(assetInfo, { evmChain: 'arbitrum_one' });
+    set(tradeLocations, [{ identifier: 'arbitrum one' }]);
+    harness = createHarness();
+
+    await edit('manual-balances-form-location', 'kraken');
+    await edit('manual-balances-form-asset', 'ARB');
+
+    expect(harness.model().location).toBe('kraken');
+  });
+
+  it('should not suggest a location while editing', async () => {
+    set(assetInfo, { evmChain: 'arbitrum_one' });
+    set(tradeLocations, [{ identifier: 'arbitrum one' }]);
+    harness = createHarness({ ...filled(), identifier: 4 });
+
+    await edit('manual-balances-form-asset', 'ARB');
+
+    expect(harness.model().location).toBe('external');
+  });
+
+  it('should arm the unsaved-changes prompt on an edit, however early', async () => {
+    harness = createHarness();
+
+    // FLIP: `useFormStateWatcher` installed its watcher behind a 500 ms timer and never saw an
+    // edit made before it arrived.
+    await edit('manual-balances-form-label', 'my wallet');
+
+    expect(harness.stateUpdated()).toBe(true);
+  });
+
+  it('should show a server error that is already present at mount', async () => {
+    harness = createHarness(filled(), { label: ['Label is already taken'] });
+    await nextTick();
+
+    // FLIP: external results reached `$errors` only once the field was dirty, which is why the
+    // dialog validates again after a failed save.
+    expect(messages('manual-balances-form-label')).toEqual(['Label is already taken']);
+  });
+
+  it('should write an edit back to the payload the dialog saves', async () => {
+    harness = createHarness();
+
+    await edit('manual-balances-form-label', 'my wallet');
+    await edit('manual-balances-form-amount', '25');
+
+    expect(harness.model().label).toBe('my wallet');
+    expect(harness.model().amount.toString()).toBe('25');
+  });
+});

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalancesForm.vue
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalancesForm.vue
@@ -1,18 +1,20 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { ManualBalance, RawManualBalance } from '@/modules/balances/types/manual-balances';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
+import {
+  type ManualBalanceFormState,
+  manualBalanceSchema,
+  toFormState,
+  toPayload,
+} from '@/modules/accounts/manual-balances/manual-balance-form';
 import ManualBalancesPriceForm from '@/modules/accounts/manual-balances/ManualBalancesPriceForm.vue';
+import { useSuggestedLocation } from '@/modules/accounts/manual-balances/use-suggested-location';
 import CustomAssetFormDialog from '@/modules/assets/admin/custom/CustomAssetFormDialog.vue';
 import { useAssetManagementApi } from '@/modules/assets/api/use-asset-management-api';
-import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import LocationSelector from '@/modules/balances/LocationSelector.vue';
 import { useManualBalanceData } from '@/modules/balances/manual/use-manual-balance-data';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useLocationStore } from '@/modules/core/common/use-location-store';
-import { useBigNumberModel, useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 import BalanceTypeInput from '@/modules/shell/components/inputs/BalanceTypeInput.vue';
@@ -31,105 +33,59 @@ const { t } = useI18n({ useScope: 'global' });
 const priceForm = useTemplateRef<InstanceType<typeof ManualBalancesPriceForm>>('priceForm');
 const openCustomAssetDialog = ref<boolean>(false);
 
-const asset = useRefPropVModel(modelValue, 'asset');
-const label = useRefPropVModel(modelValue, 'label');
-const balanceType = useRefPropVModel(modelValue, 'balanceType');
-const location = useRefPropVModel(modelValue, 'location');
-const rawAmount = useRefPropVModel(modelValue, 'amount');
+const { manualLabels } = useManualBalanceData();
 
-const locationTouched = ref<boolean>(false);
+const editing = computed<boolean>(() => 'identifier' in get(modelValue));
 
-const tags = computed<string[]>({
+const schema = computed<ZodType>(() => manualBalanceSchema({
+  amount: t('manual_balances_form.validation.amount'),
+  asset: t('manual_balances_form.validation.asset'),
+  labelEmpty: t('manual_balances_form.validation.label_empty'),
+  labelExists: (label: string) => t('manual_balances_form.validation.label_exists', { label }),
+  location: t('manual_balances_form.validation.location'),
+}, {
+  editing: get(editing),
+  takenLabels: get(manualLabels),
+}));
+
+/** The amount is text while it is typed and the tags use null for "none", so the two differ. */
+const formModel = computed<ManualBalanceFormState>({
   get() {
-    return get(modelValue).tags ?? [];
+    return toFormState(get(modelValue));
   },
-  set(tags: string[]) {
-    set(modelValue, {
-      ...get(modelValue),
-      tags: tags.length > 0 ? tags : null,
-    });
+  set(state: ManualBalanceFormState) {
+    set(modelValue, toPayload(get(modelValue), state));
   },
 });
 
-const amount = useBigNumberModel(rawAmount);
-const { manualLabels } = useManualBalanceData();
-const { tradeLocations } = storeToRefs(useLocationStore());
-const { getAssetInfo } = useAssetInfoRetrieval();
+const { errors: fieldErrors, state, touch, validate } = useModelForm<ManualBalanceFormState>({
+  model: formModel,
+  schema,
+  serverErrors: errors,
+  stateUpdated,
+});
 
-const rules = {
-  amount: {
-    required: helpers.withMessage(t('manual_balances_form.validation.amount'), required),
+const { markChosen } = useSuggestedLocation(() => state.asset, {
+  apply: (location: string): void => {
+    state.location = location;
   },
-  asset: {
-    required: helpers.withMessage(t('manual_balances_form.validation.asset'), required),
-  },
-  balanceType: {},
-  label: {
-    doesNotExist: helpers.withMessage(
-      ({ $model: label }) =>
-        t('manual_balances_form.validation.label_exists', {
-          label,
-        }),
-      (label: string) => 'identifier' in get(modelValue) || !get(manualLabels).includes(label),
-    ),
-    required: helpers.withMessage(t('manual_balances_form.validation.label_empty'), required),
-  },
-  location: {
-    required,
-  },
-  tags: {},
-};
-
-const states = {
-  amount,
-  asset,
-  balanceType,
-  label,
-  location,
-  tags,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  { $autoDirty: true, $externalResults: errors },
-);
-
-useFormStateWatcher(states, stateUpdated);
+  editing,
+});
 
 const customAssetTypes = ref<string[]>([]);
 
 const { getCustomAssetTypes } = useAssetManagementApi();
 
-async function openCustomAssetForm() {
+async function openCustomAssetForm(): Promise<void> {
   if (get(customAssetTypes).length === 0)
     set(customAssetTypes, await getCustomAssetTypes());
 
   set(openCustomAssetDialog, true);
 }
 
-async function validate(): Promise<boolean> {
-  return await get(v$).$validate();
-}
-
 async function savePrice(): Promise<boolean> {
-  return await get(priceForm)?.savePrice(get(asset)) || false;
+  return await get(priceForm)?.savePrice(state.asset) || false;
 }
-
-watch(asset, (asset) => {
-  if (!(asset && !('identifier' in get(modelValue)) && !get(locationTouched))) {
-    return;
-  }
-  const info = getAssetInfo(asset);
-  const evmChain = info?.evmChain;
-  if (!evmChain) {
-    return;
-  }
-  const foundLocation = get(tradeLocations).find(item => item.identifier === evmChain.split('_').join(' '));
-  if (foundLocation) {
-    set(location, foundLocation.identifier);
-  }
-});
 
 defineExpose({
   savePrice,
@@ -143,32 +99,32 @@ defineExpose({
     class="flex flex-col gap-2"
   >
     <RuiTextField
-      v-model="label"
+      v-model="state.label"
       data-testid="manual-balances-form-label"
       variant="outlined"
       color="primary"
       :label="t('manual_balances_form.fields.label')"
-      :error-messages="toMessages(v$.label)"
+      :error-messages="fieldErrors('label')"
       :disabled="submitting"
-      @blur="v$.label.$touch()"
+      @update:model-value="touch('label')"
     />
 
     <BalanceTypeInput
-      v-model="balanceType"
+      v-model="state.balanceType"
       :disabled="submitting"
       :label="t('manual_balances_form.fields.balance_type')"
     />
 
     <div class="flex items-start gap-4">
       <AssetSelect
-        v-model="asset"
+        v-model="state.asset"
         :label="t('common.asset')"
         data-testid="manual-balances-form-asset"
         outlined
-        :chain="location"
-        :error-messages="toMessages(v$.asset)"
+        :chain="state.location"
+        :error-messages="fieldErrors('asset')"
         :disabled="submitting"
-        @blur="v$.asset.$touch()"
+        @update:model-value="touch('asset')"
       />
       <RuiTooltip
         :popper="{ placement: 'top' }"
@@ -202,40 +158,39 @@ defineExpose({
     <ManualBalancesPriceForm
       ref="priceForm"
       :pending="submitting"
-      :asset="asset"
+      :asset="state.asset"
     />
 
     <AmountInput
-      v-model="amount"
+      v-model="state.amount"
       :label="t('common.amount')"
-      :error-messages="toMessages(v$.amount)"
+      :error-messages="fieldErrors('amount')"
       data-testid="manual-balances-form-amount"
       variant="outlined"
       autocomplete="off"
       :disabled="submitting"
-      @blur="v$.amount.$touch()"
+      @update:model-value="touch('amount')"
     />
 
     <TagInput
-      v-model="tags"
+      v-model="state.tags"
       :label="t('manual_balances_form.fields.tags')"
       :disabled="submitting"
       data-testid="manual-balances-form-tags"
     />
 
     <LocationSelector
-      v-model="location"
+      v-model="state.location"
       data-testid="manual-balances-form-location"
-      :error-messages="toMessages(v$.location)"
+      :error-messages="fieldErrors('location')"
       :disabled="submitting"
       :label="t('common.location')"
-      @blur="v$.location.$touch()"
-      @update:model-value="locationTouched = true"
+      @update:model-value="touch('location'); markChosen()"
     />
 
     <CustomAssetFormDialog
       v-model:open="openCustomAssetDialog"
-      v-model:saved-asset-id="asset"
+      v-model:saved-asset-id="state.asset"
       :types="customAssetTypes"
     />
   </div>

--- a/frontend/app/src/modules/accounts/manual-balances/manual-balance-form.spec.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/manual-balance-form.spec.ts
@@ -1,0 +1,127 @@
+import type { RawManualBalance } from '@/modules/balances/types/manual-balances';
+import { bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import {
+  type ManualBalanceFormState,
+  manualBalanceSchema,
+  toFormState,
+  toPayload,
+} from '@/modules/accounts/manual-balances/manual-balance-form';
+import { BalanceType } from '@/modules/balances/types/balances';
+
+const MESSAGES = {
+  amount: 'amount',
+  asset: 'asset',
+  labelEmpty: 'label empty',
+  labelExists: (label: string): string => `label ${label} exists`,
+  location: 'location',
+};
+
+function balance(overrides: Partial<RawManualBalance> = {}): RawManualBalance {
+  return {
+    amount: bigNumberify(10),
+    asset: 'ETH',
+    balanceType: BalanceType.ASSET,
+    label: 'my wallet',
+    location: 'external',
+    tags: null,
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<ManualBalanceFormState> = {}): ManualBalanceFormState {
+  return {
+    amount: '10',
+    asset: 'ETH',
+    balanceType: BalanceType.ASSET,
+    label: 'my wallet',
+    location: 'external',
+    tags: [],
+    ...overrides,
+  };
+}
+
+function messagesFor(value: ManualBalanceFormState, field: string, editing = false, takenLabels: string[] = []): string[] {
+  const result = manualBalanceSchema(MESSAGES, { editing, takenLabels }).safeParse(value);
+  if (result.success)
+    return [];
+  return result.error.issues.filter(issue => issue.path.join('.') === field).map(issue => issue.message);
+}
+
+describe('modules/accounts/manual-balances/manual-balance-form', () => {
+  describe('the round trip', () => {
+    it.each([
+      ['a filled balance', state()],
+      ['a cleared amount', state({ amount: '' })],
+      ['no tags', state({ tags: [] })],
+      ['tags', state({ tags: ['tag'] })],
+      ['a liability', state({ balanceType: BalanceType.LIABILITY })],
+    ])('should read %s back exactly as it was written', (_label, value) => {
+      // Anything lost here comes straight back as an edit the user never made: the form writes the
+      // payload and reads it again on the next change.
+      expect(toFormState(toPayload(balance(), value))).toEqual(value);
+    });
+
+    it('should keep the fields the form does not edit', () => {
+      const existing = { ...balance(), assetIsMissing: true, identifier: 7 };
+
+      const result = toPayload(existing, state({ label: 'renamed' }));
+
+      expect(result.identifier).toBe(7);
+      expect(result.assetIsMissing).toBe(true);
+      expect(result.label).toBe('renamed');
+    });
+
+    it('should edit a missing amount as an empty field', () => {
+      expect(toFormState(balance({ amount: bigNumberify(Number.NaN) })).amount).toBe('');
+    });
+
+    it('should offer no tags as an empty list', () => {
+      expect(toFormState(balance({ tags: null })).tags).toEqual([]);
+    });
+
+    it('should store an empty tag list as none', () => {
+      expect(toPayload(balance(), state({ tags: [] })).tags).toBeNull();
+    });
+  });
+
+  describe('the schema', () => {
+    it.each([
+      ['amount', state({ amount: '' }), MESSAGES.amount],
+      ['asset', state({ asset: '' }), MESSAGES.asset],
+      ['location', state({ location: '' }), MESSAGES.location],
+      ['label', state({ label: '' }), MESSAGES.labelEmpty],
+    ])('should require %s', (field, value, message) => {
+      expect(messagesFor(value, field)).toEqual([message]);
+    });
+
+    it.each([
+      ['amount', state({ amount: '  ' }), MESSAGES.amount],
+      ['asset', state({ asset: '  ' }), MESSAGES.asset],
+      ['label', state({ label: '  ' }), MESSAGES.labelEmpty],
+    ])('should treat a whitespace-only %s as missing', (field, value, message) => {
+      expect(messagesFor(value, field)).toEqual([message]);
+    });
+
+    it('should accept a filled balance', () => {
+      expect(manualBalanceSchema(MESSAGES, { editing: false, takenLabels: [] }).safeParse(state()).success).toBe(true);
+    });
+
+    it('should reject a label another balance already uses', () => {
+      expect(messagesFor(state(), 'label', false, ['my wallet'])).toEqual([MESSAGES.labelExists('my wallet')]);
+    });
+
+    it('should let an edited balance keep a taken label', () => {
+      expect(messagesFor(state(), 'label', true, ['my wallet'])).toEqual([]);
+    });
+
+    it('should report a taken label before reporting it as empty', () => {
+      // Both can fire at once only if the empty string is itself a stored label; the order is what
+      // the field renders.
+      expect(messagesFor(state({ label: '' }), 'label', false, [''])).toEqual([
+        MESSAGES.labelExists(''),
+        MESSAGES.labelEmpty,
+      ]);
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/manual-balances/manual-balance-form.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/manual-balance-form.ts
@@ -1,0 +1,79 @@
+import type { BalanceType } from '@/modules/balances/types/balances';
+import type { ManualBalance, RawManualBalance } from '@/modules/balances/types/manual-balances';
+import { bigNumberify } from '@rotki/common';
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+/**
+ * What the form edits. The amount is text while it is being typed, and the tags are a plain list,
+ * where the payload holds a number and uses null for "no tags".
+ */
+export interface ManualBalanceFormState {
+  amount: string;
+  asset: string;
+  balanceType: BalanceType;
+  label: string;
+  location: string;
+  tags: string[];
+}
+
+export function toFormState(balance: RawManualBalance | ManualBalance): ManualBalanceFormState {
+  const { amount, asset, balanceType, label, location, tags } = balance;
+  return {
+    amount: !amount || amount.isNaN() ? '' : amount.toString(),
+    asset,
+    balanceType,
+    label,
+    location,
+    tags: tags ?? [],
+  };
+}
+
+/**
+ * The round trip has to be lossless, or an edit written back would be read straight back in as a
+ * different value: a cleared amount becomes NaN rather than zero precisely so that reading it
+ * returns the empty field the user left, instead of refilling it with a nought they never typed.
+ * An amount in that state never reaches the api, because the dialog saves only what validates.
+ */
+export function toPayload<T extends RawManualBalance>(balance: T, state: ManualBalanceFormState): T {
+  return {
+    ...balance,
+    ...state,
+    amount: state.amount ? bigNumberify(state.amount) : bigNumberify(Number.NaN),
+    tags: state.tags.length > 0 ? state.tags : null,
+  };
+}
+
+export interface ManualBalanceMessages {
+  amount: string;
+  asset: string;
+  labelEmpty: string;
+  labelExists: (label: string) => string;
+  location: string;
+}
+
+export interface ManualBalanceOptions {
+  /** An existing balance keeps its own label, so uniqueness is not checked at all while editing. */
+  readonly editing: boolean;
+  /** The labels the other manual balances already use. */
+  readonly takenLabels: string[];
+}
+
+export function manualBalanceSchema(messages: ManualBalanceMessages, options: ManualBalanceOptions): ZodType {
+  const { editing, takenLabels } = options;
+
+  return z.object({
+    amount: requiredField(messages.amount),
+    asset: requiredField(messages.asset),
+    label: z.string().superRefine((label, ctx) => {
+      // Reported in the order the rules were declared: uniqueness first, then presence. The
+      // uniqueness check reads the label untrimmed, as it is compared against stored ones.
+      if (!editing && takenLabels.includes(label))
+        ctx.addIssue({ code: 'custom', message: messages.labelExists(label) });
+
+      if (label.trim() === '')
+        ctx.addIssue({ code: 'custom', message: messages.labelEmpty });
+    }),
+    location: requiredField(messages.location),
+  });
+}

--- a/frontend/app/src/modules/accounts/manual-balances/use-suggested-location.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/use-suggested-location.ts
@@ -1,0 +1,49 @@
+import type { MaybeRefOrGetter } from 'vue';
+import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
+import { useLocationStore } from '@/modules/core/common/use-location-store';
+
+interface SuggestedLocationOptions {
+  /** An existing balance already has the location it was saved with, so nothing is suggested. */
+  readonly editing: MaybeRefOrGetter<boolean>;
+  readonly apply: (location: string) => void;
+}
+
+interface SuggestedLocationReturn {
+  /** Call when the user picks a location, after which none is suggested again. */
+  readonly markChosen: () => void;
+}
+
+/**
+ * Fills the location in from the chain the chosen asset lives on, for as long as the user has not
+ * picked one themselves. The chain is named with underscores where the location uses spaces.
+ */
+export function useSuggestedLocation(
+  asset: MaybeRefOrGetter<string>,
+  options: SuggestedLocationOptions,
+): SuggestedLocationReturn {
+  const { apply, editing } = options;
+
+  const { getAssetInfo } = useAssetInfoRetrieval();
+  const { tradeLocations } = storeToRefs(useLocationStore());
+
+  const chosen = shallowRef<boolean>(false);
+
+  watch(() => toValue(asset), (asset) => {
+    if (!asset || toValue(editing) || get(chosen))
+      return;
+
+    const evmChain = getAssetInfo(asset)?.evmChain;
+    if (!evmChain)
+      return;
+
+    const location = get(tradeLocations).find(item => item.identifier === evmChain.split('_').join(' '));
+    if (location)
+      apply(location.identifier);
+  });
+
+  return {
+    markChosen: (): void => {
+      set(chosen, true);
+    },
+  };
+}


### PR DESCRIPTION
Migrates the five account forms from vuelidate to the zod form core, continuing the migration after settings, dashboard snapshots, asset prices, notes/tags, history tx and the singletons.

| Form | Now validates with |
|---|---|
| `blockchain/Eth2Input` | `useModelForm` + `eth2-validator-form.ts` |
| `address-book/AddressBookForm` | `useModelForm` + `address-book-form.ts` |
| `manual-balances/ManualBalancesForm` | `useModelForm` + `manual-balance-form.ts` |
| `blockchain/BtcAddressInput` | `useForm` + `use-xpub-input.ts` |
| `blockchain/AddressInput` | `useForm` + `address-entries.ts` |

That leaves assets/admin and auth as the last groups, plus the deliberately cut `AssetMovementMatchingSettingsMenu`.

## The gate this batch had to guard first

`AccountForm.validate()` returns `true` when the selected child does not expose a `validate` method. A child that stopped exposing it under that exact name would send **every account save through unvalidated**, with nothing but a debug log and no typecheck error, since `AddressBookFormDialog` typed its ref as the wrong component entirely.

The first commit pins that delegation for all four branches before anything moved. Renaming the exposed method on all four children turns all four tests red with a received `true`.

## Method

Each form is one commit carrying its `.vue`, its extracted module and its spec. Every rule was characterized against the vuelidate version first and mutation-proved on both sides of the swap: a test counts only if it fails when the rule it pins is removed.

Logic came out of the SFCs as it went, so what is left is wiring and the rules are testable without mounting anything: two composables (`use-address-suggestions`, `use-suggested-location`, `use-xpub-input`) and four pure modules.

## Behaviour changes, each asserted in a spec

- **Errors held at mount now render.** Vuelidate reached `$externalResults` through `$errors`, so a failed save was invisible on an untouched field until something touched it.
- **The unsaved-changes prompt no longer has a blind spot.** `useFormStateWatcher` installed its watcher behind a 500 ms timer and latched on the first change; `form.dirty` compares against a baseline taken at construction, so an early edit is seen and undoing an edit disarms it again.
- **Two untranslated messages got keys.** The eth2 identifier pair and the manual balance location fell back to vuelidate's own English (`The value is required` / `Value is required`); both keep the same wording, now translatable.
- **`validate()` is synchronous**, so the three intermediate account forms await it as an ordinary value.
- A server error no longer makes a form itself invalid — the core keys those separately from the schema. Unobservable through these dialogs, which clear the errors they hold before validating.

## Things worth a second pair of eyes

- `AddressInput`: the backend reports one flat `address` key for two fields, so it is fanned onto both where the errors arrive. Switching to entering several addresses starts from an empty list while the address already entered stays in the payload — pinned as it is, not fixed here.
- `ManualBalancesForm` and `Eth2Input` edit their own copy of the payload and bridge back, because the state and the payload genuinely differ (text amounts, `null` tags, a readonly payload type). The round trip has to be lossless or a write reads back as an edit nobody made; there is a property test for it.
- `BtcAddressInput`'s derivation path deliberately keeps **no** rule: what looked like one always passed and existed only to give the backend's errors a place to render.

## Checks

`typecheck` · `test:unit` (8270 tests) · `lint` (0 errors) · `knip` · `check:linked-keys` · `typos`, all on the rebased tip.

Verified in the running app: every rule renders and blocks its save, the eth2 pair clears both messages once either identifier is filled, an xpub paste still switches mode and detects Native SegWit, the address list dedupes case-insensitively, the duplicate manual-balance label interpolates, and the address book prompts on a name edit but not on a location change. No console errors.
