### PR TITLE
refactor(frontend): group the asset display props

### DIFF
--- a/frontend/app/src/modules/accounts/ModuleActivator.vue
+++ b/frontend/app/src/modules/accounts/ModuleActivator.vue
@@ -83,7 +83,7 @@ const loading = isAccountOperationRunning();
             <AppImage
               height="24px"
               width="24px"
-              contain
+              fit="contain"
               :src="module.icon"
             />
           </template>

--- a/frontend/app/src/modules/accounts/QueriedAddressDialog.vue
+++ b/frontend/app/src/modules/accounts/QueriedAddressDialog.vue
@@ -87,7 +87,7 @@ function close() {
           <AppImage
             class="icon-bg"
             size="1.5rem"
-            contain
+            fit="contain"
             :src="currentModule?.icon"
           />
           <RuiCardHeader class="p-0">

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.vue
@@ -197,9 +197,9 @@ watchDebounced(
       <template #item.asset="{ row }">
         <AssetDetails
           v-if="!row.assetIsMissing"
-          hide-actionsusd-pr
           class="[&>div]:max-w-[12rem] xl:[&>div]:max-w-[16rem] 2xl:[&>div]:max-w-[20rem]"
           :asset="row.asset"
+          :actions="{ hideActions: true }"
         />
         <ManualBalanceMissingAssetWarning v-else />
       </template>

--- a/frontend/app/src/modules/airdrops/AirdropDisplay.vue
+++ b/frontend/app/src/modules/airdrops/AirdropDisplay.vue
@@ -28,7 +28,7 @@ const imageFromIconName = computed<string | undefined>(() => {
       class="icon-bg"
       size="1.5rem"
       :src="iconUrl || imageFromIconName || image"
-      contain
+      fit="contain"
       :loading="loading"
     />
     <div>{{ name }}</div>

--- a/frontend/app/src/modules/airdrops/PoapDeliveryAirdrops.vue
+++ b/frontend/app/src/modules/airdrops/PoapDeliveryAirdrops.vue
@@ -73,7 +73,7 @@ function getImage(event: string): string {
               class="rounded-full"
               width="36px"
               height="36px"
-              contain
+              fit="contain"
               :src="getImage(row.event)"
             />
           </div>

--- a/frontend/app/src/modules/assets/AssetDetails.spec.ts
+++ b/frontend/app/src/modules/assets/AssetDetails.spec.ts
@@ -1,0 +1,117 @@
+import type { MaybeRefOrGetter } from 'vue';
+import type { AssetActions, AssetDisplay, AssetIdentifierResolution } from '@/modules/assets/types';
+import type { AssetResolutionOptions } from '@/modules/assets/use-asset-info-retrieval';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AssetDetails from '@/modules/assets/AssetDetails.vue';
+
+const IDENTIFIER = 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F';
+
+/** The options AssetDetails hands `useAssetInfo`, which is the only thing it computes itself. */
+const resolveOptions = vi.fn<(options: AssetResolutionOptions) => void>();
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', async (importOriginal) => {
+  const original = await importOriginal<object>();
+  return {
+    ...original,
+    useAssetInfoRetrieval: (): object => ({
+      useAssetInfo: (_asset: unknown, options: MaybeRefOrGetter<AssetResolutionOptions>) => computed(() => {
+        resolveOptions(toValue(options));
+        return { isCustomAsset: false, name: 'Dai Stablecoin', symbol: 'DAI' };
+      }),
+    }),
+  };
+});
+
+const AssetDetailsBase = {
+  name: 'AssetDetailsBase',
+  props: ['asset', 'display', 'actions', 'resolution'],
+  template: '<div data-testid="asset-details-base" />',
+};
+
+describe('assetDetails', () => {
+  interface Props {
+    asset?: string;
+    display?: AssetDisplay;
+    actions?: AssetActions;
+    resolution?: AssetIdentifierResolution;
+  }
+
+  type AnyProps = ComponentPublicInstance<Record<string, unknown>>;
+
+  function createWrapper(props: Props = {}): VueWrapper {
+    return mount(AssetDetails, {
+      global: { stubs: { AssetDetailsBase } },
+      props: { asset: IDENTIFIER, ...props },
+    });
+  }
+
+  function base(wrapper: VueWrapper): VueWrapper<AnyProps> {
+    return wrapper.findComponent<AnyProps>({ name: 'AssetDetailsBase' });
+  }
+
+  beforeEach(() => {
+    resolveOptions.mockClear();
+  });
+
+  describe('resolution options', () => {
+    it('should associate and skip the collection parent by default', () => {
+      createWrapper();
+
+      expect(resolveOptions).toHaveBeenLastCalledWith({ associate: true, collectionParent: false });
+    });
+
+    it('should stop associating when the resolution bag says so', () => {
+      createWrapper({ resolution: { enableAssociation: false } });
+
+      expect(resolveOptions).toHaveBeenLastCalledWith({ associate: false, collectionParent: false });
+    });
+
+    it('should resolve the collection parent when asked', () => {
+      createWrapper({ resolution: { isCollectionParent: true } });
+
+      expect(resolveOptions).toHaveBeenLastCalledWith({ associate: true, collectionParent: true });
+    });
+
+    // `options` is the escape hatch, so it has to win over what the two flags derive. Both
+    // NO_COLLECTION_RESOLVE and TradeAssetDisplay rely on that.
+    it('should let the options field override the derived flags', () => {
+      createWrapper({ resolution: { isCollectionParent: true, options: { collectionParent: false } } });
+
+      expect(resolveOptions).toHaveBeenLastCalledWith({ associate: true, collectionParent: false });
+    });
+  });
+
+  describe('forwarding', () => {
+    it('should hand the resolved asset down under the given identifier', () => {
+      const asset = base(createWrapper()).props('asset');
+
+      expect(asset).toStrictEqual({ identifier: IDENTIFIER, isCustomAsset: false, name: 'Dai Stablecoin', symbol: 'DAI' });
+    });
+
+    it('should forward the display bag untouched', () => {
+      const display: AssetDisplay = { dense: true, iconOnly: true, optimizeForVirtualScroll: true, size: '26px' };
+
+      expect(base(createWrapper({ display })).props('display')).toStrictEqual(display);
+    });
+
+    it('should forward the actions bag untouched', () => {
+      const actions: AssetActions = { hideActions: true, hideMenu: true };
+
+      expect(base(createWrapper({ actions })).props('actions')).toStrictEqual(actions);
+    });
+
+    it('should forward the resolution bag', () => {
+      const wrapper = createWrapper({ resolution: { forceChain: 'optimism', isCollectionParent: true } });
+
+      expect(base(wrapper).props('resolution')).toMatchObject({ forceChain: 'optimism', isCollectionParent: true });
+    });
+
+    it('should pass no bags on when none were given', () => {
+      const wrapper = createWrapper();
+
+      expect(base(wrapper).props('display')).toBeUndefined();
+      expect(base(wrapper).props('actions')).toBeUndefined();
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/AssetDetails.vue
+++ b/frontend/app/src/modules/assets/AssetDetails.vue
@@ -1,33 +1,19 @@
 <script setup lang="ts">
 import type { AssetInfoWithId } from '@rotki/common';
-import type { AssetActions, AssetDisplay, AssetResolution } from '@/modules/assets/types';
+import type { AssetActions, AssetDisplay, AssetIdentifierResolution } from '@/modules/assets/types';
 import AssetDetailsBase from '@/modules/assets/AssetDetailsBase.vue';
 import { type AssetResolutionOptions, useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 
 const {
+  actions,
   asset,
-  dense,
-  enableAssociation = true,
-  forceChain,
-  hideActions,
-  hideMenu,
-  iconOnly,
-  isCollectionParent = false,
-  optimizeForVirtualScroll,
-  resolutionOptions,
-  size,
+  display,
+  resolution,
 } = defineProps<{
   asset: string;
-  dense?: boolean;
-  enableAssociation?: boolean;
-  isCollectionParent?: boolean;
-  hideMenu?: boolean;
-  hideActions?: boolean;
-  iconOnly?: boolean;
-  size?: string;
-  forceChain?: string;
-  optimizeForVirtualScroll?: boolean;
-  resolutionOptions?: AssetResolutionOptions;
+  display?: AssetDisplay;
+  actions?: AssetActions;
+  resolution?: AssetIdentifierResolution;
 }>();
 
 const emit = defineEmits<{
@@ -37,44 +23,26 @@ const emit = defineEmits<{
 const { useAssetInfo } = useAssetInfoRetrieval();
 
 const assetDetails = useAssetInfo(() => asset, computed<AssetResolutionOptions>(() => ({
-  associate: enableAssociation,
-  collectionParent: isCollectionParent,
-  ...resolutionOptions,
+  associate: resolution?.enableAssociation ?? true,
+  collectionParent: resolution?.isCollectionParent ?? false,
+  ...resolution?.options,
 })));
 
 const currentAsset = computed<AssetInfoWithId>(() => ({
   ...get(assetDetails),
   identifier: asset,
 }));
-
-// Computed rather than inline literals: an object built in the template is a new identity on every
-// parent render, which would re-render the child even inside a virtualized table.
-const baseDisplay = computed<AssetDisplay>(() => ({
-  dense,
-  iconOnly,
-  optimizeForVirtualScroll,
-  showChain: !isCollectionParent,
-  size,
-}));
-
-const baseActions = computed<AssetActions>(() => ({
-  hideActions,
-  hideMenu,
-}));
-
-const baseResolution = computed<AssetResolution>(() => ({
-  enableAssociation,
-  forceChain,
-  isCollectionParent,
-}));
 </script>
 
 <template>
+  <!-- All three bags are forwarded by reference. Rebuilding them here would give the defaults a
+       second home to drift in, and would hand the child a fresh object identity every render. Only
+       `resolution.options` stops here, consumed by `useAssetInfo` above. -->
   <AssetDetailsBase
     :asset="currentAsset"
-    :display="baseDisplay"
-    :actions="baseActions"
-    :resolution="baseResolution"
+    :display="display"
+    :actions="actions"
+    :resolution="resolution"
     @refresh="emit('refresh')"
   />
 </template>

--- a/frontend/app/src/modules/assets/AssetDetails.vue
+++ b/frontend/app/src/modules/assets/AssetDetails.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { AssetInfoWithId } from '@rotki/common';
+import type { AssetActions, AssetDisplay, AssetResolution } from '@/modules/assets/types';
 import AssetDetailsBase from '@/modules/assets/AssetDetailsBase.vue';
 import { type AssetResolutionOptions, useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 
@@ -45,21 +46,35 @@ const currentAsset = computed<AssetInfoWithId>(() => ({
   ...get(assetDetails),
   identifier: asset,
 }));
+
+// Computed rather than inline literals: an object built in the template is a new identity on every
+// parent render, which would re-render the child even inside a virtualized table.
+const baseDisplay = computed<AssetDisplay>(() => ({
+  dense,
+  iconOnly,
+  optimizeForVirtualScroll,
+  showChain: !isCollectionParent,
+  size,
+}));
+
+const baseActions = computed<AssetActions>(() => ({
+  hideActions,
+  hideMenu,
+}));
+
+const baseResolution = computed<AssetResolution>(() => ({
+  enableAssociation,
+  forceChain,
+  isCollectionParent,
+}));
 </script>
 
 <template>
   <AssetDetailsBase
-    :hide-menu="hideMenu"
-    :hide-actions="hideActions"
-    :icon-only="iconOnly"
     :asset="currentAsset"
-    :dense="dense"
-    :enable-association="enableAssociation"
-    :show-chain="!isCollectionParent"
-    :is-collection-parent="isCollectionParent"
-    :size="size"
-    :force-chain="forceChain"
-    :optimize-for-virtual-scroll="optimizeForVirtualScroll"
+    :display="baseDisplay"
+    :actions="baseActions"
+    :resolution="baseResolution"
     @refresh="emit('refresh')"
   />
 </template>

--- a/frontend/app/src/modules/assets/AssetDetailsBase.spec.ts
+++ b/frontend/app/src/modules/assets/AssetDetailsBase.spec.ts
@@ -1,0 +1,199 @@
+import type { NftAsset } from '@/modules/assets/nfts';
+import type { AssetActions, AssetDisplay, AssetResolution } from '@/modules/assets/types';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import AssetDetailsBase from '@/modules/assets/AssetDetailsBase.vue';
+
+/**
+ * The children are inspected through name selectors, so their instance type is not known here.
+ * Declaring the props as an open record is what keeps `props('size')` from narrowing its key to
+ * `never`, which a `test:unit` run would not have caught.
+ */
+type AnyProps = ComponentPublicInstance<Record<string, unknown>>;
+
+type AnyPropsWrapper = VueWrapper<AnyProps>;
+
+const ASSET: NftAsset = {
+  identifier: 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F',
+  isCustomAsset: false,
+  name: 'Dai Stablecoin',
+  symbol: 'DAI',
+};
+
+const AppImage = {
+  name: 'AppImage',
+  props: ['src', 'size', 'fit'],
+  template: '<img data-testid="app-image" :src="src" />',
+};
+
+const AssetIcon = {
+  name: 'AssetIcon',
+  props: ['identifier', 'size', 'showChain', 'forceChain', 'resolutionOptions', 'optimizeForVirtualScroll'],
+  template: '<div data-testid="asset-icon" />',
+};
+
+const AssetDetailsMenuContent = {
+  name: 'AssetDetailsMenuContent',
+  props: ['asset', 'iconOnly', 'hideActions', 'isCollectionParent'],
+  template: '<div data-testid="menu-content" />',
+};
+
+// The real menu needs a popper; this keeps the activator slot (and its `attrs`) rendering so the
+// icon-only and roomy activator branches can still be told apart.
+const RuiMenu = {
+  name: 'RuiMenu',
+  template: '<div data-testid="rui-menu"><slot name="activator" :attrs="{}" /><slot /></div>',
+};
+
+describe('assetDetailsBase', () => {
+  interface Props {
+    asset?: NftAsset;
+    display?: AssetDisplay;
+    actions?: AssetActions;
+    resolution?: AssetResolution;
+  }
+
+  function createWrapper(props: Props = {}): VueWrapper {
+    return mount(AssetDetailsBase, {
+      global: {
+        plugins: [createCustomPinia()],
+        stubs: { AppImage, AssetDetailsMenuContent, AssetIcon, RuiMenu },
+      },
+      props: { asset: ASSET, ...props },
+    });
+  }
+
+  function icon(wrapper: VueWrapper): AnyPropsWrapper {
+    return wrapper.findComponent<AnyProps>({ name: 'AssetIcon' });
+  }
+
+  function listItem(wrapper: VueWrapper): AnyPropsWrapper {
+    return wrapper.findComponent<AnyProps>({ name: 'ListItem' });
+  }
+
+  function menuContent(wrapper: VueWrapper): AnyPropsWrapper {
+    return wrapper.findComponent<AnyProps>({ name: 'AssetDetailsMenuContent' });
+  }
+
+  function appImage(wrapper: VueWrapper): AnyPropsWrapper {
+    return wrapper.findComponent<AnyProps>({ name: 'AppImage' });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createCustomPinia());
+  });
+
+  describe('display defaults', () => {
+    it('should fall back to the default size when no display bag is given', () => {
+      expect(icon(createWrapper()).props('size')).toBe('30px');
+    });
+
+    it('should use the size from the display bag', () => {
+      expect(icon(createWrapper({ display: { size: '48px' } })).props('size')).toBe('48px');
+    });
+
+    // A caller forwarding its own optional size hands over a present key holding `undefined`.
+    // Spreading the bag over a defaults object would take that `undefined` as the value.
+    it('should keep the default size when the display bag holds an explicit undefined', () => {
+      expect(icon(createWrapper({ display: { size: undefined } })).props('size')).toBe('30px');
+    });
+
+    it('should show the chain by default', () => {
+      expect(icon(createWrapper()).props('showChain')).toBe(true);
+    });
+
+    it('should hide the chain when the display bag says so', () => {
+      expect(icon(createWrapper({ display: { showChain: false } })).props('showChain')).toBe(false);
+    });
+
+    it('should draw a roomy list item by default', () => {
+      expect(listItem(createWrapper()).props('size')).toBe('md');
+    });
+
+    it('should draw a compact list item when dense', () => {
+      expect(listItem(createWrapper({ display: { dense: true } })).props('size')).toBe('sm');
+    });
+
+    it('should forward optimizeForVirtualScroll to the icon', () => {
+      expect(icon(createWrapper({ display: { optimizeForVirtualScroll: true } })).props('optimizeForVirtualScroll')).toBe(true);
+    });
+  });
+
+  describe('resolution defaults', () => {
+    it('should associate the asset by default', () => {
+      expect(icon(createWrapper()).props('resolutionOptions')).toStrictEqual({ associate: true });
+    });
+
+    it('should not associate the asset when the resolution bag says so', () => {
+      expect(icon(createWrapper({ resolution: { enableAssociation: false } })).props('resolutionOptions')).toStrictEqual({ associate: false });
+    });
+
+    it('should forward forceChain to the icon', () => {
+      expect(icon(createWrapper({ resolution: { forceChain: 'optimism' } })).props('forceChain')).toBe('optimism');
+    });
+
+    it('should tell the menu content whether this is a collection parent', () => {
+      const wrapper = createWrapper({ resolution: { isCollectionParent: true } });
+
+      expect(menuContent(wrapper).props('isCollectionParent')).toBe(true);
+    });
+  });
+
+  describe('actions', () => {
+    it('should render the menu by default', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.find('[data-testid="rui-menu"]').exists()).toBe(true);
+      expect(listItem(wrapper).exists()).toBe(true);
+    });
+
+    it('should skip the menu entirely when hideMenu is set', () => {
+      const wrapper = createWrapper({ actions: { hideMenu: true } });
+
+      expect(wrapper.find('[data-testid="rui-menu"]').exists()).toBe(false);
+      expect(listItem(wrapper).exists()).toBe(true);
+    });
+
+    it('should render the bare image when hideMenu and iconOnly are both set', () => {
+      const wrapper = createWrapper({ actions: { hideMenu: true }, display: { iconOnly: true } });
+
+      expect(wrapper.find('[data-testid="rui-menu"]').exists()).toBe(false);
+      expect(listItem(wrapper).exists()).toBe(false);
+      expect(icon(wrapper).exists()).toBe(true);
+    });
+
+    it('should forward hideActions to the menu content', () => {
+      const wrapper = createWrapper({ actions: { hideActions: true } });
+
+      expect(menuContent(wrapper).props('hideActions')).toBe(true);
+    });
+
+    it('should not hide the menu actions by default', () => {
+      expect(menuContent(createWrapper()).props('hideActions')).toBe(false);
+    });
+  });
+
+  describe('image source', () => {
+    it('should draw the asset icon when the asset has no image url', () => {
+      const wrapper = createWrapper();
+
+      expect(icon(wrapper).exists()).toBe(true);
+      expect(wrapper.find('[data-testid="app-image"]').exists()).toBe(false);
+    });
+
+    it('should draw the image url when the asset has one', () => {
+      const wrapper = createWrapper({ asset: { ...ASSET, imageUrl: 'https://example.com/dai.png' } });
+
+      expect(wrapper.find('[data-testid="app-image"]').attributes('src')).toBe('https://example.com/dai.png');
+      expect(icon(wrapper).exists()).toBe(false);
+    });
+
+    it('should size the image url with the same display size', () => {
+      const wrapper = createWrapper({ asset: { ...ASSET, imageUrl: 'https://example.com/dai.png' }, display: { size: '48px' } });
+
+      expect(appImage(wrapper).props('size')).toBe('48px');
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/AssetDetailsBase.spec.ts
+++ b/frontend/app/src/modules/assets/AssetDetailsBase.spec.ts
@@ -102,14 +102,6 @@ describe('assetDetailsBase', () => {
       expect(icon(createWrapper({ display: { size: undefined } })).props('size')).toBe('30px');
     });
 
-    it('should show the chain by default', () => {
-      expect(icon(createWrapper()).props('showChain')).toBe(true);
-    });
-
-    it('should hide the chain when the display bag says so', () => {
-      expect(icon(createWrapper({ display: { showChain: false } })).props('showChain')).toBe(false);
-    });
-
     it('should draw a roomy list item by default', () => {
       expect(listItem(createWrapper()).props('size')).toBe('md');
     });
@@ -140,6 +132,16 @@ describe('assetDetailsBase', () => {
 
       expect(icon(wrapper).props('changeable')).toBeUndefined();
       expect(wrapper.find('[data-testid="asset-icon"]').attributes('changeable')).toBeUndefined();
+    });
+
+    // showChain is derived from isCollectionParent rather than being its own prop, so the two can
+    // no longer contradict each other. A collection parent stands for several chains.
+    it('should show the chain by default', () => {
+      expect(icon(createWrapper()).props('showChain')).toBe(true);
+    });
+
+    it('should hide the chain for a collection parent', () => {
+      expect(icon(createWrapper({ resolution: { isCollectionParent: true } })).props('showChain')).toBe(false);
     });
 
     it('should forward forceChain to the icon', () => {

--- a/frontend/app/src/modules/assets/AssetDetailsBase.spec.ts
+++ b/frontend/app/src/modules/assets/AssetDetailsBase.spec.ts
@@ -28,9 +28,11 @@ const AppImage = {
   template: '<img data-testid="app-image" :src="src" />',
 };
 
+// `changeable` is declared here although the real AssetIcon has no such prop: that is what lets the
+// regression test below see a value if the binding is ever passed again.
 const AssetIcon = {
   name: 'AssetIcon',
-  props: ['identifier', 'size', 'showChain', 'forceChain', 'resolutionOptions', 'optimizeForVirtualScroll'],
+  props: ['identifier', 'size', 'showChain', 'forceChain', 'resolutionOptions', 'optimizeForVirtualScroll', 'changeable'],
   template: '<div data-testid="asset-icon" />',
 };
 
@@ -128,6 +130,16 @@ describe('assetDetailsBase', () => {
 
     it('should not associate the asset when the resolution bag says so', () => {
       expect(icon(createWrapper({ resolution: { enableAssociation: false } })).props('resolutionOptions')).toStrictEqual({ associate: false });
+    });
+
+    // `changeable` was removed from AssetIcon in #7937 (May 2024) when the cache-busting timestamp
+    // went away, but two callers kept passing it, so for two years it landed as a DOM attribute and
+    // did nothing. Nothing may pass it again: neither as a prop nor as a stray attribute.
+    it('should not pass changeable to the icon', () => {
+      const wrapper = createWrapper();
+
+      expect(icon(wrapper).props('changeable')).toBeUndefined();
+      expect(wrapper.find('[data-testid="asset-icon"]').attributes('changeable')).toBeUndefined();
     });
 
     it('should forward forceChain to the icon', () => {

--- a/frontend/app/src/modules/assets/AssetDetailsBase.vue
+++ b/frontend/app/src/modules/assets/AssetDetailsBase.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { NftAsset } from '@/modules/assets/nfts';
+import type { AssetActions, AssetDisplay, AssetResolution } from '@/modules/assets/types';
 import { omit } from 'es-toolkit';
 import { useTemplateRef } from 'vue';
 import AssetDetailsMenuContent from '@/modules/assets/AssetDetailsMenuContent.vue';
@@ -15,31 +16,15 @@ defineOptions({
 });
 
 const {
+  actions,
   asset,
-  changeable,
-  dense,
-  enableAssociation = true,
-  forceChain,
-  hideActions,
-  hideMenu = false,
-  iconOnly,
-  isCollectionParent = false,
-  optimizeForVirtualScroll,
-  showChain = true,
-  size = '30px',
+  display,
+  resolution,
 } = defineProps<{
   asset: NftAsset;
-  changeable?: boolean;
-  hideActions?: boolean;
-  dense?: boolean;
-  enableAssociation?: boolean;
-  showChain?: boolean;
-  isCollectionParent?: boolean;
-  hideMenu?: boolean;
-  iconOnly?: boolean;
-  size?: string;
-  forceChain?: string;
-  optimizeForVirtualScroll?: boolean;
+  display?: AssetDisplay;
+  actions?: AssetActions;
+  resolution?: AssetResolution;
 }>();
 
 const emit = defineEmits<{
@@ -51,8 +36,26 @@ const menuContentRef = useTemplateRef<InstanceType<typeof AssetDetailsMenuConten
 
 const { isPending } = useAssetInfoCache();
 const shouldShowAmount = useSetting('shouldShowAmount');
-const { navigateToDetails } = useAssetPageNavigation(() => asset.identifier, () => isCollectionParent);
 const loading = isPending(() => asset.identifier);
+
+// Every field is read with `??` rather than by spreading the bag over a defaults object: a caller
+// forwarding an optional value gives a present key holding `undefined`, which a spread would use to
+// clobber the default. `AssetDetails` forwards its own optional `size` exactly that way.
+const dense = computed<boolean>(() => display?.dense ?? false);
+const iconOnly = computed<boolean>(() => display?.iconOnly ?? false);
+const size = computed<string>(() => display?.size ?? '30px');
+const showChain = computed<boolean>(() => display?.showChain ?? true);
+const optimizeForVirtualScroll = computed<boolean>(() => display?.optimizeForVirtualScroll ?? false);
+
+const hideMenu = computed<boolean>(() => actions?.hideMenu ?? false);
+const hideActions = computed<boolean>(() => actions?.hideActions ?? false);
+const changeable = computed<boolean>(() => actions?.changeable ?? false);
+
+const enableAssociation = computed<boolean>(() => resolution?.enableAssociation ?? true);
+const isCollectionParent = computed<boolean>(() => resolution?.isCollectionParent ?? false);
+const forceChain = computed<string | undefined>(() => resolution?.forceChain);
+
+const { navigateToDetails } = useAssetPageNavigation(() => asset.identifier, () => get(isCollectionParent));
 
 const [DefineImage, ReuseImage] = createReusableTemplate();
 
@@ -66,7 +69,7 @@ function useContextMenu(attrs: Record<string, unknown>) {
   return {
     ...omit(attrs, ['onClick']),
     onClick: () => {
-      if (!hideMenu) {
+      if (!get(hideMenu)) {
         navigateToDetails();
       }
     },

--- a/frontend/app/src/modules/assets/AssetDetailsBase.vue
+++ b/frontend/app/src/modules/assets/AssetDetailsBase.vue
@@ -85,7 +85,7 @@ watch(menuOpened, (menuOpened) => {
   <DefineImage>
     <AppImage
       v-if="asset.imageUrl"
-      contain
+      fit="contain"
       :size="size"
       :src="asset.imageUrl"
     />

--- a/frontend/app/src/modules/assets/AssetDetailsBase.vue
+++ b/frontend/app/src/modules/assets/AssetDetailsBase.vue
@@ -44,7 +44,6 @@ const loading = isPending(() => asset.identifier);
 const dense = computed<boolean>(() => display?.dense ?? false);
 const iconOnly = computed<boolean>(() => display?.iconOnly ?? false);
 const size = computed<string>(() => display?.size ?? '30px');
-const showChain = computed<boolean>(() => display?.showChain ?? true);
 const optimizeForVirtualScroll = computed<boolean>(() => display?.optimizeForVirtualScroll ?? false);
 
 const hideMenu = computed<boolean>(() => actions?.hideMenu ?? false);
@@ -53,6 +52,12 @@ const hideActions = computed<boolean>(() => actions?.hideActions ?? false);
 const enableAssociation = computed<boolean>(() => resolution?.enableAssociation ?? true);
 const isCollectionParent = computed<boolean>(() => resolution?.isCollectionParent ?? false);
 const forceChain = computed<string | undefined>(() => resolution?.forceChain);
+
+// Derived rather than its own prop. It was one, and `AssetDetails` was the only caller ever to set
+// it, always to exactly this: a collection parent stands for several chains, so naming one is wrong.
+// The other four callers left it at its `true` default with `isCollectionParent` false, which is the
+// same value. As a prop the two could also contradict each other.
+const showChain = computed<boolean>(() => !get(isCollectionParent));
 
 const { navigateToDetails } = useAssetPageNavigation(() => asset.identifier, () => get(isCollectionParent));
 

--- a/frontend/app/src/modules/assets/AssetDetailsBase.vue
+++ b/frontend/app/src/modules/assets/AssetDetailsBase.vue
@@ -49,7 +49,6 @@ const optimizeForVirtualScroll = computed<boolean>(() => display?.optimizeForVir
 
 const hideMenu = computed<boolean>(() => actions?.hideMenu ?? false);
 const hideActions = computed<boolean>(() => actions?.hideActions ?? false);
-const changeable = computed<boolean>(() => actions?.changeable ?? false);
 
 const enableAssociation = computed<boolean>(() => resolution?.enableAssociation ?? true);
 const isCollectionParent = computed<boolean>(() => resolution?.isCollectionParent ?? false);
@@ -94,7 +93,6 @@ watch(menuOpened, (menuOpened) => {
     />
     <AssetIcon
       v-else
-      :changeable="changeable"
       :size="size"
       :identifier="asset.identifier"
       :resolution-options="{ associate: enableAssociation }"

--- a/frontend/app/src/modules/assets/admin/AssetIconForm.vue
+++ b/frontend/app/src/modules/assets/admin/AssetIconForm.vue
@@ -131,7 +131,6 @@ defineExpose({
           :key="refreshKey"
           :identifier="preview"
           size="72px"
-          changeable
           no-tooltip
           :show-chain="false"
         />

--- a/frontend/app/src/modules/assets/admin/AssetIconForm.vue
+++ b/frontend/app/src/modules/assets/admin/AssetIconForm.vue
@@ -124,7 +124,7 @@ defineExpose({
           v-if="icon && previewImageSource"
           :src="previewImageSource"
           size="4.5rem"
-          contain
+          fit="contain"
         />
         <AssetIcon
           v-else-if="preview"

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetTable.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetTable.vue
@@ -113,10 +113,7 @@ function expand(item: CustomAsset) {
       class="custom-assets-table"
     >
       <template #item.name="{ row }">
-        <AssetDetailsBase
-          :actions="{ changeable: !loading }"
-          :asset="getAsset(row)"
-        />
+        <AssetDetailsBase :asset="getAsset(row)" />
       </template>
       <template #item.custom_asset_type="{ row }">
         <BadgeDisplay>

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetTable.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetTable.vue
@@ -114,7 +114,7 @@ function expand(item: CustomAsset) {
     >
       <template #item.name="{ row }">
         <AssetDetailsBase
-          :changeable="!loading"
+          :actions="{ changeable: !loading }"
           :asset="getAsset(row)"
         />
       </template>

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetTable.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetTable.vue
@@ -136,10 +136,7 @@ function getAssetLocation(row: SupportedAsset): string | undefined {
     >
       <template #item.symbol="{ row }">
         <div class="flex items-center gap-2">
-          <AssetDetailsBase
-            :actions="{ changeable: !loading }"
-            :asset="getAsset(row)"
-          />
+          <AssetDetailsBase :asset="getAsset(row)" />
           <RuiChip
             v-if="row.isRebasing"
             color="primary"

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetTable.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetTable.vue
@@ -137,7 +137,7 @@ function getAssetLocation(row: SupportedAsset): string | undefined {
       <template #item.symbol="{ row }">
         <div class="flex items-center gap-2">
           <AssetDetailsBase
-            :changeable="!loading"
+            :actions="{ changeable: !loading }"
             :asset="getAsset(row)"
           />
           <RuiChip

--- a/frontend/app/src/modules/assets/detection/NewlyDetectedAssetTable.vue
+++ b/frontend/app/src/modules/assets/detection/NewlyDetectedAssetTable.vue
@@ -175,7 +175,7 @@ onMounted(async () => {
       >
         <template #item.tokenIdentifier="{ row }">
           <AssetDetails
-            hide-menu
+            :actions="{ hideMenu: true }"
             :asset="row.tokenIdentifier"
           />
         </template>

--- a/frontend/app/src/modules/assets/types.ts
+++ b/frontend/app/src/modules/assets/types.ts
@@ -1,3 +1,4 @@
+import type { AssetResolutionOptions } from '@/modules/assets/use-asset-info-retrieval';
 import type { ConflictResolutionStrategy, PaginationRequestPayload } from '@/modules/core/common/common-types';
 import { AssetCollection, AssetInfoWithId, AssetInfoWithTransformer, SupportedAsset } from '@rotki/common';
 import { z } from 'zod';
@@ -19,7 +20,6 @@ export interface AssetDisplay {
   dense?: boolean;
   iconOnly?: boolean;
   size?: string;
-  showChain?: boolean;
   optimizeForVirtualScroll?: boolean;
 }
 
@@ -29,11 +29,19 @@ export interface AssetActions {
   hideActions?: boolean;
 }
 
-/** Which asset an identifier means. */
+/** Which asset this one is. */
 export interface AssetResolution {
   enableAssociation?: boolean;
   isCollectionParent?: boolean;
   forceChain?: string;
+}
+
+/**
+ * Resolving an identifier takes one thing more than resolving an already-resolved asset: the options
+ * handed to `useAssetInfo`.
+ */
+export interface AssetIdentifierResolution extends AssetResolution {
+  options?: AssetResolutionOptions;
 }
 
 export interface AssetDBVersion {

--- a/frontend/app/src/modules/assets/types.ts
+++ b/frontend/app/src/modules/assets/types.ts
@@ -27,7 +27,6 @@ export interface AssetDisplay {
 export interface AssetActions {
   hideMenu?: boolean;
   hideActions?: boolean;
-  changeable?: boolean;
 }
 
 /** Which asset an identifier means. */

--- a/frontend/app/src/modules/assets/types.ts
+++ b/frontend/app/src/modules/assets/types.ts
@@ -3,6 +3,40 @@ import { AssetCollection, AssetInfoWithId, AssetInfoWithTransformer, SupportedAs
 import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
 
+/**
+ * The three groups below are the props `AssetDetails` and `AssetDetailsBase` share. They are grouped
+ * because the groups ARE the forwarding boundary: `AssetDetails` resolves an identifier and hands
+ * display and actions straight through untouched, so every prop added to one had to be added to the
+ * other, and the two counts drifted apart as that upkeep was missed.
+ *
+ * Read every field with `??` rather than spreading a bag over a defaults object: a caller forwarding
+ * an optional value produces a present key holding `undefined`, which a spread would use to clobber
+ * the default.
+ */
+
+/** How the asset is drawn. */
+export interface AssetDisplay {
+  dense?: boolean;
+  iconOnly?: boolean;
+  size?: string;
+  showChain?: boolean;
+  optimizeForVirtualScroll?: boolean;
+}
+
+/** What the user may do with the asset. */
+export interface AssetActions {
+  hideMenu?: boolean;
+  hideActions?: boolean;
+  changeable?: boolean;
+}
+
+/** Which asset an identifier means. */
+export interface AssetResolution {
+  enableAssociation?: boolean;
+  isCollectionParent?: boolean;
+  forceChain?: string;
+}
+
 export interface AssetDBVersion {
   readonly local: number;
   readonly remote: number;

--- a/frontend/app/src/modules/balances/AssetBalances.vue
+++ b/frontend/app/src/modules/balances/AssetBalances.vue
@@ -201,7 +201,7 @@ const sorted = computed<AssetBalanceWithPrice[]>(() => sortAssetBalances([...get
     <template #item.asset="{ row }">
       <AssetDetails
         :asset="row.asset"
-        :is-collection-parent="!!row.breakdown"
+        :resolution="{ isCollectionParent: !!row.breakdown }"
       />
     </template>
     <template #item.perProtocol="{ row }">

--- a/frontend/app/src/modules/balances/nft/NftDetails.vue
+++ b/frontend/app/src/modules/balances/nft/NftDetails.vue
@@ -115,7 +115,7 @@ const fallbackData = computed(() => {
                 class="rounded overflow-hidden"
                 :src="renderedMedia"
                 :size="size"
-                contain
+                fit="contain"
               />
             </div>
           </template>

--- a/frontend/app/src/modules/balances/nft/NftGalleryItem.vue
+++ b/frontend/app/src/modules/balances/nft/NftGalleryItem.vue
@@ -97,7 +97,7 @@ const mediaStyle = computed<StyleValue>(() => {
             <AppImage
               v-else
               :src="renderedMedia"
-              contain
+              fit="contain"
               :style="mediaStyle"
               width="100%"
               class="object-contain aspect-square"

--- a/frontend/app/src/modules/balances/protocols/ProtocolIcon.vue
+++ b/frontend/app/src/modules/balances/protocols/ProtocolIcon.vue
@@ -46,7 +46,7 @@ const { t } = useI18n({ useScope: 'global' });
           class="rounded-full overflow-hidden"
           :src="protocolData.image"
           size="24px"
-          contain
+          fit="contain"
         />
         <RuiIcon
           v-else

--- a/frontend/app/src/modules/dashboard/ConfirmSnapshotConflictReplacementDialog.vue
+++ b/frontend/app/src/modules/dashboard/ConfirmSnapshotConflictReplacementDialog.vue
@@ -45,10 +45,10 @@ const asset = computed<string>(() => snapshot?.assetIdentifier ?? '');
       />
       <AssetDetails
         v-else
-        hide-menu
         class="max-w-[640px]"
         :asset="asset"
-        :enable-association="false"
+        :actions="{ hideMenu: true }"
+        :resolution="{ enableAssociation: false }"
       />
     </div>
   </ConfirmDialog>

--- a/frontend/app/src/modules/dashboard/DashboardAssetWarnings.vue
+++ b/frontend/app/src/modules/dashboard/DashboardAssetWarnings.vue
@@ -26,6 +26,6 @@ function onMissingAssetClick(item: AssetBalanceWithPrice): void {
   <AssetDetails
     v-else
     :asset="asset.asset"
-    :is-collection-parent="!!asset.breakdown"
+    :resolution="{ isCollectionParent: !!asset.breakdown }"
   />
 </template>

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalancesTable.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalancesTable.vue
@@ -276,8 +276,8 @@ function onDelete(payload: { index: number; location: LocationAttribution }): vo
             v-if="!isNftRow(row)"
             class="min-w-0 [&_.avatar]:ml-1.5 [&_.avatar]:mr-2"
             :asset="row.assetIdentifier"
-            :enable-association="false"
-            hide-menu
+            :actions="{ hideMenu: true }"
+            :resolution="{ enableAssociation: false }"
           />
           <NftDetails
             v-else

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotChangesList.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotChangesList.vue
@@ -87,8 +87,8 @@ const { containerProps, list, wrapperProps } = useVirtualList(items, { itemHeigh
         <AssetDetails
           v-if="item.asset && !isNft(item.asset)"
           :asset="item.asset"
-          :enable-association="false"
-          size="26px"
+          :display="{ size: '26px' }"
+          :resolution="{ enableAssociation: false }"
         />
         <span v-else-if="item.asset">{{ item.asset }}</span>
 

--- a/frontend/app/src/modules/history/balances/AccountingOverlayBucketIcon.vue
+++ b/frontend/app/src/modules/history/balances/AccountingOverlayBucketIcon.vue
@@ -19,7 +19,7 @@ const { protocolData } = useProtocolData(() => protocol);
     v-else-if="protocolData?.type === 'image'"
     :src="protocolData.image"
     size="16px"
-    contain
+    fit="contain"
     class="rounded-full overflow-hidden"
   />
   <RuiIcon

--- a/frontend/app/src/modules/history/events/HistoryEventAsset.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventAsset.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { AssetDisplay } from '@/modules/assets/types';
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import { type AssetInfoWithId, Zero } from '@rotki/common';
 import { useTemplateRef } from 'vue';
@@ -27,6 +28,14 @@ const { useAssetInfo } = useAssetInfoRetrieval();
 const assetDetails = useAssetInfo(() => event.asset, NO_COLLECTION_RESOLVE);
 
 const showBalance = computed<boolean>(() => event.eventType !== 'informational');
+
+// Computed, not a template literal: these rows are virtualized, so a fresh bag identity per render
+// would re-render every asset cell on every scroll tick.
+const assetDisplay = computed<AssetDisplay>(() => ({
+  iconOnly: true,
+  optimizeForVirtualScroll: true,
+  size: dense ? '24px' : '32px',
+}));
 const currentAsset = computed<AssetInfoWithId>(() => ({
   ...get(assetDetails),
   identifier: event.asset,
@@ -71,12 +80,10 @@ watch(menuOpened, (menuOpened) => {
         @contextmenu="openMenuHandler($event)"
       >
         <AssetDetails
-          :size="dense ? '24px' : '32px'"
-          icon-only
-          hide-menu
-          optimize-for-virtual-scroll
           :asset="event.asset"
-          :resolution-options="NO_COLLECTION_RESOLVE"
+          :display="assetDisplay"
+          :actions="{ hideMenu: true }"
+          :resolution="{ options: NO_COLLECTION_RESOLVE }"
           @refresh="emit('refresh')"
         />
         <div

--- a/frontend/app/src/modules/history/events/HistoryEventTypeCounterparty.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventTypeCounterparty.vue
@@ -90,7 +90,7 @@ const displayAddress = computed<string | undefined>(() => {
               <AppImage
                 v-if="counterpartyImageSrc"
                 :src="counterpartyImageSrc"
-                contain
+                fit="contain"
                 size="20px"
               />
             </template>

--- a/frontend/app/src/modules/history/events/prices/EventAssetPriceUpdateDialog.vue
+++ b/frontend/app/src/modules/history/events/prices/EventAssetPriceUpdateDialog.vue
@@ -162,8 +162,8 @@ watch(modelValue, (payload) => {
         <div class="flex items-center justify-between gap-3 rounded-md bg-rui-grey-50 dark:bg-rui-grey-900 px-3 py-2">
           <AssetDetails
             :asset="modelValue.asset"
-            size="28px"
-            hide-menu
+            :display="{ size: '28px' }"
+            :actions="{ hideMenu: true }"
           />
           <div class="flex flex-col items-end">
             <div class="!text-[10px] !leading-[1] text-caption text-rui-text-secondary uppercase">

--- a/frontend/app/src/modules/premium/SponsorshipView.vue
+++ b/frontend/app/src/modules/premium/SponsorshipView.vue
@@ -27,7 +27,7 @@ const data: Sponsor = {
   <div class="flex flex-wrap gap-1 gap-x-4 w-[400px] max-w-full mx-auto">
     <div class="flex items-center justify-center w-full gap-2">
       <AppImage
-        cover
+        fit="cover"
         class="rounded-md overflow-hidden"
         :class="drawer ? 'size-20 min-w-20' : 'size-24 min-w-24'"
         :alt="data.name"

--- a/frontend/app/src/modules/reports/ProfitLossEvents.vue
+++ b/frontend/app/src/modules/reports/ProfitLossEvents.vue
@@ -240,7 +240,7 @@ onMounted(async () => {
       <template #item.asset="{ row }">
         <AssetDetails
           :asset="row.assetIdentifier"
-          icon-only
+          :display="{ iconOnly: true }"
         />
       </template>
       <template #item.free_amount="{ row }">

--- a/frontend/app/src/modules/settings/explorers/Explorers.vue
+++ b/frontend/app/src/modules/settings/explorers/Explorers.vue
@@ -101,11 +101,10 @@ onMounted(() => {
       />
       <AssetDetails
         v-else
-        dense
-        size="26px"
         class="[&>div]:!py-0 -my-[0.375rem]"
         :asset="item"
-        hide-menu
+        :display="{ dense: true, size: '26px' }"
+        :actions="{ hideMenu: true }"
       />
     </CreateSelection>
 

--- a/frontend/app/src/modules/settings/general/external-services/SuppressMissingKeyServicesSetting.vue
+++ b/frontend/app/src/modules/settings/general/external-services/SuppressMissingKeyServicesSetting.vue
@@ -40,7 +40,7 @@ const [DefineServiceItem, ReuseServiceItem] = createReusableTemplate<{ item: Ser
         :src="item.icon"
         :size="size"
         class="icon-bg"
-        contain
+        fit="contain"
       />
       <span>{{ item.name }}</span>
     </div>

--- a/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.spec.ts
@@ -15,7 +15,7 @@ vi.mock('@/modules/history/LocationDisplay.vue', () => ({
 vi.mock('@/modules/shell/components/AppImage.vue', () => ({
   default: {
     name: 'AppImage',
-    props: ['src', 'size', 'contain'],
+    props: ['src', 'size', 'fit'],
     template: '<img data-testid="app-image" :src="src" />',
   },
 }));

--- a/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.vue
+++ b/frontend/app/src/modules/settings/general/rpc/RpcSettingOption.vue
@@ -29,7 +29,7 @@ const { tab, groupLabel } = defineProps<{
         v-else
         :src="tab.image"
         size="20px"
-        contain
+        fit="contain"
         class="icon-bg"
       />
       <span

--- a/frontend/app/src/modules/settings/modules/ActiveModules.vue
+++ b/frontend/app/src/modules/settings/modules/ActiveModules.vue
@@ -121,7 +121,7 @@ function showConfirmation() {
               <AppImage
                 width="24px"
                 height="24px"
-                contain
+                fit="contain"
                 :src="icon(module.identifier)"
               />
             </RuiButton>

--- a/frontend/app/src/modules/settings/modules/DefiIcon.vue
+++ b/frontend/app/src/modules/settings/modules/DefiIcon.vue
@@ -29,7 +29,7 @@ const { item, size = '1.5rem', vertical = false } = defineProps<{
       :src="item.icon"
       :size="size"
       :loading="!item.icon"
-      contain
+      fit="contain"
     />
     <div
       class="text-rui-text-secondary"

--- a/frontend/app/src/modules/settings/modules/ModuleNotActive.vue
+++ b/frontend/app/src/modules/settings/modules/ModuleNotActive.vue
@@ -37,7 +37,7 @@ const { top } = useElementBounding(wrapper);
         >
           <AppImage
             width="82px"
-            contain
+            fit="contain"
             :src="icon(module)"
           />
         </div>

--- a/frontend/app/src/modules/settings/modules/ModuleSelector.vue
+++ b/frontend/app/src/modules/settings/modules/ModuleSelector.vue
@@ -226,7 +226,7 @@ onMounted(async () => {
           <AppImage
             class="icon-bg"
             size="1.5rem"
-            contain
+            fit="contain"
             :src="row.icon"
           />
           <span>{{ row.name }}</span>

--- a/frontend/app/src/modules/shell/components/AppImage.spec.ts
+++ b/frontend/app/src/modules/shell/components/AppImage.spec.ts
@@ -1,0 +1,61 @@
+import { type DOMWrapper, mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { getPublicPlaceholderImagePath } from '@/modules/core/common/file/file';
+import AppImage from '@/modules/shell/components/AppImage.vue';
+
+describe('appImage', () => {
+  function createWrapper(props: InstanceType<typeof AppImage>['$props'] = {}): VueWrapper<InstanceType<typeof AppImage>> {
+    return mount(AppImage, {
+      global: { stubs: { RuiSkeletonLoader: true } },
+      props,
+    });
+  }
+
+  function image(wrapper: VueWrapper<InstanceType<typeof AppImage>>): DOMWrapper<Element> {
+    return wrapper.find('img');
+  }
+
+  it('should apply no object-fit class when fit is not given', () => {
+    const classes = image(createWrapper({ src: 'icon.svg' })).classes();
+
+    expect(classes).not.toContain('object-contain');
+    expect(classes).not.toContain('object-cover');
+  });
+
+  it('should apply object-contain when fit is contain', () => {
+    const classes = image(createWrapper({ fit: 'contain', src: 'icon.svg' })).classes();
+
+    expect(classes).toContain('object-contain');
+    expect(classes).not.toContain('object-cover');
+  });
+
+  it('should apply object-cover when fit is cover', () => {
+    const classes = image(createWrapper({ fit: 'cover', src: 'icon.svg' })).classes();
+
+    expect(classes).toContain('object-cover');
+    expect(classes).not.toContain('object-contain');
+  });
+
+  it('should keep imageClass alongside the object-fit class', () => {
+    const classes = image(createWrapper({ fit: 'contain', imageClass: 'rounded-full', src: 'icon.svg' })).classes();
+
+    expect(classes).toContain('object-contain');
+    expect(classes).toContain('rounded-full');
+  });
+
+  it('should keep the object-fit class on the placeholder after an error', async () => {
+    const wrapper = createWrapper({ fit: 'cover', src: 'missing.svg' });
+    await image(wrapper).trigger('error');
+
+    const fallback = image(wrapper);
+    expect(fallback.attributes('src')).toBe(getPublicPlaceholderImagePath('image.svg'));
+    expect(fallback.classes()).toContain('object-cover');
+  });
+
+  it('should render the skeleton instead of an image while loading', () => {
+    const wrapper = createWrapper({ loading: true, src: 'icon.svg' });
+
+    expect(wrapper.find('img').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'RuiSkeletonLoader' }).exists()).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/shell/components/AppImage.vue
+++ b/frontend/app/src/modules/shell/components/AppImage.vue
@@ -4,17 +4,14 @@ import { getPublicPlaceholderImagePath } from '@/modules/core/common/file/file';
 
 const {
   alt,
-  contain = false,
-  cover = false,
+  fit,
   height,
   imageClass,
   loading = false,
   maxHeight,
   maxWidth,
   size,
-  sizes,
   src,
-  srcset,
   width,
 } = defineProps<{
   width?: string | number;
@@ -23,11 +20,8 @@ const {
   maxHeight?: string | number;
   size?: string | number;
   src?: string;
-  srcset?: string;
-  sizes?: string;
   alt?: string;
-  contain?: boolean;
-  cover?: boolean;
+  fit?: 'contain' | 'cover';
   loading?: boolean;
   imageClass?: string;
 }>();
@@ -40,6 +34,13 @@ const emit = defineEmits<{
 
 const error = ref<boolean>(false);
 const success = ref<boolean>(false);
+
+const fitClass = computed<string | undefined>(() => {
+  if (fit === undefined)
+    return undefined;
+
+  return fit === 'contain' ? 'object-contain' : 'object-cover';
+});
 
 const style = computed(() => ({
   height: getSizeOrValue(height),
@@ -78,20 +79,16 @@ function onLoadStart() {
     <img
       v-else-if="error"
       :src="getPublicPlaceholderImagePath('image.svg')"
-      :class="[{ 'object-contain': contain, 'object-cover': cover }, imageClass]"
+      :class="[fitClass, imageClass]"
       loading="lazy"
       :style="style"
-      :sizes="sizes"
-      :srcset="srcset"
     />
     <img
       v-else
       :alt="alt"
-      :class="[{ 'object-contain': contain, 'object-cover': cover }, imageClass]"
+      :class="[fitClass, imageClass]"
       :style="style"
       :src="src"
-      :sizes="sizes"
-      :srcset="srcset"
       loading="lazy"
       @error="onError()"
       @loadstart="onLoadStart()"

--- a/frontend/app/src/modules/shell/components/AppImage.vue
+++ b/frontend/app/src/modules/shell/components/AppImage.vue
@@ -35,6 +35,8 @@ const emit = defineEmits<{
 const error = ref<boolean>(false);
 const success = ref<boolean>(false);
 
+// Both class names must stay literal and stay in this file: tailwind's `content` globs cover
+// `.vue` only, so moving them into a `.ts` helper would purge them with every gate still green.
 const fitClass = computed<string | undefined>(() => {
   if (fit === undefined)
     return undefined;

--- a/frontend/app/src/modules/shell/components/AssetIcon.vue
+++ b/frontend/app/src/modules/shell/components/AssetIcon.vue
@@ -299,7 +299,7 @@ const { copied, copy } = useCopy(() => identifier);
             v-else
             v-show="!pending && !error"
             :class="{ 'rounded-full overflow-hidden': flat }"
-            contain
+            fit="contain"
             :alt="displayAsset"
             :src="url"
             :loading="pending"

--- a/frontend/app/src/modules/shell/components/ChainIcon.vue
+++ b/frontend/app/src/modules/shell/components/ChainIcon.vue
@@ -30,7 +30,7 @@ const OTHER_CHAINS = [
     :max-width="size"
     :height="size"
     :max-height="size"
-    contain
+    fit="contain"
     class="icon-bg"
     :class="{ blur: !shouldShowAmount }"
   />

--- a/frontend/app/src/modules/shell/components/GlobalSearch.vue
+++ b/frontend/app/src/modules/shell/components/GlobalSearch.vue
@@ -161,7 +161,7 @@ onBeforeMount(async () => {
                 v-else-if="item.image"
                 class="icon-bg"
                 :src="item.image"
-                contain
+                fit="contain"
                 size="26px"
               />
               <RuiIcon

--- a/frontend/app/src/modules/shell/components/PrioritizedListEntry.vue
+++ b/frontend/app/src/modules/shell/components/PrioritizedListEntry.vue
@@ -46,7 +46,7 @@ const labels: { [keys in PrioritizedListId]: string } = {
     <AppImage
       v-if="data.icon"
       :size="size"
-      contain
+      fit="contain"
       :src="data.icon"
       class="icon-bg"
     />

--- a/frontend/app/src/modules/shell/components/display/BalanceDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/BalanceDisplay.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { AssetDisplay } from '@/modules/assets/types';
 import { type Balance, type BigNumber, Zero } from '@rotki/common';
 import { AssetAmountDisplay, FiatDisplay } from '@/modules/assets/amount-display/components';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
@@ -39,6 +40,9 @@ const balanceValue = useValueOrDefault(
 );
 
 const { getAssetPrice } = usePriceUtils();
+
+// Computed rather than a template literal: this renders in every balance table cell.
+const assetDisplay = computed<AssetDisplay>(() => ({ iconOnly: true, size: iconSize }));
 
 const valueInCurrency = computed<BigNumber>(() => {
   if (!calculateValue)
@@ -81,8 +85,7 @@ const valueInCurrency = computed<BigNumber>(() => {
     <AssetDetails
       v-if="!noIcon"
       :asset="asset"
-      icon-only
-      :size="iconSize"
+      :display="assetDisplay"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/shell/components/display/CounterpartyDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/CounterpartyDisplay.vue
@@ -51,7 +51,7 @@ const counterpartyImageSrc = computed<string | undefined>(() => {
       <AppImage
         v-else-if="counterpartyImageSrc"
         :src="counterpartyImageSrc"
-        contain
+        fit="contain"
         :size="size"
       />
     </div>

--- a/frontend/app/src/modules/shell/components/display/ExchangeDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/ExchangeDisplay.vue
@@ -18,7 +18,7 @@ const location = useLocationData(() => exchange);
       class="icon-bg"
       :width="size"
       :height="size"
-      contain
+      fit="contain"
       :src="location?.image ?? undefined"
     />
     <div v-text="location?.name" />

--- a/frontend/app/src/modules/shell/components/display/LocationIcon.vue
+++ b/frontend/app/src/modules/shell/components/display/LocationIcon.vue
@@ -39,7 +39,7 @@ const location = useLocationData(() => item);
         v-if="location.image"
         :src="location.image"
         :alt="location.name"
-        contain
+        fit="contain"
         :image-class="imageClass"
         :size="size"
         class="icon-bg"

--- a/frontend/app/src/modules/shell/components/inputs/AssetSelect.vue
+++ b/frontend/app/src/modules/shell/components/inputs/AssetSelect.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { NftAsset } from '@/modules/assets/nfts';
+import type { AssetActions, AssetDisplay } from '@/modules/assets/types';
 import { type AssetInfoWithId, getValidSelectorFromEvmAddress } from '@rotki/common';
 import AssetDetailsBase from '@/modules/assets/AssetDetailsBase.vue';
 import { NftHandling } from '@/modules/assets/nft-handling';
@@ -86,6 +87,12 @@ const { error, getVisibleAsset, loading, modelSearch, visibleAssets } = useAsset
 // static value and cannot call `t`, which is why it used to read a hardcoded English "Asset".
 const fieldLabel = computed<string>(() => label ?? t('asset_select.label'));
 
+// Both slots render the asset without its context menu; hoisted so the bag is one stable identity
+// rather than a fresh object per rendered row.
+const noMenu: AssetActions = { hideMenu: true };
+
+const itemDisplay = computed<AssetDisplay>(() => ({ dense }));
+
 const errors = computed<string[]>(() => {
   const messages = [...errorMessages];
   const errorMessage = get(error);
@@ -157,7 +164,7 @@ function onUpdateModelValue(value: string): void {
           v-else
           class="!py-0 pl-1"
           :asset="item"
-          hide-menu
+          :actions="noMenu"
         />
       </template>
     </template>
@@ -175,8 +182,8 @@ function onUpdateModelValue(value: string): void {
         :id="`asset-${getValidSelectorFromEvmAddress(item.identifier.toLocaleLowerCase())}`"
         :class="dense ? '!py-0 -my-0.5' : '!py-0 -my-1'"
         :asset="item"
-        :dense="dense"
-        hide-menu
+        :display="itemDisplay"
+        :actions="noMenu"
       />
     </template>
     <template #no-data>

--- a/frontend/app/src/modules/shell/components/navigation/NavigationMenuItem.vue
+++ b/frontend/app/src/modules/shell/components/navigation/NavigationMenuItem.vue
@@ -84,7 +84,7 @@ onMounted(() => {
         >
           <AppImage
             v-if="image"
-            contain
+            fit="contain"
             width="24px"
             :src="image"
             :class="active ? 'opacity-100 brightness-0 invert' : 'opacity-70 brightness-0 dark:opacity-100 dark:invert'"

--- a/frontend/app/src/modules/staking/kraken/KrakenPage.vue
+++ b/frontend/app/src/modules/staking/kraken/KrakenPage.vue
@@ -110,7 +110,7 @@ onUnmounted(() => {
       <InternalLink :to="addKrakenApiKeysLink">
         <AppImage
           width="64px"
-          contain
+          fit="contain"
           :src="getPublicProtocolImagePath('kraken.svg')"
         />
       </InternalLink>

--- a/frontend/app/src/modules/staking/kraken/KrakenStakingReceived.vue
+++ b/frontend/app/src/modules/staking/kraken/KrakenStakingReceived.vue
@@ -47,7 +47,7 @@ const { t } = useI18n({ useScope: 'global' });
       >
         <AssetDetails
           :asset="item.asset"
-          dense
+          :display="{ dense: true }"
         />
         <div class="flex items-center gap-3">
           <ValueAccuracyHint v-if="selection === 'historical'" />

--- a/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedGnosisPayCard.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/cards/WrappedGnosisPayCard.vue
@@ -32,7 +32,7 @@ const { calculateFontSize } = useWrappedFormatters();
         :src="getPublicServiceImagePath('gnosispay.png')"
         width="24px"
         height="24px"
-        contain
+        fit="contain"
       />
     </template>
     <template #header>

--- a/frontend/app/src/modules/user-data/GroupedImport.vue
+++ b/frontend/app/src/modules/user-data/GroupedImport.vue
@@ -132,7 +132,7 @@ const [DefineDisplay, ReuseDisplay] = createReusableTemplate<{
           v-if="logo"
           :src="logo"
           size="1.5rem"
-          contain
+          fit="contain"
           class="icon-bg"
         />
         <RuiIcon

--- a/frontend/app/src/modules/wallet/send/TradeAssetDisplay.vue
+++ b/frontend/app/src/modules/wallet/send/TradeAssetDisplay.vue
@@ -28,13 +28,12 @@ const name = useAssetField(data.asset, 'name', { collectionParent: false });
 <template>
   <div class="flex gap-2 items-center">
     <AssetDetails
-      icon-only
-      size="32px"
       :asset="data.asset"
-      hide-actions
-      :force-chain="getEvmChainName(data.chain) || undefined"
-      :resolution-options="{
-        collectionParent: false,
+      :display="{ iconOnly: true, size: '32px' }"
+      :actions="{ hideActions: true }"
+      :resolution="{
+        forceChain: getEvmChainName(data.chain) || undefined,
+        options: { collectionParent: false },
       }"
     />
     <div

--- a/frontend/app/src/pages/asset-manager/more/solana-token-migration/index.vue
+++ b/frontend/app/src/pages/asset-manager/more/solana-token-migration/index.vue
@@ -117,7 +117,7 @@ function handleMergeCompleted({ sourceIdentifier }: { sourceIdentifier: string; 
         <template #item.identifier="{ row }">
           <AssetDetails
             :asset="row.identifier"
-            dense
+            :display="{ dense: true }"
           />
         </template>
         <template #item.actions="{ row }">

--- a/frontend/app/src/pages/staking/[[location]].vue
+++ b/frontend/app/src/pages/staking/[[location]].vue
@@ -115,7 +115,7 @@ onMounted(async () => {
       <DefineIcon #default="{ image }">
         <AppImage
           class="icon-bg"
-          contain
+          fit="contain"
           size="1.5rem"
           :src="image"
         />
@@ -172,7 +172,7 @@ onMounted(async () => {
               <InternalLink :to="getRedirectLink(item.id)">
                 <AppImage
                   :size="imageSize"
-                  contain
+                  fit="contain"
                   :src="item.image"
                 />
               </InternalLink>

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -128,19 +128,24 @@ export default rotki({
   // consumer that does not live in this repo: renaming or grouping them cannot be verified here and
   // would break premium at runtime with nothing in our lint, typecheck or test suite noticing.
   //
-  // These four exceed their cap and cannot be fixed unilaterally, so the rule is downgraded rather
-  // than silenced: the count stays reported, and reducing it needs a coordinated premium release.
-  // Caps are restated per group because a flat config replaces a rule's options rather than merging
-  // them, and dropping the cap here would stop the warning firing at all.
+  // The rule is downgraded rather than silenced: the count stays reported, and reducing it needs a
+  // coordinated premium release. Caps are restated per group because a flat config replaces a rule's
+  // options rather than merging them, and dropping the cap here would stop the warning firing at all.
   //
   // If another registered component crosses its cap, add it here rather than reshaping its props —
   // unless the matching premium change ships with it. That is how AssetSelect left this list: its
   // five search props became one `source` object, and the bundle has to move to it in the same
   // release, since the old props no longer reach the search.
+  //
+  // Check this list against `register-components.ts` before believing it. It used to also name
+  // BlockchainAccountSelector and AssetDetails as "cannot be fixed unilaterally", and NEITHER is
+  // registered — `git log -S` finds no commit that ever added them, so the claim was wrong when
+  // written rather than gone stale. Both are reachable from the bundle only because
+  // HistoryEventsView renders them, which is a rendering dependency, not an API one. AssetDetails
+  // has since been reshaped here with no premium release; BlockchainAccountSelector moved to the
+  // internal group below, since it is free to be reshaped but has not been yet.
   files: [
     '**/src/modules/history/events/HistoryEventsView.vue',
-    '**/src/modules/accounts/BlockchainAccountSelector.vue',
-    '**/src/modules/assets/AssetDetails.vue',
   ],
   rules: {
     'vue/max-props': ['warn', { maxProps: 8 }],
@@ -167,6 +172,10 @@ export default rotki({
   // - HistoryEventNote (9): every prop it takes is derived from `event` plus useHistoryEventItem, so
   //   it could take the event instead. Gated on whether all six callers actually hold a
   //   HistoryEventEntry: ProfitLossEvents and TradeHistoryItem look like they do not.
+  // - BlockchainAccountSelector (17): the worst offender in the codebase, and NOT premium-frozen
+  //   despite the group above having claimed it was. It is a field wrapper, so most of these are
+  //   RuiAutoComplete pass-throughs (label/hint/customHint/outlined/dense/errorMessages/required)
+  //   that want to reach it as attrs rather than as declared props.
   // - AssetBalances (11): display flags that are genuinely independent, so no honest grouping
   //   exists. This one needs real decomposition.
   //   AssetDetailsBase left this list at 12 -> 4 props: `asset` plus display/actions/resolution,
@@ -180,6 +189,7 @@ export default rotki({
   files: [
     '**/src/modules/settings/api-keys/ServiceKeyCard.vue',
     '**/src/modules/history/events/HistoryEventNote.vue',
+    '**/src/modules/accounts/BlockchainAccountSelector.vue',
     '**/src/modules/balances/AssetBalances.vue',
     '**/src/modules/history/events/components/HistoryEventsDetailItem.vue',
     '**/src/modules/history/events/components/HistoryEventsVirtualTable.vue',

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -153,11 +153,8 @@ export default rotki({
   // - BigDialog (16): primaryAction/actionDisabled/actionTooltip/actionHidden are one action, and
   //   errorCount/autoScrollToError are one error concern. 4+2 props become 2, landing exactly on 12.
   //   Held up only by its 28 call sites.
-  // - AppImage (13): `contain` and `cover` are mutually exclusive object-fit modes and want to be one
-  //   `fit` prop. One prop to shed, but 31 files pass one of the two.
   files: [
     '**/src/modules/shell/components/dialogs/BigDialog.vue',
-    '**/src/modules/shell/components/AppImage.vue',
   ],
   rules: {
     'vue/max-props': ['warn', { maxProps: 12 }],

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -167,9 +167,11 @@ export default rotki({
   // - HistoryEventNote (9): every prop it takes is derived from `event` plus useHistoryEventItem, so
   //   it could take the event instead. Gated on whether all six callers actually hold a
   //   HistoryEventEntry: ProfitLossEvents and TradeHistoryItem look like they do not.
-  // - AssetDetailsBase (12), AssetBalances (11): display flags that are genuinely independent, so no
-  //   honest grouping exists. These need real decomposition. Note AssetDetailsBase is the inner
-  //   component, free to change; its AssetDetails wrapper is premium-registered and frozen.
+  // - AssetBalances (11): display flags that are genuinely independent, so no honest grouping
+  //   exists. This one needs real decomposition.
+  //   AssetDetailsBase left this list at 12 -> 4 props: `asset` plus display/actions/resolution,
+  //   grouped because those three ARE the boundary AssetDetails forwards across, not to win a
+  //   number. AssetDetails is the same three groups plus a resolution `options`.
   // - HistoryEventsDetailItem (9): already reduced from 10, and the rest are independent
   //   (groupLocationLabel and matchedMovement are unrelated in both this component and
   //   HistoryEventType; `index` carries swap sub-event ordering). Fold into the facade work below.
@@ -178,7 +180,6 @@ export default rotki({
   files: [
     '**/src/modules/settings/api-keys/ServiceKeyCard.vue',
     '**/src/modules/history/events/HistoryEventNote.vue',
-    '**/src/modules/assets/AssetDetailsBase.vue',
     '**/src/modules/balances/AssetBalances.vue',
     '**/src/modules/history/events/components/HistoryEventsDetailItem.vue',
     '**/src/modules/history/events/components/HistoryEventsVirtualTable.vue',


### PR DESCRIPTION

## In-app verification

Checked in a dev build against real data, reading computed styles and rendered props rather than eyeballing screenshots:

- **`fit="cover"`** — the login page sponsorship image, the only `cover` call site: `class="object-cover"`, computed `object-fit: cover`. This also proves tailwind still picks the class up now that it lives in `<script setup>` rather than the template.
- **`fit="contain"`** — 9 images on the managed assets page at computed `object-fit: contain`.
- **Removed props leave nothing behind** — no `srcset`, `sizes` or `changeable` attribute anywhere in the rendered DOM; the stray-attribute set on every `img` is down to `alt`/`class`/`data-image`/`loading`/`src`/`style`.
- **`dense` survives the bag, and the `??` default fires in production** — in `AssetSelect`'s open picker, an item's avatar is `w-8 h-8`, which is `ListItem` `size="sm"`; `md` would be `w-10 h-10`. The item bag passes only `{ dense }`, so `size` arrives undefined and the icon still renders at 30px, which is the `display?.size ?? '30px'` path. Row height 40px as expected.
- **The `hide-actions` fix takes effect** — the asset menu on manual balances now has 1 action button, against 2 on the managed assets table which does not hide them.

Console is clean on every page visited. The one warning seen (`Missing required prop: "tab"`) comes from the `[[tab]]` route param and is unrelated and pre-existing.

Not verified in-app: the collection-parent branch of the derived `showChain`, which needs an asset with a breakdown, and this data set has no balances. It is covered by spec instead.
