### PR TITLE
refactor(starling): share one stop sequence across the launchers

### DIFF
--- a/frontend/app/electron/main/config.spec.ts
+++ b/frontend/app/electron/main/config.spec.ts
@@ -1,5 +1,5 @@
 import { LogLevel } from '@shared/log-level';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { loadConfig } from './config';
 
 const { existsSync, readFileSync } = vi.hoisted(() => ({
@@ -67,5 +67,55 @@ describe('loadConfig', () => {
     existsSync.mockReturnValue(true);
     readFileSync.mockReturnValue(JSON.stringify({ 'data-dir': '/only-data' }));
     expect(loadConfig()).toStrictEqual({ dataDirectory: '/only-data' });
+  });
+
+  describe('instance data directory', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('should take the data directory from the instance env when there is no config file', () => {
+      existsSync.mockReturnValue(false);
+      vi.stubEnv('ROTKI_INSTANCE_DATA_DIR', '/instances/scratch');
+
+      expect(loadConfig()).toStrictEqual({ dataDirectory: '/instances/scratch' });
+    });
+
+    it('should let the instance data directory win over the config file', () => {
+      // An instance exists so as not to touch the shared data directory, so the file must not be
+      // able to pull it back onto one. This is the case that failed: ports were isolated, the data
+      // directory was not, and the run died on the shared lock.
+      existsSync.mockReturnValue(true);
+      readFileSync.mockReturnValue(JSON.stringify({ 'data-dir': '/shared/develop_data' }));
+      vi.stubEnv('ROTKI_INSTANCE_DATA_DIR', '/instances/scratch');
+
+      expect(loadConfig()).toStrictEqual({ dataDirectory: '/instances/scratch' });
+    });
+
+    it('should apply the instance data directory even when the config file is malformed', () => {
+      existsSync.mockReturnValue(true);
+      readFileSync.mockReturnValue('{ not valid json');
+      vi.stubEnv('ROTKI_INSTANCE_DATA_DIR', '/instances/scratch');
+
+      expect(loadConfig()).toStrictEqual({ dataDirectory: '/instances/scratch' });
+    });
+
+    it('should keep the other config keys when the instance overrides the data directory', () => {
+      existsSync.mockReturnValue(true);
+      readFileSync.mockReturnValue(JSON.stringify({ 'data-dir': '/shared', 'log-dir': '/var/log' }));
+      vi.stubEnv('ROTKI_INSTANCE_DATA_DIR', '/instances/scratch');
+
+      expect(loadConfig()).toStrictEqual({ dataDirectory: '/instances/scratch', logDirectory: '/var/log' });
+    });
+
+    it('should leave the config file in charge when the env var is empty', () => {
+      // An empty string is how an unset instance reaches a child process, and it must not blank out
+      // a configured data directory.
+      existsSync.mockReturnValue(true);
+      readFileSync.mockReturnValue(JSON.stringify({ 'data-dir': '/configured' }));
+      vi.stubEnv('ROTKI_INSTANCE_DATA_DIR', '');
+
+      expect(loadConfig()).toStrictEqual({ dataDirectory: '/configured' });
+    });
   });
 });

--- a/frontend/app/electron/main/config.ts
+++ b/frontend/app/electron/main/config.ts
@@ -1,9 +1,22 @@
 import type { Writeable } from '@rotki/common';
 import type { BackendOptions } from '@shared/ipc';
 import fs from 'node:fs';
+import process from 'node:process';
 import { LogLevel } from '@shared/log-level';
 
 const CONFIG_FILE = 'rotki_config.json';
+
+/**
+ * Dev only: the data directory `pnpm dev --instance` allocated for this run.
+ *
+ * `scripts/dev/services.ts` hands the electron child the instance's four ports and this directory.
+ * The ports were read (see `application.ts`) but the directory was not, so an instance run isolated
+ * its ports and then opened the *shared* data directory anyway — taking its lock and failing to
+ * start whenever another rotki was already running.
+ *
+ * It wins over the config file: an instance exists precisely so as not to touch the shared data.
+ */
+const INSTANCE_DATA_DIR_ENV = 'ROTKI_INSTANCE_DATA_DIR';
 
 const LOGLEVEL = 'loglevel';
 const LOGDIR = 'log-dir';
