### PR TITLE
Validate the assets admin forms with zod

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1229,6 +1229,12 @@
       "migration_error": "Migration failed",
       "migration_success": "Token migrated successfully",
       "solana_address": "Solana Address",
+      "validation": {
+        "address_invalid": "The address is not a valid Solana address",
+        "address_non_empty": "The Solana address cannot be empty",
+        "decimals_non_empty": "The number of decimals cannot be empty",
+        "token_kind_non_empty": "The token kind cannot be empty"
+      },
       "validation_error": "Please fill in all required fields"
     }
   },

--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingForm.spec.ts
@@ -1,0 +1,250 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { CexMapping } from '@/modules/assets/types';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import ManageCexMappingForm from '@/modules/assets/admin/cex-mapping/ManageCexMappingForm.vue';
+import '@test/i18n';
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled', 'excludes'],
+    template: '<div />',
+  };
+}
+
+describe('manageCexMappingForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ManageCexMappingForm>>;
+
+  const baseModel = (): CexMapping => ({
+    asset: 'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    location: 'kraken',
+    locationSymbol: 'USDC',
+  });
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    modelValue: CexMapping = baseModel(),
+    props: Record<string, unknown> = {},
+  ): VueWrapper<InstanceType<typeof ManageCexMappingForm>> {
+    return mount(ManageCexMappingForm, {
+      global: {
+        stubs: {
+          AssetSelect: inputStub('AssetSelect'),
+          ExchangeInput: inputStub('ExchangeInput'),
+          LocationDisplay: { name: 'LocationDisplay', props: ['identifier'], template: '<div />' },
+          RuiSwitch: inputStub('RuiSwitch'),
+          RuiTextField: inputStub('RuiTextField'),
+        },
+      },
+      props: {
+        errorMessages: {},
+        forAllExchanges: !modelValue.location,
+        modelValue,
+        ...props,
+      },
+    });
+  }
+
+  function stub(name: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>({ name });
+  }
+
+  function messages(name: string): string[] {
+    const value: unknown = stub(name).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(name: string, value: string | undefined): Promise<void> {
+    stub(name).vm.$emit('update:modelValue', value);
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  function lastModel(): CexMapping {
+    const updates = wrapper.emitted<[CexMapping]>('update:modelValue');
+    assert(updates);
+    return updates.at(-1)![0];
+  }
+
+  it('should pass validation for a mapping tied to one exchange', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should pass validation with no exchange when it covers all of them', async () => {
+    wrapper = createWrapper({ ...baseModel(), location: null });
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The location rule is the only conditional one in the form: it is required unless the mapping
+    // is being saved for every exchange.
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should fail validation once the exchange is cleared on a single-exchange mapping', async () => {
+    // The switch cannot be forced out of step with the payload: the form reads it off the location
+    // on mount. Clearing the field afterwards is what leaves the two disagreeing.
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('ExchangeInput', undefined);
+
+    expect(await wrapper.vm.validate()).toBe(false);
+    expect(messages('ExchangeInput')).toEqual([
+      'asset_management.cex_mapping.form.location_non_empty',
+    ]);
+  });
+
+  it.each([
+    ['asset'],
+    ['locationSymbol'],
+  ] as const)('should fail validation when %s is empty whatever the switch says', async (key) => {
+    wrapper = createWrapper({ ...baseModel(), [key]: '' }, { forAllExchanges: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper({ asset: '', location: null, locationSymbol: '' }, { forAllExchanges: false });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('ExchangeInput')).toEqual([]);
+    expect(messages('RuiTextField')).toEqual([]);
+    expect(messages('AssetSelect')).toEqual([]);
+  });
+
+  it('should reveal every message once validate runs', async () => {
+    wrapper = createWrapper({ asset: '', location: 'kraken', locationSymbol: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('RuiTextField')).toEqual([
+      'asset_management.cex_mapping.form.location_symbol_non_empty',
+    ]);
+    expect(messages('AssetSelect')).toEqual([
+      'asset_management.cex_mapping.form.asset_non_empty',
+    ]);
+  });
+
+  it('should say nothing about the exchange once the mapping covers all of them', async () => {
+    wrapper = createWrapper({ asset: '', location: null, locationSymbol: '' }, { forAllExchanges: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('ExchangeInput')).toEqual([]);
+    expect(messages('AssetSelect')).toEqual([
+      'asset_management.cex_mapping.form.asset_non_empty',
+    ]);
+  });
+
+  it.each([
+    [null, true],
+    ['kraken', false],
+  ])('should read the switch off a payload whose location is %s', async (location, expected) => {
+    wrapper = createWrapper({ ...baseModel(), location }, { forAllExchanges: !expected });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.emitted('update:forAllExchanges')?.at(-1)).toEqual([expected]);
+  });
+
+  it('should write a cleared exchange back as null', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    // Null is what "every exchange" means in this payload, so unlike the counterparty mapping the
+    // field is nullable on purpose.
+    await edit('ExchangeInput', undefined);
+
+    expect(lastModel().location).toBeNull();
+  });
+
+  it('should write an edited symbol back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('RuiTextField', 'DAI');
+
+    expect(lastModel().locationSymbol).toBe('DAI');
+  });
+
+  it('should flag stateUpdated once a field is edited', async () => {
+    wrapper = createWrapper();
+    // Settle the mounted work first, so what follows is the only edit in play.
+    await vi.advanceTimersByTimeAsync(600);
+
+    await edit('RuiTextField', 'DAI');
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
+  });
+
+  it('should not flag stateUpdated before anything is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).not.toEqual([true]);
+  });
+
+  it('should lock everything but the asset while editing', async () => {
+    wrapper = createWrapper(baseModel(), { editMode: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(stub('RuiSwitch').props('disabled')).toBe(true);
+    expect(stub('ExchangeInput').props('disabled')).toBe(true);
+    expect(stub('RuiTextField').props('disabled')).toBe(true);
+    expect(stub('AssetSelect').props('disabled')).toBeFalsy();
+  });
+
+  it('should lock the exchange while the mapping covers all of them', async () => {
+    wrapper = createWrapper({ ...baseModel(), location: null }, { forAllExchanges: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(stub('ExchangeInput').props('disabled')).toBe(true);
+  });
+
+  it.each([
+    ['binance', 'binanceus'],
+    ['coinbase', 'coinbaseprime'],
+  ])('should point out that a %s mapping also covers %s', async (primary, related) => {
+    wrapper = createWrapper({ ...baseModel(), location: primary }, { forAllExchanges: false });
+    await vi.advanceTimersToNextTimerAsync();
+
+    const shown = wrapper.findAllComponents({ name: 'LocationDisplay' });
+    expect(shown.map(display => display.props('identifier'))).toEqual([primary, related]);
+  });
+
+  it('should say nothing about a related exchange for any other one', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(wrapper.findAllComponents({ name: 'LocationDisplay' })).toHaveLength(0);
+  });
+
+  it('should keep a server error hidden until its field is touched', async () => {
+    const errorMessages: ValidationErrors = { locationSymbol: ['already mapped'] };
+    wrapper = createWrapper(baseModel(), { errorMessages });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('RuiTextField')).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingForm.spec.ts
@@ -240,11 +240,13 @@ describe('manageCexMappingForm', () => {
     expect(wrapper.findAllComponents({ name: 'LocationDisplay' })).toHaveLength(0);
   });
 
-  it('should keep a server error hidden until its field is touched', async () => {
+  // Deliberately flipped in the zod swap. Vuelidate read external results through $errors, so a
+  // rejected save said nothing at all on a field the user had not been in.
+  it('should show a server error on an untouched field', async () => {
     const errorMessages: ValidationErrors = { locationSymbol: ['already mapped'] };
     wrapper = createWrapper(baseModel(), { errorMessages });
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(messages('RuiTextField')).toEqual([]);
+    expect(messages('RuiTextField')).toEqual(['already mapped']);
   });
 });

--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingForm.vue
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingForm.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { CexMapping } from '@/modules/assets/types';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required, requiredIf } from '@vuelidate/validators';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { nullDefined, useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { cexMappingSchema } from '@/modules/assets/admin/cex-mapping/cex-mapping-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 import ExchangeInput from '@/modules/shell/components/inputs/ExchangeInput.vue';
@@ -27,13 +25,30 @@ const EXCLUDED_EXCHANGES = [
 
 const { t } = useI18n({ useScope: 'global' });
 
-const asset = useRefPropVModel(modelValue, 'asset');
-const locationSymbol = useRefPropVModel(modelValue, 'locationSymbol');
-const location = useRefPropVModel(modelValue, 'location');
-const locationModel = nullDefined(location);
+const schema = computed<ZodType>(() => cexMappingSchema({
+  asset: t('asset_management.cex_mapping.form.asset_non_empty'),
+  location: t('asset_management.cex_mapping.form.location_non_empty'),
+  locationSymbol: t('asset_management.cex_mapping.form.location_symbol_non_empty'),
+}, get(forAllExchanges)));
+
+const form = useModelForm<CexMapping>({
+  model: modelValue,
+  schema,
+  serverErrors: errors,
+  stateUpdated,
+});
+
+/** The input clears to `undefined`, which this payload spells `null`: a mapping for every exchange. */
+const locationModel = computed<string | undefined>({
+  get: () => form.state.location ?? undefined,
+  set: (value?: string) => {
+    form.state.location = value ?? null;
+    form.touch('location');
+  },
+});
 
 const mappingAlertInfo = computed<{ primary: string; related: string } | undefined>(() => {
-  const currentLocation = get(location);
+  const currentLocation = form.state.location;
   if (!currentLocation || get(forAllExchanges))
     return undefined;
 
@@ -56,44 +71,12 @@ function checkPassedForm() {
   }
 }
 
-const rules = {
-  asset: {
-    required: helpers.withMessage(t('asset_management.cex_mapping.form.asset_non_empty'), required),
-  },
-  location: {
-    required: helpers.withMessage(
-      t('asset_management.cex_mapping.form.location_non_empty'),
-      requiredIf(logicNot(forAllExchanges)),
-    ),
-  },
-  locationSymbol: {
-    required: helpers.withMessage(
-      t('asset_management.cex_mapping.form.location_symbol_non_empty'),
-      required,
-    ),
-  },
-};
-
-const states = {
-  asset,
-  location,
-  locationSymbol,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  { $autoDirty: true, $externalResults: errors },
-);
-
-useFormStateWatcher(states, stateUpdated);
-
 onBeforeMount(() => {
   checkPassedForm();
 });
 
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -112,23 +95,25 @@ defineExpose({
       :disabled="editMode || forAllExchanges"
       :excludes="EXCLUDED_EXCHANGES"
       clearable
-      :error-messages="toMessages(v$.location)"
+      :error-messages="form.errors('location')"
     />
     <RuiTextField
-      v-model="locationSymbol"
+      v-model="form.state.locationSymbol"
       data-testid="location-symbol"
       variant="outlined"
       color="primary"
       :disabled="editMode"
       clearable
       :label="t('asset_management.cex_mapping.location_symbol')"
-      :error-messages="toMessages(v$.locationSymbol)"
+      :error-messages="form.errors('locationSymbol')"
+      @update:model-value="form.touch('locationSymbol')"
     />
     <AssetSelect
-      v-model="asset"
+      v-model="form.state.asset"
       :label="t('asset_management.cex_mapping.recognized_as')"
       outlined
-      :error-messages="toMessages(v$.asset)"
+      :error-messages="form.errors('asset')"
+      @update:model-value="form.touch('asset')"
     />
     <RuiAlert
       v-if="mappingAlertInfo"

--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingFormDialog.vue
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingFormDialog.vue
@@ -39,7 +39,7 @@ async function save(): Promise<boolean> {
     return false;
 
   const formRef = get(form);
-  const valid = await formRef?.validate();
+  const valid = formRef?.validate();
   if (!valid)
     return false;
 

--- a/frontend/app/src/modules/assets/admin/cex-mapping/cex-mapping-form.spec.ts
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/cex-mapping-form.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { cexMappingSchema } from '@/modules/assets/admin/cex-mapping/cex-mapping-form';
+
+const messages = {
+  asset: 'asset_missing',
+  location: 'location_missing',
+  locationSymbol: 'symbol_missing',
+};
+
+const valid = {
+  asset: 'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  location: 'kraken',
+  locationSymbol: 'USDC',
+};
+
+function messagesFor(state: Record<string, unknown>, forAllExchanges = false): string[] {
+  const result = cexMappingSchema(messages, forAllExchanges).safeParse(state);
+  if (result.success)
+    return [];
+  return result.error.issues.map(issue => issue.message);
+}
+
+describe('cexMappingSchema', () => {
+  it('should accept a mapping tied to one exchange', () => {
+    expect(messagesFor(valid)).toEqual([]);
+  });
+
+  it.each([
+    [null],
+    [''],
+    ['  '],
+  ])('should report %s as a missing exchange for a single-exchange mapping', (location) => {
+    expect(messagesFor({ ...valid, location })).toEqual(['location_missing']);
+  });
+
+  it('should accept a missing exchange when the mapping covers all of them', () => {
+    expect(messagesFor({ ...valid, location: null }, true)).toEqual([]);
+  });
+
+  it.each([
+    [false],
+    [true],
+  ])('should require the asset and the symbol with the switch %s', (forAllExchanges) => {
+    expect(messagesFor({ ...valid, asset: '', locationSymbol: '' }, forAllExchanges)).toEqual([
+      'asset_missing',
+      'symbol_missing',
+    ]);
+  });
+
+  it('should keep an exchange the caller left set even when it covers all of them', () => {
+    const result = cexMappingSchema(messages, true).safeParse(valid);
+
+    // The switch does not clear the field, so the payload keeps whatever was chosen before it was
+    // flipped. What the api does with that is the dialog's business, not the schema's.
+    expect(result.success && result.data).toEqual(valid);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/cex-mapping/cex-mapping-form.ts
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/cex-mapping-form.ts
@@ -1,0 +1,32 @@
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface CexMappingMessages {
+  asset: string;
+  location: string;
+  locationSymbol: string;
+}
+
+/** Null is what "every exchange" means in this payload, so the field is nullable either way. */
+function locationField(message: string, required: boolean): ZodType<string | null> {
+  return z.string().nullable().superRefine((value, ctx) => {
+    if (required && (value === null || value.trim() === ''))
+      ctx.addIssue({ code: 'custom', message });
+  });
+}
+
+/**
+ * The exchange is required only while the mapping covers a single one, which the switch above the
+ * field decides. That switch is not part of the payload, so the condition is passed in and the
+ * schema is rebuilt when it flips, rather than the rule reaching back into form state.
+ */
+export function cexMappingSchema(
+  messages: CexMappingMessages,
+  forAllExchanges: boolean,
+): ZodType {
+  return z.object({
+    asset: requiredField(messages.asset),
+    location: locationField(messages.location, !forAllExchanges),
+    locationSymbol: requiredField(messages.locationSymbol),
+  }).passthrough();
+}

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.spec.ts
@@ -189,11 +189,13 @@ describe('manageCounterpartyMappingForm', () => {
     expect(field('counterparty-asset').props('disabled')).toBeFalsy();
   });
 
-  it('should keep a server error hidden until its field is touched', async () => {
+  // Deliberately flipped in the zod swap. Vuelidate read external results through $errors, so a
+  // rejected save said nothing at all on a field the user had not been in.
+  it('should show a server error on an untouched field', async () => {
     const errorMessages: ValidationErrors = { counterpartySymbol: ['already mapped'] };
     wrapper = createWrapper(baseModel(), { errorMessages });
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(messages('counterparty-symbol')).toEqual([]);
+    expect(messages('counterparty-symbol')).toEqual(['already mapped']);
   });
 });

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.spec.ts
@@ -152,15 +152,13 @@ describe('manageCounterpartyMappingForm', () => {
     expect(lastModel().counterparty).toBe('uniswap-v2');
   });
 
-  it('should write a cleared counterparty back as null', async () => {
+  it('should empty a cleared counterparty rather than null it', async () => {
     wrapper = createWrapper();
     await vi.advanceTimersToNextTimerAsync();
 
-    // The input is wrapped in nullDefined, so clearing it does not leave the field a string. The
-    // payload type says otherwise, and the api is what the null reaches.
     await edit('counterparty', undefined);
 
-    expect(lastModel().counterparty).toBeNull();
+    expect(lastModel().counterparty).toBe('');
     expect(await wrapper.vm.validate()).toBe(false);
   });
 

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.spec.ts
@@ -1,0 +1,201 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { CounterpartyMapping } from '@/modules/assets/admin/counterparty-mapping/schema';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import ManageCounterpartyMappingForm from '@/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.vue';
+import '@test/i18n';
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+/** Every field is a third-party input, so they are stubbed down to what the form reads back. */
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled'],
+    template: '<div />',
+  };
+}
+
+describe('manageCounterpartyMappingForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ManageCounterpartyMappingForm>>;
+
+  const baseModel = (): CounterpartyMapping => ({
+    asset: 'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    counterparty: 'uniswap-v2',
+    counterpartySymbol: 'USDC',
+  });
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    modelValue: CounterpartyMapping = baseModel(),
+    props: Record<string, unknown> = {},
+  ): VueWrapper<InstanceType<typeof ManageCounterpartyMappingForm>> {
+    return mount(ManageCounterpartyMappingForm, {
+      global: {
+        stubs: {
+          AssetSelect: inputStub('AssetSelect'),
+          CounterpartyInput: inputStub('CounterpartyInput'),
+          RuiTextField: inputStub('RuiTextField'),
+        },
+      },
+      props: { errorMessages: {}, modelValue, ...props },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(testId: string, value: string | undefined): Promise<void> {
+    field(testId).vm.$emit('update:modelValue', value);
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  function lastModel(): CounterpartyMapping {
+    const updates = wrapper.emitted<[CounterpartyMapping]>('update:modelValue');
+    assert(updates);
+    return updates.at(-1)![0];
+  }
+
+  it('should pass validation when every field is filled', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it.each([
+    ['asset'],
+    ['counterparty'],
+    ['counterpartySymbol'],
+  ] as const)('should fail validation when %s is empty', async (key) => {
+    const model = baseModel();
+    model[key] = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should treat a whitespace-only symbol as empty', async () => {
+    wrapper = createWrapper({ ...baseModel(), counterpartySymbol: '   ' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper({ asset: '', counterparty: '', counterpartySymbol: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('counterparty')).toEqual([]);
+    expect(messages('counterparty-symbol')).toEqual([]);
+    expect(messages('counterparty-asset')).toEqual([]);
+  });
+
+  it('should reveal every message once validate runs', async () => {
+    wrapper = createWrapper({ asset: '', counterparty: '', counterpartySymbol: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('counterparty')).toEqual([
+      'asset_management.counterparty_mapping.form.counterparty_non_empty',
+    ]);
+    expect(messages('counterparty-symbol')).toEqual([
+      'asset_management.counterparty_mapping.form.counterparty_symbol_non_empty',
+    ]);
+    expect(messages('counterparty-asset')).toEqual([
+      'asset_management.cex_mapping.form.asset_non_empty',
+    ]);
+  });
+
+  it('should show the symbol message once the field is emptied', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('counterparty-symbol', '');
+
+    expect(messages('counterparty-symbol')).toEqual([
+      'asset_management.counterparty_mapping.form.counterparty_symbol_non_empty',
+    ]);
+    // The untouched fields stay quiet.
+    expect(messages('counterparty')).toEqual([]);
+  });
+
+  it('should write an edit back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('counterparty-symbol', 'DAI');
+
+    expect(lastModel().counterpartySymbol).toBe('DAI');
+    expect(lastModel().counterparty).toBe('uniswap-v2');
+  });
+
+  it('should write a cleared counterparty back as null', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The input is wrapped in nullDefined, so clearing it does not leave the field a string. The
+    // payload type says otherwise, and the api is what the null reaches.
+    await edit('counterparty', undefined);
+
+    expect(lastModel().counterparty).toBeNull();
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should flag stateUpdated once a field is edited', async () => {
+    wrapper = createWrapper();
+    // Settle the mounted work first, so what follows is the only edit in play.
+    await vi.advanceTimersByTimeAsync(600);
+
+    await edit('counterparty-symbol', 'DAI');
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
+  });
+
+  it('should not flag stateUpdated before anything is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).not.toEqual([true]);
+  });
+
+  it('should lock the counterparty and its symbol while editing', async () => {
+    wrapper = createWrapper(baseModel(), { editMode: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('counterparty').props('disabled')).toBe(true);
+    expect(field('counterparty-symbol').props('disabled')).toBe(true);
+    // Repointing the mapping at another asset is the whole point of the edit dialog.
+    expect(field('counterparty-asset').props('disabled')).toBeFalsy();
+  });
+
+  it('should keep a server error hidden until its field is touched', async () => {
+    const errorMessages: ValidationErrors = { counterpartySymbol: ['already mapped'] };
+    wrapper = createWrapper(baseModel(), { errorMessages });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('counterparty-symbol')).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.vue
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.vue
@@ -65,6 +65,7 @@ defineExpose({
   <div class="flex flex-col gap-2">
     <CounterpartyInput
       v-model="counterpartyModel"
+      data-testid="counterparty"
       :label="t('common.counterparty')"
       :disabled="editMode"
       exclude-exchanges
@@ -83,6 +84,7 @@ defineExpose({
     />
     <AssetSelect
       v-model="asset"
+      data-testid="counterparty-asset"
       :label="t('asset_management.cex_mapping.recognized_as')"
       outlined
       :error-messages="toMessages(v$.asset)"

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.vue
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { CounterpartyMapping } from '@/modules/assets/admin/counterparty-mapping/schema';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { counterpartyMappingSchema } from '@/modules/assets/admin/counterparty-mapping/counterparty-mapping-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import CounterpartyInput from '@/modules/history/events/mapping/CounterpartyInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 
@@ -19,55 +17,34 @@ const { editMode = false } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const asset = useRefPropVModel(modelValue, 'asset');
-const counterpartySymbol = useRefPropVModel(modelValue, 'counterpartySymbol');
-const counterparty = useRefPropVModel(modelValue, 'counterparty');
+const schema = computed<ZodType>(() => counterpartyMappingSchema({
+  asset: t('asset_management.cex_mapping.form.asset_non_empty'),
+  counterparty: t('asset_management.counterparty_mapping.form.counterparty_non_empty'),
+  counterpartySymbol: t('asset_management.counterparty_mapping.form.counterparty_symbol_non_empty'),
+}));
+
+const form = useModelForm<CounterpartyMapping>({
+  model: modelValue,
+  schema,
+  serverErrors: errors,
+  stateUpdated,
+});
+
 /**
  * The input clears to `undefined`, which used to be written back as `null` into a field the payload
- * types as a string. Nothing downstream ever saw it, because save is gated on a `required` that a
- * cleared field fails either way, so it empties instead of lying about its type.
+ * types as a string. Nothing downstream ever saw it, because save is gated on a rule a cleared field
+ * fails either way, so it empties instead of lying about its type.
  */
 const counterpartyModel = computed<string | undefined>({
-  get: () => get(counterparty),
+  get: () => form.state.counterparty,
   set: (value?: string) => {
-    set(counterparty, value ?? '');
+    form.state.counterparty = value ?? '';
+    form.touch('counterparty');
   },
 });
 
-const rules = {
-  asset: {
-    required: helpers.withMessage(t('asset_management.cex_mapping.form.asset_non_empty'), required),
-  },
-  counterparty: {
-    required: helpers.withMessage(
-      t('asset_management.counterparty_mapping.form.counterparty_non_empty'),
-      required,
-    ),
-  },
-  counterpartySymbol: {
-    required: helpers.withMessage(
-      t('asset_management.counterparty_mapping.form.counterparty_symbol_non_empty'),
-      required,
-    ),
-  },
-};
-
-const states = {
-  asset,
-  counterparty,
-  counterpartySymbol,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  { $autoDirty: true, $externalResults: errors },
-);
-
-useFormStateWatcher(states, stateUpdated);
-
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -80,24 +57,26 @@ defineExpose({
       :disabled="editMode"
       exclude-exchanges
       clearable
-      :error-messages="toMessages(v$.counterparty)"
+      :error-messages="form.errors('counterparty')"
     />
     <RuiTextField
-      v-model="counterpartySymbol"
+      v-model="form.state.counterpartySymbol"
       data-testid="counterparty-symbol"
       variant="outlined"
       color="primary"
       :disabled="editMode"
       clearable
       :label="t('asset_management.counterparty_mapping.counterparty_symbol')"
-      :error-messages="toMessages(v$.counterpartySymbol)"
+      :error-messages="form.errors('counterpartySymbol')"
+      @update:model-value="form.touch('counterpartySymbol')"
     />
     <AssetSelect
-      v-model="asset"
+      v-model="form.state.asset"
       data-testid="counterparty-asset"
       :label="t('asset_management.cex_mapping.recognized_as')"
       outlined
-      :error-messages="toMessages(v$.asset)"
+      :error-messages="form.errors('asset')"
+      @update:model-value="form.touch('asset')"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.vue
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.vue
@@ -4,7 +4,7 @@ import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import useVuelidate from '@vuelidate/core';
 import { helpers, required } from '@vuelidate/validators';
 import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { nullDefined, useRefPropVModel } from '@/modules/core/common/validation/model';
+import { useRefPropVModel } from '@/modules/core/common/validation/model';
 import { toMessages } from '@/modules/core/common/validation/validation';
 import CounterpartyInput from '@/modules/history/events/mapping/CounterpartyInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
@@ -22,7 +22,17 @@ const { t } = useI18n({ useScope: 'global' });
 const asset = useRefPropVModel(modelValue, 'asset');
 const counterpartySymbol = useRefPropVModel(modelValue, 'counterpartySymbol');
 const counterparty = useRefPropVModel(modelValue, 'counterparty');
-const counterpartyModel = nullDefined(counterparty);
+/**
+ * The input clears to `undefined`, which used to be written back as `null` into a field the payload
+ * types as a string. Nothing downstream ever saw it, because save is gated on a `required` that a
+ * cleared field fails either way, so it empties instead of lying about its type.
+ */
+const counterpartyModel = computed<string | undefined>({
+  get: () => get(counterparty),
+  set: (value?: string) => {
+    set(counterparty, value ?? '');
+  },
+});
 
 const rules = {
   asset: {

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingFormDialog.vue
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingFormDialog.vue
@@ -38,7 +38,7 @@ async function save(): Promise<boolean> {
     return false;
 
   const formRef = get(form);
-  const valid = await formRef?.validate();
+  const valid = formRef?.validate();
   if (!valid)
     return false;
 

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/counterparty-mapping-form.spec.ts
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/counterparty-mapping-form.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { counterpartyMappingSchema } from '@/modules/assets/admin/counterparty-mapping/counterparty-mapping-form';
+
+const messages = {
+  asset: 'asset_missing',
+  counterparty: 'counterparty_missing',
+  counterpartySymbol: 'symbol_missing',
+};
+
+const valid = {
+  asset: 'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  counterparty: 'uniswap-v2',
+  counterpartySymbol: 'USDC',
+};
+
+function messagesFor(state: Record<string, unknown>): string[] {
+  const result = counterpartyMappingSchema(messages).safeParse(state);
+  if (result.success)
+    return [];
+  return result.error.issues.map(issue => issue.message);
+}
+
+describe('counterpartyMappingSchema', () => {
+  it('should accept a fully filled mapping', () => {
+    expect(messagesFor(valid)).toEqual([]);
+  });
+
+  it.each([
+    ['asset', 'asset_missing'],
+    ['counterparty', 'counterparty_missing'],
+    ['counterpartySymbol', 'symbol_missing'],
+  ])('should report %s under its own message when empty', (key, message) => {
+    expect(messagesFor({ ...valid, [key]: '' })).toEqual([message]);
+  });
+
+  it('should treat a whitespace-only value as empty', () => {
+    expect(messagesFor({ ...valid, counterpartySymbol: '  \t ' })).toEqual(['symbol_missing']);
+  });
+
+  it('should report every empty field rather than stopping at the first', () => {
+    expect(messagesFor({ asset: '', counterparty: '', counterpartySymbol: '' })).toEqual([
+      'asset_missing',
+      'counterparty_missing',
+      'symbol_missing',
+    ]);
+  });
+
+  it('should report a missing field under the same message as an empty one', () => {
+    expect(messagesFor({ counterparty: 'uniswap-v2', counterpartySymbol: 'USDC' })).toEqual([
+      'asset_missing',
+    ]);
+  });
+
+  it('should build a fresh schema per call', () => {
+    const first = counterpartyMappingSchema(messages);
+    const second = counterpartyMappingSchema({ ...messages, asset: 'other' });
+
+    expect(first.safeParse({ ...valid, asset: '' }).error?.issues[0]?.message).toBe('asset_missing');
+    expect(second.safeParse({ ...valid, asset: '' }).error?.issues[0]?.message).toBe('other');
+  });
+});

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/counterparty-mapping-form.ts
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/counterparty-mapping-form.ts
@@ -1,0 +1,25 @@
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface CounterpartyMappingMessages {
+  asset: string;
+  counterparty: string;
+  counterpartySymbol: string;
+}
+
+interface CounterpartyMappingState {
+  asset: string;
+  counterparty: string;
+  counterpartySymbol: string;
+}
+
+/** Built per call: a zod builder is mutable, so a shared instance would leak between callers. */
+export function counterpartyMappingSchema(
+  messages: CounterpartyMappingMessages,
+): ZodType<CounterpartyMappingState> {
+  return z.object({
+    asset: requiredField(messages.asset),
+    counterparty: requiredField(messages.counterparty),
+    counterpartySymbol: requiredField(messages.counterpartySymbol),
+  });
+}

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetForm.spec.ts
@@ -1,0 +1,208 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { CustomAsset } from '@/modules/assets/types';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import CustomAssetForm from '@/modules/assets/admin/custom/CustomAssetForm.vue';
+import '@test/i18n';
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+const saveIcon = vi.fn<(identifier: string) => void>();
+
+/** Every field is a third-party input, so they are stubbed down to what the form reads back. */
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur'],
+    name,
+    props: ['modelValue', 'errorMessages', 'items', 'disabled'],
+    template: '<div />',
+  };
+}
+
+const AssetIconFormStub = {
+  methods: { saveIcon },
+  name: 'AssetIconForm',
+  props: ['identifier'],
+  template: '<div />',
+};
+
+describe('customAssetForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof CustomAssetForm>>;
+
+  const baseModel = (): CustomAsset => ({
+    customAssetType: 'real estate',
+    identifier: 'custom-1',
+    name: 'A house',
+    notes: 'bought in 2019',
+  });
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    saveIcon.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    modelValue: CustomAsset = baseModel(),
+    props: Record<string, unknown> = {},
+  ): VueWrapper<InstanceType<typeof CustomAssetForm>> {
+    return mount(CustomAssetForm, {
+      global: {
+        stubs: {
+          AssetIconForm: AssetIconFormStub,
+          AutoCompleteWithSearchSync: inputStub('AutoCompleteWithSearchSync'),
+          RuiTextArea: inputStub('RuiTextArea'),
+          RuiTextField: inputStub('RuiTextField'),
+        },
+      },
+      props: { errorMessages: {}, modelValue, types: ['real estate', 'art'], ...props },
+    });
+  }
+
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.findComponent<StubInstance>(`[data-testid=${testId}]`);
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(testId: string, value: string | undefined): Promise<void> {
+    const input = field(testId);
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  function lastModel(): CustomAsset {
+    const updates = wrapper.emitted<[CustomAsset]>('update:modelValue');
+    assert(updates);
+    return updates.at(-1)![0];
+  }
+
+  it('should pass validation when the name and the type are filled', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it.each([
+    ['name'],
+    ['customAssetType'],
+  ] as const)('should fail validation when %s is empty', async (key) => {
+    const model = baseModel();
+    model[key] = '';
+    wrapper = createWrapper(model);
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should pass validation with no notes at all', async () => {
+    wrapper = createWrapper({ ...baseModel(), notes: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    // Notes carries a rule that always returns true. It exists to hold server errors, not to
+    // reject anything, and the field is never required.
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should treat a whitespace-only name as empty', async () => {
+    wrapper = createWrapper({ ...baseModel(), name: '   ' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper({ ...baseModel(), customAssetType: '', name: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('name')).toEqual([]);
+    expect(messages('type')).toEqual([]);
+  });
+
+  it('should reveal both messages once validate runs', async () => {
+    wrapper = createWrapper({ ...baseModel(), customAssetType: '', name: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The e2e suite pins the rendered text of both of these.
+    expect(messages('name')).toEqual(['asset_form.name_non_empty']);
+    expect(messages('type')).toEqual(['asset_form.type_non_empty']);
+  });
+
+  it('should show the name message once the field is emptied', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('name', '');
+
+    expect(messages('name')).toEqual(['asset_form.name_non_empty']);
+    // The untouched field stays quiet.
+    expect(messages('type')).toEqual([]);
+  });
+
+  it('should write an edit back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('name', 'A boat');
+
+    expect(lastModel().name).toBe('A boat');
+    expect(lastModel().customAssetType).toBe('real estate');
+  });
+
+  it('should keep the type list the caller passed', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('type').props('items')).toEqual(['real estate', 'art']);
+  });
+
+  it('should flag stateUpdated once a field is edited', async () => {
+    wrapper = createWrapper();
+    // Settle the mounted work first, so what follows is the only edit in play.
+    await vi.advanceTimersByTimeAsync(600);
+
+    await edit('name', 'A boat');
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
+  });
+
+  it('should not flag stateUpdated before anything is edited', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).not.toEqual([true]);
+  });
+
+  it('should hand the saved identifier to the icon form', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    wrapper.vm.saveIcon('custom-2');
+
+    expect(saveIcon).toHaveBeenCalledWith('custom-2');
+  });
+
+  it('should keep a server error hidden until its field is touched', async () => {
+    const errorMessages: ValidationErrors = { name: ['already taken'] };
+    wrapper = createWrapper(baseModel(), { errorMessages });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('name')).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetForm.spec.ts
@@ -198,11 +198,13 @@ describe('customAssetForm', () => {
     expect(saveIcon).toHaveBeenCalledWith('custom-2');
   });
 
-  it('should keep a server error hidden until its field is touched', async () => {
+  // Deliberately flipped in the zod swap. Vuelidate read external results through $errors, so a
+  // rejected save said nothing at all on a field the user had not been in.
+  it('should show a server error on an untouched field', async () => {
     const errorMessages: ValidationErrors = { name: ['already taken'] };
     wrapper = createWrapper(baseModel(), { errorMessages });
     await vi.advanceTimersToNextTimerAsync();
 
-    expect(messages('name')).toEqual([]);
+    expect(messages('name')).toEqual(['already taken']);
   });
 });

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetForm.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetForm.vue
@@ -1,12 +1,10 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { CustomAsset } from '@/modules/assets/types';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
 import AssetIconForm from '@/modules/assets/admin/AssetIconForm.vue';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { refOptional, useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { customAssetSchema } from '@/modules/assets/admin/custom/custom-asset-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import AutoCompleteWithSearchSync from '@/modules/shell/components/inputs/AutoCompleteWithSearchSync.vue';
 
 const modelValue = defineModel<CustomAsset>({ required: true });
@@ -17,45 +15,37 @@ const { types } = defineProps<{
   types: string[];
 }>();
 
-const customAssetType = useRefPropVModel(modelValue, 'customAssetType');
-const name = useRefPropVModel(modelValue, 'name');
-const notes = refOptional(useRefPropVModel(modelValue, 'notes'), '');
-
 const assetIconFormRef = useTemplateRef<InstanceType<typeof AssetIconForm>>('assetIconFormRef');
 
 const { t } = useI18n({ useScope: 'global' });
 
-const rules = {
-  name: {
-    required: helpers.withMessage(t('asset_form.name_non_empty'), required),
+const schema = computed<ZodType>(() => customAssetSchema({
+  customAssetType: t('asset_form.type_non_empty'),
+  name: t('asset_form.name_non_empty'),
+}));
+
+const form = useModelForm<CustomAsset>({
+  model: modelValue,
+  schema,
+  serverErrors: errors,
+  stateUpdated,
+});
+
+/** The field shows an empty box for an asset with no notes, and clearing it puts one back. */
+const notes = computed<string>({
+  get: () => form.state.notes ?? '',
+  set: (value?: string) => {
+    form.state.notes = value ?? null;
   },
-  notes: { externalServerValidation: () => true },
-  type: {
-    required: helpers.withMessage(t('asset_form.type_non_empty'), required),
-  },
-};
+});
 
-const states = {
-  name,
-  notes,
-  type: customAssetType,
-};
-
-const v$ = useVuelidate(
-  rules,
-  states,
-  { $autoDirty: true, $externalResults: errors },
-);
-
-useFormStateWatcher(states, stateUpdated);
-
-function saveIcon(identifier: string) {
+function saveIcon(identifier: string): void {
   get(assetIconFormRef)?.saveIcon(identifier);
 }
 
 defineExpose({
   saveIcon,
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -63,23 +53,23 @@ defineExpose({
   <div class="flex flex-col gap-2">
     <div class="grid md:grid-cols-2 gap-x-4 gap-y-2">
       <RuiTextField
-        v-model="name"
+        v-model="form.state.name"
         data-testid="name"
         variant="outlined"
         color="primary"
         clearable
         :label="t('common.name')"
-        :error-messages="toMessages(v$.name)"
-        @blur="v$.name.$touch()"
+        :error-messages="form.errors('name')"
+        @update:model-value="form.touch('name')"
       />
       <AutoCompleteWithSearchSync
-        v-model="customAssetType"
+        v-model="form.state.customAssetType"
         data-testid="type"
         :items="types"
         clearable
         :label="t('common.type')"
-        :error-messages="toMessages(v$.type)"
-        @blur="v$.type.$touch()"
+        :error-messages="form.errors('customAssetType')"
+        @update:model-value="form.touch('customAssetType')"
       />
     </div>
     <RuiTextArea
@@ -92,7 +82,6 @@ defineExpose({
       auto-grow
       clearable
       :label="t('common.notes')"
-      @blur="v$.notes.$touch()"
     />
 
     <AssetIconForm

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetFormDialog.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetFormDialog.vue
@@ -46,7 +46,7 @@ async function save() {
     return false;
 
   const formRef = get(form);
-  const valid = await formRef?.validate();
+  const valid = formRef?.validate();
   if (!valid)
     return false;
 
@@ -126,7 +126,6 @@ watchImmediate([open, () => editableItem], ([open, editableItem]) => {
       v-model:error-messages="errorMessages"
       v-model:state-updated="stateUpdated"
       :types="types"
-      :edit-mode="!!editableItem"
     />
   </BigDialog>
 </template>

--- a/frontend/app/src/modules/assets/admin/custom/custom-asset-form.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/custom-asset-form.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { customAssetSchema } from '@/modules/assets/admin/custom/custom-asset-form';
+
+const messages = {
+  customAssetType: 'type_missing',
+  name: 'name_missing',
+};
+
+const valid = {
+  customAssetType: 'real estate',
+  identifier: 'custom-1',
+  name: 'A house',
+  notes: 'bought in 2019',
+};
+
+function messagesFor(state: Record<string, unknown>): string[] {
+  const result = customAssetSchema(messages).safeParse(state);
+  if (result.success)
+    return [];
+  return result.error.issues.map(issue => issue.message);
+}
+
+describe('customAssetSchema', () => {
+  it('should accept a filled asset', () => {
+    expect(messagesFor(valid)).toEqual([]);
+  });
+
+  it.each([
+    ['customAssetType', 'type_missing'],
+    ['name', 'name_missing'],
+  ])('should report %s under its own message when empty', (key, message) => {
+    expect(messagesFor({ ...valid, [key]: '' })).toEqual([message]);
+  });
+
+  it('should treat a whitespace-only name as empty', () => {
+    expect(messagesFor({ ...valid, name: '  ' })).toEqual(['name_missing']);
+  });
+
+  it('should accept an asset with no notes', () => {
+    expect(messagesFor({ ...valid, notes: null })).toEqual([]);
+  });
+
+  it('should carry the fields it does not validate', () => {
+    const result = customAssetSchema(messages).safeParse(valid);
+
+    // Notes and the identifier reach the api untouched. Rejecting them here would block the save
+    // with nothing on screen, since neither has a message bound to it.
+    expect(result.success && result.data).toEqual(valid);
+  });
+
+  it('should report both empty fields rather than stopping at the first', () => {
+    expect(messagesFor({ ...valid, customAssetType: '', name: '' })).toEqual([
+      'type_missing',
+      'name_missing',
+    ]);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/custom/custom-asset-form.ts
+++ b/frontend/app/src/modules/assets/admin/custom/custom-asset-form.ts
@@ -1,0 +1,22 @@
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface CustomAssetMessages {
+  customAssetType: string;
+  name: string;
+}
+
+/**
+ * The name and the type are the only rules this form has ever had.
+ *
+ * Notes carried a rule that always returned true, which existed to hold server errors rather than
+ * to reject anything, and the identifier is carried untouched. Both pass through: a structural rule
+ * over a field with no message bound to it would block the save with nothing on screen to explain
+ * it. Server-side failures arrive through `setServerErrors` instead.
+ */
+export function customAssetSchema(messages: CustomAssetMessages): ZodType {
+  return z.object({
+    customAssetType: requiredField(messages.customAssetType),
+    name: requiredField(messages.name),
+  }).passthrough();
+}

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.vue
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.vue
@@ -42,7 +42,7 @@ async function save(): Promise<boolean> {
     return false;
 
   const formRef = get(form);
-  const valid = await formRef?.validate();
+  const valid = formRef?.validate();
   if (!valid)
     return false;
 

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationForm.spec.ts
@@ -1,0 +1,230 @@
+import type { ComponentPublicInstance } from 'vue';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import '@test/i18n';
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn().mockReturnValue({
+    getAssetInfo: vi.fn().mockReturnValue({ name: 'Old token', symbol: 'OLD' }),
+  }),
+}));
+
+const SolanaTokenMigrationForm = (
+  await import('@/modules/assets/admin/solana-token-migration/SolanaTokenMigrationForm.vue')
+).default;
+
+/** Real mint addresses, since the address rule runs the base58 check on them. */
+const VALID_ADDRESS = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const OTHER_ADDRESS = 'So11111111111111111111111111111111111111112';
+
+interface MigrationData {
+  address: string;
+  decimals: number | null;
+  tokenKind: string;
+}
+
+/** The stubs below declare their props at runtime, so their instances are typed loosely. */
+type StubInstance = ComponentPublicInstance<Record<string, unknown>>;
+
+function inputStub(name: string): Record<string, unknown> {
+  return {
+    emits: ['update:modelValue', 'blur', 'input'],
+    name,
+    props: ['modelValue', 'errorMessages', 'disabled', 'options'],
+    template: '<div />',
+  };
+}
+
+describe('solanaTokenMigrationForm', () => {
+  let wrapper: VueWrapper<InstanceType<typeof SolanaTokenMigrationForm>>;
+
+  const baseModel = (): MigrationData => ({
+    address: VALID_ADDRESS,
+    decimals: 6,
+    tokenKind: 'spl-token',
+  });
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.useRealTimers();
+  });
+
+  function createWrapper(
+    modelValue: MigrationData = baseModel(),
+    props: Record<string, unknown> = {},
+  ): VueWrapper<InstanceType<typeof SolanaTokenMigrationForm>> {
+    return mount(SolanaTokenMigrationForm, {
+      global: {
+        stubs: {
+          AmountInput: inputStub('AmountInput'),
+          RuiMenuSelect: inputStub('RuiMenuSelect'),
+          RuiTextField: inputStub('RuiTextField'),
+        },
+      },
+      props: { errorMessages: {}, modelValue, ...props },
+    });
+  }
+
+  /** The test ids sit on the wrapping cell, which is what the e2e page object addresses too. */
+  function field(testId: string): VueWrapper<StubInstance> {
+    return wrapper.find(`[data-testid=${testId}]`).findComponent<StubInstance>('*');
+  }
+
+  function messages(testId: string): string[] {
+    const value: unknown = field(testId).props('errorMessages');
+    assert(Array.isArray(value));
+    return value.map(String);
+  }
+
+  async function edit(testId: string, value: string): Promise<void> {
+    const input = field(testId);
+    input.vm.$emit('update:modelValue', value);
+    input.vm.$emit('input', value);
+    input.vm.$emit('blur');
+    await vi.advanceTimersToNextTimerAsync();
+  }
+
+  function lastModel(): MigrationData {
+    const updates = wrapper.emitted<[MigrationData]>('update:modelValue');
+    assert(updates);
+    return updates.at(-1)![0];
+  }
+
+  it('should pass validation for a real address with a kind and decimals', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it('should accept zero decimals', async () => {
+    wrapper = createWrapper({ ...baseModel(), decimals: 0 });
+    await vi.advanceTimersToNextTimerAsync();
+
+    // Zero is a value like any other here, which is what vuelidate's required reported too.
+    expect(await wrapper.vm.validate()).toBe(true);
+  });
+
+  it.each([
+    ['address', ''],
+    ['tokenKind', ''],
+    ['decimals', null],
+  ] as const)('should fail validation when %s is missing', async (key, empty) => {
+    wrapper = createWrapper({ ...baseModel(), [key]: empty });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should reject an address that is not base58', async () => {
+    wrapper = createWrapper({ ...baseModel(), address: 'not-a-solana-address' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(await wrapper.vm.validate()).toBe(false);
+  });
+
+  it('should show no message before anything is edited', async () => {
+    wrapper = createWrapper({ address: '', decimals: null, tokenKind: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(messages('address-input')).toEqual([]);
+    expect(messages('decimals-input')).toEqual([]);
+    expect(messages('token-kind-select')).toEqual([]);
+  });
+
+  it('should report a missing value in vuelidate english', async () => {
+    wrapper = createWrapper({ address: '', decimals: null, tokenKind: '' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    // None of the three rules was given a message, so all three fall back to the library's own
+    // untranslated string.
+    expect(messages('address-input')).toEqual(['Value is required']);
+    expect(messages('decimals-input')).toEqual(['Value is required']);
+    expect(messages('token-kind-select')).toEqual(['Value is required']);
+  });
+
+  it('should say nothing at all about a malformed address', async () => {
+    wrapper = createWrapper({ ...baseModel(), address: 'not-a-solana-address' });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await wrapper.vm.validate();
+    await vi.advanceTimersToNextTimerAsync();
+
+    // The base58 rule is a bare function, and vuelidate defaults a bare rule's message to the empty
+    // string, so the field goes red with nothing written under it.
+    expect(messages('address-input')).toEqual(['']);
+  });
+
+  it('should parse the typed decimals into a number', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('decimals-input', '18');
+
+    expect(lastModel().decimals).toBe(18);
+  });
+
+  it.each([
+    ['', null],
+    ['abc', null],
+  ])('should store %s decimals as null', async (typed, expected) => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('decimals-input', typed);
+
+    expect(lastModel().decimals).toBe(expected);
+  });
+
+  it('should write an edited address back into the model', async () => {
+    wrapper = createWrapper();
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('address-input', OTHER_ADDRESS);
+
+    expect(lastModel().address).toBe(OTHER_ADDRESS);
+  });
+
+  it('should drop a server error for the field being typed into', async () => {
+    const errorMessages: ValidationErrors = {
+      address: ['already migrated'],
+      decimals: ['wrong'],
+    };
+    wrapper = createWrapper(baseModel(), { errorMessages });
+    await vi.advanceTimersToNextTimerAsync();
+
+    await edit('address-input', OTHER_ADDRESS);
+
+    const updates = wrapper.emitted<[ValidationErrors]>('update:errorMessages');
+    assert(updates);
+    expect(updates.at(-1)![0]).toEqual({ decimals: ['wrong'] });
+  });
+
+  it('should flag stateUpdated once a field is edited', async () => {
+    wrapper = createWrapper();
+    // Settle the mounted work first, so what follows is the only edit in play.
+    await vi.advanceTimersByTimeAsync(600);
+
+    await edit('address-input', OTHER_ADDRESS);
+
+    expect(wrapper.emitted('update:stateUpdated')?.at(-1)).toEqual([true]);
+  });
+
+  it('should lock every field while the migration runs', async () => {
+    wrapper = createWrapper(baseModel(), { loading: true });
+    await vi.advanceTimersToNextTimerAsync();
+
+    expect(field('address-input').props('disabled')).toBe(true);
+    expect(field('decimals-input').props('disabled')).toBe(true);
+    expect(field('token-kind-select').props('disabled')).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationForm.spec.ts
@@ -138,30 +138,38 @@ describe('solanaTokenMigrationForm', () => {
     expect(messages('token-kind-select')).toEqual([]);
   });
 
-  it('should report a missing value in vuelidate english', async () => {
+  // The three messages below replace vuelidate's untranslated "Value is required", which is what
+  // every one of these rules reported before the swap.
+  it('should report each missing value under its own message', async () => {
     wrapper = createWrapper({ address: '', decimals: null, tokenKind: '' });
     await vi.advanceTimersToNextTimerAsync();
 
     await wrapper.vm.validate();
     await vi.advanceTimersToNextTimerAsync();
 
-    // None of the three rules was given a message, so all three fall back to the library's own
-    // untranslated string.
-    expect(messages('address-input')).toEqual(['Value is required']);
-    expect(messages('decimals-input')).toEqual(['Value is required']);
-    expect(messages('token-kind-select')).toEqual(['Value is required']);
+    expect(messages('address-input')).toEqual([
+      'asset_management.solana_token_migration.validation.address_non_empty',
+    ]);
+    expect(messages('decimals-input')).toEqual([
+      'asset_management.solana_token_migration.validation.decimals_non_empty',
+    ]);
+    expect(messages('token-kind-select')).toEqual([
+      'asset_management.solana_token_migration.validation.token_kind_non_empty',
+    ]);
   });
 
-  it('should say nothing at all about a malformed address', async () => {
+  // Before the swap the base58 rule was a bare function, which vuelidate defaults to an empty
+  // message, so a malformed address turned the field red and said nothing.
+  it('should say what is wrong with a malformed address', async () => {
     wrapper = createWrapper({ ...baseModel(), address: 'not-a-solana-address' });
     await vi.advanceTimersToNextTimerAsync();
 
     await wrapper.vm.validate();
     await vi.advanceTimersToNextTimerAsync();
 
-    // The base58 rule is a bare function, and vuelidate defaults a bare rule's message to the empty
-    // string, so the field goes red with nothing written under it.
-    expect(messages('address-input')).toEqual(['']);
+    expect(messages('address-input')).toEqual([
+      'asset_management.solana_token_migration.validation.address_invalid',
+    ]);
   });
 
   it('should parse the typed decimals into a number', async () => {

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationForm.vue
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationForm.vue
@@ -1,13 +1,10 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import { isValidSolanaAddress } from '@rotki/common';
-import useVuelidate from '@vuelidate/core';
-import { required } from '@vuelidate/validators';
+import { solanaTokenMigrationSchema } from '@/modules/assets/admin/solana-token-migration/solana-token-migration-form';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { solanaTokenKindsData } from '@/modules/core/common/chains';
-import { useFormStateWatcher } from '@/modules/core/common/use-form';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 
 interface SolanaTokenMigrationData {
@@ -27,10 +24,21 @@ const { loading, oldAsset } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const address = useRefPropVModel(modelValue, 'address');
-const decimals = useRefPropVModel(modelValue, 'decimals');
-const tokenKind = useRefPropVModel(modelValue, 'tokenKind');
 const { getAssetInfo } = useAssetInfoRetrieval();
+
+const schema = computed<ZodType>(() => solanaTokenMigrationSchema({
+  addressInvalid: t('asset_management.solana_token_migration.validation.address_invalid'),
+  addressMissing: t('asset_management.solana_token_migration.validation.address_non_empty'),
+  decimalsMissing: t('asset_management.solana_token_migration.validation.decimals_non_empty'),
+  tokenKindMissing: t('asset_management.solana_token_migration.validation.token_kind_non_empty'),
+}));
+
+const form = useModelForm<SolanaTokenMigrationData>({
+  model: modelValue,
+  schema,
+  serverErrors: errors,
+  stateUpdated,
+});
 
 const assetDetails = computed<string | undefined>(() => {
   if (!oldAsset) {
@@ -49,35 +57,16 @@ const assetDetails = computed<string | undefined>(() => {
   return `${description}${details.name} (${oldAsset})`;
 });
 
-const decimalsModel = computed({
+const decimalsModel = computed<string>({
   get() {
-    const value = get(decimals);
+    const value = form.state.decimals;
     return value !== null ? `${value}` : '';
   },
   set(value: string) {
-    const parsedValue = parseDecimals(value);
-    set(decimals, parsedValue);
+    form.state.decimals = parseDecimals(value);
+    form.touch('decimals');
   },
 });
-
-const states = {
-  address,
-  decimals,
-  tokenKind,
-};
-
-const v$ = useVuelidate({
-  address: {
-    required,
-    validated: (v: string) => !v || isValidSolanaAddress(v),
-  },
-  decimals: {
-    required,
-  },
-  tokenKind: { required },
-}, states, { $autoDirty: true, $externalResults: errors });
-
-useFormStateWatcher(states, stateUpdated);
 
 function parseDecimals(value?: string): number | null {
   if (!value)
@@ -96,7 +85,7 @@ function clearFieldError(field: keyof SolanaTokenMigrationData) {
 }
 
 defineExpose({
-  validate: () => get(v$).$validate(),
+  validate: (): boolean => form.validate(),
 });
 </script>
 
@@ -116,13 +105,13 @@ defineExpose({
         data-testid="address-input"
       >
         <RuiTextField
-          v-model="address"
+          v-model="form.state.address"
           variant="outlined"
           color="primary"
-          :error-messages="toMessages(v$.address)"
+          :error-messages="form.errors('address')"
           :label="t('asset_management.solana_token_migration.solana_address')"
           :disabled="loading"
-          @blur="v$.address.$touch()"
+          @update:model-value="form.touch('address')"
           @input="clearFieldError('address')"
         />
       </div>
@@ -137,9 +126,8 @@ defineExpose({
           color="primary"
           integer
           :label="t('asset_form.labels.decimals')"
-          :error-messages="toMessages(v$.decimals)"
+          :error-messages="form.errors('decimals')"
           :disabled="loading"
-          @blur="v$.decimals.$touch()"
           @input="clearFieldError('decimals')"
         />
       </div>
@@ -149,15 +137,15 @@ defineExpose({
         data-testid="token-kind-select"
       >
         <RuiMenuSelect
-          v-model="tokenKind"
+          v-model="form.state.tokenKind"
           :label="t('asset_form.labels.token_kind')"
           :options="solanaTokenKindsData"
-          :error-messages="toMessages(v$.tokenKind)"
+          :error-messages="form.errors('tokenKind')"
           :disabled="loading"
           key-attr="identifier"
           text-attr="label"
           variant="outlined"
-          @update:model-value="clearFieldError('tokenKind')"
+          @update:model-value="form.touch('tokenKind'); clearFieldError('tokenKind')"
         />
       </div>
     </div>

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/solana-token-migration-form.spec.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/solana-token-migration-form.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { solanaTokenMigrationSchema } from '@/modules/assets/admin/solana-token-migration/solana-token-migration-form';
+
+const messages = {
+  addressInvalid: 'address_invalid',
+  addressMissing: 'address_missing',
+  decimalsMissing: 'decimals_missing',
+  tokenKindMissing: 'kind_missing',
+};
+
+const valid = {
+  address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+  decimals: 6,
+  tokenKind: 'spl-token',
+};
+
+function messagesFor(state: Record<string, unknown>): string[] {
+  const result = solanaTokenMigrationSchema(messages).safeParse(state);
+  if (result.success)
+    return [];
+  return result.error.issues.map(issue => issue.message);
+}
+
+describe('solanaTokenMigrationSchema', () => {
+  it('should accept a real mint address', () => {
+    expect(messagesFor(valid)).toEqual([]);
+  });
+
+  it('should accept zero decimals', () => {
+    expect(messagesFor({ ...valid, decimals: 0 })).toEqual([]);
+  });
+
+  it('should report a cleared decimals field', () => {
+    expect(messagesFor({ ...valid, decimals: null })).toEqual(['decimals_missing']);
+  });
+
+  it('should report an empty token kind', () => {
+    expect(messagesFor({ ...valid, tokenKind: '' })).toEqual(['kind_missing']);
+  });
+
+  it('should report an empty address as missing rather than malformed', () => {
+    expect(messagesFor({ ...valid, address: '' })).toEqual(['address_missing']);
+  });
+
+  it.each([
+    ['not-a-solana-address'],
+    ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'],
+    ['abc'],
+  ])('should reject %s as malformed', (address) => {
+    expect(messagesFor({ ...valid, address })).toEqual(['address_invalid']);
+  });
+
+  it('should carry the fields it does not validate', () => {
+    const result = solanaTokenMigrationSchema(messages).safeParse({ ...valid, identifier: 'old' });
+
+    expect(result.success && result.data).toEqual({ ...valid, identifier: 'old' });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/solana-token-migration-form.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/solana-token-migration-form.ts
@@ -1,0 +1,26 @@
+import { isValidSolanaAddress } from '@rotki/common';
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface SolanaTokenMigrationMessages {
+  addressInvalid: string;
+  addressMissing: string;
+  decimalsMissing: string;
+  tokenKindMissing: string;
+}
+
+/**
+ * The address is checked for shape only once it holds something, so an empty field reports that it
+ * is empty rather than that it is malformed, which is the order vuelidate reported them in.
+ *
+ * Decimals are a number, so the rule fires on a cleared field rather than on a zero: zero decimals
+ * is a real token setting, and vuelidate's `required` accepted it too.
+ */
+export function solanaTokenMigrationSchema(messages: SolanaTokenMigrationMessages): ZodType {
+  return z.object({
+    address: requiredField(messages.addressMissing)
+      .refine(value => value.trim() === '' || isValidSolanaAddress(value), messages.addressInvalid),
+    decimals: z.number({ error: messages.decimalsMissing }),
+    tokenKind: requiredField(messages.tokenKindMissing),
+  }).passthrough();
+}


### PR DESCRIPTION
Continues the vuelidate to zod migration with four of the five `assets/admin` roots: the
counterparty mapping, the custom asset form, the solana token migration and the cex mapping.
`use-managed-asset-form-validation.ts` is deliberately left out: its 595-line consumer wants a
decomposition first, which is a separate PR.

Each form comes as two commits, a characterization against the vuelidate version and then the swap,
so the behaviour it had is written down before anything moves. Every characterization was checked
with a negative control (mutating the rule reddened 4, 4, 2 and 1 tests) before being trusted. The
rules themselves move into plain modules with their own specs, and the components keep the wiring.

### Behaviour changes, all deliberate

- **A server error now shows on an untouched field.** Vuelidate read external results through
  `$errors`, so a rejected save said nothing at all until the user went back into the field.
- **The solana migration form gets four new messages.** None of its rules carried one, so a missing
  value reported vuelidate's untranslated "Value is required", and the base58 check, being a bare
  function, defaulted to an empty message: a malformed address turned the field red and explained
  nothing.
- **Clearing the counterparty writes an empty string, not `null`,** into a field the payload types
  as a string. Save is gated on a rule a cleared field fails either way, so nothing downstream saw
  it. The cex mapping keeps its `null`, where it genuinely means "every exchange".
- The custom asset dialog stops passing an `edit-mode` prop the form never declared, and two dialogs
  drop an `await` now that `validate()` is synchronous.

### Notes for review

- Notes on the custom asset form keeps no rule at all. It carried one that always returned true,
  which existed only as a place for server errors to land, and it has no message bound to it.
- The exchange rule is the one conditional in the batch. The switch that decides it is not part of
  the payload, so it is a parameter of the schema builder rather than a rule reaching into state.

### Verification

Unit (853 files / 8479 tests), typecheck, lint, knip and typos are green, as are the two e2e specs
that cover this UI (`assets`, `price-manager`), all re-run after the rebase onto the accounts batch.

Driven in the running app as well: the messages render in English on an empty save, they clear as
the field is fixed, the exchange rule appears and disappears as the switch flips, the unsaved-changes
prompt arms on the first edit, and a cex mapping and a custom asset were saved and read back. The
solana form could not be reached in-app, since it needs a solana token pending migration and a fresh
profile has none.