### PR TITLE
Fix two colibri tests broken by the shipped asset list

### DIFF
--- a/.github/workflows/rotki_ci.yml
+++ b/.github/workflows/rotki_ci.yml
@@ -67,7 +67,9 @@ jobs:
                   - tag: run all py tests
                     value: nightly
               - name: colibri
-                paths: [colibri, Cargo.toml, Cargo.lock]
+                # The colibri tests read the packaged global database, so a new asset list has to
+                # run them too. Leaving it out let a shipped asset break them for six days.
+                paths: [colibri, Cargo.toml, Cargo.lock, rotkehlchen/data/global.db]
               - name: starling
                 paths: [crates, Cargo.toml, Cargo.lock]
               - name: documentation

--- a/colibri/src/api/assets.rs
+++ b/colibri/src/api/assets.rs
@@ -671,27 +671,29 @@ mod tests {
         .unwrap();
     }
 
+    /// Adds a hyperliquid token under an identifier no asset list can ship, so that adding the
+    /// real token to the packaged database cannot collide with this fixture's primary key.
     async fn add_hyperliquid_token(state: &Arc<AppState>) {
         let conn = state.globaldb.conn.lock().await;
         conn.execute(
             "INSERT INTO assets(identifier, name, type) VALUES (?, ?, ?)",
             rusqlite::params![
-                "hyperc:0x6781b92b6ea5d8ed37d275eb201f64af",
-                "$MAX",
+                "hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef",
+                "$FIXTURE",
                 AssetType::HyperliquidToken.serialize_for_db(),
             ],
         )
         .unwrap();
         conn.execute(
             "INSERT INTO common_asset_details(identifier, symbol) VALUES (?, ?)",
-            rusqlite::params!["hyperc:0x6781b92b6ea5d8ed37d275eb201f64af", "MAX"],
+            rusqlite::params!["hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef", "FXTRSYM"],
         )
         .unwrap();
         conn.execute(
             "INSERT INTO hyperliquid_tokens(identifier, address, decimals) VALUES (?, ?, ?)",
             rusqlite::params![
-                "hyperc:0x6781b92b6ea5d8ed37d275eb201f64af",
-                "0x6781b92b6ea5d8ed37d275eb201f64af",
+                "hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef",
+                "0xdeadbeefdeadbeefdeadbeefdeadbeef",
                 6,
             ],
         )
@@ -841,7 +843,7 @@ mod tests {
         let (status, body) = call_search(
             state.clone(),
             AssetsLevenshteinSearch {
-                value: Some("MAX".to_string()),
+                value: Some("FXTRSYM".to_string()),
                 evm_chain: None,
                 asset_type: Some("hyperliquid token".to_string()),
                 address: None,
@@ -855,7 +857,7 @@ mod tests {
         let result = body.get("result").and_then(|v| v.as_array()).unwrap();
         assert!(result.iter().any(|entry| {
             entry.get("identifier").and_then(|v| v.as_str())
-                == Some("hyperc:0x6781b92b6ea5d8ed37d275eb201f64af")
+                == Some("hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef")
                 && entry.get("asset_type").and_then(|v| v.as_str()) == Some("hyperliquid token")
         }));
 
@@ -865,7 +867,7 @@ mod tests {
                 value: None,
                 evm_chain: None,
                 asset_type: None,
-                address: Some("0x6781B92B6EA5D8ED37D275EB201F64AF".to_string()),
+                address: Some("0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF".to_string()),
                 limit: 25,
                 search_nfts: false,
             },
@@ -876,7 +878,7 @@ mod tests {
         let result = body.get("result").and_then(|v| v.as_array()).unwrap();
         assert!(result.iter().any(|entry| {
             entry.get("identifier").and_then(|v| v.as_str())
-                == Some("hyperc:0x6781b92b6ea5d8ed37d275eb201f64af")
+                == Some("hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef")
         }));
     }
 

--- a/colibri/src/globaldb/assets.rs
+++ b/colibri/src/globaldb/assets.rs
@@ -276,6 +276,10 @@ mod tests {
         );
     }
 
+    // The fixture identifier is deliberately one no asset list can ship. `create_globaldb!` copies
+    // the packaged database, so a fixture built on a real identifier starts failing the day that
+    // asset is added: the insert hits the primary key. That is how this test broke, and nothing
+    // caught it, because a change to the shipped database does not run the colibri job.
     #[tokio::test]
     async fn test_get_hyperliquid_asset_mapping() {
         let globaldb = create_globaldb!().await.unwrap();
@@ -284,22 +288,22 @@ mod tests {
             conn.execute(
                 "INSERT INTO assets(identifier, name, type) VALUES (?, ?, ?)",
                 rusqlite::params![
-                    "hyperc:0x6781b92b6ea5d8ed37d275eb201f64af",
-                    "$MAX",
+                    "hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef",
+                    "$FIXTURE",
                     AssetType::HyperliquidToken.serialize_for_db(),
                 ],
             )
             .unwrap();
             conn.execute(
                 "INSERT INTO common_asset_details(identifier, symbol) VALUES (?, ?)",
-                rusqlite::params!["hyperc:0x6781b92b6ea5d8ed37d275eb201f64af", "MAX",],
+                rusqlite::params!["hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef", "FIXTURE",],
             )
             .unwrap();
             conn.execute(
                 "INSERT INTO hyperliquid_tokens(identifier, address, decimals) VALUES (?, ?, ?)",
                 rusqlite::params![
-                    "hyperc:0x6781b92b6ea5d8ed37d275eb201f64af",
-                    "0x6781b92b6ea5d8ed37d275eb201f64af",
+                    "hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef",
+                    "0xdeadbeefdeadbeefdeadbeefdeadbeef",
                     6,
                 ],
             )
@@ -307,14 +311,14 @@ mod tests {
         }
 
         let (assets, _) = globaldb
-            .get_assets_mappings(&["hyperc:0x6781b92b6ea5d8ed37d275eb201f64af".to_string()])
+            .get_assets_mappings(&["hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef".to_string()])
             .await
             .unwrap();
         let asset = assets
-            .get("hyperc:0x6781b92b6ea5d8ed37d275eb201f64af")
+            .get("hyperc:0xdeadbeefdeadbeefdeadbeefdeadbeef")
             .unwrap();
-        assert_eq!(asset.name, "$MAX");
-        assert_eq!(asset.symbol, "MAX");
+        assert_eq!(asset.name, "$FIXTURE");
+        assert_eq!(asset.symbol, "FIXTURE");
         assert_eq!(asset.asset_type, "hyperliquid token");
         assert!(asset.evm_chain.is_none());
     }


### PR DESCRIPTION
Two colibri tests have been failing on `develop` since 10 August:

- `globaldb::assets::tests::test_get_hyperliquid_asset_mapping`
- `api::assets::tests::test_search_hyperliquid_token_by_symbol_and_address`

Both die on `UNIQUE constraint failed: assets.identifier`.

## What happened

Both tests insert `hyperc:0x6781b92b6ea5d8ed37d275eb201f64af` ($MAX) into the database themselves.
#12834 ("New list of assets") added that asset to the packaged `rotkehlchen/data/global.db`, and
`create_globaldb!` copies that database, so the fixture insert now collides with a row that is
already there.

## Why no run went red

The colibri job's path group is `[colibri, Cargo.toml, Cargo.lock]`. `rotkehlchen/data/global.db`
belongs to the backend group, so #12834 ran the backend tests and skipped colibri entirely, even
though the colibri tests read that exact file.

Two things kept it hidden for six days:

- the job is `pull_request`-only (`github.event_name != 'push'`), so develop's own pushes never run it;
- it declares `needs: [check-changes, check-typos]`, so a branch with a failing typos check skips it too.

It finally surfaced on an unrelated PR that touches colibri and had just had its typos failure fixed.

## The fix

1. The fixtures move to an identifier and address no asset list can ship. Neither test asserts
   anything about the real token, only that a hyperliquid row round-trips through the mapping and
   the search, so nothing is lost.
2. `rotkehlchen/data/global.db` joins the colibri path group, so a shipped-database change runs
   these tests from now on.

While re-aiming a negative control I also found the search fixture's name and symbol were both
`MAX`-shaped, so searching for `MAX` matched the `$MAX` name and the half of the test named after
the symbol passed without the symbol taking part. Breaking the symbol alone left it green. The
fixture now uses a symbol distinct from its name, and breaking it fails the test.

## Verification

- `cargo test -p colibri --locked`: 60 passed, 0 failed (was 58 passed, 2 failed)
- `cargo clippy -p colibri --all-targets --locked` and `cargo fmt --check` clean
- Confirmed the failures reproduce on a clean checkout of the `develop` tip with no changes, so they
  are not caused by any in-flight branch