### PR TITLE
Fix the nightly e2e asset filter test

### DIFF
--- a/frontend/app/tests/e2e/pages/pill-filter-bar.ts
+++ b/frontend/app/tests/e2e/pages/pill-filter-bar.ts
@@ -76,6 +76,12 @@ export class PillFilterBar {
    * narrowed — every selection goes through the search box first. Search matches the option's
    * *label*, so pass `search` explicitly whenever the label differs from the wire value
    * (`uniswap-v2` renders as `Uniswap V2`).
+   *
+   * Narrowing is only enough when the query names the value. On the asset field the search runs
+   * remotely and returns up to fifty ranked results, so a query matching many assets equally well
+   * (a symbol several chains share) leaves the intended one somewhere in the list but outside the
+   * rendered window, and this waits for a row that never appears. Search such a field by
+   * identifier or address, which the app parses into an exact address lookup.
    */
   async selectValue(value: string, search?: string): Promise<void> {
     await this.searchValues(search ?? value);

--- a/frontend/app/tests/e2e/specs/history/pill-filter.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/pill-filter.spec.ts
@@ -345,9 +345,17 @@ test.describe.serial('history events pill filter', () => {
 
   // The asset field is the only one whose values are fetched rather than listed, so its editor
   // drives a remote search instead of filtering a local list.
+  //
+  // Searched by identifier rather than by `USDC`, because a symbol search cannot say *which* USDC
+  // comes back: every chain's USDC scores an identical levenshtein distance, and assets tied on
+  // distance come out in whatever order the query returns them. The list is virtualized, so a row
+  // ranked past the first screenful is not in the DOM at all, which is how a symbol search left
+  // this waiting for an option that was in the results but never rendered. An identifier (or a bare
+  // address) is parsed into an address search by `parseAssetSearchKeyword`, which matches the one
+  // token and leaves nothing to rank.
   test('the asset editor filters on a remotely searched asset', async () => {
     await bar.addField('asset');
-    await bar.selectValue(A_USDC, 'USDC');
+    await bar.selectValue(A_USDC);
     await bar.closeEditor('asset');
 
     await expectRows(1);


### PR DESCRIPTION
## Problem

`e2e / shard-3` has failed every nightly run since 2026-08-11, always on the same test and on both attempts:

```
[chromium] › tests/e2e/specs/history/pill-filter.spec.ts:348:3
  › history events pill filter › the asset editor filters on a remotely searched asset
TimeoutError: locator.waitFor: Timeout 10000ms exceeded.
  waiting for [data-testid=value-select-option][data-key="eip155:1/erc20:0xA0b8…eB48"]
```

The test typed `USDC` into the asset editor and then waited for **mainnet** USDC to become visible. Nothing guarantees it is there:

- the backend ranks a levenshtein search by distance to the casefolded query, so every chain's USDC ties at distance 0, and the order among tied rows is just the order the query returns them in, which is not stable across environments;
- `ValueSelectList` is virtualized and renders roughly seventeen rows, so a tied row ranked past the first screenful is **not in the DOM at all**.

The failure artifact confirms it: the list was full of USDC rows (Polygon, Monad, zkSync Era, Gnosis, Hyperliquid, Base, Fantom, …) and mainnet was simply outside the rendered window. The same spec passes locally on every run, which is why this only ever showed up in the nightly.

## Fix

Search by identifier. `parseAssetSearchKeyword` turns an EVM identifier (or a bare address) into an exact address lookup, which matches the one token and leaves nothing to rank, so the row is always first. The address is unique in the packaged `global.db`.

The two other tests that touch a USDC already state that they will not predict this ranking; this one now matches them. `PillFilterBar.selectValue` gains a note that narrowing is only sufficient when the query names the value, since the hazard applies to any remotely searched field.

## Verification

- Full spec locally: 43 passed (the test drops from 3.6s to 1.4s, since far fewer rows come back).
- Negative control: swapping in the Optimism USDC fails with `Expected: 1, Received: 0`, so the test still proves *which* USDC was applied rather than just that some pill appeared.