### PR TITLE
Validate the auth forms with zod

### DIFF
--- a/frontend/app/src/modules/auth/create-account/credentials/CreateAccountCredentialsForm.vue
+++ b/frontend/app/src/modules/auth/create-account/credentials/CreateAccountCredentialsForm.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { LoginCredentials } from '@/modules/auth/login';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required, sameAs } from '@vuelidate/validators';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import {
+  type CredentialsFormState,
+  credentialsSchema,
+} from '@/modules/auth/create-account/credentials/credentials-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 
 const form = defineModel<LoginCredentials>('form', { required: true });
 const valid = defineModel<boolean>('valid', { required: true });
@@ -16,91 +18,90 @@ const { loading = false } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const username = useRefPropVModel(form, 'username');
-const password = useRefPropVModel(form, 'password');
-
-const rules = {
-  password: {
-    required: helpers.withMessage(t('create_account.credentials.validation.non_empty_password'), required),
+/**
+ * The validated state is spread across three models, because only two of its four fields are
+ * credentials. This presents them as the one object the form validates and writes each half back
+ * where it came from. The round trip has to be lossless, or the core reads its own write back as an
+ * edit nobody made.
+ */
+const bridgedState = computed<CredentialsFormState>({
+  get: () => ({
+    password: get(form).password,
+    passwordConfirm: get(passwordConfirm),
+    userPrompted: get(userPrompted),
+    username: get(form).username,
+  }),
+  set: (next: CredentialsFormState) => {
+    set(form, { ...get(form), password: next.password, username: next.username });
+    set(passwordConfirm, next.passwordConfirm);
+    set(userPrompted, next.userPrompted);
   },
-  passwordConfirm: {
-    isMatch: helpers.withMessage(
-      t('create_account.credentials.validation.password_confirmation_mismatch'),
-      sameAs(computed<string>(() => get(form).password)),
-    ),
-    required: helpers.withMessage(t('create_account.credentials.validation.non_empty_password_confirmation'), required),
-  },
-  username: {
-    isValidUsername: helpers.withMessage(
-      t('create_account.credentials.validation.valid_username'),
-      (v: string): boolean => !!(v && /^[\w.-]+$/.test(v)),
-    ),
-    required: helpers.withMessage(t('create_account.credentials.validation.non_empty_username'), required),
-  },
-  userPrompted: {
-    required: helpers.withMessage(t('create_account.credentials.validation.check_prompt'), sameAs(true)),
-  },
-};
-
-const v$ = useVuelidate(
-  rules,
-  {
-    password,
-    passwordConfirm,
-    username,
-    userPrompted,
-  },
-  {
-    $autoDirty: true,
-  },
-);
-
-watchImmediate(v$, ({ $invalid }) => {
-  set(valid, !$invalid);
 });
+
+const schema = computed<ZodType>(() => credentialsSchema({
+  confirmationMismatch: t('create_account.credentials.validation.password_confirmation_mismatch'),
+  emptyConfirmation: t('create_account.credentials.validation.non_empty_password_confirmation'),
+  emptyPassword: t('create_account.credentials.validation.non_empty_password'),
+  invalidUsername: t('create_account.credentials.validation.valid_username'),
+  prompt: t('create_account.credentials.validation.check_prompt'),
+  requiredUsername: t('create_account.credentials.validation.non_empty_username'),
+}));
+
+const { errors, state, touch, valid: parses } = useModelForm<CredentialsFormState>({
+  model: bridgedState,
+  schema,
+});
+
+// Immediate, so the wizard step starts with a real answer. A plain watch would leave `valid` at its
+// default and Continue would gate on a stale value.
+syncRefs(parses, valid);
 </script>
 
 <template>
   <div>
     <div class="space-y-3">
       <RuiTextField
-        v-model="username"
+        v-model="state.username"
         dense
         color="primary"
         variant="outlined"
         autofocus
         data-testid="create-account__fields__username"
         :label="t('create_account.credentials.label_username')"
-        :error-messages="toMessages(v$.username)"
+        :error-messages="errors('username')"
         :disabled="loading"
+        @update:model-value="touch('username')"
       />
       <RuiRevealableTextField
-        v-model="password"
+        v-model="state.password"
         dense
         color="primary"
         variant="outlined"
         data-testid="create-account__fields__password"
         :label="t('create_account.credentials.label_password')"
-        :error-messages="toMessages(v$.password)"
+        :error-messages="errors('password')"
         :disabled="loading"
+        @update:model-value="touch('password')"
       />
       <RuiRevealableTextField
-        v-model="passwordConfirm"
+        v-model="state.passwordConfirm"
         dense
         color="primary"
         variant="outlined"
         data-testid="create-account__fields__password-repeat"
         :label="t('create_account.credentials.label_password_repeat')"
-        :error-messages="toMessages(v$.passwordConfirm)"
+        :error-messages="errors('passwordConfirm')"
         :disabled="loading"
+        @update:model-value="touch('passwordConfirm')"
       />
     </div>
     <RuiCheckbox
-      v-model="userPrompted"
+      v-model="state.userPrompted"
       data-testid="create-account__boxes__user-prompted"
       :disabled="loading"
       color="primary"
-      :error-messages="toMessages(v$.userPrompted)"
+      :error-messages="errors('userPrompted')"
+      @update:model-value="touch('userPrompted')"
     >
       {{ t('create_account.credentials.label_password_backup_reminder') }}
     </RuiCheckbox>

--- a/frontend/app/src/modules/auth/create-account/credentials/credentials-form.ts
+++ b/frontend/app/src/modules/auth/create-account/credentials/credentials-form.ts
@@ -1,0 +1,51 @@
+import { z, type ZodType } from 'zod';
+import { usernameField } from '@/modules/auth/credentials-fields';
+import { requiredField } from '@/modules/core/form/fields';
+
+/**
+ * What the form validates, which is wider than the credentials it contributes to: the confirmation
+ * is never sent, and the backup prompt is a consent tick rather than a value.
+ */
+export interface CredentialsFormState {
+  password: string;
+  passwordConfirm: string;
+  userPrompted: boolean;
+  username: string;
+}
+
+export interface CredentialsFormMessages {
+  confirmationMismatch: string;
+  emptyConfirmation: string;
+  emptyPassword: string;
+  invalidUsername: string;
+  prompt: string;
+  requiredUsername: string;
+}
+
+/**
+ * Both of the confirmation's rules sit on the object rather than on the field, so the comparison can
+ * read the password without the schema depending on the state it is validating. Their order is the
+ * order vuelidate declared them in, mismatch before missing, which a cleared confirmation reports
+ * both of.
+ */
+function confirmationIssues(state: CredentialsFormState, messages: CredentialsFormMessages, ctx: z.RefinementCtx): void {
+  if (state.passwordConfirm !== state.password)
+    ctx.addIssue({ code: 'custom', message: messages.confirmationMismatch, path: ['passwordConfirm'] });
+
+  if (state.passwordConfirm.trim() === '')
+    ctx.addIssue({ code: 'custom', message: messages.emptyConfirmation, path: ['passwordConfirm'] });
+}
+
+export function credentialsSchema(messages: CredentialsFormMessages): ZodType {
+  return z.object({
+    password: requiredField(messages.emptyPassword),
+    passwordConfirm: z.string(),
+    userPrompted: z.boolean().superRefine((value, ctx) => {
+      if (!value)
+        ctx.addIssue({ code: 'custom', message: messages.prompt });
+    }),
+    username: usernameField({ invalid: messages.invalidUsername, required: messages.requiredUsername }),
+  }).superRefine((state, ctx) => {
+    confirmationIssues(state, messages, ctx);
+  });
+}

--- a/frontend/app/src/modules/auth/create-account/premium/CreateAccountPremiumForm.vue
+++ b/frontend/app/src/modules/auth/create-account/premium/CreateAccountPremiumForm.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { PremiumSetup } from '@/modules/auth/login';
-import useVuelidate from '@vuelidate/core';
-import { helpers, requiredIf } from '@vuelidate/validators';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { premiumSetupSchema } from '@/modules/auth/create-account/premium/premium-setup-form';
+import { useModelForm } from '@/modules/core/form/use-model-form';
 
 const form = defineModel<PremiumSetup>('form', { required: true });
 const valid = defineModel<boolean>('valid', { required: true });
@@ -15,48 +14,43 @@ const { loading, enabled } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const apiKey = useRefPropVModel(form, 'apiKey');
-const apiSecret = useRefPropVModel(form, 'apiSecret');
+const schema = computed<ZodType>(() => premiumSetupSchema({
+  apiKey: t('premium_credentials.validation.non_empty_key'),
+  apiSecret: t('premium_credentials.validation.non_empty_secret'),
+}, enabled));
 
-const rules = {
-  apiKey: {
-    required: helpers.withMessage(t('premium_credentials.validation.non_empty_key'), requiredIf(() => enabled)),
-  },
-  apiSecret: {
-    required: helpers.withMessage(t('premium_credentials.validation.non_empty_secret'), requiredIf(() => enabled)),
-  },
-};
-
-const v$ = useVuelidate(rules, form, {
-  $autoDirty: true,
-  $stopPropagation: true,
+const { errors, state, touch, valid: parses } = useModelForm<PremiumSetup>({
+  model: form,
+  schema,
 });
 
-watchImmediate(v$, ({ $invalid }) => {
-  set(valid, !$invalid);
-});
+// Immediate, so the step above starts with a real answer. A plain watch would leave `valid` at
+// whatever the wizard defaulted it to, and Continue would gate on a stale value.
+syncRefs(parses, valid);
 </script>
 
 <template>
   <div v-if="enabled">
     <div class="space-y-3">
       <RuiRevealableTextField
-        v-model.trim="apiKey"
+        v-model.trim="state.apiKey"
         dense
         variant="outlined"
         :disabled="loading"
         color="primary"
         :label="t('premium_credentials.label_api_key')"
-        :error-messages="toMessages(v$.apiKey)"
+        :error-messages="errors('apiKey')"
+        @update:model-value="touch('apiKey')"
       />
       <RuiRevealableTextField
-        v-model.trim="apiSecret"
+        v-model.trim="state.apiSecret"
         dense
         variant="outlined"
         :disabled="loading"
         color="primary"
         :label="t('premium_credentials.label_api_secret')"
-        :error-messages="toMessages(v$.apiSecret)"
+        :error-messages="errors('apiSecret')"
+        @update:model-value="touch('apiSecret')"
       />
     </div>
   </div>

--- a/frontend/app/src/modules/auth/create-account/premium/premium-setup-form.ts
+++ b/frontend/app/src/modules/auth/create-account/premium/premium-setup-form.ts
@@ -1,0 +1,26 @@
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+
+export interface PremiumSetupMessages {
+  apiKey: string;
+  apiSecret: string;
+}
+
+/**
+ * Whether premium is being set up at all is a choice the wizard step above owns, not part of the
+ * payload, so it is a parameter here and the schema is rebuilt when it flips, rather than a rule
+ * reaching back into form state.
+ *
+ * `syncDatabase` travels in the same payload but has never had a rule; it passes through untouched,
+ * because giving a carried field a structural type is what once made a form unsaveable with nothing
+ * on screen.
+ */
+export function premiumSetupSchema(messages: PremiumSetupMessages, enabled: boolean): ZodType {
+  if (!enabled)
+    return z.object({}).passthrough();
+
+  return z.object({
+    apiKey: requiredField(messages.apiKey),
+    apiSecret: requiredField(messages.apiSecret),
+  }).passthrough();
+}

--- a/frontend/app/src/modules/auth/credentials-fields.spec.ts
+++ b/frontend/app/src/modules/auth/credentials-fields.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { usernameField } from '@/modules/auth/credentials-fields';
+
+/**
+ * The username rule is the one piece of validation the login form and the create-account form share,
+ * so it is pinned here rather than only through each of them. A divergence between the two would let
+ * the wizard create an account that login then refuses.
+ */
+describe('usernameField', () => {
+  const schema = z.object({
+    username: usernameField({ invalid: 'invalid', required: 'required' }),
+  });
+
+  function messages(username: string): string[] {
+    const result = schema.safeParse({ username });
+    if (result.success)
+      return [];
+
+    return result.error.issues.map(issue => issue.message);
+  }
+
+  it.each([
+    ['user_name'],
+    ['user.name'],
+    ['user-name'],
+    ['User1'],
+    ['1'],
+  ])('should accept %s', (username) => {
+    expect(messages(username)).toStrictEqual([]);
+  });
+
+  it.each([
+    ['user name'],
+    ['user@name'],
+    ['user/name'],
+    ['üser'],
+  ])('should reject %s as badly formed', (username) => {
+    expect(messages(username)).toStrictEqual(['invalid']);
+  });
+
+  // Both rules report, format first, because vuelidate evaluated every rule and listed them in
+  // declaration order. The forms assert the same pair through their own fields.
+  it('should report both messages for an empty name', () => {
+    expect(messages('')).toStrictEqual(['invalid', 'required']);
+  });
+
+  // Whitespace is what separates "present" from "non-empty": it fails the format rule too, since a
+  // space is outside the allowed set.
+  it('should report both messages for a whitespace-only name', () => {
+    expect(messages('   ')).toStrictEqual(['invalid', 'required']);
+  });
+});

--- a/frontend/app/src/modules/auth/credentials-fields.ts
+++ b/frontend/app/src/modules/auth/credentials-fields.ts
@@ -1,0 +1,29 @@
+import { z, type ZodType } from 'zod';
+
+export interface UsernameMessages {
+  /** Shown when the name holds anything outside the allowed set. */
+  invalid: string;
+  /** Shown when the name is missing. */
+  required: string;
+}
+
+/** The character set the backend accepts for a user directory name. */
+const USERNAME_PATTERN = /^[\w.-]+$/;
+
+/**
+ * Shared by the login form and the create-account form, which had the same regex written out twice
+ * with different message keys. Keeping one copy matters beyond tidiness: were the two to drift, the
+ * wizard would happily create an account that the login form then refuses to accept.
+ *
+ * Both rules report, and the format one reports first, because vuelidate evaluated every rule and
+ * listed them in declaration order. An empty name therefore says both things, as it always has.
+ */
+export function usernameField(messages: UsernameMessages): ZodType<string> {
+  return z.string({ error: messages.required }).superRefine((value, ctx) => {
+    if (!USERNAME_PATTERN.test(value))
+      ctx.addIssue({ code: 'custom', message: messages.invalid });
+
+    if (value.trim() === '')
+      ctx.addIssue({ code: 'custom', message: messages.required });
+  });
+}

--- a/frontend/app/src/modules/auth/login/LoginForm.spec.ts
+++ b/frontend/app/src/modules/auth/login/LoginForm.spec.ts
@@ -319,17 +319,16 @@ describe('loginForm', () => {
       expect(messagesOf(field)).toStrictEqual([]);
     });
 
-    // Characterizing, NOT endorsing: `isValidUrl` requires a dotted host, so the most obvious local
-    // backend address a user would type is rejected. Pinned so the migration reproduces today's
-    // behaviour rather than silently changing it; fixing it is a separate decision.
-    it('should reject http://localhost:4242', async () => {
+    // Was pinned as rejected while the rule used the shared dotted-host regex, which took
+    // `http://127.0.0.1:4242` and refused the name for the same machine. Fixed deliberately.
+    it('should accept http://localhost:4242', async () => {
       wrapper = createWrapper();
       set(backendDisplay, true);
       set(backendUrl, 'http://localhost:4242');
       await nextTick();
 
       const field = wrapper.findComponent<StubInstance>({ name: 'LoginCustomBackendFields' });
-      expect(messagesOf(field)).toStrictEqual(['login.custom_backend.validation.url']);
+      expect(messagesOf(field)).toStrictEqual([]);
     });
 
     // The length bound sits in the same rule as the url check, so it reports the same message.

--- a/frontend/app/src/modules/auth/login/LoginForm.spec.ts
+++ b/frontend/app/src/modules/auth/login/LoginForm.spec.ts
@@ -379,6 +379,18 @@ describe('loginForm', () => {
       ]);
     });
 
+    // The core retires a server error once the field it was reported against is edited. Filling the
+    // name from the saved profile happens after the error is recorded and is not a user edit, so it
+    // must not count as one: the alert would go on naming the user while the field said nothing.
+    it('should keep a username error through the restore from storage', async () => {
+      set(storedUsername, 'saved-user');
+      wrapper = createWrapper({ errors: ['User saved-user does not exist'] });
+      await flushPromises();
+
+      expect(usernameField().props('modelValue')).toBe('saved-user');
+      expect(messagesOf(usernameField())).toStrictEqual(['User saved-user does not exist']);
+    });
+
     it('should route an unrecognised error to neither field', async () => {
       wrapper = createWrapper({ errors: ['Something else went wrong'] });
       await nextTick();

--- a/frontend/app/src/modules/auth/login/LoginForm.vue
+++ b/frontend/app/src/modules/auth/login/LoginForm.vue
@@ -103,8 +103,10 @@ const hasServerError = computed<boolean>(() => Object.keys(get(serverErrors)).le
 
 const isLoggedInError = useArraySome(() => errors, error => error.includes('is already logged in'));
 
-// `parses` is a ComputedRef, and the form api is a plain object, so binding `!parses` straight into
-// the template would bind a truthy ref and the gate would never engage.
+// Note for anyone porting another form: `form.valid` read off the api object does NOT unwrap in a
+// template, so `:disabled="!form.valid"` would gate on a truthy ref and never engage. Destructuring
+// it, as here, makes it a setup binding the compiler unwraps, so that trap does not apply. This
+// computed exists only because the gate is four terms wide.
 const submitDisabled = computed<boolean>(() =>
   !get(parses) || loading || get(conflictExist) || get(customBackendDisplay),
 );
@@ -130,8 +132,13 @@ function updateFocus() {
 // component can never race that flow.
 function loadSettings(): void {
   loadRememberSettings();
-  if (!state.username)
+  if (!state.username) {
     state.username = resolveStoredUsername();
+    // A server error is remembered against the value it was reported for, so that editing the field
+    // retires it. Filling the name from the saved profile is not such an edit, and would otherwise
+    // drop a rejection the screen is still showing in its alert.
+    setServerErrors(get(serverErrors));
+  }
 
   loadBackendSettings();
 }

--- a/frontend/app/src/modules/auth/login/LoginForm.vue
+++ b/frontend/app/src/modules/auth/login/LoginForm.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
+import type { ZodType } from 'zod';
 import type { LoginCredentials, SyncApproval } from '@/modules/auth/login';
-import { isValidUrl } from '@rotki/common';
 import { externalLinks } from '@shared/external-links';
-import useVuelidate from '@vuelidate/core';
-import { helpers, required, requiredIf } from '@vuelidate/validators';
 import { focusInput } from '@/modules/auth/login/focus-input';
 import IncompleteUpgradeAlert from '@/modules/auth/login/IncompleteUpgradeAlert.vue';
+import { classifyLoginErrors, type LoginFormState, loginSchema } from '@/modules/auth/login/login-form';
 import LoginBackendToggle from '@/modules/auth/login/LoginBackendToggle.vue';
 import LoginCustomBackendFields from '@/modules/auth/login/LoginCustomBackendFields.vue';
 import LoginRememberOptions from '@/modules/auth/login/LoginRememberOptions.vue';
@@ -17,7 +16,7 @@ import { useLoginRememberOptions } from '@/modules/auth/login/use-login-remember
 import { useLogout } from '@/modules/auth/use-logout';
 import { useSavedProfiles } from '@/modules/auth/use-saved-profiles';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { useForm } from '@/modules/core/form/use-form';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 
 const {
@@ -50,9 +49,7 @@ const backendChanged = (url: string | null) => emit('backend-changed', url);
 
 const { logoutRemoteSession } = useLogout();
 
-const username = ref<string>('');
 const usernameSearch = ref<string>('');
-const password = ref<string>('');
 
 const usernameFieldRef = useTemplateRef<InstanceType<typeof LoginUsernameField>>('usernameFieldRef');
 const passwordRef = useTemplateRef('passwordRef');
@@ -77,71 +74,40 @@ const {
   storedUsername,
 } = useLoginRememberOptions({ isDocker: () => !!isDocker });
 
-const rules = {
-  customBackendUrl: {
-    isValidUrl: helpers.withMessage(
-      t('login.custom_backend.validation.url'),
-      (v: string): boolean => !get(customBackendDisplay) || (v.length < 300 && isValidUrl(v)),
-    ),
-    required: helpers.withMessage(t('login.custom_backend.validation.non_empty'), requiredIf(customBackendDisplay)),
-  },
-  password: {
-    required: helpers.withMessage(t('login.validation.non_empty_password'), required),
-  },
-  username: {
-    isValidUsername: helpers.withMessage(
-      t('login.validation.valid_username'),
-      (v: string): boolean => !!(v && /^[\w.-]+$/.test(v)),
-    ),
-    required: helpers.withMessage(t('login.validation.non_empty_username'), required),
-  },
-};
+const schema = computed<ZodType>(() => loginSchema({
+  emptyPassword: t('login.validation.non_empty_password'),
+  emptyUrl: t('login.custom_backend.validation.non_empty'),
+  invalidUrl: t('login.custom_backend.validation.url'),
+  invalidUsername: t('login.validation.valid_username'),
+  requiredUsername: t('login.validation.non_empty_username'),
+}, get(customBackendDisplay)));
 
-const v$ = useVuelidate(
-  rules,
-  {
-    customBackendUrl,
-    password,
-    username,
-  },
-  {
-    $autoDirty: true,
-  },
-);
-
-watch([username, password], ([username, password], [oldUsername, oldPassword]) => {
-  // touched should not be emitted when restoring from local storage
-  if (!oldUsername && username === get(storedUsername))
-    return;
-
-  if (username !== oldUsername || password !== oldPassword)
-    touched();
+const {
+  errors: fieldErrors,
+  setServerErrors,
+  state,
+  touch,
+  valid: parses,
+} = useForm<LoginFormState, LoginFormState>({
+  initial: (): LoginFormState => ({ customBackendUrl: '', password: '', username: '' }),
+  schema,
+  // The screen above owns the attempt; this form only reports the credentials through its emit.
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (current): LoginFormState => ({ ...current }),
 });
+
+const serverErrors = computed<Record<string, string[]>>(() => classifyLoginErrors(errors));
+
+/** Whether the rejection is about the credentials, which is what picks the actionable alert. */
+const hasServerError = computed<boolean>(() => Object.keys(get(serverErrors)).length > 0);
 
 const isLoggedInError = useArraySome(() => errors, error => error.includes('is already logged in'));
 
-const usernameError = useArrayFind(() => errors, error => error.startsWith('User '));
-const passwordError = useArrayFind(() => errors, error => error.startsWith('Wrong password '));
-
-const hasServerError = computed(() => !!get(usernameError) || !!get(passwordError));
-
-const usernameErrors = computed(() => {
-  const formErrors = [...toMessages(get(v$).username)];
-  const serverError = get(usernameError);
-  if (serverError)
-    formErrors.push(serverError);
-
-  return formErrors;
-});
-
-const passwordErrors = computed(() => {
-  const formErrors = [...toMessages(get(v$).password)];
-  const serverError = get(passwordError);
-  if (serverError)
-    formErrors.push(serverError);
-
-  return formErrors;
-});
+// `parses` is a ComputedRef, and the form api is a plain object, so binding `!parses` straight into
+// the template would bind a truthy ref and the gate would never engage.
+const submitDisabled = computed<boolean>(() =>
+  !get(parses) || loading || get(conflictExist) || get(customBackendDisplay),
+);
 
 async function logout() {
   const { success } = await logoutRemoteSession();
@@ -151,7 +117,7 @@ async function logout() {
 
 function updateFocus() {
   nextTick(() => {
-    if (get(username))
+    if (state.username)
       focusInput(get(passwordRef));
     else
       get(usernameFieldRef)?.focus();
@@ -164,11 +130,50 @@ function updateFocus() {
 // component can never race that flow.
 function loadSettings(): void {
   loadRememberSettings();
-  if (!get(username))
-    set(username, resolveStoredUsername());
+  if (!state.username)
+    state.username = resolveStoredUsername();
 
   loadBackendSettings();
 }
+
+async function login(actions?: { syncApproval?: SyncApproval; resumeFromBackup?: boolean }) {
+  const credentials: LoginCredentials = {
+    password: state.password,
+    username: state.username,
+    ...actions,
+  };
+  emit('login', credentials);
+  await rememberCredentials(state.username, state.password);
+}
+
+function abortLogin() {
+  resetSyncConflict();
+  resetIncompleteUpgradeConflict();
+}
+
+watch(() => [state.username, state.password], ([username, password], [oldUsername, oldPassword]) => {
+  // touched should not be emitted when restoring from local storage
+  if (!oldUsername && username === get(storedUsername))
+    return;
+
+  if (username !== oldUsername || password !== oldPassword)
+    touched();
+});
+
+// The url is owned by the backend panel's composable; the form carries a copy so it can be validated
+// alongside the credentials. Touch is deliberately not part of the immediate run: an untouched empty
+// url must stay silent until the user has actually been in the field.
+watchImmediate(customBackendUrl, (url) => {
+  state.customBackendUrl = url;
+});
+
+watch(customBackendUrl, () => {
+  touch('customBackendUrl');
+});
+
+watchImmediate(serverErrors, (value) => {
+  setServerErrors(value);
+}, { deep: true });
 
 onBeforeMount(async () => {
   await loadProfiles();
@@ -182,21 +187,6 @@ onBeforeMount(async () => {
 onMounted(() => {
   updateFocus();
 });
-
-async function login(actions?: { syncApproval?: SyncApproval; resumeFromBackup?: boolean }) {
-  const credentials: LoginCredentials = {
-    password: get(password),
-    username: get(username),
-    ...actions,
-  };
-  emit('login', credentials);
-  await rememberCredentials(get(username), get(password));
-}
-
-function abortLogin() {
-  resetSyncConflict();
-  resetIncompleteUpgradeConflict();
-}
 </script>
 
 <template>
@@ -240,27 +230,29 @@ function abortLogin() {
           >
             <LoginUsernameField
               ref="usernameFieldRef"
-              v-model="username"
+              v-model="state.username"
               v-model:search="usernameSearch"
               :disabled="loading || conflictExist || customBackendDisplay"
               :loading="loading"
               :is-docker="isDocker"
-              :error-messages="usernameErrors"
+              :error-messages="fieldErrors('username')"
+              @update:model-value="touch('username')"
               @new-account="newAccount()"
             />
 
             <RuiRevealableTextField
               ref="passwordRef"
-              v-model="password"
+              v-model="state.password"
               variant="outlined"
               color="primary"
               autocomplete="current-password"
-              :error-messages="passwordErrors"
+              :error-messages="fieldErrors('password')"
               :disabled="loading || conflictExist || customBackendDisplay"
               class="mb-2 [&>div]:bg-transparent"
               :label="t('login.label_password')"
               data-testid="password-input"
               dense
+              @update:model-value="touch('password')"
             />
 
             <div class="flex items-center justify-between">
@@ -285,7 +277,7 @@ function abortLogin() {
               :loading="loading"
               :saved="customBackendSaved"
               :color="serverColor"
-              :error-messages="toMessages(v$.customBackendUrl)"
+              :error-messages="fieldErrors('customBackendUrl')"
               @save="saveBackend()"
               @clear="clearBackend()"
             />
@@ -301,7 +293,7 @@ function abortLogin() {
               <RuiButton
                 color="primary"
                 size="lg"
-                :disabled="v$.$invalid || loading || conflictExist || customBackendDisplay"
+                :disabled="submitDisabled"
                 :loading="loading"
                 type="submit"
                 data-testid="login-submit"

--- a/frontend/app/src/modules/auth/login/PasswordConfirmationDialog.spec.ts
+++ b/frontend/app/src/modules/auth/login/PasswordConfirmationDialog.spec.ts
@@ -182,14 +182,19 @@ describe('passwordConfirmationDialog', () => {
   });
 
   describe('when the backend has reported an error', () => {
-    it('should show that error instead of the local message', async () => {
+    // Deliberately flipped in the zod swap. The old computed returned `[errorMessage]` and threw the
+    // field's own messages away, so clearing the box while a rejection was on screen said nothing at
+    // all about the box now being empty. The core keys the two channels apart and shows both.
+    it('should show that error alongside the local message', async () => {
       harness = createHarness({ errorMessage: 'Wrong password' });
       await confirm();
 
-      expect(messages()).toStrictEqual(['Wrong password']);
+      expect(messages()).toStrictEqual([
+        'password_confirmation_dialog.validation.non_empty_password',
+        'Wrong password',
+      ]);
     });
 
-    // The server error wins unconditionally, so it keeps showing over an untouched empty field.
     it('should show that error even before the user types', async () => {
       harness = createHarness({ errorMessage: 'Wrong password' });
       await nextTick();
@@ -202,6 +207,18 @@ describe('passwordConfirmationDialog', () => {
       await confirm();
 
       expect(harness.confirmed()).toStrictEqual([]);
+    });
+
+    // New under the core: a rejection is reported against the value that earned it, so retyping
+    // retires it. The old computed kept showing it until the caller replaced the prop.
+    it('should drop that error once the password is edited', async () => {
+      harness = createHarness({ errorMessage: 'Wrong password' });
+      await nextTick();
+      expect(messages()).toStrictEqual(['Wrong password']);
+
+      await type('another');
+
+      expect(messages()).toStrictEqual([]);
     });
   });
 

--- a/frontend/app/src/modules/auth/login/PasswordConfirmationDialog.vue
+++ b/frontend/app/src/modules/auth/login/PasswordConfirmationDialog.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
-import useVuelidate from '@vuelidate/core';
-import { helpers, required } from '@vuelidate/validators';
-import { toMessages } from '@/modules/core/common/validation/validation';
+import { z, type ZodType } from 'zod';
+import { requiredField } from '@/modules/core/form/fields';
+import { useForm } from '@/modules/core/form/use-form';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
+
+interface PasswordConfirmationState {
+  password: string;
+}
 
 const display = defineModel<boolean>({ required: true });
 
@@ -21,39 +25,44 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 const { getPassword } = useInterop();
 
-const password = ref<string>('');
 const storedPassword = ref<string>('');
 
-const rules = {
-  password: {
-    required: helpers.withMessage(
-      t('password_confirmation_dialog.validation.non_empty_password'),
-      required,
-    ),
-  },
-};
+const schema = computed<ZodType>(() => z.object({
+  password: requiredField(t('password_confirmation_dialog.validation.non_empty_password')),
+}));
 
-const v$ = useVuelidate(rules, { password }, { $autoDirty: true });
-
-const passwordErrors = computed<string[]>(() => {
-  const errors = toMessages(get(v$).password);
-  if (errorMessage)
-    return [errorMessage];
-
-  return errors;
+const form = useForm<PasswordConfirmationState, PasswordConfirmationState>({
+  initial: (): PasswordConfirmationState => ({ password: '' }),
+  schema,
+  // The dialog reports the password upwards and nothing else; the caller owns the attempt.
+  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+  transform: (state): PasswordConfirmationState => ({ ...state }),
 });
 
-async function confirmPassword(): Promise<void> {
-  if (!await get(v$).$validate())
+/**
+ * The rejection the caller is holding, shown on the field it belongs to. The core keys it apart
+ * from the schema so the two now show together, where the old computed replaced one with the other.
+ * It is re-applied on open because `reset()` drops it along with everything else.
+ */
+function showServerError(): void {
+  form.setServerErrors(errorMessage ? { password: [errorMessage] } : {});
+}
+
+function confirmPassword(): void {
+  if (!form.validate())
     return;
 
-  emit('confirm', get(password));
+  emit('confirm', form.state.password);
 }
+
+watchImmediate(() => errorMessage, () => {
+  showServerError();
+});
 
 watchImmediate(display, async (isDisplayed) => {
   if (isDisplayed) {
-    set(password, '');
-    get(v$).$reset();
+    form.reset();
+    showServerError();
     // Fetch stored password when dialog opens
     if (username)
       set(storedPassword, await getPassword(username));
@@ -84,14 +93,15 @@ watchImmediate(display, async (isDisplayed) => {
         </i18n-t>
 
         <RuiTextField
-          v-model="password"
+          v-model="form.state.password"
           variant="outlined"
           color="primary"
           :label="t('password_confirmation_dialog.password_label')"
-          :error-messages="passwordErrors"
+          :error-messages="form.errors('password')"
           type="password"
           autofocus
           data-testid="password-confirmation-input"
+          @update:model-value="form.touch('password')"
           @keydown.enter="confirmPassword()"
         />
       </div>

--- a/frontend/app/src/modules/auth/login/login-form.spec.ts
+++ b/frontend/app/src/modules/auth/login/login-form.spec.ts
@@ -1,5 +1,79 @@
 import { describe, expect, it } from 'vitest';
-import { classifyLoginErrors } from '@/modules/auth/login/login-form';
+import { classifyLoginErrors, type LoginFormMessages, loginSchema } from '@/modules/auth/login/login-form';
+
+const MESSAGES: LoginFormMessages = {
+  emptyPassword: 'empty-password',
+  emptyUrl: 'empty-url',
+  invalidUrl: 'invalid-url',
+  invalidUsername: 'invalid-username',
+  requiredUsername: 'required-username',
+};
+
+/** What the backend-url field says, with the rest of the form filled in so only it can report. */
+function urlMessages(customBackendUrl: string, backendOpen: boolean = true): string[] {
+  const result = loginSchema(MESSAGES, backendOpen).safeParse({
+    customBackendUrl,
+    password: 'password',
+    username: 'user',
+  });
+
+  if (result.success)
+    return [];
+
+  return result.error.issues
+    .filter(issue => issue.path[0] === 'customBackendUrl')
+    .map(issue => issue.message);
+}
+
+/**
+ * The address the app will fetch from, so it is parsed rather than pattern-matched. The rule this
+ * replaces reused the shared `isValidUrl`, whose regex demands a dotted host: it took
+ * `http://127.0.0.1:4242` and refused `http://localhost:4242`, which name the same machine.
+ */
+describe('the backend url rule', () => {
+  it.each([
+    ['http://localhost:4242'],
+    ['http://127.0.0.1:4242'],
+    ['https://rotki.example.com'],
+    ['https://example.com:8080/api'],
+    ['http://[::1]:4242'],
+    ['http://backend'],
+  ])('should accept %s', (value) => {
+    expect(urlMessages(value)).toStrictEqual([]);
+  });
+
+  it.each([
+    ['not a url'],
+    ['localhost:4242'],
+    ['ftp://example.com'],
+    // Only something fetchable is any use here, so anything outside http(s) is out.
+    ['javascript:alert(1)'],
+    ['file:///etc/passwd'],
+  ])('should reject %s', (value) => {
+    expect(urlMessages(value)).toStrictEqual(['invalid-url']);
+  });
+
+  it('should report both messages for an empty url', () => {
+    expect(urlMessages('')).toStrictEqual(['invalid-url', 'empty-url']);
+  });
+
+  it('should reject a url of 300 characters or more', () => {
+    expect(urlMessages(`http://localhost/${'a'.repeat(300)}`)).toStrictEqual(['invalid-url']);
+  });
+
+  it('should accept one just under the bound', () => {
+    const prefix = 'http://localhost/';
+    const url = `${prefix}${'a'.repeat(299 - prefix.length)}`;
+    expect(url).toHaveLength(299);
+    expect(urlMessages(url)).toStrictEqual([]);
+  });
+
+  // The panel being shut takes the whole field out of play, however bad what it holds is.
+  it('should say nothing at all while the panel is closed', () => {
+    expect(urlMessages('not a url', false)).toStrictEqual([]);
+    expect(urlMessages('', false)).toStrictEqual([]);
+  });
+});
 
 /**
  * The backend reports a failed login as a flat list of sentences, so which field a message is about

--- a/frontend/app/src/modules/auth/login/login-form.spec.ts
+++ b/frontend/app/src/modules/auth/login/login-form.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { classifyLoginErrors } from '@/modules/auth/login/login-form';
+
+/**
+ * The backend reports a failed login as a flat list of sentences, so which field a message is about
+ * can only be read off its wording. That guesswork is pinned here rather than only through the form,
+ * because it is the part most likely to rot: a reworded backend message silently stops reaching the
+ * field it belongs to, and the login screen goes on looking healthy.
+ */
+describe('classifyLoginErrors', () => {
+  it('should route a user message to the username', () => {
+    expect(classifyLoginErrors(['User john does not exist'])).toStrictEqual({
+      username: ['User john does not exist'],
+    });
+  });
+
+  it('should route a password message to the password', () => {
+    expect(classifyLoginErrors(['Wrong password for user john'])).toStrictEqual({
+      password: ['Wrong password for user john'],
+    });
+  });
+
+  it('should route both when both are reported', () => {
+    expect(classifyLoginErrors(['User john does not exist', 'Wrong password for user john'])).toStrictEqual({
+      password: ['Wrong password for user john'],
+      username: ['User john does not exist'],
+    });
+  });
+
+  // Anything else belongs to no field; the screen shows it whole in its own alert instead.
+  it.each([
+    ['Something else went wrong'],
+    ['user john does not exist'],
+    ['The user is already logged in'],
+  ])('should claim no field for %s', (message) => {
+    expect(classifyLoginErrors([message])).toStrictEqual({});
+  });
+
+  it('should claim no field for an empty list', () => {
+    expect(classifyLoginErrors([])).toStrictEqual({});
+  });
+
+  // Only the first of a kind is shown, which is what the two lookups it replaced did.
+  it('should keep the first message of each kind', () => {
+    expect(classifyLoginErrors(['User a is gone', 'User b is gone'])).toStrictEqual({
+      username: ['User a is gone'],
+    });
+  });
+});

--- a/frontend/app/src/modules/auth/login/login-form.ts
+++ b/frontend/app/src/modules/auth/login/login-form.ts
@@ -1,4 +1,3 @@
-import { isValidUrl } from '@rotki/common';
 import { z, type ZodType } from 'zod';
 import { usernameField } from '@/modules/auth/credentials-fields';
 import { requiredField } from '@/modules/core/form/fields';
@@ -25,6 +24,27 @@ export interface LoginFormMessages {
 }
 
 /**
+ * An address the app can actually reach a backend on: an http(s) url with a host.
+ *
+ * The shared `isValidUrl` is not that test. Its regex demands a dotted host, which is right for
+ * spotting links in a message but wrong here: it accepted `http://127.0.0.1:4242` and refused
+ * `http://localhost:4242`, which name the same machine. Parsing beats pattern-matching for a value
+ * whose only job is to be fetched from.
+ */
+function isBackendUrl(value: string): boolean {
+  if (value.length >= MAX_BACKEND_URL_LENGTH)
+    return false;
+
+  try {
+    const url = new URL(value);
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.hostname.length > 0;
+  }
+  catch {
+    return false;
+  }
+}
+
+/**
  * The panel holding this field can be closed, in which case none of it is validated. That is a piece
  * of screen state rather than of the credentials, so it parameterises the builder.
  *
@@ -36,7 +56,7 @@ function backendUrlField(messages: LoginFormMessages, open: boolean): ZodType<st
     if (!open)
       return;
 
-    if (value.length >= MAX_BACKEND_URL_LENGTH || !isValidUrl(value))
+    if (!isBackendUrl(value))
       ctx.addIssue({ code: 'custom', message: messages.invalidUrl });
 
     if (value.trim() === '')

--- a/frontend/app/src/modules/auth/login/login-form.ts
+++ b/frontend/app/src/modules/auth/login/login-form.ts
@@ -1,0 +1,77 @@
+import { isValidUrl } from '@rotki/common';
+import { z, type ZodType } from 'zod';
+import { usernameField } from '@/modules/auth/credentials-fields';
+import { requiredField } from '@/modules/core/form/fields';
+
+/** The prefixes the backend puts on a rejection, which are all there is to say which field it means. */
+const USERNAME_ERROR_PREFIX = 'User ';
+const PASSWORD_ERROR_PREFIX = 'Wrong password ';
+
+/** A url longer than this is refused before it is parsed. */
+const MAX_BACKEND_URL_LENGTH = 300;
+
+export interface LoginFormState {
+  customBackendUrl: string;
+  password: string;
+  username: string;
+}
+
+export interface LoginFormMessages {
+  emptyPassword: string;
+  emptyUrl: string;
+  invalidUrl: string;
+  invalidUsername: string;
+  requiredUsername: string;
+}
+
+/**
+ * The panel holding this field can be closed, in which case none of it is validated. That is a piece
+ * of screen state rather than of the credentials, so it parameterises the builder.
+ *
+ * The length bound shares the format rule's message, as it did before: there is one message bound to
+ * this field for both.
+ */
+function backendUrlField(messages: LoginFormMessages, open: boolean): ZodType<string> {
+  return z.string().superRefine((value, ctx) => {
+    if (!open)
+      return;
+
+    if (value.length >= MAX_BACKEND_URL_LENGTH || !isValidUrl(value))
+      ctx.addIssue({ code: 'custom', message: messages.invalidUrl });
+
+    if (value.trim() === '')
+      ctx.addIssue({ code: 'custom', message: messages.emptyUrl });
+  });
+}
+
+export function loginSchema(messages: LoginFormMessages, backendOpen: boolean): ZodType {
+  return z.object({
+    customBackendUrl: backendUrlField(messages, backendOpen),
+    password: requiredField(messages.emptyPassword),
+    username: usernameField({ invalid: messages.invalidUsername, required: messages.requiredUsername }),
+  });
+}
+
+/**
+ * Routes the flat list of messages a failed login comes back with onto the field each one is about.
+ *
+ * The backend says which field it means only through the wording, so this is prefix matching and
+ * cannot be anything better until the api reports errors per field. Keeping it in one named place is
+ * the point: it used to be two inline searches, with the same two prefixes implicitly restated by
+ * the alert deciding whether to call itself a credential problem.
+ *
+ * Anything matching neither prefix belongs to no field and is left for the alert to show whole.
+ */
+export function classifyLoginErrors(errors: string[]): Record<string, string[]> {
+  const classified: Record<string, string[]> = {};
+
+  const username = errors.find(error => error.startsWith(USERNAME_ERROR_PREFIX));
+  if (username)
+    classified.username = [username];
+
+  const password = errors.find(error => error.startsWith(PASSWORD_ERROR_PREFIX));
+  if (password)
+    classified.password = [password];
+
+  return classified;
+}


### PR DESCRIPTION
Migrates the four auth forms from vuelidate to the zod form core, the last group of the migration apart from the managed-asset composable.

| Form | Now validates with |
|---|---|
| `login/PasswordConfirmationDialog` | `useForm` |
| `create-account/premium/CreateAccountPremiumForm` | `useModelForm` + `premium-setup-form.ts` |
| `create-account/credentials/CreateAccountCredentialsForm` | `useModelForm` + `credentials-form.ts` |
| `login/LoginForm` | `useForm` + `login-form.ts` |

The username rule was written out twice with different message keys, so it moves to a shared `credentials-fields.ts`. That one matters beyond tidiness: were the two copies to drift, the wizard would create an account the login form then refuses.

## The line that could have broken everything

Both create-account forms gate Continue on a `valid` model written by `watchImmediate(v$, ({ $invalid }) => ...)`. The port is `syncRefs(form.valid, valid)`, which is immediate. A plain `watch` skips the initial run, `valid` keeps the wizard's default, and Continue dead-locks.

That is not a hypothetical: swapping `syncRefs` for `watch` turns 8 tests red on the premium form and 3 on the credentials form, including **"should advance the wizard when continue is pressed"** in both step parents. Without those specs it would have surfaced as 28 e2e specs hanging at step 3.

## Method

Characterization came first, in #12905 — 1,474 lines across six specs, written against the vuelidate version and asserting through each form's real seam rather than its markup, so they carry through the swap. Every rule is mutation-proved on both sides:

| Control | Red |
|---|---|
| `syncRefs` → plain `watch` (premium / credentials) | 8 / 3, incl. both wizard-advance tests |
| Drop the confirmation's cross-field rule | 6 |
| Swap the two username messages | exactly 1, the order test |
| Break the three-model bridge round trip | 7 |
| Submit gate ignores validity | 8 |
| Reword the password error prefix | 2 |
| Drop `requiredField`, then swap it for `min(1)` | 7, then exactly 1 (the whitespace test) |

## Behaviour changes, each asserted

- **A rejected password confirmation now shows both messages.** `PasswordConfirmationDialog` returned `[errorMessage]` and discarded the field's own, so clearing the box while a rejection was on screen said nothing about it now being empty. It is also reported against the value that earned it, so retyping retires it.
- **`http://localhost:4242` is accepted as a custom backend url** (own commit). The rule reused the shared `isValidUrl`, whose regex demands a dotted host: it took `http://127.0.0.1:4242` and refused the name for the same machine. It now parses rather than pattern-matches, and keeps the http(s) restriction. `isValidUrl` is untouched — the dotted-host assumption is right for its other caller, spotting links in a message.
- **`$stopPropagation` is gone from the premium form.** Neither create-account wrapper calls `useVuelidate`, so it guarded a parent validator that does not exist; a zod form joins no validator tree at all.
- **Restoring a remembered username no longer marks that field touched.** `$autoDirty` counted the write as a change; the core touches on the input event. A stored name cannot fail the regex, since it was created through the same rule this PR deduplicates, but the difference is real and uncovered either way.

## Deliberately kept

Editing the password away from the confirmation still disables Continue **with no message anywhere on screen**, because the confirmation field is not touched. It was pinned as-is in the characterization and the core reproduces it unchanged. Flipping it is a one-line decision, better taken on its own.

## Things worth a second pair of eyes

- `CreateAccountCredentialsForm` validates across **three** models, since only two of its four fields are credentials: the confirmation is never sent and the backup prompt is consent. A computed presents them as one object and writes each half back. The round trip has to be lossless or the core reads its own write back as an edit nobody made.
- The backend-url rule stays in `LoginForm` rather than moving to `useCustomBackend`, which would have read better. That composable is mocked wholesale in the spec, so moving the rule there would have silently emptied the only coverage of the localhost case and the length bound.
- `classifyLoginErrors` is still prefix matching. The api reports a failed login as a flat list of sentences, so the field can only be read off the wording. It is at least in one named, tested place now, instead of two inline searches with the prefixes implicitly restated by the alert.

## Not included

`LoginForm` is 375 lines and two extractions are available: its error-alert region, and a `use-login-bootstrap` for the open-the-screen logic. Both are structure-only, and the alert region has no unit coverage at all, so they are better as their own PR where the diff is a pure move.

`@vuelidate/*` cannot be dropped yet: the managed-asset composable and the deliberately-cut `AssetMovementMatchingSettingsMenu` still hold callers.

## Checks

`typecheck` · `test:unit` · `lint` (0 errors) · `knip` · `check:linked-keys` · `typos`.
