### PR TITLE
fix(decoding): guard unloaded protocol caches

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/convex/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/convex/decoder.py
@@ -80,8 +80,11 @@ class ConvexDecoder(EvmDecoderInterface, ReloadableCacheDecoderMixin):
 
     @property
     def pools(self) -> dict[ChecksumEvmAddress, str]:
-        assert isinstance(self.cache_data[0], dict), 'ConvexDecoder cache_data[0] is not a dict'
-        return self.cache_data[0]
+        if (pools := self.cached_container(0)) is None:
+            return {}  # no pools known until the cache is loaded
+
+        assert isinstance(pools, dict), 'ConvexDecoder cache_data[0] is not a dict'
+        return pools
 
     def _cache_mapping_methods(self) -> tuple[Callable[[DecoderContext], EvmDecodingOutput]]:
         return (self._decode_pool_events,)

--- a/rotkehlchen/chain/evm/decoding/balancer/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/balancer/decoder.py
@@ -67,8 +67,11 @@ class BalancerCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoder
 
     @property
     def pools(self) -> set[ChecksumEvmAddress]:
-        assert isinstance(self.cache_data[0], set), f'{self.counterparty} Decoder cache_data[0] is not a set'  # noqa: E501
-        return self.cache_data[0]
+        if (pools := self.cached_container(0)) is None:
+            return set()  # no pools known until the cache is loaded
+
+        assert isinstance(pools, set), f'{self.counterparty} Decoder cache_data[0] is not a set'
+        return pools
 
     def _decode_gauge_events(self, context: DecoderContext) -> EvmDecodingOutput:
         if context.tx_log.topics[0] not in (DEPOSIT_TOPIC_V2, WITHDRAW_TOPIC_V2):

--- a/rotkehlchen/chain/evm/decoding/curve/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/curve/decoder.py
@@ -299,8 +299,11 @@ class CurveCommonDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderMix
 
     @property
     def pools(self) -> dict[ChecksumEvmAddress, list[ChecksumEvmAddress]]:
-        assert isinstance(self.cache_data[0], dict), 'CurveDecoder cache_data[0] is not a dict'
-        return self.cache_data[0]
+        if (pools := self.cached_container(0)) is None:
+            return {}  # no pools known until the cache is loaded
+
+        assert isinstance(pools, dict), 'CurveDecoder cache_data[0] is not a dict'
+        return pools
 
     def _decode_curve_remove_events(
             self,

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -1381,7 +1381,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
                 context=context,
             )
             if err:
-                return FAILED_ENRICHMENT_OUTPUT
+                continue  # a broken enricher must not hide the ones after it, same as try_all_rules  # noqa: E501
 
             if transfer_enrich != FAILED_ENRICHMENT_OUTPUT:
                 return transfer_enrich

--- a/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/gearbox/decoder.py
@@ -83,8 +83,10 @@ class GearboxCommonDecoder(EvmDecoderInterface, ReloadableCacheDecoderMixin):
 
     @property
     def pools(self) -> dict[ChecksumEvmAddress, GearboxPoolData]:
-        assert isinstance(self.cache_data[0], dict), 'GearboxCommonDecoder cache_data[0] is not a dict'  # noqa: E501
-        pools = self.cache_data[0]
+        if (pools := self.cached_container(0)) is None:
+            return {}  # no pools known until the cache is loaded
+
+        assert isinstance(pools, dict), 'GearboxCommonDecoder cache_data[0] is not a dict'
         for pool_data in pools.values():
             if pool_data.farming_pool_token:
                 self.farming_pool_tokens.add(pool_data.farming_pool_token)

--- a/rotkehlchen/chain/evm/decoding/interfaces.py
+++ b/rotkehlchen/chain/evm/decoding/interfaces.py
@@ -450,7 +450,15 @@ class ReloadableCacheDecoderMixin(ReloadableDecoderMixin, ABC):
         self.query_data_method = query_data_method
         self.read_data_from_cache_method = read_data_from_cache_method
         self.chain_id = chain_id
+        # Stays the empty tuple until the first reload_data(). Anything reading a container
+        # out of it must go through cached_container() instead of indexing it directly: the
+        # enricher rules run for every token transfer and are not gated on reload_data()
+        # having populated the mapping, so they can be reached while this is still empty.
         self.cache_data: tuple[dict[ChecksumEvmAddress, Any] | set[ChecksumEvmAddress], ...] = ()
