### PR TITLE
Name the field the event forms carry

### DIFF
--- a/frontend/app/scripts/chunk-groups.ts
+++ b/frontend/app/scripts/chunk-groups.ts
@@ -51,8 +51,6 @@ export const vendorGroups: VendorGroup[] = [
       '@vueuse/math',
       '@vueuse/core',
       '@vueuse/shared',
-      '@vuelidate/core',
-      '@vuelidate/validators',
       'ofetch',
       'es-toolkit',
       'imask',

--- a/frontend/app/src/modules/history/management/forms/asset-movement-event-form.ts
+++ b/frontend/app/src/modules/history/management/forms/asset-movement-event-form.ts
@@ -9,6 +9,7 @@ import dayjs from 'dayjs';
 import { z, type ZodType } from 'zod';
 import { msg } from '@/message-key';
 import {
+  carriedThrough,
   requiredAmount,
   requiredAsset,
   requiredEventType,
@@ -87,7 +88,7 @@ export function assetMovementSchema(): ZodType {
       location: requiredLocation(),
       locationLabel: serverValidatedOnly(),
       notes: serverValidatedOnly(),
-      priceIntent: z.unknown().optional(),
+      priceIntent: carriedThrough(),
       timestamp: z.number(),
       transactionId: serverValidatedOnly(),
       uniqueId: serverValidatedOnly(),

--- a/frontend/app/src/modules/history/management/forms/bitcoin-event-form.ts
+++ b/frontend/app/src/modules/history/management/forms/bitcoin-event-form.ts
@@ -9,6 +9,7 @@ import {
   toNullableText,
 } from '@/modules/history/management/forms/common/group-identifier';
 import {
+  carriedThrough,
   requiredAmount,
   requiredBitcoinTxId,
   requiredEventSubtype,
@@ -83,7 +84,7 @@ export function bitcoinEventSchema(editing: boolean, counterparties: () => strin
     location: requiredLocation(),
     locationLabel: serverValidatedOnly(),
     notes: serverValidatedOnly(),
-    priceIntent: z.unknown().optional(),
+    priceIntent: carriedThrough(),
     sequenceIndex: requiredSequenceIndex(),
     timestamp: z.number(),
     txRef: requiredBitcoinTxId(),

--- a/frontend/app/src/modules/history/management/forms/eth-block-event-form.ts
+++ b/frontend/app/src/modules/history/management/forms/eth-block-event-form.ts
@@ -9,6 +9,7 @@ import {
   toNullableText,
 } from '@/modules/history/management/forms/common/group-identifier';
 import {
+  carriedThrough,
   requiredAmount,
   requiredBlockNumber,
   requiredFeeRecipient,
@@ -53,7 +54,7 @@ export function ethBlockSchema(editing: boolean): ZodType {
     groupIdentifier: groupIdentifierSchema(editing),
     hasActualGroupIdentifier: z.boolean(),
     isMevReward: z.boolean(),
-    priceIntent: z.unknown().optional(),
+    priceIntent: carriedThrough(),
     timestamp: z.number(),
     validatorIndex: requiredValidatorIndex(),
   });

--- a/frontend/app/src/modules/history/management/forms/eth-deposit-event-form.ts
+++ b/frontend/app/src/modules/history/management/forms/eth-deposit-event-form.ts
@@ -9,6 +9,7 @@ import {
   toNullableText,
 } from '@/modules/history/management/forms/common/group-identifier';
 import {
+  carriedThrough,
   requiredAmount,
   requiredDepositor,
   requiredEvmTxHash,
@@ -54,7 +55,7 @@ export function ethDepositSchema(editing: boolean): ZodType {
     extraData: z.unknown(),
     groupIdentifier: groupIdentifierSchema(editing),
     hasActualGroupIdentifier: z.boolean(),
-    priceIntent: z.unknown().optional(),
+    priceIntent: carriedThrough(),
     sequenceIndex: requiredSequenceIndex(),
     timestamp: z.number(),
     txRef: requiredEvmTxHash(),

--- a/frontend/app/src/modules/history/management/forms/eth-withdrawal-event-form.ts
+++ b/frontend/app/src/modules/history/management/forms/eth-withdrawal-event-form.ts
@@ -9,6 +9,7 @@ import {
   toNullableText,
 } from '@/modules/history/management/forms/common/group-identifier';
 import {
+  carriedThrough,
   requiredAmount,
   requiredValidatorIndex,
   requiredWithdrawalAddress,
@@ -45,7 +46,7 @@ export function ethWithdrawalSchema(editing: boolean): ZodType {
     groupIdentifier: groupIdentifierSchema(editing),
     hasActualGroupIdentifier: z.boolean(),
     isExit: z.boolean(),
-    priceIntent: z.unknown().optional(),
+    priceIntent: carriedThrough(),
     timestamp: z.number(),
     validatorIndex: requiredValidatorIndex(),
     withdrawalAddress: requiredWithdrawalAddress(),

--- a/frontend/app/src/modules/history/management/forms/event-field-schemas.ts
+++ b/frontend/app/src/modules/history/management/forms/event-field-schemas.ts
@@ -148,3 +148,16 @@ export function validCounterparty(counterparties: () => string[]): z.ZodType<str
 export function serverValidatedOnly(): z.ZodString {
   return z.string();
 }
+
+/**
+ * A value the form carries but never validates, named so that the absence of a rule reads as a
+ * decision rather than an omission.
+ *
+ * `priceIntent` is a pending historic-price write that `HistoryEventAssetPriceForm` reports upwards
+ * for the form to run at save time. It is bound to no input of its own, so a structural rule over it
+ * could only fail with nothing on screen to explain why, the same error-sink the no-op Vuelidate
+ * rules were. Its shape is enforced by `PriceIntent` at the type level instead.
+ */
+export function carriedThrough(): z.ZodOptional<z.ZodUnknown> {
+  return z.unknown().optional();
+}

--- a/frontend/app/src/modules/history/management/forms/evm-event-form.ts
+++ b/frontend/app/src/modules/history/management/forms/evm-event-form.ts
@@ -9,6 +9,7 @@ import {
   toNullableText,
 } from '@/modules/history/management/forms/common/group-identifier';
 import {
+  carriedThrough,
   optionalEthAddress,
   requiredAmount,
   requiredAsset,
@@ -87,7 +88,7 @@ export function evmEventSchema(editing: boolean, counterparties: () => string[])
     location: requiredLocation(),
     locationLabel: serverValidatedOnly(),
     notes: serverValidatedOnly(),
-    priceIntent: z.unknown().optional(),
+    priceIntent: carriedThrough(),
     sequenceIndex: requiredSequenceIndex(),
     timestamp: z.number(),
     txRef: requiredEvmTxHash(),

--- a/frontend/app/src/modules/history/management/forms/online-history-event-form.ts
+++ b/frontend/app/src/modules/history/management/forms/online-history-event-form.ts
@@ -8,6 +8,7 @@ import {
   groupIdentifierSchema,
 } from '@/modules/history/management/forms/common/group-identifier';
 import {
+  carriedThrough,
   requiredAmount,
   requiredAsset,
   requiredEventSubtype,
@@ -68,7 +69,7 @@ export function onlineHistorySchema(editing: boolean): ZodType {
     location: requiredLocation(),
     locationLabel: serverValidatedOnly(),
     notes: serverValidatedOnly(),
-    priceIntent: z.unknown().optional(),
+    priceIntent: carriedThrough(),
     sequenceIndex: requiredSequenceIndex(),
     timestamp: z.number(),
   });

--- a/frontend/app/src/modules/history/management/forms/solana-event-form.ts
+++ b/frontend/app/src/modules/history/management/forms/solana-event-form.ts
@@ -9,6 +9,7 @@ import {
   toNullableText,
 } from '@/modules/history/management/forms/common/group-identifier';
 import {
+  carriedThrough,
   optionalSolanaAddress,
   requiredAmount,
   requiredAsset,
@@ -81,7 +82,7 @@ export function solanaEventSchema(editing: boolean, counterparties: () => string
     hasActualGroupIdentifier: z.boolean(),
     locationLabel: serverValidatedOnly(),
     notes: serverValidatedOnly(),
-    priceIntent: z.unknown().optional(),
+    priceIntent: carriedThrough(),
     sequenceIndex: requiredSequenceIndex(),
     timestamp: z.number(),
     txRef: requiredSolanaSignature(),

--- a/frontend/app/src/modules/history/management/forms/swap-event-form.ts
+++ b/frontend/app/src/modules/history/management/forms/swap-event-form.ts
@@ -11,6 +11,7 @@ import { omit } from 'es-toolkit';
 import { z, type ZodType } from 'zod';
 import { msg } from '@/message-key';
 import {
+  carriedThrough,
   requiredAmount,
   requiredAsset,
   requiredLocation,
@@ -89,11 +90,11 @@ export function swapSchema(): ZodType {
     receiveAmount: requiredAmount(),
     receiveAsset: requiredAsset(),
     receiveNotes: serverValidatedOnly(),
-    receivePriceIntent: z.unknown().optional(),
+    receivePriceIntent: carriedThrough(),
     spendAmount: requiredAmount(),
     spendAsset: requiredAsset(),
     spendNotes: serverValidatedOnly(),
-    spendPriceIntent: z.unknown().optional(),
+    spendPriceIntent: carriedThrough(),
     timestamp: z.number(),
     uniqueId: serverValidatedOnly(),
   });


### PR DESCRIPTION
Two small cleanups left over from the vuelidate to zod migration.

### Name the field the event forms carry

`priceIntent: z.unknown().optional()` was repeated across eight event schemas, and the swap form carried two more. An unnamed `z.unknown()` reads as a field nobody got round to validating, when it is the opposite: a pending historic-price write that the asset-price child reports upwards for the form to run at save time, bound to no input of its own.

A structural rule over it could therefore only fail with nothing on screen to explain why, which is the error sink the no-op vuelidate rules were. `carriedThrough()` says that in one place, beside `serverValidatedOnly()`, which already names the same kind of decision for server-checked fields. Its shape stays enforced by `PriceIntent` at the type level.

### Drop vuelidate from the vendor chunking

The `utils` vendor group still named `@vuelidate/core` and `@vuelidate/validators` after the last form left them behind, so the chunker carried two packages that are no longer installed.

Nothing reports it: `frontend/scripts` is listed in `tsconfig.node.json` but no gate runs that project, and knip sees the module rather than the entries inside it.

### Testing

No behaviour change. `pnpm run typecheck`, `pnpm run lint:file:check` on every changed file, and `pnpm run test:unit src/modules/history/management/forms/` (290 tests) all pass.