@@ -41,20 +54,29 @@ function applyConfig(config: Record<string, any>, options: Writeable<Partial<Bac
     options.sqliteInstructions = Number.parseInt(config[SQLITE_INSTRUCTIONS]);
 }
 
+function applyInstanceDataDir(options: Writeable<Partial<BackendOptions>>): void {
+  const dataDirectory = process.env[INSTANCE_DATA_DIR_ENV];
+  if (dataDirectory)
+    options.dataDirectory = dataDirectory;
+}
+
 export function loadConfig(): Partial<BackendOptions> {
   const options: Writeable<Partial<BackendOptions>> = {};
   const filePath = CONFIG_FILE;
-  const configExists = fs.existsSync(filePath);
-  if (!configExists)
-    return options;
 
-  try {
-    const configFile = fs.readFileSync(filePath);
-    const config = JSON.parse(configFile.toString());
-    applyConfig(config, options);
-    return options;
+  if (fs.existsSync(filePath)) {
+    try {
+      const configFile = fs.readFileSync(filePath);
+      const config = JSON.parse(configFile.toString());
+      applyConfig(config, options);
+    }
+    catch {
+      // An unreadable or malformed config is ignored, as it always has been — but the instance
+      // override below still has to run, or a broken config file would silently put an instance
+      // back on the shared data directory.
+    }
   }
-  catch {
-    return options;
-  }
+
+  applyInstanceDataDir(options);
+  return options;
 }

--- a/frontend/app/electron/main/starling-handler.ts
+++ b/frontend/app/electron/main/starling-handler.ts
@@ -11,10 +11,9 @@ import { eventLastError, getMcpServerState, isMcpCrash, isServiceLive, setMcpSer
 import { BackendCode, type BackendOptions, StarlingServiceStatus } from '@shared/ipc';
 import { selectPort } from '@shared/port-utils';
 import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingInvocation } from '@shared/starling/starling-args';
-import { definedOptions, spawnStarling } from '@shared/starling/starling-launch';
+import { definedOptions, spawnStarling, stopStarling } from '@shared/starling/starling-launch';
 import { StarlingEvent, StarlingMethod, StarlingService } from '@shared/starling/starling-protocol';
 import { StarlingRpc } from '@shared/starling/starling-rpc';
-import { wait } from '@shared/utils';
 
 /** starling exits with this code when the data dir is already locked (main.rs). */
 const EXIT_DATADIR_IN_USE = 3;
@@ -322,23 +321,20 @@ export class StarlingHandler {
     if (!child)
       return;
 
+    // `exiting` stays here rather than moving into stopStarling: the exit handler reads it to tell
+    // an expected teardown from a crash, which is this class's business, not the helper's.
     this.exiting = true;
-    this.logger.debug('Stopping starling');
-    try {
-      await Promise.race([this.rpc.request(StarlingMethod.STOP).catch(() => undefined), wait(STOP_REQUEST_TIMEOUT)]);
-    }
-    catch {
-      // best-effort; fall through to wait/kill
-    }
-
-    if (this.child) {
-      const exited = this.exited ?? Promise.resolve(null);
-      const timedOut = await Promise.race([exited.then(() => false), wait(EXIT_MARGIN).then(() => true)]);
-      if (timedOut && this.child) {
-        this.logger.warn('starling did not exit in time, killing it');
-        this.child.kill('SIGKILL');
-      }
-    }
+    await stopStarling({
+      child,
+      exited: this.exited ?? Promise.resolve(null),
+      exitMarginMs: EXIT_MARGIN,
+      logger: {
+        debug: message => this.logger.debug(message),
+        warn: message => this.logger.warn(message),
+      },
+      rpc: this.rpc,
+      stopTimeoutMs: STOP_REQUEST_TIMEOUT,
+    });
     this.child = undefined;
     this.exiting = false;
   }

--- a/frontend/app/scripts/start-starling.ts
+++ b/frontend/app/scripts/start-starling.ts
@@ -2,10 +2,9 @@ import path from 'node:path';
 import process from 'node:process';
 import { cac } from 'cac';
 import consola from 'consola';
-import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingBackendOptions, type StarlingInvocation } from '../shared/starling/starling-args';
-import { requestStarlingStart, spawnStarling } from '../shared/starling/starling-launch';
+import { buildStarlingInvocation, type StarlingBackendOptions, type StarlingInvocation } from '../shared/starling/starling-args';
+import { requestStarlingStart, spawnStarling, stopStarling } from '../shared/starling/starling-launch';
 import { describeResolvedCore } from '../shared/starling/starling-launchers';