+
+    def cached_container(self, index: int) -> dict[ChecksumEvmAddress, Any] | set[ChecksumEvmAddress] | None:  # noqa: E501
+        """Return the cache container at `index`, or None if the cache is not loaded yet."""
+        return self.cache_data[index] if index < len(self.cache_data) else None
 
     @abstractmethod
     def _cache_mapping_methods(self) -> tuple[Callable, ...]:
@@ -514,8 +522,11 @@ class ReloadablePoolsAndGaugesDecoderMixin(ReloadableCacheDecoderMixin, ABC):
     def gauges(self) -> set[ChecksumEvmAddress]:
         """method to get gauges from `cache_data`.
         The structure is common in the decoders using this logic"""
-        assert isinstance(self.cache_data[1], set), 'Decoder cache_data[1] is not a set'
-        return self.cache_data[1]
+        if (gauges := self.cached_container(1)) is None:
+            return set()  # no gauges known until the cache is loaded
+
+        assert isinstance(gauges, set), 'Decoder cache_data[1] is not a set'
+        return gauges
 
     @abstractmethod
     def _decode_pool_events(self, context: DecoderContext) -> EvmDecodingOutput:

--- a/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/velodrome/decoder.py
@@ -110,8 +110,11 @@ class VelodromeLikeDecoder(EvmDecoderInterface, ReloadablePoolsAndGaugesDecoderM
 
     @property
     def pools(self) -> set[ChecksumEvmAddress]:
-        assert isinstance(self.cache_data[0], set), f'{self.counterparty} Decoder cache_data[0] is not a set'  # noqa: E501
-        return self.cache_data[0]
+        if (pools := self.cached_container(0)) is None:
+            return set()  # no pools known until the cache is loaded
+
+        assert isinstance(pools, set), f'{self.counterparty} Decoder cache_data[0] is not a set'
+        return pools
 
     def post_cache_update_callback(self) -> None:
         self.protocol_addresses.update(self.pools)

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -7,8 +7,17 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.gitcoin.constants import GITCOIN_GRANTS_OLD1
 from rotkehlchen.chain.evm.constants import GENESIS_HASH, ZERO_ADDRESS
-from rotkehlchen.chain.evm.decoding.constants import CPT_ACCOUNT_DELEGATION
+from rotkehlchen.chain.evm.decoding.constants import (
+    CPT_ACCOUNT_DELEGATION,
+    ERC20_OR_ERC721_TRANSFER,
+)
+from rotkehlchen.chain.evm.decoding.interfaces import ReloadableCacheDecoderMixin
+from rotkehlchen.chain.evm.decoding.structures import (
+    FAILED_ENRICHMENT_OUTPUT,
+    TransferEnrichmentOutput,
+)
 from rotkehlchen.chain.evm.l2_with_l1_fees.types import L2WithL1FeesTransaction
+from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
 from rotkehlchen.chain.evm.types import EvmAccount, string_to_evm_address
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH, A_SAI
@@ -54,6 +63,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
+    from rotkehlchen.chain.evm.decoding.structures import EnricherContext
     from rotkehlchen.chain.optimism.decoding.decoder import OptimismTransactionDecoder
     from rotkehlchen.chain.optimism.transactions import OptimismTransactions
     from rotkehlchen.db.dbhandler import DBHandler
@@ -753,3 +763,98 @@ def test_write_events_relocates_sequence_index_collision(
         (3, 'first at 3'),
         (4, 'second at 3'),  # relocated past the max used index instead of being dropped
     ]
+
+
+@pytest.mark.parametrize('ethereum_accounts', [[
+    '0x4bBa290826C253BD854121346c370a9886d1bC26',
+    '0x38C3f1Ab36BdCa29133d8AF7A19811D10B6CA3FC',
+]])
+def test_decoding_before_protocol_caches_are_loaded(
+        database: DBHandler,
+        ethereum_accounts: list[ChecksumEvmAddress],
+        ethereum_transaction_decoder: EthereumTransactionDecoder,
+) -> None:
+    """Decoding a plain token transfer must work before reload_data() has populated the
+    protocol caches.
+
+    The enricher rules run for every ERC20/721 transfer and are not gated on the
+    address mappings, so some of them read a protocol cache container (e.g. balancer v3's
+    gauges) while `cache_data` is still the empty tuple. That used to raise IndexError,
+    which decode_safely turned into a user facing error per transfer log.
+    """
+    from_address, to_address = ethereum_accounts
+    transaction = EvmTransaction(
+        tx_hash=(tx_hash := make_evm_tx_hash()),
+        chain_id=ChainID.ETHEREUM,
+        timestamp=Timestamp(1700000000),
+        block_number=18000000,
+        from_address=from_address,
+        to_address=(usdt_address := string_to_evm_address('0xdAC17F958D2ee523a2206206994597C13D831ec7')),  # noqa: E501
+        value=0,
+        gas=45000,
+        gas_price=10000000000,
+        gas_used=45000,
+        input_data=b'',
+        nonce=0,
+    )
+    with database.user_write() as write_cursor:
+        DBEvmTx(database).add_transactions(write_cursor, [transaction], relevant_address=None)
+
+    receipt = EvmTxReceipt(
+        tx_hash=tx_hash,
+        chain_id=ChainID.ETHEREUM,
+        contract_address=None,
+        status=True,
+        tx_type=0,
+        logs=[EvmTxReceiptLog(
+            log_index=0,
+            data=(1000000).to_bytes(32, 'big'),
+            address=usdt_address,
+            topics=[
+                ERC20_OR_ERC721_TRANSFER,
+                bytes(12) + bytes.fromhex(from_address[2:]),
+                bytes(12) + bytes.fromhex(to_address[2:]),
+            ],
+        )],
+    )
+    for decoder in ethereum_transaction_decoder.decoders.values():
+        assert not isinstance(decoder, ReloadableCacheDecoderMixin) or decoder.cache_data == (), \
+            'the caches must still be unloaded for this test to exercise the regression'
+
+    events, _, _ = ethereum_transaction_decoder._decode_transaction(
+        transaction=transaction,
+        tx_receipt=receipt,
+    )
+    assert [(x.event_type, x.event_subtype) for x in events] == [
+        (HistoryEventType.SPEND, HistoryEventSubType.FEE),
+        (HistoryEventType.TRANSFER, HistoryEventSubType.NONE),
+    ]
+    assert database.msg_aggregator.consume_errors() == []
+
+
+def test_one_failing_enricher_does_not_hide_the_rest(
+        ethereum_transaction_decoder: EthereumTransactionDecoder,
+) -> None:
+    """A raising enricher rule must not stop the enrichers after it from being tried,
+    the same way try_all_rules keeps going over the remaining event rules."""
+    reached = []
+
+    def raising_enricher(context: EnricherContext) -> TransferEnrichmentOutput:
+        raise IndexError('boom')
+
+    def recording_enricher(context: EnricherContext) -> TransferEnrichmentOutput:
+        reached.append(context)
+        return FAILED_ENRICHMENT_OUTPUT
+
+    # EvmDecodingRules is frozen, so swap the rules in place and put them back after
+    enricher_rules = ethereum_transaction_decoder.rules.token_enricher_rules
+    original_rules = enricher_rules.copy()
+    enricher_rules[:] = [raising_enricher, recording_enricher]
+    try:
+        assert ethereum_transaction_decoder._enrich_protocol_transfers(
+            context=Mock(transaction=Mock(tx_hash=make_evm_tx_hash())),
+        ) == FAILED_ENRICHMENT_OUTPUT
+    finally:
+        enricher_rules[:] = original_rules
+
+    assert len(reached) == 1


### PR DESCRIPTION
ReloadableCacheDecoderMixin.cache_data is the empty tuple until the first reload_data(), but the pools/gauges accessors index it blindly. The enricher rules run for every ERC20/721 transfer log and are not gated on the address mappings, so balancer v3's gauge-claim enricher reads self.gauges in that state and raises IndexError. decode_safely then turns each one into a full traceback log plus a user facing "Decoding of transaction ... failed" error, once per transfer log. Curve lending and gearbox read a cache container from their enrichers the same way.

Route the accessors through a new cached_container() that reports the unloaded state, and return an empty container for it: no pools or gauges are known before the cache is read.

Also let _enrich_protocol_transfers keep going after a rule raises instead of returning, so one broken enricher no longer skips every enricher after it. try_all_rules and run_all_post_decoding_rules already continue.

