### PR TITLE
Decompose the history events virtual table

### DIFF
--- a/frontend/app/src/modules/history/balances/BalanceDivergenceView.vue
+++ b/frontend/app/src/modules/history/balances/BalanceDivergenceView.vue
@@ -153,7 +153,7 @@ watch([modelSelectedAsset, modelSelectedChain, modelSelectedLocationLabel], clea
         <HistoryEventNote
           :notes="error"
           :chain="modelSelectedChain"
-          :asset="modelSelectedAsset"
+          :context="{ asset: modelSelectedAsset }"
         />
       </RuiAlert>
     </div>

--- a/frontend/app/src/modules/history/events/HistoryEventNote.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventNote.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { ExplorerUrls } from '@/modules/assets/asset-urls';
-import { type BigNumber, Blockchain } from '@rotki/common';
+import { Blockchain } from '@rotki/common';
 import { AssetAmountDisplay, ValueDisplay } from '@/modules/assets/amount-display/components';
-import { type NoteFormat, NoteType, useHistoryEventNote } from '@/modules/history/events/use-history-event-note';
+import { type HistoryEventNoteContext, type NoteFormat, NoteType, useHistoryEventNote } from '@/modules/history/events/use-history-event-note';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 import Flag from '@/modules/shell/components/Flag.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
@@ -13,38 +13,30 @@ defineOptions({
 });
 
 const {
-  amount,
-  asset = '',
-  blockNumber,
   chain = Blockchain.ETH,
-  counterparty,
-  extraData,
+  context,
   notes = '',
-  noTxRef,
-  validatorIndex,
 } = defineProps<{
   notes?: string;
-  amount?: BigNumber | BigNumber[];
-  asset?: string;
+  /** The event the note describes, as far as resolving its placeholders needs it. */
+  context?: HistoryEventNoteContext;
+  /** Chain the explorer links resolve against; unlike `context` it is a display concern. */
   chain?: string;
-  noTxRef?: boolean;
-  validatorIndex?: number;
-  blockNumber?: number;
-  counterparty?: string;
-  extraData?: Record<string, any>;
 }>();
 
 const { formatNotes } = useHistoryEventNote();
 
+const asset = computed<string>(() => context?.asset ?? '');
+
 const formattedNotes: ComputedRef<NoteFormat[]> = formatNotes({
-  amount: () => amount,
-  assetId: () => asset,
-  blockNumber: () => blockNumber,
-  counterparty: () => counterparty,
-  extraData: () => extraData,
+  amount: () => context?.amount,
+  assetId: asset,
+  blockNumber: () => context?.blockNumber,
+  counterparty: () => context?.counterparty,
+  extraData: () => context?.extraData,
   notes: () => notes,
-  noTxRef: () => noTxRef,
-  validatorIndex: () => validatorIndex,
+  noTxRef: () => context?.noTxRef ?? false,
+  validatorIndex: () => context?.validatorIndex,
 });
 
 function isLinkType(t: any): t is keyof ExplorerUrls {

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -3,6 +3,7 @@ import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types
 import type { PullLocationTransactionPayload } from '@/modules/history/events/event-payloads';
 import type { HistoryEventsRestrictions } from '@/modules/history/events/history-events-restrictions';
 import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import type { HistoryEventsTableHighlight, HistoryEventsTableSource } from '@/modules/history/events/types';
 import type { Filters } from '@/modules/history/events/use-events-filter';
 import { AccountingOverlayToggle, BalanceDivergenceToggle } from '@/modules/history/balances/components';
 import { OverlayMode } from '@/modules/history/balances/use-accounting-overlay';
@@ -32,6 +33,7 @@ import {
   type EventPriceUpdatePayload,
   provideEventPriceUpdate,
 } from '@/modules/history/events/prices/use-event-price-update-trigger';
+import { provideHistoryEventsSelection } from '@/modules/history/events/use-history-events-selection-context';
 import RefreshButton from '@/modules/shell/components/RefreshButton.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
@@ -119,6 +121,23 @@ const actions = useHistoryEventsActions({
 });
 
 const selectionMode = useHistoryEventsSelectionMode();
+
+// Read at the leaves (the row checkboxes) rather than threaded through the table and row switch.
+provideHistoryEventsSelection(selectionMode);
+
+const tableSource = computed<HistoryEventsTableSource>(() => ({
+  excludeIgnored: !get(toggles).showIgnoredAssets,
+  groupLoading: get(groupLoading),
+  groups: get(groups),
+  identifiers: get(identifiers),
+  requestPayload: get(toggles).matchExactEvents ? get(requestPayload) : undefined,
+}));
+
+const tableHighlight = computed<HistoryEventsTableHighlight>(() => ({
+  groupIdentifier: get(highlightedGroupIdentifier),
+  identifiers: get(highlightedIdentifiers),
+  types: get(highlightTypes),
+}));
 
 // Store grouped events for checking complete EVM transactions
 const groupedEventsByTxRef = ref<Record<string, HistoryEventRow[]>>({});
@@ -285,17 +304,10 @@ watchDebounced(route, async () => {
               v-model:sort="sort"
               v-model:pagination="pagination"
               :table-height-offset="tableHeightOffset"
-              :group-loading="groupLoading"
               :processing="processing || refreshing"
-              :groups="groups"
-              :request-payload="toggles.matchExactEvents ? requestPayload : undefined"
-              :exclude-ignored="!toggles.showIgnoredAssets"
+              :source="tableSource"
+              :highlight="tableHighlight"
               :has-active-filters="hasActiveFilters"
-              :identifiers="identifiers"
-              :highlighted-group-identifier="highlightedGroupIdentifier"
-              :highlighted-identifiers="highlightedIdentifiers"
-              :highlight-types="highlightTypes"
-              :selection="selectionMode"
               :duplicate-handling-status="duplicateHandlingStatus"
               @clear-filters="clearFilters()"
               @show:dialog="dialogContainer?.show($event)"

--- a/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.spec.ts
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.spec.ts
@@ -1,0 +1,62 @@
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import HistoryEventsDetailItem from '@/modules/history/events/components/HistoryEventsDetailItem.vue';
+import { provideHistoryEventsSelection } from '@/modules/history/events/use-history-events-selection-context';
+import { useHistoryEventsSelectionMode } from '@/modules/history/events/use-selection-mode';
+
+const event = createMock<HistoryEventEntry>({
+  asset: 'ETH',
+  autoNotes: 'Receive 1 ETH',
+  eventSubtype: 'none',
+  eventType: 'receive',
+  identifier: 1,
+  location: 'ethereum',
+  sequenceIndex: 0,
+});
+
+/**
+ * `provideSelection` mirrors what HistoryEventsView does. The row reads selection through inject
+ * rather than a prop, so an embedding that provides nothing must still render, just without
+ * checkboxes — that negative case is the point of the pair below.
+ */
+function mountItem(provideSelection: boolean): VueWrapper {
+  return mount({
+    components: { HistoryEventsDetailItem },
+    setup() {
+      if (provideSelection) {
+        const selection = useHistoryEventsSelectionMode();
+        selection.setAvailableIds([1]);
+        selection.actions.toggle();
+        provideHistoryEventsSelection(selection);
+      }
+      return { completeGroupEvents: [event], event };
+    },
+    template: '<HistoryEventsDetailItem :event="event" :index="0" :complete-group-events="completeGroupEvents" />',
+  }, {
+    global: {
+      plugins: [createCustomPinia()],
+      provide: libraryDefaults,
+      // `shallow` would stub the component under test too; only its children should be stubs.
+      stubs: { HistoryEventsDetailItem: false },
+    },
+    shallow: true,
+  });
+}
+
+describe('modules/history/events/components/HistoryEventsDetailItem', () => {
+  it('should render a checkbox when a provided selection is in selection mode', () => {
+    const wrapper = mountItem(true);
+
+    expect(wrapper.findComponent({ name: 'RuiCheckbox' }).exists()).toBe(true);
+  });
+
+  it('should render without a checkbox when no selection is provided', () => {
+    const wrapper = mountItem(false);
+
+    expect(wrapper.findComponent({ name: 'RuiCheckbox' }).exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import type { HistoryEventDeletePayload } from '@/modules/history/events/types';
-import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
 import type { HistoryEventEditData } from '@/modules/history/management/forms/form-types';
 import AccountingOverlayCell from '@/modules/history/balances/AccountingOverlayCell.vue';
 import { getHighlightClass, type HighlightType } from '@/modules/history/events/action-types';
@@ -9,6 +8,7 @@ import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
 import HistoryEventNote from '@/modules/history/events/HistoryEventNote.vue';
 import HistoryEventsListItemAction from '@/modules/history/events/HistoryEventsListItemAction.vue';
 import HistoryEventType from '@/modules/history/events/HistoryEventType.vue';
+import { injectHistoryEventsSelection } from '@/modules/history/events/use-history-events-selection-context';
 import { useHistoryEventItem } from '../use-history-event-item';
 
 const {
@@ -19,7 +19,6 @@ const {
   matchedMovement,
   hideActions,
   highlightType,
-  selection,
   variant = 'row',
 } = defineProps<{
   event: HistoryEventEntry;
@@ -35,7 +34,6 @@ const {
   hideActions?: boolean;
   /** The highlight colour. Its presence is what highlights the row. */
   highlightType?: HighlightType;
-  selection?: UseHistoryEventsSelectionModeReturn;
   variant?: 'row' | 'card';
 }>();
 
@@ -45,6 +43,8 @@ const emit = defineEmits<{
   'show:missing-rule-action': [data: HistoryEventEditData];
   'refresh': [];
 }>();
+
+const selection = injectHistoryEventsSelection();
 
 const {
   blockNumber,

--- a/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import type { HistoryEventDeletePayload } from '@/modules/history/events/types';
+import type { HistoryEventNoteContext } from '@/modules/history/events/use-history-event-note';
 import type { HistoryEventEditData } from '@/modules/history/management/forms/form-types';
 import AccountingOverlayCell from '@/modules/history/balances/AccountingOverlayCell.vue';
 import { getHighlightClass, type HighlightType } from '@/modules/history/events/action-types';
@@ -74,6 +75,15 @@ const isSelectedModel = computed<boolean>({
 });
 
 const isCard = computed<boolean>(() => variant === 'card');
+
+const noteContext = computed<HistoryEventNoteContext>(() => ({
+  amount: event.amount,
+  asset: event.asset,
+  blockNumber: get(blockNumber),
+  counterparty: get(counterparty),
+  extraData: get(extraData),
+  validatorIndex: get(validatorIndex),
+}));
 </script>
 
 <template>
@@ -123,13 +133,8 @@ const isCard = computed<boolean>(() => variant === 'card');
     <div class="flex items-start justify-between gap-2">
       <HistoryEventNote
         :notes="notes"
-        :amount="event.amount"
-        :asset="event.asset"
+        :context="noteContext"
         :chain="chain"
-        :counterparty="counterparty"
-        :validator-index="validatorIndex"
-        :block-number="blockNumber"
-        :extra-data="extraData"
         class="flex-1 min-w-0 overflow-hidden line-clamp-2 text-sm text-rui-text-secondary"
       />
 
@@ -183,13 +188,8 @@ const isCard = computed<boolean>(() => variant === 'card');
 
     <HistoryEventNote
       :notes="notes"
-      :amount="event.amount"
-      :asset="event.asset"
+      :context="noteContext"
       :chain="chain"
-      :counterparty="counterparty"
-      :validator-index="validatorIndex"
-      :block-number="blockNumber"
-      :extra-data="extraData"
       class="flex-1 min-w-0 overflow-hidden line-clamp-2"
     />
 

--- a/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsDetailItem.vue
@@ -76,6 +76,25 @@ const isSelectedModel = computed<boolean>({
 
 const isCard = computed<boolean>(() => variant === 'card');
 
+/**
+ * Whether the row layout has built its action cluster yet.
+ *
+ * The cluster carries a RuiMenu, whose `useElementSize` reads `offsetWidth` on mount and so forces
+ * a synchronous layout right after the virtual list mutated the DOM. Over a scroll that was the
+ * table's largest source of forced reflow. It is invisible until the row is hovered, so it is built
+ * on first hover, or when focus enters the row, which is how a keyboard reaches it. Once built it
+ * stays: unmounting on leave would pay the cost again on the next hover.
+ *
+ * The card layout does not gate: it is the narrow-viewport variant, where there is no hover.
+ */
+const actionsRevealed = shallowRef<boolean>(false);
+
+const showActions = computed<boolean>(() => !hideActions && (get(hasMissingRule) || get(actionsRevealed)));
+
+function revealActions(): void {
+  set(actionsRevealed, true);
+}
+
 const noteContext = computed<HistoryEventNoteContext>(() => ({
   amount: event.amount,
   asset: event.asset,
@@ -161,6 +180,8 @@ const noteContext = computed<HistoryEventNoteContext>(() => ({
       { 'opacity-50': hiddenEvent },
       getHighlightClass(highlightType),
     ]"
+    @pointerenter="revealActions()"
+    @focusin="revealActions()"
   >
     <RuiCheckbox
       v-if="showCheckbox"
@@ -196,7 +217,7 @@ const noteContext = computed<HistoryEventNoteContext>(() => ({
     <AccountingOverlayCell :event="event" />
 
     <HistoryEventsListItemAction
-      v-if="!hideActions"
+      v-if="showActions"
       :item="event"
       :index="index"
       :complete-group-events="completeGroupEvents"
@@ -205,6 +226,12 @@ const noteContext = computed<HistoryEventNoteContext>(() => ({
       @edit-event="emit('edit-event', $event)"
       @delete-event="emit('delete-event', $event)"
       @show:missing-rule-action="emit('show:missing-rule-action', $event)"
+    />
+    <!-- Holds the cluster's width so revealing it does not reflow the row. -->
+    <div
+      v-else-if="!hideActions"
+      class="w-24 shrink-0"
+      aria-hidden="true"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsMatchedMovementItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsMatchedMovementItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import type { HistoryEventDeletePayload, HistoryEventUnlinkPayload } from '@/modules/history/events/types';
+import type { HistoryEventNoteContext } from '@/modules/history/events/use-history-event-note';
 import type { HistoryEventEditData } from '@/modules/history/management/forms/form-types';
 import AccountingOverlayCell from '@/modules/history/balances/AccountingOverlayCell.vue';
 import { getHighlightClass, type HighlightType } from '@/modules/history/events/action-types';
@@ -62,6 +63,11 @@ const isSelectedModel = computed<boolean>({
 });
 
 const isCard = computed<boolean>(() => variant === 'card');
+
+const noteContext = computed<HistoryEventNoteContext>(() => ({
+  amount: get(primaryEvent).amount,
+  asset: get(primaryEvent).asset,
+}));
 </script>
 
 <template>
@@ -125,8 +131,7 @@ const isCard = computed<boolean>(() => variant === 'card');
     <div class="flex items-start justify-between gap-2">
       <HistoryEventNote
         :notes="compactNotes"
-        :amount="primaryEvent.amount"
-        :asset="primaryEvent.asset"
+        :context="noteContext"
         :chain="chain"
         class="flex-1 min-w-0 overflow-hidden line-clamp-2 text-sm text-rui-text-secondary"
       />
@@ -197,8 +202,7 @@ const isCard = computed<boolean>(() => variant === 'card');
 
     <HistoryEventNote
       :notes="compactNotes"
-      :amount="primaryEvent.amount"
-      :asset="primaryEvent.asset"
+      :context="noteContext"
       :chain="chain"
       class="flex-1 min-w-0 overflow-hidden self-center line-clamp-2"
     />

--- a/frontend/app/src/modules/history/events/components/HistoryEventsMatchedMovementItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsMatchedMovementItem.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import type { HistoryEventDeletePayload, HistoryEventUnlinkPayload } from '@/modules/history/events/types';
-import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
 import type { HistoryEventEditData } from '@/modules/history/management/forms/form-types';
 import AccountingOverlayCell from '@/modules/history/balances/AccountingOverlayCell.vue';
 import { getHighlightClass, type HighlightType } from '@/modules/history/events/action-types';
@@ -9,9 +8,10 @@ import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
 import HistoryEventNote from '@/modules/history/events/HistoryEventNote.vue';
 import HistoryEventsListItemAction from '@/modules/history/events/HistoryEventsListItemAction.vue';
 import HistoryEventType from '@/modules/history/events/HistoryEventType.vue';
+import { injectHistoryEventsSelection } from '@/modules/history/events/use-history-events-selection-context';
 import { useHistoryMatchedMovementItem } from '../use-history-matched-movement-item';
 
-const { events: eventsProp, selection, variant = 'row' } = defineProps<{
+const { events: eventsProp, variant = 'row' } = defineProps<{
   events: HistoryEventEntry[];
   /**
    * All events in the same group, including hidden and ignored events.
@@ -22,7 +22,6 @@ const { events: eventsProp, selection, variant = 'row' } = defineProps<{
   hideActions?: boolean;
   highlight?: boolean;
   highlightType?: HighlightType;
-  selection?: UseHistoryEventsSelectionModeReturn;
   variant?: 'row' | 'card';
 }>();
 
@@ -36,6 +35,8 @@ const emit = defineEmits<{
 }>();
 
 const events = computed<HistoryEventEntry[]>(() => eventsProp);
+
+const selection = injectHistoryEventsSelection();
 
 const {
   canUnlink,

--- a/frontend/app/src/modules/history/events/components/HistoryEventsRowPlaceholder.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsRowPlaceholder.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+const { variant } = defineProps<{
+  variant: 'row' | 'card';
+}>();
+
+const card = computed<boolean>(() => variant === 'card');
+</script>
+
+<template>
+  <div
+    class="animate-pulse contain-content"
+    :class="card ? 'p-3 border-b border-default' : 'h-[72px] flex items-center gap-4 border-b border-default px-4 pl-6'"
+  >
+    <template v-if="card">
+      <!-- Top row: Event type with icon -->
+      <div class="flex items-center gap-3 mb-2">
+        <div class="size-10 rounded-full bg-rui-grey-300 dark:bg-rui-grey-700 shrink-0" />
+        <div class="flex flex-col gap-1">
+          <div class="h-4 w-20 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
+          <div class="h-3 w-14 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
+        </div>
+      </div>
+      <!-- Middle row: Asset & Amount -->
+      <div class="flex items-center gap-2 mb-2">
+        <div class="size-8 rounded-full bg-rui-grey-300 dark:bg-rui-grey-700" />
+        <div class="flex flex-col gap-1">
+          <div class="h-4 w-24 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
+          <div class="h-3 w-16 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
+        </div>
+      </div>
+      <!-- Bottom row: Notes -->
+      <div class="h-3 w-3/4 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
+    </template>
+    <template v-else>
+      <div class="w-56 shrink-0 flex items-center gap-3">
+        <div class="size-10 rounded-full bg-rui-grey-300 dark:bg-rui-grey-700" />
+        <div class="flex flex-col gap-1.5">
+          <div class="h-4 w-20 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
+          <div class="h-3 w-14 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
+        </div>
+      </div>
+      <div class="w-56 xl:w-60 shrink-0 flex items-center gap-2">
+        <div class="size-8 rounded-full bg-rui-grey-300 dark:bg-rui-grey-700" />
+        <div class="flex flex-col gap-1.5">
+          <div class="h-4 w-24 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
+          <div class="h-3 w-16 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
+        </div>
+      </div>
+      <div class="flex-1 min-w-0 flex flex-col gap-1.5">
+        <div class="h-3.5 w-3/4 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
+        <div class="h-3 w-1/2 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
+      </div>
+      <div class="w-24 shrink-0" />
+    </template>
+  </div>
+</template>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsSwapItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsSwapItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import type { HistoryEventDeletePayload } from '@/modules/history/events/types';
+import type { HistoryEventNoteContext } from '@/modules/history/events/use-history-event-note';
 import type { HistoryEventEditData } from '@/modules/history/management/forms/form-types';
 import AccountingOverlayCell from '@/modules/history/balances/AccountingOverlayCell.vue';
 import { getHighlightClass, type HighlightType } from '@/modules/history/events/action-types';
@@ -71,6 +72,11 @@ const isSelectedModel = computed<boolean>({
 });
 
 const isCard = computed<boolean>(() => variant === 'card');
+
+const noteContext = computed<HistoryEventNoteContext>(() => ({
+  amount: get(events).map(item => item.amount),
+  counterparty: get(counterparty),
+}));
 
 // A combined bridge row represents both legs, so show a neutral label instead
 // of the primary (out) leg's directional one.
@@ -180,8 +186,7 @@ const typeLabel = computed<string | undefined>(() =>
       <HistoryEventNote
         :notes="compactNotes"
         :chain="chain"
-        :amount="events.map(item => item.amount)"
-        :counterparty="counterparty"
+        :context="noteContext"
         class="flex-1 min-w-0 overflow-hidden line-clamp-2 text-sm text-rui-text-secondary"
       />
 
@@ -294,8 +299,7 @@ const typeLabel = computed<string | undefined>(() =>
       <HistoryEventNote
         :notes="compactNotes"
         :chain="chain"
-        :amount="events.map(item => item.amount)"
-        :counterparty="counterparty"
+        :context="noteContext"
         class="flex-1 min-w-0 overflow-hidden self-center line-clamp-2"
       />
     </div>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsSwapItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsSwapItem.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import type { HistoryEventDeletePayload } from '@/modules/history/events/types';
-import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
 import type { HistoryEventEditData } from '@/modules/history/management/forms/form-types';
 import AccountingOverlayCell from '@/modules/history/balances/AccountingOverlayCell.vue';
 import { getHighlightClass, type HighlightType } from '@/modules/history/events/action-types';
@@ -9,9 +8,10 @@ import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
 import HistoryEventNote from '@/modules/history/events/HistoryEventNote.vue';
 import HistoryEventsListItemAction from '@/modules/history/events/HistoryEventsListItemAction.vue';
 import HistoryEventType from '@/modules/history/events/HistoryEventType.vue';
+import { injectHistoryEventsSelection } from '@/modules/history/events/use-history-events-selection-context';
 import { useHistorySwapItem } from '../use-history-swap-item';
 
-const { events: eventsProp, selection, variant = 'row' } = defineProps<{
+const { events: eventsProp, variant = 'row' } = defineProps<{
   events: HistoryEventEntry[];
   /**
    * All events in the same group, including hidden and ignored events.
@@ -22,7 +22,6 @@ const { events: eventsProp, selection, variant = 'row' } = defineProps<{
   hideActions?: boolean;
   highlight?: boolean;
   highlightType?: HighlightType;
-  selection?: UseHistoryEventsSelectionModeReturn;
   variant?: 'row' | 'card';
 }>();
 
@@ -37,6 +36,8 @@ const emit = defineEmits<{
 const events = computed<HistoryEventEntry[]>(() => eventsProp);
 
 const { t } = useI18n({ useScope: 'global' });
+
+const selection = injectHistoryEventsSelection();
 
 const {
   chain,

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualRow.spec.ts
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualRow.spec.ts
@@ -1,0 +1,232 @@
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import type { VirtualRow } from '@/modules/history/events/use-virtual-rows';
+import { createMock } from '@test/utils/create-mock';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import HistoryEventsDetailItem from '@/modules/history/events/components/HistoryEventsDetailItem.vue';
+import HistoryEventsGroupItem from '@/modules/history/events/components/HistoryEventsGroupItem.vue';
+import HistoryEventsLoadMoreRow from '@/modules/history/events/components/HistoryEventsLoadMoreRow.vue';
+import HistoryEventsMatchedMovementItem from '@/modules/history/events/components/HistoryEventsMatchedMovementItem.vue';
+import HistoryEventsRowPlaceholder from '@/modules/history/events/components/HistoryEventsRowPlaceholder.vue';
+import HistoryEventsSwapCollapseRow from '@/modules/history/events/components/HistoryEventsSwapCollapseRow.vue';
+import HistoryEventsSwapItem from '@/modules/history/events/components/HistoryEventsSwapItem.vue';
+import HistoryEventsVirtualRow from '@/modules/history/events/components/HistoryEventsVirtualRow.vue';
+import { type HistoryEventsRowContext, provideHistoryEventsRowContext } from '@/modules/history/events/use-history-events-row-context';
+
+function createEvent(identifier: number): HistoryEventEntry {
+  return createMock<HistoryEventEntry>({ identifier });
+}
+
+const groupEvents = [createEvent(1), createEvent(2)];
+const subgroupEvents = [createEvent(3), createEvent(4)];
+
+function createContext(): HistoryEventsRowContext {
+  return {
+    actions: {
+      addEvent: vi.fn(),
+      addMissingRule: vi.fn(),
+      deleteEvents: vi.fn(),
+      deleteTransaction: vi.fn(),
+      editEvent: vi.fn(),
+      loadMore: vi.fn(),
+      redecode: vi.fn(),
+      redecodeWithOptions: vi.fn(),
+      refresh: vi.fn(),
+      toggleIgnore: vi.fn(),
+      toggleMovementExpanded: vi.fn(),
+      toggleShowIgnoredAssets: vi.fn(),
+      toggleSwapExpanded: vi.fn(),
+      unlinkEvent: vi.fn(),
+      unlinkGroup: vi.fn(),
+    },
+    display: {
+      duplicateHandlingStatus: computed(() => undefined),
+      eventsLoading: ref(false),
+      hideActions: computed<boolean>(() => false),
+      variant: computed<'row' | 'card'>(() => 'row'),
+    },
+    highlight: {
+      getHighlightType: vi.fn(),
+      getSwapHighlightType: vi.fn(),
+      isGroupHighlighted: vi.fn().mockReturnValue(false),
+      isHighlighted: vi.fn().mockReturnValue(false),
+      isSwapHighlighted: vi.fn().mockReturnValue(false),
+    },
+    lookups: {
+      completeEventsForItem: vi.fn().mockReturnValue(groupEvents),
+      completeSubgroupEvents: vi.fn().mockReturnValue(subgroupEvents),
+      groupEvents: vi.fn().mockReturnValue(groupEvents),
+      groupLocationLabel: vi.fn().mockReturnValue('kraken'),
+      ignoredAssets: vi.fn().mockReturnValue(undefined),
+    },
+  };
+}
+
+let context: HistoryEventsRowContext;
+
+/**
+ * Mounted through a host so the row resolves its context the way the virtual table supplies it:
+ * a provide from an ancestor, not a prop. Children are stubbed because what this component owns
+ * is the choice of child and the arguments it hands over, not their rendering.
+ */
+function mountRow(row: VirtualRow): VueWrapper {
+  return mount({
+    components: { HistoryEventsVirtualRow },
+    setup() {
+      provideHistoryEventsRowContext(context);
+      return { row };
+    },
+    template: '<HistoryEventsVirtualRow :row="row" />',
+  }, {
+    global: {
+      provide: libraryDefaults,
+      // `shallow` would stub the component under test too; only its children should be stubs.
+      stubs: { HistoryEventsVirtualRow: false },
+    },
+    shallow: true,
+  });
+}
+
+describe('modules/history/events/components/HistoryEventsVirtualRow', () => {
+  beforeEach(() => {
+    context = createContext();
+  });
+
+  it('should render a group header for a group-header row', () => {
+    const group = createEvent(10);
+    const wrapper = mountRow({ data: group, groupId: 'group-1', type: 'group-header' });
+
+    const item = wrapper.findComponent(HistoryEventsGroupItem);
+    expect(item.exists()).toBe(true);
+    expect(item.props('group')).toBe(group);
+    expect(item.props('groupEvents')).toBe(groupEvents);
+    expect(context.lookups.groupEvents).toHaveBeenCalledWith('group-1');
+    expect(wrapper.findComponent(HistoryEventsDetailItem).exists()).toBe(false);
+  });
+
+  it('should render a placeholder for an event-placeholder row', () => {
+    const wrapper = mountRow({ groupId: 'group-1', index: 0, type: 'event-placeholder' });
+
+    const placeholder = wrapper.findComponent(HistoryEventsRowPlaceholder);
+    expect(placeholder.exists()).toBe(true);
+    expect(placeholder.props('variant')).toBe('row');
+  });
+
+  it('should render a detail item for an event-row', () => {
+    const event = createEvent(11);
+    const wrapper = mountRow({ data: event, groupId: 'group-1', index: 2, type: 'event-row' });
+
+    const item = wrapper.findComponent(HistoryEventsDetailItem);
+    expect(item.exists()).toBe(true);
+    expect(item.props('event')).toBe(event);
+    expect(item.props('index')).toBe(2);
+    expect(item.props('completeGroupEvents')).toBe(groupEvents);
+    expect(item.props('groupLocationLabel')).toBe('kraken');
+  });
+
+  it('should render a swap item for a swap-row', () => {
+    const wrapper = mountRow({
+      events: subgroupEvents,
+      groupId: 'group-1',
+      index: 0,
+      swapKey: 'group-1-3',
+      type: 'swap-row',
+    });
+
+    const item = wrapper.findComponent(HistoryEventsSwapItem);
+    expect(item.exists()).toBe(true);
+    expect(item.props('events')).toBe(subgroupEvents);
+    expect(item.props('completeGroupEvents')).toBe(subgroupEvents);
+  });
+
+  it('should render a collapse row for a swap-collapse row', () => {
+    const wrapper = mountRow({
+      bridge: true,
+      eventCount: 3,
+      groupId: 'group-1',
+      swapKey: 'group-1-3',
+      type: 'swap-collapse',
+    });
+
+    const item = wrapper.findComponent(HistoryEventsSwapCollapseRow);
+    expect(item.exists()).toBe(true);
+    expect(item.props('eventCount')).toBe(3);
+    expect(item.props('labelType')).toBe('bridge');
+  });
+
+  it('should render a matched movement item for a matched-movement-row', () => {
+    const wrapper = mountRow({
+      events: subgroupEvents,
+      groupId: 'group-1',
+      index: 0,
+      movementKey: 'group-1-3',
+      type: 'matched-movement-row',
+    });
+
+    const item = wrapper.findComponent(HistoryEventsMatchedMovementItem);
+    expect(item.exists()).toBe(true);
+    expect(item.props('events')).toBe(subgroupEvents);
+  });
+
+  it('should render a movement collapse row for a matched-movement-collapse row', () => {
+    const wrapper = mountRow({
+      eventCount: 2,
+      groupId: 'group-1',
+      movementKey: 'group-1-3',
+      type: 'matched-movement-collapse',
+    });
+
+    const item = wrapper.findComponent(HistoryEventsSwapCollapseRow);
+    expect(item.exists()).toBe(true);
+    expect(item.props('labelType')).toBe('movement');
+    expect(item.props('eventCount')).toBe(2);
+  });
+
+  it('should render a load more row for a load-more row', () => {
+    const wrapper = mountRow({ groupId: 'group-1', hiddenCount: 4, totalCount: 10, type: 'load-more' });
+
+    const item = wrapper.findComponent(HistoryEventsLoadMoreRow);
+    expect(item.exists()).toBe(true);
+    expect(item.props('hiddenCount')).toBe(4);
+  });
+
+  it('should route a row callback to the context action with its group id', async () => {
+    const event = createEvent(12);
+    const wrapper = mountRow({ data: event, groupId: 'group-7', index: 0, type: 'event-row' });
+
+    const payload = { type: 'delete', ids: [12] } as const;
+    await wrapper.findComponent(HistoryEventsDetailItem).vm.$emit('delete-event', payload);
+    expect(context.actions.deleteEvents).toHaveBeenCalledWith(payload);
+
+    await wrapper.findComponent(HistoryEventsDetailItem).vm.$emit('refresh');
+    expect(context.actions.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('should expand a swap through the context rather than its own state', async () => {
+    const wrapper = mountRow({
+      bridge: false,
+      eventCount: 3,
+      groupId: 'group-1',
+      swapKey: 'group-1-3',
+      type: 'swap-collapse',
+    });
+
+    await wrapper.findComponent(HistoryEventsSwapCollapseRow).vm.$emit('collapse');
+    expect(context.actions.toggleSwapExpanded).toHaveBeenCalledWith('group-1-3');
+  });
+
+  it('should load more events for the row group', async () => {
+    const wrapper = mountRow({ groupId: 'group-9', hiddenCount: 4, totalCount: 10, type: 'load-more' });
+
+    await wrapper.findComponent(HistoryEventsLoadMoreRow).vm.$emit('load-more');
+    expect(context.actions.loadMore).toHaveBeenCalledWith('group-9');
+  });
+
+  it('should pass the card variant down when the context switches layout', () => {
+    context.display.variant = computed<'row' | 'card'>(() => 'card');
+    const wrapper = mountRow({ groupId: 'group-1', index: 0, type: 'event-placeholder' });
+
+    expect(wrapper.findComponent(HistoryEventsRowPlaceholder).props('variant')).toBe('card');
+  });
+});

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualRow.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualRow.vue
@@ -113,7 +113,6 @@ const { duplicateHandlingStatus, eventsLoading, hideActions, variant } = display
   <HistoryEventsSwapCollapseRow
     v-else-if="row.type === 'matched-movement-collapse'"
     :event-count="row.eventCount"
-    :events="lookups.groupEvents(row.groupId)"
     label-type="movement"
     @unlink-event="actions.unlinkGroup(row.groupId)"
     @collapse="actions.toggleMovementExpanded(row.movementKey)"
@@ -123,7 +122,6 @@ const { duplicateHandlingStatus, eventsLoading, hideActions, variant } = display
   <HistoryEventsLoadMoreRow
     v-else-if="row.type === 'load-more'"
     :hidden-count="row.hiddenCount"
-    :total-count="row.totalCount"
     @load-more="actions.loadMore(row.groupId)"
   />
 </template>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualRow.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualRow.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import type { VirtualRow } from '@/modules/history/events/use-virtual-rows';
+import { injectHistoryEventsRowContext } from '@/modules/history/events/use-history-events-row-context';
+import HistoryEventsDetailItem from './HistoryEventsDetailItem.vue';
+import HistoryEventsGroupItem from './HistoryEventsGroupItem.vue';
+import HistoryEventsLoadMoreRow from './HistoryEventsLoadMoreRow.vue';
+import HistoryEventsMatchedMovementItem from './HistoryEventsMatchedMovementItem.vue';
+import HistoryEventsRowPlaceholder from './HistoryEventsRowPlaceholder.vue';
+import HistoryEventsSwapCollapseRow from './HistoryEventsSwapCollapseRow.vue';
+import HistoryEventsSwapItem from './HistoryEventsSwapItem.vue';
+
+defineProps<{
+  row: VirtualRow;
+}>();
+
+const { actions, display, highlight, lookups } = injectHistoryEventsRowContext();
+
+// Lifted to the top level so the template unwraps them; a ref nested in an object does not.
+const { duplicateHandlingStatus, eventsLoading, hideActions, selection, variant } = display;
+</script>
+
+<template>
+  <!-- Group Header -->
+  <HistoryEventsGroupItem
+    v-if="row.type === 'group-header'"
+    :group="row.data"
+    :group-events="lookups.groupEvents(row.groupId)"
+    :hide-actions="hideActions"
+    :loading="eventsLoading"
+    :duplicate-handling-status="duplicateHandlingStatus"
+    :ignored-assets="lookups.ignoredAssets(row.groupId)"
+    :highlight-type="highlight.isGroupHighlighted(row.groupId) ? highlight.getHighlightType(row.data) : undefined"
+    :variant="variant"
+    @add-event="actions.addEvent($event, row.data)"
+    @toggle-ignore="actions.toggleIgnore($event)"
+    @toggle-show-ignored-assets="actions.toggleShowIgnoredAssets(row.groupId)"
+    @redecode="actions.redecode($event, row.data.groupIdentifier)"
+    @redecode-with-options="actions.redecodeWithOptions($event, row.data.groupIdentifier)"
+    @delete-tx="actions.deleteTransaction($event)"
+    @delete-events="actions.deleteEvents({ type: 'delete', ids: $event })"
+    @fix-duplicate="actions.refresh()"
+    @ignore-duplicate="actions.refresh()"
+  />
+
+  <!-- Event Placeholder -->
+  <HistoryEventsRowPlaceholder
+    v-else-if="row.type === 'event-placeholder'"
+    :variant="variant"
+  />
+
+  <!-- Event Detail -->
+  <HistoryEventsDetailItem
+    v-else-if="row.type === 'event-row'"
+    :event="row.data"
+    :index="row.index"
+    :complete-group-events="lookups.completeEventsForItem(row.groupId, row.data)"
+    :group-location-label="lookups.groupLocationLabel(row.groupId)"
+    :matched-movement="row.matchedMovement"
+    :hide-actions="hideActions"
+    :highlight-type="highlight.isHighlighted(row.data) ? highlight.getHighlightType(row.data) : undefined"
+    :selection="selection"
+    :variant="variant"
+    @edit-event="actions.editEvent($event, row.groupId)"
+    @delete-event="actions.deleteEvents($event)"
+    @show:missing-rule-action="actions.addMissingRule($event, row.groupId)"
+    @refresh="actions.refresh()"
+  />
+
+  <!-- Swap -->
+  <HistoryEventsSwapItem
+    v-else-if="row.type === 'swap-row'"
+    :events="row.events"
+    :complete-group-events="lookups.completeSubgroupEvents(row.events)"
+    :group-location-label="lookups.groupLocationLabel(row.groupId)"
+    :hide-actions="hideActions"
+    :highlight="highlight.isSwapHighlighted(row.events)"
+    :highlight-type="highlight.getSwapHighlightType(row.events)"
+    :selection="selection"
+    :variant="variant"
+    @edit-event="actions.editEvent($event, row.groupId)"
+    @delete-event="actions.deleteEvents($event)"
+    @show:missing-rule-action="actions.addMissingRule($event, row.groupId)"
+    @refresh="actions.refresh()"
+    @toggle-expand="actions.toggleSwapExpanded(row.swapKey)"
+  />
+
+  <!-- Swap Collapse -->
+  <HistoryEventsSwapCollapseRow
+    v-else-if="row.type === 'swap-collapse'"
+    :event-count="row.eventCount"
+    :subgroup-id="row.subgroupId"
+    :label-type="row.bridge ? 'bridge' : undefined"
+    @collapse="actions.toggleSwapExpanded(row.swapKey)"
+  />
+
+  <!-- Matched Movement -->
+  <HistoryEventsMatchedMovementItem
+    v-else-if="row.type === 'matched-movement-row'"
+    :events="row.events"
+    :complete-group-events="lookups.completeSubgroupEvents(row.events)"
+    :group-location-label="lookups.groupLocationLabel(row.groupId)"
+    :hide-actions="hideActions"
+    :highlight="highlight.isSwapHighlighted(row.events)"
+    :highlight-type="highlight.getSwapHighlightType(row.events)"
+    :selection="selection"
+    :variant="variant"
+    @edit-event="actions.editEvent($event, row.groupId)"
+    @delete-event="actions.deleteEvents($event)"
+    @show:missing-rule-action="actions.addMissingRule($event, row.groupId)"
+    @unlink-event="actions.unlinkEvent($event)"
+    @refresh="actions.refresh()"
+    @toggle-expand="actions.toggleMovementExpanded(row.movementKey)"
+  />
+
+  <!-- Matched Movement Collapse -->
+  <HistoryEventsSwapCollapseRow
+    v-else-if="row.type === 'matched-movement-collapse'"
+    :event-count="row.eventCount"
+    :events="lookups.groupEvents(row.groupId)"
+    label-type="movement"
+    @unlink-event="actions.unlinkGroup(row.groupId)"
+    @collapse="actions.toggleMovementExpanded(row.movementKey)"
+  />
+
+  <!-- Load More -->
+  <HistoryEventsLoadMoreRow
+    v-else-if="row.type === 'load-more'"
+    :hidden-count="row.hiddenCount"
+    :total-count="row.totalCount"
+    @load-more="actions.loadMore(row.groupId)"
+  />
+</template>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualRow.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualRow.vue
@@ -16,7 +16,7 @@ defineProps<{
 const { actions, display, highlight, lookups } = injectHistoryEventsRowContext();
 
 // Lifted to the top level so the template unwraps them; a ref nested in an object does not.
-const { duplicateHandlingStatus, eventsLoading, hideActions, selection, variant } = display;
+const { duplicateHandlingStatus, eventsLoading, hideActions, variant } = display;
 </script>
 
 <template>
@@ -58,7 +58,6 @@ const { duplicateHandlingStatus, eventsLoading, hideActions, selection, variant 
     :matched-movement="row.matchedMovement"
     :hide-actions="hideActions"
     :highlight-type="highlight.isHighlighted(row.data) ? highlight.getHighlightType(row.data) : undefined"
-    :selection="selection"
     :variant="variant"
     @edit-event="actions.editEvent($event, row.groupId)"
     @delete-event="actions.deleteEvents($event)"
@@ -75,7 +74,6 @@ const { duplicateHandlingStatus, eventsLoading, hideActions, selection, variant 
     :hide-actions="hideActions"
     :highlight="highlight.isSwapHighlighted(row.events)"
     :highlight-type="highlight.getSwapHighlightType(row.events)"
-    :selection="selection"
     :variant="variant"
     @edit-event="actions.editEvent($event, row.groupId)"
     @delete-event="actions.deleteEvents($event)"
@@ -102,7 +100,6 @@ const { duplicateHandlingStatus, eventsLoading, hideActions, selection, variant 
     :hide-actions="hideActions"
     :highlight="highlight.isSwapHighlighted(row.events)"
     :highlight-type="highlight.getSwapHighlightType(row.events)"
-    :selection="selection"
     :variant="variant"
     @edit-event="actions.editEvent($event, row.groupId)"
     @delete-event="actions.deleteEvents($event)"

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -6,19 +6,11 @@ import type { HistoryEventRequestPayload } from '@/modules/history/events/reques
 import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
 import type { HistoryEventsTableEmits } from '@/modules/history/events/types';
 import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
+import { provideHistoryEventsRowContext } from '@/modules/history/events/use-history-events-row-context';
+import { useHistoryEventsTable } from '@/modules/history/events/use-history-events-table';
 import UpgradeRow from '@/modules/history/UpgradeRow.vue';
-import { useHistoryEventsData } from '../use-history-events-data';
-import { useHistoryEventsForms } from '../use-history-events-forms';
-import { useHistoryEventsOperations } from '../use-history-events-operations';
-import { useVirtualRows } from '../use-virtual-rows';
-import { useVirtualScrollHighlight } from '../use-virtual-scroll-highlight';
-import HistoryEventsDetailItem from './HistoryEventsDetailItem.vue';
-import HistoryEventsGroupItem from './HistoryEventsGroupItem.vue';
-import HistoryEventsLoadMoreRow from './HistoryEventsLoadMoreRow.vue';
-import HistoryEventsMatchedMovementItem from './HistoryEventsMatchedMovementItem.vue';
-import HistoryEventsSwapCollapseRow from './HistoryEventsSwapCollapseRow.vue';
-import HistoryEventsSwapItem from './HistoryEventsSwapItem.vue';
 import HistoryEventsVirtualHeader from './HistoryEventsVirtualHeader.vue';
+import HistoryEventsVirtualRow from './HistoryEventsVirtualRow.vue';
 
 const sort = defineModel<DataTableSortData<HistoryEventEntry>>('sort', { required: true });
 const pagination = defineModel<TablePaginationData>('pagination', { required: true });
@@ -65,144 +57,38 @@ const { t } = useI18n({ useScope: 'global' });
 
 const DEFAULT_TABLE_HEIGHT_OFFSET = 390;
 
+const RedecodeConfirmationDialog = defineAsyncComponent(() => import('./RedecodeConfirmationDialog.vue'));
+
+const { redecode, rowContext, shell, virtual } = useHistoryEventsTable({
+  duplicateHandlingStatus: () => duplicateHandlingStatus,
+  excludeIgnored: () => excludeIgnored,
+  groupLoading: () => groupLoading,
+  groups: () => rawGroups,
+  hideActions: () => hideActions,
+  highlightedGroupIdentifier: () => highlightedGroupIdentifier,
+  highlightedIdentifiers: () => highlightedIdentifiers,
+  highlightTypes: () => highlightTypes,
+  identifiers: () => identifiers,
+  pagination,
+  requestPayload: () => requestPayload,
+  selection: () => selection,
+}, emit);
+
+const { entriesFoundTotal, found, groups, loading, showUpgradeRow, total } = shell;
+const { containerProps, list, wrapperProps } = virtual;
+const {
+  confirm: confirmRedecode,
+  hasCustomEvents,
+  modelShow: modelShowRedecodeConfirmation,
+  payload: redecodePayload,
+  showIndexerOptions,
+} = redecode;
+
 const tableContainerStyle = computed<{ height: string }>(() => ({
   height: `calc(100vh - ${tableHeightOffset ?? DEFAULT_TABLE_HEIGHT_OFFSET}px)`,
 }));
 
-const RedecodeConfirmationDialog = defineAsyncComponent(() => import('./RedecodeConfirmationDialog.vue'));
-
-// Event data management
-const {
-  completeEventsMapped,
-  displayedEventsMapped,
-  entriesFoundTotal,
-  events,
-  eventsLoading,
-  found,
-  getCompleteEventsForItem,
-  getCompleteSubgroupEvents,
-  getGroupEvents,
-  groups,
-  groupsShowingIgnoredAssets,
-  groupsWithHiddenIgnoredAssets,
-  isSubgroupIncomplete,
-  loading,
-  rawEvents,
-  showUpgradeRow,
-  toggleShowIgnoredAssets,
-  total,
-} = useHistoryEventsData({
-  excludeIgnored: () => excludeIgnored,
-  groupLoading: () => groupLoading,
-  groups: () => rawGroups,
-  identifiers: () => identifiers,
-  requestPayload: () => requestPayload,
-}, emit);
-
-// Virtual rows - flatten groups into virtual row list
-// Use displayedEventsMapped for display (respects excludeIgnored filter)
-const { flattenedRows, getCardHeight, getRowHeight, loadMoreEvents, toggleMovementExpanded, toggleSwapExpanded } = useVirtualRows(
-  groups,
-  displayedEventsMapped,
-  isSubgroupIncomplete,
-);
-
-// Virtual list with scroll and highlight management
-const {
-  containerProps,
-  getHighlightType,
-  getSwapHighlightType,
-  isCardLayout,
-  isGroupHighlighted,
-  isHighlighted,
-  isSwapHighlighted,
-  virtualList,
-  wrapperProps,
-} = useVirtualScrollHighlight({
-  flattenedRows,
-  getRowHeight,
-  getCardHeight,
-  highlightedGroupIdentifier: () => highlightedGroupIdentifier,
-  highlightedIdentifiers: () => highlightedIdentifiers,
-  highlightTypes: () => highlightTypes,
-  loading,
-  pagination,
-});
-
-// Variant based on breakpoint
-const itemVariant = computed<'row' | 'card'>(() => get(isCardLayout) ? 'card' : 'row');
-
-// Event operations (delete, redecode, etc.)
-const {
-  confirmDelete,
-  confirmRedecode,
-  confirmTxAndEventsDelete,
-  confirmUnlink,
-  unlinkGroup,
-  hasCustomEvents,
-  redecode,
-  redecodePayload,
-  redecodeWithOptions,
-  showIndexerOptions,
-  modelShowRedecodeConfirmation,
-  suggestNextSequenceId,
-  toggle,
-} = useHistoryEventsOperations({
-  completeEventsMapped,
-  flattenedEvents: events,
-}, emit);
-
-// Form operations
-const {
-  addEvent,
-  addMissingRule,
-  editEvent,
-} = useHistoryEventsForms(suggestNextSequenceId, emit);
-
-// Emit event IDs when events change
-watch([events, completeEventsMapped, rawEvents], ([newEvents, groupedEvents, rawEventsData]) => {
-  const eventIds = newEvents.map(event => event.identifier);
-  emit('update-event-ids', { eventIds, groupedEvents, rawEvents: rawEventsData });
-}, { immediate: true });
-
-// Create a lookup map for O(1) group access
-const groupsMap = computed<Map<string, HistoryEventEntry>>(() => {
-  const map = new Map<string, HistoryEventEntry>();
-  for (const group of get(groups)) {
-    map.set(group.groupIdentifier, group);
-  }
-  return map;
-});
-
-// Helper to find group by ID (O(1) lookup)
-function findGroup(groupId: string): HistoryEventEntry | undefined {
-  return get(groupsMap).get(groupId);
-}
-
-// Handler for edit event with group lookup
-function handleEditEvent(data: Parameters<typeof editEvent>[0], groupId: string): void {
-  const group = findGroup(groupId);
-  if (group)
-    editEvent(data, group);
-}
-
-// Handler for missing rule action with group lookup
-function handleMissingRuleAction(data: Parameters<typeof addMissingRule>[0], groupId: string): void {
-  const group = findGroup(groupId);
-  if (group)
-    addMissingRule(data, group);
-}
-
-/**
- * The group's ignored-asset state, or undefined when it has none to reveal and none revealed, in
- * which case the group row shows no indicator.
- */
-function ignoredAssetsState(groupId: string): 'hidden' | 'showing' | undefined {
-  if (get(groupsShowingIgnoredAssets).has(groupId))
-    return 'showing';
-
-  return get(groupsWithHiddenIgnoredAssets).has(groupId) ? 'hidden' : undefined;
-}
+provideHistoryEventsRowContext(rowContext);
 </script>
 
 <template>
@@ -285,163 +171,11 @@ function ignoredAssetsState(groupId: string): 'hidden' | 'showing' | undefined {
       class="overflow-auto will-change-transform dark:bg-dark-surface"
     >
       <div v-bind="wrapperProps">
-        <template
-          v-for="{ data: row, index } in virtualList"
+        <HistoryEventsVirtualRow
+          v-for="{ data: row, index } in list"
           :key="`${row.type}-${row.groupId}-${index}`"
-        >
-          <!-- Group Header -->
-          <HistoryEventsGroupItem
-            v-if="row.type === 'group-header'"
-            :group="row.data"
-            :group-events="getGroupEvents(row.groupId)"
-            :hide-actions="hideActions"
-            :loading="eventsLoading"
-            :duplicate-handling-status="duplicateHandlingStatus"
-            :ignored-assets="ignoredAssetsState(row.groupId)"
-            :highlight-type="isGroupHighlighted(row.groupId) ? getHighlightType(row.data) : undefined"
-            :variant="itemVariant"
-            @add-event="addEvent($event, row.data)"
-            @toggle-ignore="toggle($event)"
-            @toggle-show-ignored-assets="toggleShowIgnoredAssets(row.groupId)"
-            @redecode="redecode($event, row.data.groupIdentifier)"
-            @redecode-with-options="redecodeWithOptions($event, row.data.groupIdentifier)"
-            @delete-tx="confirmTxAndEventsDelete($event)"
-            @delete-events="confirmDelete({ type: 'delete', ids: $event })"
-            @fix-duplicate="emit('refresh')"
-            @ignore-duplicate="emit('refresh')"
-          />
-
-          <!-- Event Placeholder -->
-          <div
-            v-else-if="row.type === 'event-placeholder'"
-            class="animate-pulse contain-content"
-            :class="isCardLayout ? 'p-3 border-b border-default' : 'h-[72px] flex items-center gap-4 border-b border-default px-4 pl-6'"
-          >
-            <template v-if="isCardLayout">
-              <!-- Top row: Event type with icon -->
-              <div class="flex items-center gap-3 mb-2">
-                <div class="size-10 rounded-full bg-rui-grey-300 dark:bg-rui-grey-700 shrink-0" />
-                <div class="flex flex-col gap-1">
-                  <div class="h-4 w-20 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
-                  <div class="h-3 w-14 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
-                </div>
-              </div>
-              <!-- Middle row: Asset & Amount -->
-              <div class="flex items-center gap-2 mb-2">
-                <div class="size-8 rounded-full bg-rui-grey-300 dark:bg-rui-grey-700" />
-                <div class="flex flex-col gap-1">
-                  <div class="h-4 w-24 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
-                  <div class="h-3 w-16 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
-                </div>
-              </div>
-              <!-- Bottom row: Notes -->
-              <div class="h-3 w-3/4 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
-            </template>
-            <template v-else>
-              <div class="w-56 shrink-0 flex items-center gap-3">
-                <div class="size-10 rounded-full bg-rui-grey-300 dark:bg-rui-grey-700" />
-                <div class="flex flex-col gap-1.5">
-                  <div class="h-4 w-20 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
-                  <div class="h-3 w-14 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
-                </div>
-              </div>
-              <div class="w-56 xl:w-60 shrink-0 flex items-center gap-2">
-                <div class="size-8 rounded-full bg-rui-grey-300 dark:bg-rui-grey-700" />
-                <div class="flex flex-col gap-1.5">
-                  <div class="h-4 w-24 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
-                  <div class="h-3 w-16 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
-                </div>
-              </div>
-              <div class="flex-1 min-w-0 flex flex-col gap-1.5">
-                <div class="h-3.5 w-3/4 rounded bg-rui-grey-300 dark:bg-rui-grey-700" />
-                <div class="h-3 w-1/2 rounded bg-rui-grey-200 dark:bg-rui-grey-800" />
-              </div>
-              <div class="w-24 shrink-0" />
-            </template>
-          </div>
-
-          <!-- Event Detail -->
-          <HistoryEventsDetailItem
-            v-else-if="row.type === 'event-row'"
-            :event="row.data"
-            :index="row.index"
-            :complete-group-events="getCompleteEventsForItem(row.groupId, row.data)"
-            :group-location-label="findGroup(row.groupId)?.locationLabel ?? undefined"
-            :matched-movement="row.matchedMovement"
-            :hide-actions="hideActions"
-            :highlight-type="isHighlighted(row.data) ? getHighlightType(row.data) : undefined"
-            :selection="selection"
-            :variant="itemVariant"
-            @edit-event="handleEditEvent($event, row.groupId)"
-            @delete-event="confirmDelete($event)"
-            @show:missing-rule-action="handleMissingRuleAction($event, row.groupId)"
-            @refresh="emit('refresh')"
-          />
-
-          <!-- Swap -->
-          <HistoryEventsSwapItem
-            v-else-if="row.type === 'swap-row'"
-            :events="row.events"
-            :complete-group-events="getCompleteSubgroupEvents(row.events)"
-            :group-location-label="findGroup(row.groupId)?.locationLabel ?? undefined"
-            :hide-actions="hideActions"
-            :highlight="isSwapHighlighted(row.events)"
-            :highlight-type="getSwapHighlightType(row.events)"
-            :selection="selection"
-            :variant="itemVariant"
-            @edit-event="handleEditEvent($event, row.groupId)"
-            @delete-event="confirmDelete($event)"
-            @show:missing-rule-action="handleMissingRuleAction($event, row.groupId)"
-            @refresh="emit('refresh')"
-            @toggle-expand="toggleSwapExpanded(row.swapKey)"
-          />
-
-          <!-- Swap Collapse -->
-          <HistoryEventsSwapCollapseRow
-            v-else-if="row.type === 'swap-collapse'"
-            :event-count="row.eventCount"
-            :subgroup-id="row.subgroupId"
-            :label-type="row.bridge ? 'bridge' : undefined"
-            @collapse="toggleSwapExpanded(row.swapKey)"
-          />
-
-          <!-- Matched Movement -->
-          <HistoryEventsMatchedMovementItem
-            v-else-if="row.type === 'matched-movement-row'"
-            :events="row.events"
-            :complete-group-events="getCompleteSubgroupEvents(row.events)"
-            :group-location-label="findGroup(row.groupId)?.locationLabel ?? undefined"
-            :hide-actions="hideActions"
-            :highlight="isSwapHighlighted(row.events)"
-            :highlight-type="getSwapHighlightType(row.events)"
-            :selection="selection"
-            :variant="itemVariant"
-            @edit-event="handleEditEvent($event, row.groupId)"
-            @delete-event="confirmDelete($event)"
-            @show:missing-rule-action="handleMissingRuleAction($event, row.groupId)"
-            @unlink-event="confirmUnlink($event)"
-            @refresh="emit('refresh')"
-            @toggle-expand="toggleMovementExpanded(row.movementKey)"
-          />
-
-          <!-- Matched Movement Collapse -->
-          <HistoryEventsSwapCollapseRow
-            v-else-if="row.type === 'matched-movement-collapse'"
-            :event-count="row.eventCount"
-            :events="getGroupEvents(row.groupId)"
-            label-type="movement"
-            @unlink-event="unlinkGroup(row.groupId)"
-            @collapse="toggleMovementExpanded(row.movementKey)"
-          />
-
-          <!-- Load More -->
-          <HistoryEventsLoadMoreRow
-            v-else-if="row.type === 'load-more'"
-            :hidden-count="row.hiddenCount"
-            :total-count="row.totalCount"
-            @load-more="loadMoreEvents(row.groupId)"
-          />
-        </template>
+          :row="row"
+        />
       </div>
     </div>
   </div>

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualTable.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
 import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
-import type { Collection } from '@/modules/core/common/collection';
-import type { DuplicateHandlingStatus, HighlightType } from '@/modules/history/events/action-types';
-import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
-import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
-import type { HistoryEventsTableEmits } from '@/modules/history/events/types';
-import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
+import type { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import type { HistoryEventsTableEmits, HistoryEventsTableHighlight, HistoryEventsTableSource } from '@/modules/history/events/types';
 import { provideHistoryEventsRowContext } from '@/modules/history/events/use-history-events-row-context';
 import { useHistoryEventsTable } from '@/modules/history/events/use-history-events-table';
 import UpgradeRow from '@/modules/history/UpgradeRow.vue';
@@ -16,34 +13,22 @@ const sort = defineModel<DataTableSortData<HistoryEventEntry>>('sort', { require
 const pagination = defineModel<TablePaginationData>('pagination', { required: true });
 
 const {
-  groups: rawGroups,
-  requestPayload,
-  excludeIgnored,
-  groupLoading,
+  source,
+  highlight,
   hasActiveFilters,
   processing,
   tableHeightOffset,
-  identifiers,
-  highlightedGroupIdentifier,
-  highlightedIdentifiers,
-  highlightTypes,
   hideActions,
-  selection,
   duplicateHandlingStatus,
 } = defineProps<{
-  groups: Collection<HistoryEventRow>;
-  requestPayload: HistoryEventRequestPayload | undefined;
-  excludeIgnored: boolean;
-  groupLoading: boolean;
+  /** What to render: the groups plus everything scoping the per-group event fetch. */
+  source: HistoryEventsTableSource;
+  /** Which rows to call out, and how. */
+  highlight?: HistoryEventsTableHighlight;
   hasActiveFilters?: boolean;
   processing?: boolean;
   tableHeightOffset?: number;
-  identifiers?: string[];
-  highlightedGroupIdentifier?: string;
-  highlightedIdentifiers?: string[];
-  highlightTypes?: Record<string, HighlightType>;
   hideActions?: boolean;
-  selection?: UseHistoryEventsSelectionModeReturn;
   duplicateHandlingStatus?: DuplicateHandlingStatus;
 }>();
 
@@ -61,17 +46,16 @@ const RedecodeConfirmationDialog = defineAsyncComponent(() => import('./Redecode
 
 const { redecode, rowContext, shell, virtual } = useHistoryEventsTable({
   duplicateHandlingStatus: () => duplicateHandlingStatus,
-  excludeIgnored: () => excludeIgnored,
-  groupLoading: () => groupLoading,
-  groups: () => rawGroups,
+  excludeIgnored: () => source.excludeIgnored,
+  groupLoading: () => source.groupLoading,
+  groups: () => source.groups,
   hideActions: () => hideActions,
-  highlightedGroupIdentifier: () => highlightedGroupIdentifier,
-  highlightedIdentifiers: () => highlightedIdentifiers,
-  highlightTypes: () => highlightTypes,
-  identifiers: () => identifiers,
+  highlightedGroupIdentifier: () => highlight?.groupIdentifier,
+  highlightedIdentifiers: () => highlight?.identifiers,
+  highlightTypes: () => highlight?.types,
+  identifiers: () => source.identifiers,
   pagination,
-  requestPayload: () => requestPayload,
-  selection: () => selection,
+  requestPayload: () => source.requestPayload,
 }, emit);
 
 const { entriesFoundTotal, found, groups, loading, showUpgradeRow, total } = shell;

--- a/frontend/app/src/modules/history/events/types.ts
+++ b/frontend/app/src/modules/history/events/types.ts
@@ -1,9 +1,39 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { HighlightType } from '@/modules/history/events/action-types';
 import type { DialogShowOptions } from '@/modules/history/events/dialog-types';
 import type {
   PullEthBlockEventPayload,
   PullLocationTransactionPayload,
 } from '@/modules/history/events/event-payloads';
+import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
+
+/**
+ * What the events table renders, as one unit: the paginated groups the embedding owns plus
+ * everything that scopes the per-group event fetch underneath them.
+ */
+export interface HistoryEventsTableSource {
+  /** Paginated group collection owned by the caller; its identifiers scope the event fetch. */
+  groups: Collection<HistoryEventRow>;
+  /** Current filter payload, reused as the base of the event fetch. */
+  requestPayload: HistoryEventRequestPayload | undefined;
+  /** Whether the caller is fetching groups; turning true cancels the in-flight event fetch. */
+  groupLoading: boolean;
+  /** Hides events whose asset is ignored, unless the user reveals them per group. */
+  excludeIgnored: boolean;
+  /** Restricts the event fetch to these identifiers; undefined loads the whole page. */
+  identifiers?: string[];
+}
+
+/** Which rows to call out, and how. Absent when the embedding highlights nothing. */
+export interface HistoryEventsTableHighlight {
+  /** Group to highlight as a whole; the auto-scroll falls back to it when no ids are given. */
+  groupIdentifier?: string;
+  /** Individual event identifiers to highlight and scroll to. */
+  identifiers?: string[];
+  /** Style per target, keyed by event identifier or by `group:<groupIdentifier>`. */
+  types?: Record<string, HighlightType>;
+}
 
 interface HistoryEventIgnorePayload {
   readonly type: 'ignore';

--- a/frontend/app/src/modules/history/events/use-history-event-note.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-note.ts
@@ -45,6 +45,21 @@ interface FormatNoteParams {
   extraData?: MaybeRefOrGetter<Record<string, any> | undefined>;
 }
 
+/**
+ * What a note is resolved against: the same inputs as `FormatNoteParams` minus the note itself,
+ * as plain values. Callers hold these together (they all come off one event, one P&L row or one
+ * wallet transaction), so they travel as one prop rather than seven.
+ */
+export interface HistoryEventNoteContext {
+  amount?: BigNumber | BigNumber[];
+  asset?: string;
+  noTxRef?: boolean;
+  validatorIndex?: number;
+  blockNumber?: number;
+  counterparty?: string;
+  extraData?: Record<string, any>;
+}
+
 interface UseHistoryEventNoteReturn {
   formatNotes: (params: FormatNoteParams) => ComputedRef<NoteFormat[]>;
 }

--- a/frontend/app/src/modules/history/events/use-history-events-row-context.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-row-context.ts
@@ -3,7 +3,6 @@ import type { DuplicateHandlingStatus, HighlightType } from '@/modules/history/e
 import type { LocationAndTxRef, PullEventPayload } from '@/modules/history/events/event-payloads';
 import type { HistoryEventEntry, StandaloneEditableEvents } from '@/modules/history/events/schemas';
 import type { HistoryEventDeletePayload, HistoryEventUnlinkPayload } from '@/modules/history/events/types';
-import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
 import type { HistoryEventEditData } from '@/modules/history/management/forms/form-types';
 
 /** Presentation state shared by every row, regardless of its kind. */
@@ -13,7 +12,6 @@ export interface HistoryEventsRowDisplay {
   hideActions: ComputedRef<boolean>;
   eventsLoading: Readonly<Ref<boolean>>;
   duplicateHandlingStatus: ComputedRef<DuplicateHandlingStatus | undefined>;
-  selection: ComputedRef<UseHistoryEventsSelectionModeReturn | undefined>;
 }
 
 /** Reads into the loaded event data. All are map lookups, safe to call per row. */

--- a/frontend/app/src/modules/history/events/use-history-events-row-context.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-row-context.ts
@@ -1,0 +1,85 @@
+import type { ComputedRef, InjectionKey, Ref } from 'vue';
+import type { DuplicateHandlingStatus, HighlightType } from '@/modules/history/events/action-types';
+import type { LocationAndTxRef, PullEventPayload } from '@/modules/history/events/event-payloads';
+import type { HistoryEventEntry, StandaloneEditableEvents } from '@/modules/history/events/schemas';
+import type { HistoryEventDeletePayload, HistoryEventUnlinkPayload } from '@/modules/history/events/types';
+import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
+import type { HistoryEventEditData } from '@/modules/history/management/forms/form-types';
+
+/** Presentation state shared by every row, regardless of its kind. */
+export interface HistoryEventsRowDisplay {
+  /** Wide table row or narrow card, decided once from the viewport breakpoint. */
+  variant: ComputedRef<'row' | 'card'>;
+  hideActions: ComputedRef<boolean>;
+  eventsLoading: Readonly<Ref<boolean>>;
+  duplicateHandlingStatus: ComputedRef<DuplicateHandlingStatus | undefined>;
+  selection: ComputedRef<UseHistoryEventsSelectionModeReturn | undefined>;
+}
+
+/** Reads into the loaded event data. All are map lookups, safe to call per row. */
+export interface HistoryEventsRowLookups {
+  groupEvents: (groupId: string) => HistoryEventEntry[];
+  completeEventsForItem: (groupId: string, event: HistoryEventEntry) => HistoryEventEntry[];
+  completeSubgroupEvents: (events: HistoryEventEntry[]) => HistoryEventEntry[];
+  groupLocationLabel: (groupId: string) => string | undefined;
+  /**
+   * The group's ignored-asset state, or undefined when it has none to reveal and none revealed, in
+   * which case the group row shows no indicator.
+   */
+  ignoredAssets: (groupId: string) => 'hidden' | 'showing' | undefined;
+}
+
+export interface HistoryEventsRowHighlight {
+  isGroupHighlighted: (groupId: string) => boolean;
+  isHighlighted: (event: HistoryEventEntry) => boolean;
+  isSwapHighlighted: (events: HistoryEventEntry[]) => boolean;
+  getHighlightType: (event: HistoryEventEntry) => HighlightType | undefined;
+  getSwapHighlightType: (events: HistoryEventEntry[]) => HighlightType | undefined;
+}
+
+/** Everything a row can trigger. Each resolves its own group, so rows pass ids, not entries. */
+export interface HistoryEventsRowActions {
+  addEvent: (group: StandaloneEditableEvents, row: HistoryEventEntry) => void;
+  editEvent: (data: HistoryEventEditData, groupId: string) => void;
+  addMissingRule: (data: HistoryEventEditData, groupId: string) => void;
+  deleteEvents: (payload: HistoryEventDeletePayload) => void;
+  deleteTransaction: (payload: LocationAndTxRef) => void;
+  unlinkEvent: (payload: HistoryEventUnlinkPayload) => void;
+  unlinkGroup: (groupId: string) => void;
+  toggleIgnore: (event: HistoryEventEntry) => Promise<void>;
+  toggleShowIgnoredAssets: (groupId: string) => void;
+  redecode: (payload: PullEventPayload, eventIdentifier: string) => void;
+  redecodeWithOptions: (payload: PullEventPayload, groupIdentifier: string) => void;
+  toggleSwapExpanded: (swapKey: string) => void;
+  toggleMovementExpanded: (movementKey: string) => void;
+  loadMore: (groupId: string) => void;
+  refresh: () => void;
+}
+
+/**
+ * What the virtual table hands down to its rows.
+ *
+ * Provided once by `HistoryEventsVirtualTable` and injected by `HistoryEventsVirtualRow`, so a row
+ * takes only the `VirtualRow` it renders and nothing is drilled through the row switch.
+ */
+export interface HistoryEventsRowContext {
+  display: HistoryEventsRowDisplay;
+  lookups: HistoryEventsRowLookups;
+  highlight: HistoryEventsRowHighlight;
+  actions: HistoryEventsRowActions;
+}
+
+const HistoryEventsRowContextKey: InjectionKey<HistoryEventsRowContext> = Symbol('history-events-row-context');
+
+export function provideHistoryEventsRowContext(context: HistoryEventsRowContext): void {
+  provide(HistoryEventsRowContextKey, context);
+}
+
+export function injectHistoryEventsRowContext(): HistoryEventsRowContext {
+  const context = inject(HistoryEventsRowContextKey);
+
+  if (!context)
+    throw new Error('History event rows must be rendered inside HistoryEventsVirtualTable');
+
+  return context;
+}

--- a/frontend/app/src/modules/history/events/use-history-events-row-context.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-row-context.ts
@@ -6,7 +6,7 @@ import type { HistoryEventDeletePayload, HistoryEventUnlinkPayload } from '@/mod
 import type { HistoryEventEditData } from '@/modules/history/management/forms/form-types';
 
 /** Presentation state shared by every row, regardless of its kind. */
-export interface HistoryEventsRowDisplay {
+interface HistoryEventsRowDisplay {
   /** Wide table row or narrow card, decided once from the viewport breakpoint. */
   variant: ComputedRef<'row' | 'card'>;
   hideActions: ComputedRef<boolean>;
@@ -15,7 +15,7 @@ export interface HistoryEventsRowDisplay {
 }
 
 /** Reads into the loaded event data. All are map lookups, safe to call per row. */
-export interface HistoryEventsRowLookups {
+interface HistoryEventsRowLookups {
   groupEvents: (groupId: string) => HistoryEventEntry[];
   completeEventsForItem: (groupId: string, event: HistoryEventEntry) => HistoryEventEntry[];
   completeSubgroupEvents: (events: HistoryEventEntry[]) => HistoryEventEntry[];
@@ -27,7 +27,7 @@ export interface HistoryEventsRowLookups {
   ignoredAssets: (groupId: string) => 'hidden' | 'showing' | undefined;
 }
 
-export interface HistoryEventsRowHighlight {
+interface HistoryEventsRowHighlight {
   isGroupHighlighted: (groupId: string) => boolean;
   isHighlighted: (event: HistoryEventEntry) => boolean;
   isSwapHighlighted: (events: HistoryEventEntry[]) => boolean;
@@ -36,7 +36,7 @@ export interface HistoryEventsRowHighlight {
 }
 
 /** Everything a row can trigger. Each resolves its own group, so rows pass ids, not entries. */
-export interface HistoryEventsRowActions {
+interface HistoryEventsRowActions {
   addEvent: (group: StandaloneEditableEvents, row: HistoryEventEntry) => void;
   editEvent: (data: HistoryEventEditData, groupId: string) => void;
   addMissingRule: (data: HistoryEventEditData, groupId: string) => void;

--- a/frontend/app/src/modules/history/events/use-history-events-selection-context.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-selection-context.ts
@@ -1,0 +1,19 @@
+import type { InjectionKey } from 'vue';
+import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
+
+const HistoryEventsSelectionKey: InjectionKey<UseHistoryEventsSelectionModeReturn> = Symbol('history-events-selection');
+
+/**
+ * Shares the view's selection mode with the event rows that render checkboxes.
+ *
+ * Selection is owned by `HistoryEventsView` but only ever read at the leaves, so it is provided
+ * rather than threaded through the table and the row switch. An embedding that has no selection
+ * mode simply does not provide it, and the rows render without checkboxes.
+ */
+export function provideHistoryEventsSelection(selection: UseHistoryEventsSelectionModeReturn): void {
+  provide(HistoryEventsSelectionKey, selection);
+}
+
+export function injectHistoryEventsSelection(): UseHistoryEventsSelectionModeReturn | undefined {
+  return inject(HistoryEventsSelectionKey, undefined);
+}

--- a/frontend/app/src/modules/history/events/use-history-events-table.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-table.ts
@@ -8,7 +8,6 @@ import type { HistoryEventRequestPayload } from '@/modules/history/events/reques
 import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
 import type { HistoryEventsTableEmitFn } from '@/modules/history/events/types';
 import type { HistoryEventsRowContext } from '@/modules/history/events/use-history-events-row-context';
-import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
 import { useHistoryEventsData } from '@/modules/history/events/use-history-events-data';
 import { useHistoryEventsForms } from '@/modules/history/events/use-history-events-forms';
 import { useHistoryEventsOperations } from '@/modules/history/events/use-history-events-operations';
@@ -30,8 +29,6 @@ export interface UseHistoryEventsTableOptions {
   hideActions: MaybeRefOrGetter<boolean | undefined>;
   /** Duplicate-handling state a group header shows, when the view is triaging duplicates. */
   duplicateHandlingStatus: MaybeRefOrGetter<DuplicateHandlingStatus | undefined>;
-  /** Multi-select state owned by the view; undefined when the embedding has no selection mode. */
-  selection: MaybeRefOrGetter<UseHistoryEventsSelectionModeReturn | undefined>;
   /** Group to highlight as a whole; the auto-scroll falls back to it when no identifiers are given. */
   highlightedGroupIdentifier: MaybeRefOrGetter<string | undefined>;
   /** Individual event identifiers to highlight and scroll to. */
@@ -94,7 +91,6 @@ export function useHistoryEventsTable(
     identifiers,
     pagination,
     requestPayload,
-    selection,
   } = options;
 
   const data = useHistoryEventsData({
@@ -175,7 +171,6 @@ export function useHistoryEventsTable(
       duplicateHandlingStatus: computed<DuplicateHandlingStatus | undefined>(() => toValue(duplicateHandlingStatus)),
       eventsLoading: data.eventsLoading,
       hideActions: computed<boolean>(() => toValue(hideActions) ?? false),
-      selection: computed<UseHistoryEventsSelectionModeReturn | undefined>(() => toValue(selection)),
       variant,
     },
     highlight: {

--- a/frontend/app/src/modules/history/events/use-history-events-table.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-table.ts
@@ -1,0 +1,231 @@
+import type { TablePaginationData } from '@rotki/ui-library';
+import type { UseVirtualListReturn } from '@vueuse/core';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { Collection } from '@/modules/core/common/collection';
+import type { DuplicateHandlingStatus, HighlightType } from '@/modules/history/events/action-types';
+import type { PullEventPayload } from '@/modules/history/events/event-payloads';
+import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
+import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
+import type { HistoryEventsTableEmitFn } from '@/modules/history/events/types';
+import type { HistoryEventsRowContext } from '@/modules/history/events/use-history-events-row-context';
+import type { UseHistoryEventsSelectionModeReturn } from '@/modules/history/events/use-selection-mode';
+import { useHistoryEventsData } from '@/modules/history/events/use-history-events-data';
+import { useHistoryEventsForms } from '@/modules/history/events/use-history-events-forms';
+import { useHistoryEventsOperations } from '@/modules/history/events/use-history-events-operations';
+import { useVirtualRows, type VirtualRow } from '@/modules/history/events/use-virtual-rows';
+import { useVirtualScrollHighlight } from '@/modules/history/events/use-virtual-scroll-highlight';
+
+export interface UseHistoryEventsTableOptions {
+  /** Paginated group collection owned by the caller's pagination filter. */
+  groups: MaybeRefOrGetter<Collection<HistoryEventRow>>;
+  /** Current filter payload, reused as the base of the per-group event fetch. */
+  requestPayload: MaybeRefOrGetter<HistoryEventRequestPayload | undefined>;
+  /** When true, events whose asset is ignored are hidden unless revealed per group. */
+  excludeIgnored: MaybeRefOrGetter<boolean>;
+  /** Whether the caller is fetching groups; turning true cancels the in-flight event fetch. */
+  groupLoading: MaybeRefOrGetter<boolean>;
+  /** Restricts the event fetch to these identifiers; undefined loads the whole page. */
+  identifiers: MaybeRefOrGetter<string[] | undefined>;
+  /** Hides every row action, for embeddings that render events read-only. */
+  hideActions: MaybeRefOrGetter<boolean | undefined>;
+  /** Duplicate-handling state a group header shows, when the view is triaging duplicates. */
+  duplicateHandlingStatus: MaybeRefOrGetter<DuplicateHandlingStatus | undefined>;
+  /** Multi-select state owned by the view; undefined when the embedding has no selection mode. */
+  selection: MaybeRefOrGetter<UseHistoryEventsSelectionModeReturn | undefined>;
+  /** Group to highlight as a whole; the auto-scroll falls back to it when no identifiers are given. */
+  highlightedGroupIdentifier: MaybeRefOrGetter<string | undefined>;
+  /** Individual event identifiers to highlight and scroll to. */
+  highlightedIdentifiers: MaybeRefOrGetter<string[] | undefined>;
+  /** Highlight style per target, keyed by event identifier or by `group:<groupIdentifier>`. */
+  highlightTypes: MaybeRefOrGetter<Record<string, HighlightType> | undefined>;
+  /** Table pagination state; a page change resets the scroll unless a highlight scroll is pending. */
+  pagination: Ref<TablePaginationData>;
+}
+
+export interface UseHistoryEventsTableReturn {
+  /** State the table shell renders itself: header, upgrade row, loading and empty states. */
+  shell: {
+    loading: Readonly<Ref<boolean>>;
+    groups: ComputedRef<HistoryEventEntry[]>;
+    total: ComputedRef<number>;
+    found: ComputedRef<number>;
+    entriesFoundTotal: ComputedRef<number | undefined>;
+    showUpgradeRow: ComputedRef<boolean>;
+  };
+  /** Bindings for the virtual scroll container and the rows currently in view. */
+  virtual: {
+    containerProps: UseVirtualListReturn<VirtualRow>['containerProps'];
+    wrapperProps: UseVirtualListReturn<VirtualRow>['wrapperProps'];
+    list: UseVirtualListReturn<VirtualRow>['list'];
+  };
+  /** Redecode confirmation dialog, owned by the table shell rather than by a row. */
+  redecode: {
+    modelShow: Ref<boolean>;
+    payload: Readonly<Ref<PullEventPayload | undefined>>;
+    hasCustomEvents: Readonly<Ref<boolean>>;
+    showIndexerOptions: Readonly<Ref<boolean>>;
+    confirm: (event: { payload: PullEventPayload; deleteCustom: boolean; customIndexersOrder?: string[] }) => void;
+  };
+  /** To be handed to `provideHistoryEventsRowContext` by the table component. */
+  rowContext: HistoryEventsRowContext;
+}
+
+/**
+ * Composes the five composables the virtual table runs on: the per-group event fetch, the flattened
+ * virtual rows, the scroll and highlight bindings, the event operations and the form dialogs.
+ *
+ * They are wired in a fixed order (each feeds the next), which is why they are assembled here
+ * rather than in the component: the component keeps only what its own template renders, and
+ * everything the rows need is bundled into `rowContext` for provide/inject.
+ */
+export function useHistoryEventsTable(
+  options: UseHistoryEventsTableOptions,
+  emit: HistoryEventsTableEmitFn,
+): UseHistoryEventsTableReturn {
+  const {
+    duplicateHandlingStatus,
+    excludeIgnored,
+    groupLoading,
+    groups: groupCollection,
+    hideActions,
+    highlightedGroupIdentifier,
+    highlightedIdentifiers,
+    highlightTypes,
+    identifiers,
+    pagination,
+    requestPayload,
+    selection,
+  } = options;
+
+  const data = useHistoryEventsData({
+    excludeIgnored,
+    groupLoading,
+    groups: groupCollection,
+    identifiers,
+    requestPayload,
+  }, emit);
+
+  const rows = useVirtualRows(data.groups, data.displayedEventsMapped, data.isSubgroupIncomplete);
+
+  const scroll = useVirtualScrollHighlight({
+    flattenedRows: rows.flattenedRows,
+    getCardHeight: rows.getCardHeight,
+    getRowHeight: rows.getRowHeight,
+    highlightedGroupIdentifier,
+    highlightedIdentifiers,
+    highlightTypes,
+    loading: data.loading,
+    pagination,
+  });
+
+  const operations = useHistoryEventsOperations({
+    completeEventsMapped: data.completeEventsMapped,
+    flattenedEvents: data.events,
+  }, emit);
+
+  const forms = useHistoryEventsForms(operations.suggestNextSequenceId, emit);
+
+  /** Lookup map for O(1) group access from a row's group id. */
+  const groupsMap = computed<Map<string, HistoryEventEntry>>(() =>
+    new Map(get(data.groups).map(group => [group.groupIdentifier, group])),
+  );
+
+  const variant = computed<'row' | 'card'>(() => get(scroll.isCardLayout) ? 'card' : 'row');
+
+  function findGroup(groupId: string): HistoryEventEntry | undefined {
+    return get(groupsMap).get(groupId);
+  }
+
+  function ignoredAssetsState(groupId: string): 'hidden' | 'showing' | undefined {
+    if (get(data.groupsShowingIgnoredAssets).has(groupId))
+      return 'showing';
+
+    return get(data.groupsWithHiddenIgnoredAssets).has(groupId) ? 'hidden' : undefined;
+  }
+
+  const rowContext: HistoryEventsRowContext = {
+    actions: {
+      addEvent: forms.addEvent,
+      addMissingRule: (payload, groupId): void => {
+        const group = findGroup(groupId);
+        if (group)
+          forms.addMissingRule(payload, group);
+      },
+      deleteEvents: operations.confirmDelete,
+      deleteTransaction: operations.confirmTxAndEventsDelete,
+      editEvent: (payload, groupId): void => {
+        const group = findGroup(groupId);
+        if (group)
+          forms.editEvent(payload, group);
+      },
+      loadMore: rows.loadMoreEvents,
+      redecode: operations.redecode,
+      redecodeWithOptions: operations.redecodeWithOptions,
+      refresh: (): void => {
+        emit('refresh');
+      },
+      toggleIgnore: operations.toggle,
+      toggleMovementExpanded: rows.toggleMovementExpanded,
+      toggleShowIgnoredAssets: data.toggleShowIgnoredAssets,
+      toggleSwapExpanded: rows.toggleSwapExpanded,
+      unlinkEvent: operations.confirmUnlink,
+      unlinkGroup: operations.unlinkGroup,
+    },
+    display: {
+      duplicateHandlingStatus: computed<DuplicateHandlingStatus | undefined>(() => toValue(duplicateHandlingStatus)),
+      eventsLoading: data.eventsLoading,
+      hideActions: computed<boolean>(() => toValue(hideActions) ?? false),
+      selection: computed<UseHistoryEventsSelectionModeReturn | undefined>(() => toValue(selection)),
+      variant,
+    },
+    highlight: {
+      getHighlightType: scroll.getHighlightType,
+      getSwapHighlightType: scroll.getSwapHighlightType,
+      isGroupHighlighted: scroll.isGroupHighlighted,
+      isHighlighted: scroll.isHighlighted,
+      isSwapHighlighted: scroll.isSwapHighlighted,
+    },
+    lookups: {
+      completeEventsForItem: data.getCompleteEventsForItem,
+      completeSubgroupEvents: data.getCompleteSubgroupEvents,
+      groupEvents: data.getGroupEvents,
+      groupLocationLabel: (groupId: string): string | undefined => findGroup(groupId)?.locationLabel ?? undefined,
+      ignoredAssets: ignoredAssetsState,
+    },
+  };
+
+  // Mirrors the loaded events up to the view, which owns deletion and selection state. The
+  // inversion is known debt: the view is meant to become the data owner, at which point this
+  // watcher and the `update-event-ids` emit both go away.
+  watch([data.events, data.completeEventsMapped, data.rawEvents], ([events, groupedEvents, rawEvents]) => {
+    emit('update-event-ids', {
+      eventIds: events.map(event => event.identifier),
+      groupedEvents,
+      rawEvents,
+    });
+  }, { immediate: true });
+
+  return {
+    redecode: {
+      confirm: operations.confirmRedecode,
+      hasCustomEvents: operations.hasCustomEvents,
+      modelShow: operations.modelShowRedecodeConfirmation,
+      payload: operations.redecodePayload,
+      showIndexerOptions: operations.showIndexerOptions,
+    },
+    rowContext,
+    shell: {
+      entriesFoundTotal: data.entriesFoundTotal,
+      found: data.found,
+      groups: data.groups,
+      loading: data.loading,
+      showUpgradeRow: data.showUpgradeRow,
+      total: data.total,
+    },
+    virtual: {
+      containerProps: scroll.containerProps,
+      list: scroll.virtualList,
+      wrapperProps: scroll.wrapperProps,
+    },
+  };
+}

--- a/frontend/app/src/modules/reports/ProfitLossEvents.vue
+++ b/frontend/app/src/modules/reports/ProfitLossEvents.vue
@@ -296,14 +296,16 @@ onMounted(async () => {
           <HistoryEventNote
             v-if="isTransactionEvent(row)"
             :notes="row.notes"
-            :amount="row.taxableAmount.isZero() ? row.freeAmount : row.taxableAmount"
-            :asset="row.assetIdentifier"
+            :context="{
+              amount: row.taxableAmount.isZero() ? row.freeAmount : row.taxableAmount,
+              asset: row.assetIdentifier,
+            }"
             :chain="getChain(row.location)"
           />
           <HistoryEventNote
             v-else
             :notes="row.notes"
-            :asset="row.assetIdentifier"
+            :context="{ asset: row.assetIdentifier }"
           />
         </div>
         <div

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleEventsDialog.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleEventsDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import type { HistoryEventsTableSource } from '@/modules/history/events/types';
 import type { Filters } from '@/modules/history/events/use-events-filter';
 import { useServerTable } from '@/modules/core/table/use-server-table';
 import HistoryEventsVirtualTable from '@/modules/history/events/components/HistoryEventsVirtualTable.vue';
@@ -48,6 +49,14 @@ const {
   }],
 });
 
+const source = computed<HistoryEventsTableSource>(() => ({
+  excludeIgnored: false,
+  groupLoading: get(groupLoading),
+  groups: get(groups),
+  identifiers: get(eventIdentifiers),
+  requestPayload: get(requestPayload),
+}));
+
 onMounted(() => {
   refetch();
 });
@@ -73,11 +82,7 @@ watch(display, (value) => {
         v-model:sort="sort"
         v-model:pagination="pagination"
         hide-actions
-        :groups="groups"
-        :exclude-ignored="false"
-        :group-loading="groupLoading"
-        :request-payload="requestPayload"
-        :identifiers="eventIdentifiers"
+        :source="source"
         @set-page="setPage($event)"
       />
 

--- a/frontend/app/src/modules/wallet/send/TradeHistoryItem.vue
+++ b/frontend/app/src/modules/wallet/send/TradeHistoryItem.vue
@@ -58,7 +58,7 @@ const dot = '•';
           class="text-sm inline-flex flex-wrap whitespace-break-spaces items-center [&_.shrink]:!text-xs"
           :notes="item.context"
           :chain="item.chain"
-          v-bind="item.metadata"
+          :context="item.metadata"
         />
       </div>
     </div>

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -169,9 +169,6 @@ export default rotki({
   //
   // - ServiceKeyCard (12): primaryAction/actionDisabled/hideAction/addButtonText/editButtonText are
   //   all one action; 5 props become 1, which lands exactly on 8.
-  // - HistoryEventNote (9): every prop it takes is derived from `event` plus useHistoryEventItem, so
-  //   it could take the event instead. Gated on whether all six callers actually hold a
-  //   HistoryEventEntry: ProfitLossEvents and TradeHistoryItem look like they do not.
   // - BlockchainAccountSelector (17): the worst offender in the codebase, and NOT premium-frozen
   //   despite the group above having claimed it was. It is a field wrapper, so most of these are
   //   RuiAutoComplete pass-throughs (label/hint/customHint/outlined/dense/errorMessages/required)
@@ -183,7 +180,6 @@ export default rotki({
   //   number. AssetDetails is the same three groups plus a resolution `options`.
   files: [
     '**/src/modules/settings/api-keys/ServiceKeyCard.vue',
-    '**/src/modules/history/events/HistoryEventNote.vue',
     '**/src/modules/accounts/BlockchainAccountSelector.vue',
     '**/src/modules/balances/AssetBalances.vue',
   ],

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -181,30 +181,14 @@ export default rotki({
   //   AssetDetailsBase left this list at 12 -> 4 props: `asset` plus display/actions/resolution,
   //   grouped because those three ARE the boundary AssetDetails forwards across, not to win a
   //   number. AssetDetails is the same three groups plus a resolution `options`.
-  // - HistoryEventsDetailItem (9): already reduced from 10, and the rest are independent
-  //   (groupLocationLabel and matchedMovement are unrelated in both this component and
-  //   HistoryEventType; `index` carries swap sub-event ordering). Fold into the facade work below.
-  // - HistoryEventsVirtualTable (14): deferred to the facade redesign, which also owns its 8
-  //   max-template-depth errors and its 20/20 @rotki/max-dependencies ceiling.
   files: [
     '**/src/modules/settings/api-keys/ServiceKeyCard.vue',
     '**/src/modules/history/events/HistoryEventNote.vue',
     '**/src/modules/accounts/BlockchainAccountSelector.vue',
     '**/src/modules/balances/AssetBalances.vue',
-    '**/src/modules/history/events/components/HistoryEventsDetailItem.vue',
-    '**/src/modules/history/events/components/HistoryEventsVirtualTable.vue',
   ],
   rules: {
     'vue/max-props': ['warn', { maxProps: 8 }],
-  },
-}, {
-  // HistoryEventsVirtualTable's remaining depth comes from the row markup it hosts inline. Extracting
-  // that markup needs one more import and the file already sits at the @rotki/max-dependencies ceiling
-  // of 20, so the fix is the facade redesign that also owns its prop count, not a local change. Warn
-  // rather than block until that lands.
-  files: ['**/src/modules/history/events/components/HistoryEventsVirtualTable.vue'],
-  rules: {
-    'vue/max-template-depth': 'warn',
   },
 }, {
   // Coverage is armed on the `page` fixture in `tests/e2e/fixtures/test-fixtures`, so a spec that


### PR DESCRIPTION
Decomposes `HistoryEventsVirtualTable`, which owned five composables, a seven-branch row switch and the placeholder skeleton markup, sat at exactly 20/20 `@rotki/max-dependencies` imports, and drilled every lookup, highlight helper and action by hand into each branch.

No behaviour change is intended, beyond the two performance commits described below.

### What changed

**`useHistoryEventsTable`** composes the five composables the table runs on (data → virtual rows → scroll/highlight → operations → forms) in their fixed wiring order and returns them grouped by consumer: `shell`, `virtual`, `redecode`, `rowContext`. It composes rather than re-exports, so it is not the barrel it replaces.

**`useHistoryEventsRowContext`** carries what rows need behind a typed `InjectionKey`, grouped into `display` / `lookups` / `highlight` / `actions`, following the convention already in the module (`prices/use-event-price-update-trigger.ts`).

**`HistoryEventsVirtualRow`** hosts the row switch and takes a single prop, the `VirtualRow` it renders. **`HistoryEventsRowPlaceholder`** takes the skeleton.

**Props.** The table drops from 14 to 7: `source` bundles the five inputs the event fetch reads, `highlight` bundles the three highlight props, and `selection` stops being a prop entirely — the view provides it and the three row items that render checkboxes inject it. `HistoryEventNote` drops from 9 props to 3: eight of them were the arguments to `formatNotes`, now one `context` object typed as `HistoryEventNoteContext`.

### Performance

One commit on top, found by profiling the table against ~11k seeded events.

**The action cluster is no longer mounted for every row.** It was built for each row and hidden with `opacity-0` until hover. It carries a `RuiMenu`, whose `useElementSize` reads `offsetWidth` on mount, forcing a synchronous layout immediately after the virtual list mutated the DOM — over a scroll, the table's largest source of forced reflow, which a trace put at 232ms. It is now built on the row's first hover, or when focus enters the row so a keyboard still reaches it, and kept from then on. Rows with a missing accounting rule build it immediately, since their warning button is visible without hovering; a spacer holds the column width so revealing it does not reflow the row. The card layout is unchanged — it is the narrow-viewport variant, where there is no hover. Measured after: forced reflow **232ms → 83ms**, DOM per row **81 → 56 nodes**.

A second commit dropping the virtual list's overscan from 15 to 5 was tried and abandoned. It halves the resident row count, but it does not reduce what a scroll costs — the number of rows crossing the window per scroll is the same either way — and it breaks `pill-filter.spec.ts`, whose `expectRows` counts rows in the DOM and expects a full `PAGE_SIZE`. In a virtualized list that assertion only ever held because the overscan happened to be large enough to render a whole page; at 5 the DOM holds 6 of the 10. Not worth rewriting a helper used ~30 times for a change that does not help scrolling.

Worth stating plainly: at realistic scroll velocities (20-80px per event) the table produces no long tasks either before or after. The measurable cost only appears under a fast scrollbar drag. The remaining cost is spread across what a row renders, with the largest single item — about a fifth of it — being the always-mounted copy and explorer buttons on every `HashLink` chip. That one is left alone here: `HashLink` is used app-wide and gating it changes visible UI, so it wants its own change.

### Lint

The module goes from 11 warnings to **0**. The frontend is at 0 errors and 7 warnings, all `vue/max-props`, none of them in history.

Three exceptions are removed from `eslint.config.js` rather than left standing:

- `vue/max-template-depth` is at zero project-wide, so its `HistoryEventsVirtualTable` downgrade block is deleted and the rule errors everywhere again.
- `HistoryEventsVirtualTable`, `HistoryEventsDetailItem` and `HistoryEventNote` leave the `vue/max-props` warn list, so all three are held to the error-level cap of 8.

### Tests

`events/components/` had no specs at all. Adds a case per `VirtualRow` type over a stubbed context, plus a pair pinning that selection reaches the rows through inject: one with a provided selection in selection mode, one without, so the checkbox assertion can actually fail.

Writing them surfaced two dead bindings inherited from the old table template — `HistoryEventsSwapCollapseRow` declares no `events` prop and `HistoryEventsLoadMoreRow` no `totalCount`, so both were landing as stray DOM attributes. Removed.

### Verified

Typecheck clean, 0 lint errors, 2049 unit tests pass across `history`, `reports`, `wallet` and `settings/accounting`.

In-app against seeded data (~11k events): all eight row branches render, including the placeholder caught mid-load; row and card layouts; swap, bridge and matched-movement expand/collapse; load-more; pagination; the declared-field filter bar writing its query to the url; the empty state; selection mode, where toggling a row checkbox moves the toolbar to "1 selected" — the provide/inject path that replaced the `selection` prop; the redecode confirmation dialog through the facade's `v-model`; and the Liquity and **Kraken** mounts. Console clean throughout.

**`AccountingRuleEventsDialog`**, the table's second consumer, is now verified too: with an event-specific accounting rule present, its "N events" action opens the dialog and the table renders inside it under the new seven-prop API.

`TradeHistoryItem` is the one call site not exercised in-app, since reaching it means broadcasting a wallet transaction. Its change is `v-bind="item.metadata"` → `:context="item.metadata"`, and `metadata` is built in `use-transaction-manager.ts` as exactly `{ amount, asset }`, so it maps onto `HistoryEventNoteContext` with nothing dropped. Note the old `v-bind` sat after `:chain`, so a `chain` key in `metadata` would previously have overridden the explicit binding; there is no such key.

### Not in scope

The inversion itself — `update-event-ids`, `groupedEventsByTxRef` and `originalGroups` — is untouched, along with the `HistoryEventRow` union and the query layer. Those are the next step of the restructure and depend on two open decisions.