-import { StarlingMethod } from '../shared/starling/starling-protocol';
 import { StarlingRpc } from '../shared/starling/starling-rpc';
 
 /**
@@ -102,6 +101,10 @@ async function startStarling(options: StarlingE2eOptions): Promise<void> {
     onStderr: line => process.stderr.write(`${line}\n`),
   });
 
+  const stopLogger = {
+    debug: (message: string): void => consola.info(message),
+    warn: (message: string): void => consola.warn(message),
+  };
   let stopping = false;
 
   function cleanup(signal: string): void {
@@ -109,18 +112,12 @@ async function startStarling(options: StarlingE2eOptions): Promise<void> {
       return;
     stopping = true;
     consola.info(`Received ${signal}, stopping starling...`);
-    // Ask for the ordered teardown and let starling tree-kill core and colibri
-    // itself: they run in their own process groups, so nothing else reaches them
-    // and killing the supervisor early strands both. Escalate only once its own
-    // grace has elapsed. The `exited` await below holds this process open until
-    // the tree is actually down.
-    rpc.request(StarlingMethod.STOP).catch(() => undefined);
-    setTimeout(() => {
-      if (child.exitCode === null) {
-        consola.warn('starling did not exit within its grace period, killing it');
-        child.kill('SIGKILL');
-      }
-    }, SHUTDOWN_GRACE_SECS * 1000);
+    // A signal handler cannot await, so the teardown is deliberately left running: the `exited`
+    // await at the end of this function is what holds the process open until the tree is down.
+    // Previously this fired `stop` and started a kill timer in parallel, so it never learned whether
+    // the request was even accepted and escalated on a clock rather than on the child.
+    stopStarling({ child, exited, logger: stopLogger, rpc })
+      .catch(error => consola.error(`stopping starling failed: ${error instanceof Error ? error.message : String(error)}`));
   }
 
   process.on('SIGTERM', () => cleanup('SIGTERM'));

--- a/frontend/app/shared/starling/starling-launch.spec.ts
+++ b/frontend/app/shared/starling/starling-launch.spec.ts
@@ -2,8 +2,8 @@
 import type { StarlingInvocation } from './starling-args';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { definedOptions, requestStarlingStart, spawnStarling } from './starling-launch';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { definedOptions, requestStarlingStart, spawnStarling, type StarlingProcess, stopStarling, type StopStarlingLogger, type StopStarlingResult } from './starling-launch';
 import { StarlingMethod } from './starling-protocol';
 import { StarlingRpc } from './starling-rpc';
 
@@ -19,6 +19,10 @@ class FakeChild extends EventEmitter {
   readonly stdin = new PassThrough();
   readonly stdout = new PassThrough();
   readonly stderr = new PassThrough();
+  /** Node reports both as null while the process is alive, which is what the stop guard reads. */
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly kill = vi.fn<(signal?: NodeJS.Signals) => boolean>();
 }
 
 const invocation: StarlingInvocation = {
@@ -170,5 +174,117 @@ describe('requestStarlingStart', () => {
     await requestStarlingStart(rpc, { logDirectory: '/logs', dataDirectory: undefined }, 'debug');
 
     expect(request).toHaveBeenCalledWith('start', { logDirectory: '/logs', loglevel: 'debug' });
+  });
+});
+
+describe('stopStarling', () => {
+  const STOP_GRACE = 10_000;
+  const EXIT_MARGIN = 5_000;
+
+  let child: FakeChild;
+  let rpc: StarlingRpc;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    child = new FakeChild();
+    spawnMock.mockReturnValue(child);
+    rpc = makeRpc();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Spawn through the real path, so the stop is driven against the object callers actually hold. */
+  function launch(): StarlingProcess {
+    return spawnStarling({ invocation, rpc, onStderr: vi.fn() });
+  }
+
+  function exit(code: number = 0): void {
+    child.exitCode = code;
+    child.emit('exit', code, null);
+  }
+
+  async function stop(process: StarlingProcess, logger?: StopStarlingLogger): Promise<StopStarlingResult> {
+    return stopStarling({
+      child: process.child,
+      exited: process.exited,
+      exitMarginMs: EXIT_MARGIN,
+      logger,
+      rpc,
+      stopTimeoutMs: STOP_GRACE,
+    });
+  }
+
+  it('should request the ordered teardown and leave a supervisor that exits in time alone', async () => {
+    const request = vi.spyOn(rpc, 'request').mockResolvedValue(undefined);
+    const starling = launch();
+
+    const stopping = stop(starling);
+    await vi.advanceTimersByTimeAsync(0);
+    exit(0);
+
+    expect(await stopping).toEqual({ acknowledged: true, alreadyExited: false, killed: false });
+    expect(request).toHaveBeenCalledWith(StarlingMethod.STOP);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('should give the supervisor its exit margin once the stop grace elapses', async () => {
+    // The regression this helper exists for: the dev launcher raced `stop` against the grace and
+    // then killed as soon as that race resolved, so a starling still reaping core and colibri got
+    // SIGKILLed mid-teardown and orphaned both.
+    vi.spyOn(rpc, 'request').mockReturnValue(new Promise<never>(() => {}));
+    const starling = launch();
+
+    const stopping = stop(starling);
+
+    await vi.advanceTimersByTimeAsync(STOP_GRACE);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(EXIT_MARGIN - 1);
+    exit(0);
+
+    expect(await stopping).toEqual({ acknowledged: false, alreadyExited: false, killed: false });
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('should kill the supervisor that outlasts both waits', async () => {
+    vi.spyOn(rpc, 'request').mockReturnValue(new Promise<never>(() => {}));
+    const logger = { debug: vi.fn(), warn: vi.fn() };
+    const starling = launch();
+
+    const stopping = stop(starling, logger);
+    await vi.advanceTimersByTimeAsync(STOP_GRACE + EXIT_MARGIN);
+
+    expect(await stopping).toEqual({ acknowledged: false, alreadyExited: false, killed: true });
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(logger.warn).toHaveBeenCalledWith('starling did not exit in time, killing it');
+  });
+
+  it('should not wait on a supervisor that is already gone', async () => {
+    const request = vi.spyOn(rpc, 'request');
+    const starling = launch();
+    exit(1);
+
+    expect(await stop(starling)).toEqual({ acknowledged: false, alreadyExited: true, killed: false });
+    expect(request).not.toHaveBeenCalled();
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('should keep waiting for the exit when the stop request rejects', async () => {
+    // A child that dies mid-request rejects every pending one, so a rejected `stop` usually means
+    // the teardown is already happening — escalating on it would kill what is on its way out.
+    vi.spyOn(rpc, 'request').mockRejectedValue(new Error('starling exited'));
+    const starling = launch();
+
+    const stopping = stop(starling);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    exit(0);
+
+    expect(await stopping).toEqual({ acknowledged: false, alreadyExited: false, killed: false });
+    expect(child.kill).not.toHaveBeenCalled();
   });
 });

--- a/frontend/app/shared/starling/starling-launch.ts
+++ b/frontend/app/shared/starling/starling-launch.ts
@@ -1,8 +1,8 @@
-import type { StarlingBackendOptions, StarlingInvocation } from './starling-args';
 import type { StarlingRpc } from './starling-rpc';
 import { type ChildProcess, spawn } from 'node:child_process';
 import process from 'node:process';
 import readline from 'node:readline';
+import { SHUTDOWN_GRACE_SECS, type StarlingBackendOptions, type StarlingInvocation } from './starling-args';
 import { StarlingMethod } from './starling-protocol';
 
 /** How the supervisor went away: an exit code, or the signal that killed it. */
@@ -87,6 +87,100 @@ export async function requestStarlingStart(
   loglevel: string,
 ): Promise<void> {
   await rpc.request(StarlingMethod.START, { ...definedOptions(options), loglevel });
+}
+
+/** The two lines this teardown has to say. Satisfied by LogService, consola and the dev logger alike. */
+export interface StopStarlingLogger {
+  debug: (message: string) => void;
+  warn: (message: string) => void;
+}
+
+export interface StopStarlingOptions {
+  /** The control client. Its `stop` is the ordered-teardown request. */
+  rpc: StarlingRpc;
+  child: ChildProcess;
+  /** Settles once the child is gone — `StarlingProcess.exited`, or any promise that tracks it. */
+  exited: Promise<unknown>;
+  /**
+   * How long `stop` may take to answer. starling only replies once the backend tree is down, which
+   * it gives itself `SHUTDOWN_GRACE_SECS` to do, so anything shorter gives up on a shutdown that is
+   * still going fine.
+   */
+  stopTimeoutMs?: number;
+  /** Extra time the supervisor gets to exit itself once its own grace elapsed, before SIGKILL. */
+  exitMarginMs?: number;
+  logger?: StopStarlingLogger;
+}
+
+export interface StopStarlingResult {
+  /** The child was already gone, so nothing was requested. */
+  alreadyExited: boolean;
+  /** `stop` answered within its timeout, rather than the timeout winning the race. */
+  acknowledged: boolean;
+  /** The supervisor had to be SIGKILLed because it outlasted both waits. */
+  killed: boolean;
+}
+
+const SECOND = 1000;
+const DEFAULT_EXIT_MARGIN_MS = 5_000;
+
+/**
+ * Local on purpose. `shared/utils.ts` has the same helper, but it is not in the tsconfig project
+ * that compiles `shared/starling/` (TS6307), so importing it there does not typecheck — which is
+ * why this timer was hand-written in each launcher to begin with.
+ */
+async function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Ask starling to stop, give it its own grace, and only then kill it.
+ *
+ * ⚠️ The waits are not politeness. starling spawns core and colibri into their own process groups
+ * precisely so it can reap them, which means **nothing else can**: killing the supervisor before its
+ * escalation has run orphans both. That rule is the reason the supervisor exists, and it was
+ * hand-written three times (electron, dev, e2e) with three different sets of mistakes before it
+ * moved here.
+ *
+ * Callers keep their own re-entry guard. This function does not own one, because the flag also tells
+ * each caller's `exit` handler whether the exit was expected, which is caller state — but it is safe
+ * to call on an already-dead child, which it reports as `alreadyExited`.
+ */
+export async function stopStarling(options: StopStarlingOptions): Promise<StopStarlingResult> {
+  const {
+    rpc,
+    child,
+    exited,
+    stopTimeoutMs = SHUTDOWN_GRACE_SECS * SECOND,
+    exitMarginMs = DEFAULT_EXIT_MARGIN_MS,
+    logger,
+  } = options;
+
+  if (child.exitCode !== null || child.signalCode !== null)
+    return { acknowledged: false, alreadyExited: true, killed: false };
+
+  logger?.debug('stopping starling');
+
+  // A rejected `stop` is not a failure to handle: the child dying mid-request rejects every pending
+  // one (see spawnStarling), and that is the outcome we were waiting for anyway.
+  const acknowledged = await Promise.race([
+    rpc.request(StarlingMethod.STOP).then(() => true).catch(() => false),
+    wait(stopTimeoutMs).then(() => false),
+  ]);
+
+  // Second wait, on the child rather than the request: `stop` answering does not mean the process is
+  // gone, and it timing out does not mean the shutdown failed.
+  const exitedInTime = await Promise.race([
+    exited.then(() => true),
+    wait(exitMarginMs).then(() => false),
+  ]);
+
+  if (exitedInTime || child.exitCode !== null || child.signalCode !== null)
+    return { acknowledged, alreadyExited: false, killed: false };
+
+  logger?.warn('starling did not exit in time, killing it');
+  child.kill('SIGKILL');
+  return { acknowledged, alreadyExited: false, killed: true };
 }
 
 /**

--- a/frontend/scripts/dev/starling.ts
+++ b/frontend/scripts/dev/starling.ts
@@ -2,8 +2,7 @@ import path from 'node:path';
 import process from 'node:process';
 import { selectPort } from '../../app/shared/port-utils';
 import { buildStarlingInvocation, SHUTDOWN_GRACE_SECS, type StarlingBackendOptions } from '../../app/shared/starling/starling-args';
-import { requestStarlingStart, spawnStarling } from '../../app/shared/starling/starling-launch';
-import { StarlingMethod } from '../../app/shared/starling/starling-protocol';
+import { requestStarlingStart, spawnStarling, stopStarling } from '../../app/shared/starling/starling-launch';
 import { StarlingRpc } from '../../app/shared/starling/starling-rpc';
 import { createDevLogger, formatDevLine } from './logger';
 import { registerShutdownHook } from './process-pool';
@@ -48,10 +47,6 @@ export interface StarlingDevEnv {
 export interface StarlingDevPorts {
   /** The port core actually bound, after any probing. */
   corePort: number;
-}
-
-async function wait(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 /**
@@ -149,12 +144,15 @@ export async function startStarlingSupervisor(
     if (stopping || child.exitCode !== null)
       return;
     stopping = true;
-    logger.info('stopping starling');
-    // Ask for the ordered teardown, then outwait the grace starling gives its
-    // own children. Killing it earlier orphans the very processes it reaps.
-    await Promise.race([rpc.request(StarlingMethod.STOP).catch(() => undefined), wait(STOP_REQUEST_TIMEOUT_MS)]);
-    if (child.exitCode === null)
-      child.kill('SIGKILL');
+    // The teardown rule lives in stopStarling. This used to kill as soon as the stop race resolved,
+    // which SIGKILLed a supervisor that was still reaping core and colibri.
+    await stopStarling({
+      child,
+      exited,
+      logger: { debug: message => logger.info(message), warn: message => logger.warn(message) },
+      rpc,
+      stopTimeoutMs: STOP_REQUEST_TIMEOUT_MS,
+    });
   });
 
   // A supervisor that dies before `start` replies rejects the request below, but


### PR DESCRIPTION
Two related dev-tooling changes: the second was found while verifying the first.

## 1. `refactor(starling): share one stop sequence`

Three launchers (electron, dev, e2e) each hand-wrote the same teardown rule, and they had drifted. The rule is the reason the supervisor exists: **ask starling to stop, give it its own grace, only then kill it.** core and colibri run in their own process groups precisely so starling can reap them, which means nothing else can — killing the supervisor before its escalation has run orphans both.

Two of the three copies were wrong:

- the **dev** launcher killed as soon as the stop race resolved, with no wait on the child, so a supervisor still tearing the tree down was SIGKILLed mid-teardown;
- the **e2e** launcher never awaited the stop request and escalated on a fixed timer instead, so it could not tell an accepted stop from a rejected one.

`stopStarling` now holds the sequence and all three call sites use it.

Callers keep their own re-entry guard rather than the helper owning it: the flag also tells each caller's `exit` handler whether the exit was expected, which is caller state. The helper is instead safe to call on an already-dead child and reports that.

The timer is defined locally rather than taken from `shared/utils`, which is not in the tsconfig project that compiles `shared/starling` (TS6307) — the reason it was hand-written in each launcher to begin with.

## 2. `fix(dev): honour the instance data directory in electron`

`pnpm dev --instance` hands the electron child five instance variables (`scripts/dev/services.ts`). Four of them, the ports, are read in `application.ts`. `ROTKI_INSTANCE_DATA_DIR` was read **nowhere** — it appeared exactly once in the tree, on the line that writes it.

So an instance isolated its ports and then opened the *shared* data directory anyway. It took that directory's lock, which meant an instance could not run beside another rotki at all (exit 3, "data directory is already in use"), and the ~5 GB it had just seeded went unused.

`loadConfig` now applies the variable after the config file, so the instance wins. That meant dropping the early return for a missing config file, which is the common case and would have skipped the override entirely. An empty value is ignored rather than treated as a directory, so an unset instance cannot blank out a configured `data-dir`.

## Testing

**Unit** — 5 tests for `stopStarling` (exits in time, gets its exit margin after the grace, escalation, already-dead child, rejected stop) and 5 for the data-dir override. Every test was checked against a deliberate mutation rather than trusted for being green:

| Mutation | Caught by |
|---|---|
| kill as soon as the stop race resolves (the dev bug) | 3 tests, including the exit-margin one |
| drop the already-exited guard | the already-gone test, alone |
| never escalate to SIGKILL | the SIGKILL test, alone |
| apply the data-dir override before the config file | the two precedence tests |
| restore the early return for a missing config file | the no-config-file test |
| treat an empty env value as a directory | the empty-value test |

**Runtime** — this touches teardown, whose failure mode is orphaned processes and held ports, and no unit test can observe that:

| Path | Result |
|---|---|
| full e2e suite, 4 shards | 236 tests pass, 9.3 min, no ports left bound |
| e2e launcher, isolated | tree down in 1.26 s, no orphans, all ports released |
| dev launcher | tree down in 253 ms; backends logged graceful shutdown, not a kill |
| electron | clean exit 0, no orphans, ports released |

Also gated: typecheck, eslint on every changed file, knip, typos.
