### PR TITLE
refactor(frontend): extract logic out of the two fattest SFCs and test it

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -6235,6 +6235,9 @@
       "title": "rotki Browser Wallet Bridge",
       "wallet_status": "Wallet Status"
     },
+    "errors": {
+      "rejected": "Request is rejected by user"
+    },
     "never_interacted": "You have never interacted with this address before.",
     "recent_transactions": {
       "no_data": "No recent transactions",

--- a/frontend/app/src/modules/settings/evm/IndexerOrderSetting.spec.ts
+++ b/frontend/app/src/modules/settings/evm/IndexerOrderSetting.spec.ts
@@ -1,0 +1,180 @@
+import type { EvmChainInfo } from '@/modules/core/api/types/chains';
+import { Blockchain } from '@rotki/common';
+import { updateGeneralSettings } from '@test/utils/general-settings';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import IndexerOrderSetting from '@/modules/settings/evm/IndexerOrderSetting.vue';
+import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
+import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
+
+const chains: EvmChainInfo[] = [
+  {
+    evmChainName: 'optimism',
+    id: Blockchain.OPTIMISM,
+    image: '',
+    name: 'Optimism',
+    nativeToken: 'ETH',
+    type: 'evm',
+  },
+  {
+    evmChainName: 'gnosis',
+    id: 'gnosis',
+    image: '',
+    name: 'Gnosis',
+    nativeToken: 'XDAI',
+    type: 'evm',
+  },
+];
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const { computed } = await import('vue');
+  const mod = await vi.importActual<typeof import('@/modules/core/common/use-supported-chains')>(
+    '@/modules/core/common/use-supported-chains',
+  );
+  return {
+    ...mod,
+    useSupportedChains: vi.fn().mockReturnValue({
+      getChain: (evmChainName: string): string => evmChainName,
+      getChainName: (chain: string): string => (chain === 'gnosis' ? 'Gnosis' : 'Optimism'),
+      getEvmChainName: (chain: string): string | undefined => chain,
+      matchChain: (): undefined => undefined,
+      txEvmChains: computed(() => chains),
+      useChainImageUrl: () => computed(() => ''),
+    }),
+  };
+});
+
+vi.mock('@/modules/settings/use-settings-operations', async () => {
+  const mod = await vi.importActual<typeof import('@/modules/settings/use-settings-operations')>(
+    '@/modules/settings/use-settings-operations',
+  );
+  return {
+    ...mod,
+    useSettingsOperations: vi.fn().mockReturnValue({
+      applyFrontendSettingLocal: vi.fn(),
+      enableModule: vi.fn(),
+      setKrakenAccountType: vi.fn(),
+      update: vi.fn().mockResolvedValue({ success: true }),
+      updateFrontendSetting: vi.fn().mockResolvedValue({ success: true }),
+    }),
+  };
+});
+
+describe('indexerOrderSetting', () => {
+  let wrapper: VueWrapper<InstanceType<typeof IndexerOrderSetting>>;
+
+  function createWrapper(): VueWrapper<InstanceType<typeof IndexerOrderSetting>> {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    return mount(IndexerOrderSetting, {
+      global: { plugins: [pinia] },
+      provide: libraryDefaults,
+    });
+  }
+
+  async function mountWith(
+    defaultEvmIndexerOrder: EvmIndexer[],
+    evmIndexersOrder: Record<string, EvmIndexer[]> = {},
+  ): Promise<void> {
+    wrapper = createWrapper();
+    updateGeneralSettings({ defaultEvmIndexerOrder, evmIndexersOrder });
+    await nextTick();
+    await flushPromises();
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // The menu teleports to the body; without unmounting, the next test's document query would
+    // read this test's leftover menu instead of its own.
+    wrapper?.unmount();
+    document.body.innerHTML = '';
+  });
+
+  it('should render only the default tab when no chain has an override', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT]);
+
+    expect(wrapper.find('[data-testid=indexer-order-setting]').exists()).toBe(true);
+    expect(wrapper.findAll('[data-testid=indexer-tab]')).toHaveLength(1);
+    expect(wrapper.find('[data-testid=default-indexer-order]').exists()).toBe(true);
+  });
+
+  it('should add a tab for each chain that has an override', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN], { gnosis: [EvmIndexer.ETHERSCAN] });
+
+    const tabs = wrapper.findAll('[data-testid=indexer-tab]');
+    expect(tabs).toHaveLength(2);
+    expect(tabs[1].attributes('data-key')).toBe('gnosis');
+  });
+
+  /** The menu content is teleported out of the wrapper, so it has to be read off the document. */
+  async function openChainMenu(): Promise<HTMLElement[]> {
+    await wrapper.find('[data-testid=add-chain-button]').trigger('click');
+    await flushPromises();
+    return Array.from(document.querySelectorAll<HTMLElement>('[data-testid=chain-menu-item]'));
+  }
+
+  it('should offer only the chains without an override in the add menu', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN], { gnosis: [EvmIndexer.ETHERSCAN] });
+
+    const options = await openChainMenu();
+
+    expect(options).toHaveLength(1);
+    expect(options[0].dataset.key).toBe(Blockchain.OPTIMISM);
+  });
+
+  it('should disable the add button once every chain has an override', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN], {
+      gnosis: [EvmIndexer.ETHERSCAN],
+      optimism: [EvmIndexer.ETHERSCAN],
+    });
+
+    expect(wrapper.find('[data-testid=add-chain-button]').attributes('disabled')).toBeDefined();
+  });
+
+  it('should persist the new chain order keyed by evm chain name', async () => {
+    await mountWith([EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
+
+    const [option] = await openChainMenu();
+    option.click();
+    await flushPromises();
+
+    const { update } = useSettingsOperations();
+    expect(update).toHaveBeenCalledWith({
+      evmIndexersOrder: { optimism: [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN] },
+    });
+  });
+
+  it('should prompt for an api key when the leading indexer needs one', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN]);
+
+    expect(wrapper.find('[data-testid=missing-api-key-alert]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=missing-api-key-alert]').text()).toContain('Etherscan');
+  });
+
+  it('should not prompt for an api key when the leading indexer needs none', async () => {
+    await mountWith([EvmIndexer.ROUTESCAN, EvmIndexer.ETHERSCAN]);
+
+    expect(wrapper.find('[data-testid=missing-api-key-alert]').exists()).toBe(false);
+  });
+
+  it('should warn about the chains with indexer caveats', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN], { gnosis: [EvmIndexer.ETHERSCAN] });
+    wrapper.findComponent<{ modelValue: string }>('[data-testid=indexer-tabs]').vm.$emit('update:model-value', 'gnosis');
+    await nextTick();
+
+    const warnings = wrapper.findAll('[data-testid=chain-warning-alert]');
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].text()).toBe('evm_settings.indexer.chain_warnings.gnosis_key_required');
+  });
+
+  it('should not warn on the default tab', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN], { gnosis: [EvmIndexer.ETHERSCAN] });
+
+    expect(wrapper.findAll('[data-testid=chain-warning-alert]')).toHaveLength(0);
+  });
+});

--- a/frontend/app/src/modules/settings/evm/IndexerOrderSetting.spec.ts
+++ b/frontend/app/src/modules/settings/evm/IndexerOrderSetting.spec.ts
@@ -1,4 +1,5 @@
 import type { EvmChainInfo } from '@/modules/core/api/types/chains';
+import type PrioritizedList from '@/modules/shell/components/PrioritizedList.vue';
 import { Blockchain } from '@rotki/common';
 import { updateGeneralSettings } from '@test/utils/general-settings';
 import { libraryDefaults } from '@test/utils/provide-defaults';
@@ -44,6 +45,13 @@ vi.mock('@/modules/core/common/use-supported-chains', async () => {
       useChainImageUrl: () => computed(() => ''),
     }),
   };
+});
+
+const push = vi.fn();
+
+vi.mock('vue-router', async () => {
+  const mod = await vi.importActual<typeof import('vue-router')>('vue-router');
+  return { ...mod, useRouter: vi.fn(() => ({ push })) };
 });
 
 vi.mock('@/modules/settings/use-settings-operations', async () => {
@@ -164,8 +172,7 @@ describe('indexerOrderSetting', () => {
 
   it('should warn about the chains with indexer caveats', async () => {
     await mountWith([EvmIndexer.ETHERSCAN], { gnosis: [EvmIndexer.ETHERSCAN] });
-    wrapper.findComponent<{ modelValue: string }>('[data-testid=indexer-tabs]').vm.$emit('update:model-value', 'gnosis');
-    await nextTick();
+    await selectTab('gnosis');
 
     const warnings = wrapper.findAll('[data-testid=chain-warning-alert]');
     expect(warnings).toHaveLength(1);
@@ -176,5 +183,85 @@ describe('indexerOrderSetting', () => {
     await mountWith([EvmIndexer.ETHERSCAN], { gnosis: [EvmIndexer.ETHERSCAN] });
 
     expect(wrapper.findAll('[data-testid=chain-warning-alert]')).toHaveLength(0);
+  });
+
+  async function selectTab(tab: string): Promise<void> {
+    await wrapper.find(`[data-testid=indexer-tab][data-key="${tab}"]`).trigger('click');
+    await nextTick();
+  }
+
+  function defaultList(): VueWrapper<InstanceType<typeof PrioritizedList>> {
+    return wrapper.findComponent<typeof PrioritizedList>('[data-testid=default-indexer-order]');
+  }
+
+  function chainList(): VueWrapper<InstanceType<typeof PrioritizedList>> {
+    return wrapper.findComponent<typeof PrioritizedList>('[data-testid=chain-indexer-order]');
+  }
+
+  it('should apply a reordered default order', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT]);
+    expect(defaultList().props('modelValue')).toEqual([EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT]);
+
+    defaultList().vm.$emit('update:model-value', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
+    await nextTick();
+
+    expect(defaultList().props('modelValue')).toEqual([EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
+  });
+
+  it('should re-evaluate the api key prompt after a reorder', async () => {
+    await mountWith([EvmIndexer.ROUTESCAN, EvmIndexer.ETHERSCAN]);
+    expect(wrapper.find('[data-testid=missing-api-key-alert]').exists()).toBe(false);
+
+    defaultList().vm.$emit('update:model-value', [EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN]);
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=missing-api-key-alert]').exists()).toBe(true);
+  });
+
+  it('should apply a reordered chain order', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN], { gnosis: [EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT] });
+    await selectTab('gnosis');
+
+    chainList().vm.$emit('update:model-value', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
+    await nextTick();
+
+    expect(chainList().props('modelValue')).toEqual([EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
+  });
+
+  it('should persist the remaining overrides when a chain is removed', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN], {
+      gnosis: [EvmIndexer.ETHERSCAN],
+      optimism: [EvmIndexer.ETHERSCAN],
+    });
+
+    wrapper.findAllComponents({ name: 'IndexerTabLabel' })[0].vm.$emit('remove', 'gnosis');
+    await flushPromises();
+
+    const { update } = useSettingsOperations();
+    expect(update).toHaveBeenCalledWith({ evmIndexersOrder: { optimism: [EvmIndexer.ETHERSCAN] } });
+    expect(wrapper.findAll('[data-testid=indexer-tab]')).toHaveLength(2);
+  });
+
+  it('should return to the default tab when the open chain is removed', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN], { gnosis: [EvmIndexer.ETHERSCAN] });
+    await selectTab('gnosis');
+    expect(chainList().exists()).toBe(true);
+
+    wrapper.findAllComponents({ name: 'IndexerTabLabel' })[0].vm.$emit('remove', 'gnosis');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid=default-indexer-order]').exists()).toBe(true);
+  });
+
+  it('should route to the api key page for the indexer it asks about', async () => {
+    await mountWith([EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN]);
+
+    await wrapper.find('[data-testid=missing-api-key-alert] button').trigger('click');
+    await flushPromises();
+
+    expect(push).toHaveBeenCalledWith({
+      name: '/api-keys/external/',
+      query: { service: EvmIndexer.ETHERSCAN },
+    });
   });
 });

--- a/frontend/app/src/modules/settings/evm/IndexerOrderSetting.vue
+++ b/frontend/app/src/modules/settings/evm/IndexerOrderSetting.vue
@@ -1,22 +1,8 @@
 <script setup lang="ts">
-import { NotificationGroup, notificationGroupOf, toCapitalCase } from '@rotki/common';
-import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { useNotificationCooldown } from '@/modules/core/notifications/use-notification-cooldown';
-import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
+import type { ChainItem } from '@/modules/settings/evm/evm-indexer-utils';
 import IndexerTabLabel from '@/modules/settings/evm/IndexerTabLabel.vue';
+import { useEvmIndexerOrder } from '@/modules/settings/evm/use-evm-indexer-order';
 import SettingCategoryHeader from '@/modules/settings/SettingCategoryHeader.vue';
-import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
-import { PrioritizedListData } from '@/modules/settings/types/prioritized-list-data';
-import {
-  BLOCKSCOUT_PRIO_LIST_ITEM,
-  ETHERSCAN_PRIO_LIST_ITEM,
-  type PrioritizedListId,
-  ROUTESCAN_PRIO_LIST_ITEM,
-} from '@/modules/settings/types/prioritized-list-id';
-import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
-import { useEvmIndexerSettings } from '@/modules/settings/use-evm-indexer-settings';
-import { useSettingModel } from '@/modules/settings/use-setting-model';
-import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
 import ChainIcon from '@/modules/shell/components/ChainIcon.vue';
 import PrioritizedList from '@/modules/shell/components/PrioritizedList.vue';
 
@@ -28,268 +14,44 @@ defineSlots<{
   footer: () => any;
 }>();
 
-interface ChainItem {
-  id: string;
-  name: string;
-}
-
-interface TabItem {
-  id: string;
-  isDefault: boolean;
-  name?: string;
-}
-
 const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
 
-const DEFAULT_TAB = 'default';
-
-const { getChain, getChainName, getEvmChainName, txEvmChains } = useSupportedChains();
-const { defaultEvmIndexerOrder, evmIndexersOrder } = useEvmIndexerSettings();
-const { update: updateSettings } = useSettingsOperations();
-const { getApiKey, useApiKey } = useExternalApiKeys();
-const { resetSchedule } = useNotificationCooldown();
-
-const { error: defaultWriteError, model: defaultOrderModel, success: defaultWriteSuccess } = useSettingModel('defaultEvmIndexerOrder', { debounce: 0 });
-const { error: chainWriteError, model: chainOrdersModel, success: chainWriteSuccess } = useSettingModel('evmIndexersOrder', { debounce: 0 });
-const { clearAll: clearDefault, error: defaultError, setError: setDefaultError, setSuccess: setDefaultSuccess, success: defaultSuccess } = useClearableMessages();
-const { clearAll: clearChain, error: chainError, setError: setChainError, setSuccess: setChainSuccess, success: chainSuccess } = useClearableMessages();
-
-const pendingChainName = ref<string>('');
-
-const etherscanApiKey = useApiKey('etherscan');
-
-const activeTab = ref<string>(DEFAULT_TAB);
 const showChainMenu = ref<boolean>(false);
 
-const localDefaultOrder = ref<PrioritizedListId[]>([]);
-const localChainOrders = ref<Record<string, PrioritizedListId[]>>({});
+const {
+  addChain,
+  availableChainItems,
+  availableIndexers,
+  chainError,
+  chainOrders,
+  chainSuccess,
+  chainWarnings,
+  currentOrder,
+  defaultError,
+  defaultOrder,
+  defaultSuccess,
+  missingApiKeyIndexer,
+  modelActiveTab,
+  primaryIndexerService,
+  removeChain,
+  tabs,
+  updateChainOrder,
+  updateDefaultOrder,
+} = useEvmIndexerOrder();
 
-const allIndexerItems = [
-  ETHERSCAN_PRIO_LIST_ITEM,
-  BLOCKSCOUT_PRIO_LIST_ITEM,
-  ROUTESCAN_PRIO_LIST_ITEM,
-];
-
-const CHAIN_SUPPORTED_INDEXERS: Record<string, typeof allIndexerItems> = {
-  binance_sc: [ETHERSCAN_PRIO_LIST_ITEM],
-};
-
-function getAvailableIndexersForChain(chainId: string | null): PrioritizedListData<PrioritizedListId> {
-  const items = chainId && chainId in CHAIN_SUPPORTED_INDEXERS
-    ? CHAIN_SUPPORTED_INDEXERS[chainId]
-    : allIndexerItems;
-
-  return new PrioritizedListData<PrioritizedListId>(items);
-}
-
-const availableIndexers = computed<PrioritizedListData<PrioritizedListId>>(() => {
-  const tab = get(activeTab);
-  const chainId = tab === DEFAULT_TAB ? null : tab;
-  return getAvailableIndexersForChain(chainId);
-});
-
-const configuredChains = computed<string[]>(() => Object.keys(get(localChainOrders)));
-
-const availableChainItems = computed<ChainItem[]>(() => {
-  const configured = get(configuredChains);
-  return get(txEvmChains)
-    .filter(chain => !configured.includes(chain.id))
-    .map(chain => ({
-      id: chain.id,
-      name: chain.name,
-    }));
-});
-
-const tabs = computed<TabItem[]>(() => {
-  const chainTabs: TabItem[] = get(configuredChains).map(chain => ({
-    id: chain,
-    isDefault: false,
-    name: getChainName(chain),
-  }));
-
-  return [
-    { id: DEFAULT_TAB, isDefault: true },
-    ...chainTabs,
-  ];
-});
-
-function resetLocalValues(): void {
-  const defaultOrder = get(defaultEvmIndexerOrder);
-  set(localDefaultOrder, defaultOrder ? [...defaultOrder] : [EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT, EvmIndexer.ROUTESCAN]);
-
-  const chainOrders = get(evmIndexersOrder);
-  if (chainOrders) {
-    // Convert evmChainName keys to chain ids for internal use
-    const converted: Record<string, PrioritizedListId[]> = {};
-    for (const [evmChainName, order] of Object.entries(chainOrders)) {
-      const chain = getChain(evmChainName);
-      converted[chain] = [...order];
-    }
-    set(localChainOrders, converted);
-  }
-  else {
-    set(localChainOrders, {});
-  }
-}
-
-const evmIndexerValues: string[] = Object.values(EvmIndexer);
-
-function isEvmIndexer(value: PrioritizedListId): value is EvmIndexer {
-  return evmIndexerValues.includes(value);
-}
-
-function toEvmChainNameKeys(orders: Record<string, PrioritizedListId[]>): Record<string, EvmIndexer[]> {
-  const result: Record<string, EvmIndexer[]> = {};
-  for (const [chain, order] of Object.entries(orders)) {
-    const evmChainName = getEvmChainName(chain);
-    if (evmChainName)
-      result[evmChainName] = order.filter(isEvmIndexer);
-  }
-  return result;
-}
-
-async function addChain(chain: ChainItem): Promise<void> {
-  const orders = { ...get(localChainOrders) };
-  const chainAvailableIndexers = getAvailableIndexersForChain(chain.id);
-  // Filter default order to only include indexers available for this chain
-  const filteredOrder = get(localDefaultOrder).filter(
-    indexer => chainAvailableIndexers.itemDataForId(indexer) !== undefined,
-  );
-  orders[chain.id] = filteredOrder.length > 0 ? filteredOrder : [EvmIndexer.ETHERSCAN];
-  set(localChainOrders, orders);
-  set(activeTab, chain.id);
+async function onAddChain(chain: ChainItem): Promise<void> {
   set(showChainMenu, false);
-  await updateSettings({ evmIndexersOrder: toEvmChainNameKeys(orders) });
-  forgetNoIndexerSchedule();
+  await addChain(chain);
 }
 
-async function removeChain(chain: string): Promise<void> {
-  const orders = { ...get(localChainOrders) };
-  delete orders[chain];
-  set(localChainOrders, orders);
-  if (get(activeTab) === chain) {
-    set(activeTab, DEFAULT_TAB);
-  }
-  await updateSettings({ evmIndexersOrder: toEvmChainNameKeys(orders) });
-  forgetNoIndexerSchedule();
-}
-
-const currentOrder = computed<PrioritizedListId[]>(() => {
-  const tab = get(activeTab);
-  if (tab === DEFAULT_TAB)
-    return get(localDefaultOrder);
-
-  return get(localChainOrders)[tab] ?? [];
-});
-
-const chainWarnings = computed<string[]>(() => {
-  const tab = get(activeTab);
-  if (tab === DEFAULT_TAB)
-    return [];
-
-  const warnings: string[] = [];
-  const order = get(currentOrder);
-
-  if (tab === 'optimism' && order.includes(EvmIndexer.BLOCKSCOUT))
-    warnings.push(t('evm_settings.indexer.chain_warnings.optimism_blockscout'));
-
-  if (tab === 'base' && (order.length === 0 || order[0] !== EvmIndexer.BLOCKSCOUT))
-    warnings.push(t('evm_settings.indexer.chain_warnings.base_limited_indexers'));
-
-  if (tab === 'gnosis')
-    warnings.push(t('evm_settings.indexer.chain_warnings.gnosis_key_required'));
-
-  return warnings;
-});
-
-const missingApiKeyIndexer = computed<string | null>(() => {
-  const order = get(currentOrder);
-  if (order.length === 0)
-    return null;
-
-  const firstIndexer = order[0];
-
-  if (firstIndexer === EvmIndexer.ETHERSCAN) {
-    if (!get(etherscanApiKey))
-      return toCapitalCase(EvmIndexer.ETHERSCAN);
-  }
-  else if (firstIndexer === EvmIndexer.BLOCKSCOUT && !getApiKey('blockscout')) {
-    return toCapitalCase(EvmIndexer.BLOCKSCOUT);
-  }
-
-  return null;
-});
-
-function navigateToApiKeys(): void {
-  const order = get(currentOrder);
-  if (order.length === 0)
+async function navigateToApiKeys(): Promise<void> {
+  const service = primaryIndexerService();
+  if (!service)
     return;
 
-  const firstIndexer = order[0];
-  if (firstIndexer === EvmIndexer.ETHERSCAN) {
-    router.push({ name: '/api-keys/external/', query: { service: EvmIndexer.ETHERSCAN } });
-  }
-  else if (firstIndexer === EvmIndexer.BLOCKSCOUT) {
-    router.push({ name: '/api-keys/external/', query: { service: EvmIndexer.BLOCKSCOUT } });
-  }
+  await router.push({ name: '/api-keys/external/', query: { service } });
 }
-
-/**
- * Let the no-indexer warnings interrupt again after the user reorders indexers. Every entry is
- * cleared rather than just the edited chain's, because the default order applies to each chain
- * that has no override of its own.
- */
-function forgetNoIndexerSchedule(): void {
-  resetSchedule(group => notificationGroupOf(group) === NotificationGroup.NO_AVAILABLE_INDEXERS);
-}
-
-function updateDefaultOrder(value: PrioritizedListId[]): void {
-  set(localDefaultOrder, value);
-  set(defaultOrderModel, value.filter(isEvmIndexer));
-  forgetNoIndexerSchedule();
-}
-
-function updateChainOrder(chainId: string, value: PrioritizedListId[]): void {
-  const orders = { ...get(localChainOrders) };
-  orders[chainId] = value;
-  set(localChainOrders, orders);
-  set(pendingChainName, getChainName(chainId));
-  set(chainOrdersModel, toEvmChainNameKeys(orders));
-  forgetNoIndexerSchedule();
-}
-
-watchImmediate([evmIndexersOrder, defaultEvmIndexerOrder], () => {
-  resetLocalValues();
-});
-
-watch(defaultOrderModel, () => {
-  clearDefault();
-});
-
-watch(defaultWriteSuccess, (saved) => {
-  if (saved)
-    setDefaultSuccess(t('evm_settings.indexer.default_updated'), true);
-});
-
-watch(defaultWriteError, (message) => {
-  if (message)
-    setDefaultError(message, true);
-});
-
-watch(chainOrdersModel, () => {
-  clearChain();
-});
-
-watch(chainWriteSuccess, (saved) => {
-  if (saved)
-    setChainSuccess(t('evm_settings.indexer.chain_updated', { chain: get(pendingChainName) }), true);
-});
-
-watch(chainWriteError, (message) => {
-  if (message)
-    setChainError(message, true);
-});
 </script>
 
 <template>
@@ -310,7 +72,7 @@ watch(chainWriteError, (message) => {
     <div class="pt-6">
       <div class="flex items-center gap-2 mb-4">
         <RuiTabs
-          v-model="activeTab"
+          v-model="modelActiveTab"
           color="primary"
           class="flex-1 !h-auto overflow-hidden"
           data-testid="indexer-tabs"
@@ -361,7 +123,7 @@ watch(chainWriteError, (message) => {
               class="w-full"
               data-testid="chain-menu-item"
               :data-key="chain.id"
-              @click="addChain(chain)"
+              @click="onAddChain(chain)"
             >
               <template #prepend>
                 <ChainIcon
@@ -406,16 +168,16 @@ watch(chainWriteError, (message) => {
       </RuiAlert>
 
       <RuiAlert
-        v-for="(warning, index) in chainWarnings"
-        :key="index"
+        v-for="warning in chainWarnings"
+        :key="warning"
         type="warning"
         class="mb-4"
         data-testid="chain-warning-alert"
       >
-        {{ warning }}
+        {{ t(warning) }}
       </RuiAlert>
 
-      <RuiTabItems v-model="activeTab">
+      <RuiTabItems v-model="modelActiveTab">
         <RuiTabItem
           v-for="tab in tabs"
           :key="tab.id"
@@ -424,11 +186,11 @@ watch(chainWriteError, (message) => {
           <PrioritizedList
             v-if="tab.isDefault"
             data-testid="default-indexer-order"
-            :model-value="localDefaultOrder"
+            :model-value="defaultOrder"
             :all-items="availableIndexers"
             :status="{ error: defaultError, success: defaultSuccess }"
             :item-data-name="t('evm_settings.indexer.data_name')"
-            :disable-delete="localDefaultOrder.length <= 1"
+            :disable-delete="defaultOrder.length <= 1"
             @update:model-value="updateDefaultOrder($event)"
           >
             <template #title>
@@ -439,11 +201,11 @@ watch(chainWriteError, (message) => {
             v-else
             data-testid="chain-indexer-order"
             :data-key="tab.id"
-            :model-value="localChainOrders[tab.id] ?? []"
+            :model-value="chainOrders[tab.id] ?? []"
             :all-items="availableIndexers"
             :status="{ error: chainError, success: chainSuccess }"
             :item-data-name="t('evm_settings.indexer.data_name')"
-            :disable-delete="(localChainOrders[tab.id]?.length ?? 0) <= 1"
+            :disable-delete="(chainOrders[tab.id]?.length ?? 0) <= 1"
             @update:model-value="updateChainOrder(tab.id, $event)"
           >
             <template #title>

--- a/frontend/app/src/modules/settings/evm/evm-indexer-utils.spec.ts
+++ b/frontend/app/src/modules/settings/evm/evm-indexer-utils.spec.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildTabs,
+  DEFAULT_INDEXER_TAB,
+  getAvailableChainItems,
+  getAvailableIndexersForChain,
+  getChainIndexerWarnings,
+  getMissingApiKeyIndexer,
+  isEvmIndexer,
+  keyedPrimaryIndexer,
+  orderForChain,
+  toChainIdKeys,
+  toEvmChainNameKeys,
+} from '@/modules/settings/evm/evm-indexer-utils';
+import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
+import { EmptyListId } from '@/modules/settings/types/prioritized-list-id';
+
+describe('evm-indexer-utils', () => {
+  describe('isEvmIndexer', () => {
+    it('should accept every indexer id', () => {
+      expect(isEvmIndexer(EvmIndexer.ETHERSCAN)).toBe(true);
+      expect(isEvmIndexer(EvmIndexer.BLOCKSCOUT)).toBe(true);
+      expect(isEvmIndexer(EvmIndexer.ROUTESCAN)).toBe(true);
+    });
+
+    it('should reject an id from another prioritized list', () => {
+      expect(isEvmIndexer(EmptyListId)).toBe(false);
+    });
+  });
+
+  describe('getAvailableIndexersForChain', () => {
+    it('should offer every indexer for the default tab', () => {
+      const available = getAvailableIndexersForChain(null);
+
+      expect(available.itemDataForId(EvmIndexer.ETHERSCAN)).toBeDefined();
+      expect(available.itemDataForId(EvmIndexer.BLOCKSCOUT)).toBeDefined();
+      expect(available.itemDataForId(EvmIndexer.ROUTESCAN)).toBeDefined();
+    });
+
+    it('should offer every indexer for a chain with no restriction', () => {
+      const available = getAvailableIndexersForChain('optimism');
+
+      expect(available.itemDataForId(EvmIndexer.BLOCKSCOUT)).toBeDefined();
+    });
+
+    it('should restrict a chain that only one indexer serves', () => {
+      const available = getAvailableIndexersForChain('binance_sc');
+
+      expect(available.itemDataForId(EvmIndexer.ETHERSCAN)).toBeDefined();
+      expect(available.itemDataForId(EvmIndexer.BLOCKSCOUT)).toBeUndefined();
+      expect(available.itemDataForId(EvmIndexer.ROUTESCAN)).toBeUndefined();
+    });
+  });
+
+  describe('orderForChain', () => {
+    it('should keep the order a chain fully supports', () => {
+      expect(orderForChain('optimism', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]))
+        .toEqual([EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
+    });
+
+    it('should drop the indexers a restricted chain cannot use', () => {
+      expect(orderForChain('binance_sc', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]))
+        .toEqual([EvmIndexer.ETHERSCAN]);
+    });
+
+    it('should fall back to etherscan rather than leave a chain with no indexer', () => {
+      expect(orderForChain('binance_sc', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ROUTESCAN]))
+        .toEqual([EvmIndexer.ETHERSCAN]);
+      expect(orderForChain('optimism', [])).toEqual([EvmIndexer.ETHERSCAN]);
+    });
+  });
+
+  describe('toEvmChainNameKeys', () => {
+    const getEvmChainName = (chain: string): string | undefined =>
+      chain === 'unknown' ? undefined : `${chain}_name`;
+
+    it('should rekey the orders by evm chain name', () => {
+      expect(toEvmChainNameKeys({ optimism: [EvmIndexer.ETHERSCAN] }, getEvmChainName))
+        .toEqual({ optimism_name: [EvmIndexer.ETHERSCAN] });
+    });
+
+    it('should drop a chain with no evm chain name', () => {
+      expect(toEvmChainNameKeys({ unknown: [EvmIndexer.ETHERSCAN] }, getEvmChainName)).toEqual({});
+    });
+
+    it('should drop entries that are not indexers', () => {
+      expect(toEvmChainNameKeys({ optimism: [EmptyListId, EvmIndexer.ETHERSCAN] }, getEvmChainName))
+        .toEqual({ optimism_name: [EvmIndexer.ETHERSCAN] });
+    });
+  });
+
+  describe('toChainIdKeys', () => {
+    const getChain = (evmChainName: string): string => evmChainName.replace('_name', '');
+
+    it('should rekey the stored orders by chain id', () => {
+      expect(toChainIdKeys({ optimism_name: [EvmIndexer.ETHERSCAN] }, getChain))
+        .toEqual({ optimism: [EvmIndexer.ETHERSCAN] });
+    });
+
+    it('should return an empty record when nothing is stored', () => {
+      expect(toChainIdKeys(undefined, getChain)).toEqual({});
+    });
+
+    it('should copy the stored arrays rather than alias them', () => {
+      const stored = { optimism_name: [EvmIndexer.ETHERSCAN] };
+      const converted = toChainIdKeys(stored, getChain);
+      converted.optimism.push(EvmIndexer.BLOCKSCOUT);
+
+      expect(stored.optimism_name).toEqual([EvmIndexer.ETHERSCAN]);
+    });
+  });
+
+  describe('buildTabs', () => {
+    it('should always lead with the default tab', () => {
+      expect(buildTabs([], () => 'unused')).toEqual([{ id: DEFAULT_INDEXER_TAB, isDefault: true }]);
+    });
+
+    it('should name each configured chain', () => {
+      const getChainName = vi.fn<(chain: string) => string>().mockReturnValue('Optimism');
+
+      expect(buildTabs(['optimism'], getChainName)).toEqual([
+        { id: DEFAULT_INDEXER_TAB, isDefault: true },
+        { id: 'optimism', isDefault: false, name: 'Optimism' },
+      ]);
+    });
+  });
+
+  describe('getAvailableChainItems', () => {
+    it('should exclude the chains that already have an override', () => {
+      const chains = [{ id: 'optimism', name: 'Optimism' }, { id: 'base', name: 'Base' }];
+
+      expect(getAvailableChainItems(chains, ['optimism'])).toEqual([{ id: 'base', name: 'Base' }]);
+    });
+  });
+
+  describe('getChainIndexerWarnings', () => {
+    it('should not warn on the default tab', () => {
+      expect(getChainIndexerWarnings(DEFAULT_INDEXER_TAB, [EvmIndexer.BLOCKSCOUT])).toEqual([]);
+    });
+
+    it('should warn when optimism includes blockscout', () => {
+      expect(getChainIndexerWarnings('optimism', [EvmIndexer.BLOCKSCOUT]))
+        .toEqual(['evm_settings.indexer.chain_warnings.optimism_blockscout']);
+      expect(getChainIndexerWarnings('optimism', [EvmIndexer.ETHERSCAN])).toEqual([]);
+    });
+
+    it('should warn when base does not lead with blockscout', () => {
+      expect(getChainIndexerWarnings('base', [EvmIndexer.ETHERSCAN]))
+        .toEqual(['evm_settings.indexer.chain_warnings.base_limited_indexers']);
+      expect(getChainIndexerWarnings('base', []))
+        .toEqual(['evm_settings.indexer.chain_warnings.base_limited_indexers']);
+      expect(getChainIndexerWarnings('base', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN])).toEqual([]);
+    });
+
+    it('should always warn on gnosis', () => {
+      expect(getChainIndexerWarnings('gnosis', [EvmIndexer.ETHERSCAN]))
+        .toEqual(['evm_settings.indexer.chain_warnings.gnosis_key_required']);
+    });
+
+    it('should return an empty list for a chain with no caveat', () => {
+      expect(getChainIndexerWarnings('arbitrum_one', [EvmIndexer.BLOCKSCOUT])).toEqual([]);
+    });
+  });
+
+  describe('keyedPrimaryIndexer', () => {
+    it('should name the leading indexer when it needs a key', () => {
+      expect(keyedPrimaryIndexer([EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN])).toBe(EvmIndexer.ETHERSCAN);
+      expect(keyedPrimaryIndexer([EvmIndexer.BLOCKSCOUT])).toBe(EvmIndexer.BLOCKSCOUT);
+    });
+
+    it('should ignore an indexer that needs no key', () => {
+      expect(keyedPrimaryIndexer([EvmIndexer.ROUTESCAN, EvmIndexer.ETHERSCAN])).toBeUndefined();
+    });
+
+    it('should ignore an empty order', () => {
+      expect(keyedPrimaryIndexer([])).toBeUndefined();
+    });
+  });
+
+  describe('getMissingApiKeyIndexer', () => {
+    const noKeys = (): boolean => false;
+    const allKeys = (): boolean => true;
+
+    it('should name the leading indexer whose key is missing', () => {
+      expect(getMissingApiKeyIndexer([EvmIndexer.ETHERSCAN], noKeys)).toBe('Etherscan');
+      expect(getMissingApiKeyIndexer([EvmIndexer.BLOCKSCOUT], noKeys)).toBe('Blockscout');
+    });
+
+    it('should stay quiet once the key is entered', () => {
+      expect(getMissingApiKeyIndexer([EvmIndexer.ETHERSCAN], allKeys)).toBeUndefined();
+    });
+
+    it('should only consider the leading indexer', () => {
+      expect(getMissingApiKeyIndexer([EvmIndexer.ROUTESCAN, EvmIndexer.ETHERSCAN], noKeys)).toBeUndefined();
+    });
+
+    it('should ask about the leading indexer only', () => {
+      const hasApiKey = vi.fn<(indexer: EvmIndexer) => boolean>().mockReturnValue(true);
+      getMissingApiKeyIndexer([EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN], hasApiKey);
+
+      expect(hasApiKey).toHaveBeenCalledExactlyOnceWith(EvmIndexer.BLOCKSCOUT);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/evm/evm-indexer-utils.ts
+++ b/frontend/app/src/modules/settings/evm/evm-indexer-utils.ts
@@ -1,0 +1,151 @@
+import { toCapitalCase } from '@rotki/common';
+import { type MessageKey, msg } from '@/message-key';
+import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
+import { PrioritizedListData, type PrioritizedListItemData } from '@/modules/settings/types/prioritized-list-data';
+import {
+  BLOCKSCOUT_PRIO_LIST_ITEM,
+  ETHERSCAN_PRIO_LIST_ITEM,
+  type PrioritizedListId,
+  ROUTESCAN_PRIO_LIST_ITEM,
+} from '@/modules/settings/types/prioritized-list-id';
+
+/** Tab id standing for the global default order, as opposed to a per-chain override. */
+export const DEFAULT_INDEXER_TAB = 'default';
+
+export interface ChainItem {
+  id: string;
+  name: string;
+}
+
+export interface TabItem {
+  id: string;
+  isDefault: boolean;
+  name?: string;
+}
+
+/** Order applied when the backend has no stored default yet. */
+export const DEFAULT_INDEXER_ORDER: EvmIndexer[] = [
+  EvmIndexer.ETHERSCAN,
+  EvmIndexer.BLOCKSCOUT,
+  EvmIndexer.ROUTESCAN,
+];
+
+const ALL_INDEXER_ITEMS: Array<PrioritizedListItemData<EvmIndexer>> = [
+  ETHERSCAN_PRIO_LIST_ITEM,
+  BLOCKSCOUT_PRIO_LIST_ITEM,
+  ROUTESCAN_PRIO_LIST_ITEM,
+];
+
+/** Chains that only a subset of the indexers can serve. Anything absent supports all of them. */
+const CHAIN_SUPPORTED_INDEXERS = new Map<string, Array<PrioritizedListItemData<EvmIndexer>>>([
+  ['binance_sc', [ETHERSCAN_PRIO_LIST_ITEM]],
+]);
+
+const evmIndexerValues: string[] = Object.values(EvmIndexer);
+
+export function isEvmIndexer(value: PrioritizedListId): value is EvmIndexer {
+  return evmIndexerValues.includes(value);
+}
+
+/** Indexers selectable for a chain; `null` asks for the default tab's full set. */
+export function getAvailableIndexersForChain(chainId: string | null): PrioritizedListData<PrioritizedListId> {
+  const items = (chainId === null ? undefined : CHAIN_SUPPORTED_INDEXERS.get(chainId)) ?? ALL_INDEXER_ITEMS;
+  return new PrioritizedListData<PrioritizedListId>(items);
+}
+
+/** Restrict an order to the indexers a chain actually supports, never leaving it empty. */
+export function orderForChain(chainId: string, order: PrioritizedListId[]): EvmIndexer[] {
+  const available = getAvailableIndexersForChain(chainId);
+  const filtered = order.filter(indexer => available.itemDataForId(indexer) !== undefined).filter(isEvmIndexer);
+  return filtered.length > 0 ? filtered : [EvmIndexer.ETHERSCAN];
+}
+
+/** Chain-id keyed orders as the backend wants them: keyed by evm chain name, indexers only. */
+export function toEvmChainNameKeys(
+  orders: Record<string, PrioritizedListId[]>,
+  getEvmChainName: (chain: string) => string | undefined,
+): Record<string, EvmIndexer[]> {
+  const result: Record<string, EvmIndexer[]> = {};
+  for (const [chain, order] of Object.entries(orders)) {
+    const evmChainName = getEvmChainName(chain);
+    if (evmChainName)
+      result[evmChainName] = order.filter(isEvmIndexer);
+  }
+  return result;
+}
+
+/** The inverse: backend orders keyed by evm chain name, converted to chain ids for local use. */
+export function toChainIdKeys(
+  orders: Record<string, EvmIndexer[]> | undefined,
+  getChain: (evmChainName: string) => string,
+): Record<string, PrioritizedListId[]> {
+  if (!orders)
+    return {};
+
+  const result: Record<string, PrioritizedListId[]> = {};
+  for (const [evmChainName, order] of Object.entries(orders))
+    result[getChain(evmChainName)] = [...order];
+
+  return result;
+}
+
+export function buildTabs(configuredChains: string[], getChainName: (chain: string) => string): TabItem[] {
+  return [
+    { id: DEFAULT_INDEXER_TAB, isDefault: true },
+    ...configuredChains.map(chain => ({
+      id: chain,
+      isDefault: false,
+      name: getChainName(chain),
+    })),
+  ];
+}
+
+/** Chains still available to add, i.e. those without an override of their own. */
+export function getAvailableChainItems(chains: ChainItem[], configuredChains: string[]): ChainItem[] {
+  return chains
+    .filter(chain => !configuredChains.includes(chain.id))
+    .map(({ id, name }) => ({ id, name }));
+}
+
+/** Chain-specific caveats about the selected order. Keys are resolved by the caller. */
+export function getChainIndexerWarnings(tab: string, order: PrioritizedListId[]): MessageKey[] {
+  if (tab === DEFAULT_INDEXER_TAB)
+    return [];
+
+  const warnings: MessageKey[] = [];
+
+  if (tab === 'optimism' && order.includes(EvmIndexer.BLOCKSCOUT))
+    warnings.push(msg.$t('evm_settings.indexer.chain_warnings.optimism_blockscout'));
+
+  if (tab === 'base' && (order.length === 0 || order[0] !== EvmIndexer.BLOCKSCOUT))
+    warnings.push(msg.$t('evm_settings.indexer.chain_warnings.base_limited_indexers'));
+
+  if (tab === 'gnosis')
+    warnings.push(msg.$t('evm_settings.indexer.chain_warnings.gnosis_key_required'));
+
+  return warnings;
+}
+
+/** The indexers whose api key the user is expected to provide themselves. */
+const KEYED_INDEXERS: EvmIndexer[] = [EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT];
+
+/** First indexer in the order, when it is one the user has to supply a key for. */
+export function keyedPrimaryIndexer(order: PrioritizedListId[]): EvmIndexer | undefined {
+  const first = order.at(0);
+  if (first === undefined || !isEvmIndexer(first) || !KEYED_INDEXERS.includes(first))
+    return undefined;
+
+  return first;
+}
+
+/** Display name of the primary indexer when it needs a key the user has not entered. */
+export function getMissingApiKeyIndexer(
+  order: PrioritizedListId[],
+  hasApiKey: (indexer: EvmIndexer) => boolean,
+): string | undefined {
+  const primary = keyedPrimaryIndexer(order);
+  if (primary === undefined || hasApiKey(primary))
+    return undefined;
+
+  return toCapitalCase(primary);
+}

--- a/frontend/app/src/modules/settings/evm/use-evm-indexer-order.ts
+++ b/frontend/app/src/modules/settings/evm/use-evm-indexer-order.ts
@@ -1,0 +1,185 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { MessageKey } from '@/message-key';
+import type { PrioritizedListData } from '@/modules/settings/types/prioritized-list-data';
+import type { PrioritizedListId } from '@/modules/settings/types/prioritized-list-id';
+import { NotificationGroup, notificationGroupOf } from '@rotki/common';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useNotificationCooldown } from '@/modules/core/notifications/use-notification-cooldown';
+import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
+import { buildTabs, type ChainItem, DEFAULT_INDEXER_ORDER, DEFAULT_INDEXER_TAB, getAvailableChainItems, getAvailableIndexersForChain, getChainIndexerWarnings, getMissingApiKeyIndexer, isEvmIndexer, keyedPrimaryIndexer, orderForChain, type TabItem, toChainIdKeys, toEvmChainNameKeys } from '@/modules/settings/evm/evm-indexer-utils';
+import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
+import { useEvmIndexerSettings } from '@/modules/settings/use-evm-indexer-settings';
+import { useSettingModel } from '@/modules/settings/use-setting-model';
+import { useSettingWriteFeedback } from '@/modules/settings/use-setting-write-feedback';
+import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
+
+interface UseEvmIndexerOrderReturn {
+  readonly modelActiveTab: Ref<string>;
+  readonly tabs: ComputedRef<TabItem[]>;
+  readonly availableChainItems: ComputedRef<ChainItem[]>;
+  readonly availableIndexers: ComputedRef<PrioritizedListData<PrioritizedListId>>;
+  readonly currentOrder: ComputedRef<PrioritizedListId[]>;
+  readonly defaultOrder: ComputedRef<PrioritizedListId[]>;
+  readonly chainOrders: ComputedRef<Record<string, PrioritizedListId[]>>;
+  readonly chainWarnings: ComputedRef<MessageKey[]>;
+  readonly missingApiKeyIndexer: ComputedRef<string | undefined>;
+  readonly defaultError: Readonly<Ref<string>>;
+  readonly defaultSuccess: Readonly<Ref<string>>;
+  readonly chainError: Readonly<Ref<string>>;
+  readonly chainSuccess: Readonly<Ref<string>>;
+  readonly addChain: (chain: ChainItem) => Promise<void>;
+  readonly removeChain: (chain: string) => Promise<void>;
+  readonly updateDefaultOrder: (value: PrioritizedListId[]) => void;
+  readonly updateChainOrder: (chainId: string, value: PrioritizedListId[]) => void;
+  readonly primaryIndexerService: () => EvmIndexer | undefined;
+}
+
+/**
+ * Local editing state for the EVM indexer order: the global default plus the per-chain overrides,
+ * the tab they are edited under, and the write feedback for each of the two settings.
+ *
+ * The local orders are keyed by chain id while the settings are keyed by evm chain name, so every
+ * read converts inwards and every write converts back out.
+ */
+export function useEvmIndexerOrder(): UseEvmIndexerOrderReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const modelActiveTab = shallowRef<string>(DEFAULT_INDEXER_TAB);
+  const pendingChainName = shallowRef<string>('');
+  const localDefaultOrder = ref<PrioritizedListId[]>([]);
+  const localChainOrders = ref<Record<string, PrioritizedListId[]>>({});
+
+  const { getChain, getChainName, getEvmChainName, txEvmChains } = useSupportedChains();
+  const { defaultEvmIndexerOrder, evmIndexersOrder } = useEvmIndexerSettings();
+  const { update: updateSettings } = useSettingsOperations();
+  const { useApiKey } = useExternalApiKeys();
+  const { resetSchedule } = useNotificationCooldown();
+
+  const defaultOrderState = useSettingModel('defaultEvmIndexerOrder', { debounce: 0 });
+  const chainOrdersState = useSettingModel('evmIndexersOrder', { debounce: 0 });
+
+  const { error: defaultError, success: defaultSuccess } = useSettingWriteFeedback(
+    defaultOrderState,
+    () => t('evm_settings.indexer.default_updated'),
+  );
+  const { error: chainError, success: chainSuccess } = useSettingWriteFeedback(
+    chainOrdersState,
+    () => t('evm_settings.indexer.chain_updated', { chain: get(pendingChainName) }),
+  );
+
+  const etherscanApiKey = useApiKey('etherscan');
+  const blockscoutApiKey = useApiKey('blockscout');
+
+  const configuredChains = computed<string[]>(() => Object.keys(get(localChainOrders)));
+
+  const availableIndexers = computed<PrioritizedListData<PrioritizedListId>>(() => {
+    const tab = get(modelActiveTab);
+    return getAvailableIndexersForChain(tab === DEFAULT_INDEXER_TAB ? null : tab);
+  });
+
+  const availableChainItems = computed<ChainItem[]>(() =>
+    getAvailableChainItems(get(txEvmChains), get(configuredChains)),
+  );
+
+  const tabs = computed<TabItem[]>(() => buildTabs(get(configuredChains), getChainName));
+
+  const currentOrder = computed<PrioritizedListId[]>(() => {
+    const tab = get(modelActiveTab);
+    if (tab === DEFAULT_INDEXER_TAB)
+      return get(localDefaultOrder);
+
+    return get(localChainOrders)[tab] ?? [];
+  });
+
+  const defaultOrder = computed<PrioritizedListId[]>(() => get(localDefaultOrder));
+
+  const chainOrders = computed<Record<string, PrioritizedListId[]>>(() => get(localChainOrders));
+
+  const chainWarnings = computed<MessageKey[]>(() => getChainIndexerWarnings(get(modelActiveTab), get(currentOrder)));
+
+  const missingApiKeyIndexer = computed<string | undefined>(() => getMissingApiKeyIndexer(
+    get(currentOrder),
+    indexer => !!(indexer === EvmIndexer.ETHERSCAN ? get(etherscanApiKey) : get(blockscoutApiKey)),
+  ));
+
+  /**
+   * Let the no-indexer warnings interrupt again after the user reorders indexers. Every entry is
+   * cleared rather than just the edited chain's, because the default order applies to each chain
+   * that has no override of its own.
+   */
+  function forgetNoIndexerSchedule(): void {
+    resetSchedule(group => notificationGroupOf(group) === NotificationGroup.NO_AVAILABLE_INDEXERS);
+  }
+
+  async function persistChainOrders(orders: Record<string, PrioritizedListId[]>): Promise<void> {
+    await updateSettings({ evmIndexersOrder: toEvmChainNameKeys(orders, getEvmChainName) });
+    forgetNoIndexerSchedule();
+  }
+
+  async function addChain(chain: ChainItem): Promise<void> {
+    const orders = { ...get(localChainOrders), [chain.id]: orderForChain(chain.id, get(localDefaultOrder)) };
+    set(localChainOrders, orders);
+    set(modelActiveTab, chain.id);
+    await persistChainOrders(orders);
+  }
+
+  async function removeChain(chain: string): Promise<void> {
+    const orders = { ...get(localChainOrders) };
+    delete orders[chain];
+    set(localChainOrders, orders);
+    if (get(modelActiveTab) === chain)
+      set(modelActiveTab, DEFAULT_INDEXER_TAB);
+
+    await persistChainOrders(orders);
+  }
+
+  function updateDefaultOrder(value: PrioritizedListId[]): void {
+    set(localDefaultOrder, value);
+    set(defaultOrderState.model, value.filter(isEvmIndexer));
+    forgetNoIndexerSchedule();
+  }
+
+  function updateChainOrder(chainId: string, value: PrioritizedListId[]): void {
+    const orders = { ...get(localChainOrders), [chainId]: value };
+    set(localChainOrders, orders);
+    set(pendingChainName, getChainName(chainId));
+    set(chainOrdersState.model, toEvmChainNameKeys(orders, getEvmChainName));
+    forgetNoIndexerSchedule();
+  }
+
+  /** The keyed indexer the api-key prompt refers to, for routing to its settings row. */
+  function primaryIndexerService(): EvmIndexer | undefined {
+    return keyedPrimaryIndexer(get(currentOrder));
+  }
+
+  function resetLocalValues(): void {
+    const defaultOrder = get(defaultEvmIndexerOrder);
+    set(localDefaultOrder, defaultOrder ? [...defaultOrder] : [...DEFAULT_INDEXER_ORDER]);
+    set(localChainOrders, toChainIdKeys(get(evmIndexersOrder), getChain));
+  }
+
+  watchImmediate([evmIndexersOrder, defaultEvmIndexerOrder], () => {
+    resetLocalValues();
+  });
+
+  return {
+    addChain,
+    availableChainItems,
+    availableIndexers,
+    chainError,
+    chainOrders,
+    chainSuccess,
+    chainWarnings,
+    currentOrder,
+    defaultError,
+    defaultOrder,
+    defaultSuccess,
+    missingApiKeyIndexer,
+    modelActiveTab,
+    primaryIndexerService,
+    removeChain,
+    tabs,
+    updateChainOrder,
+    updateDefaultOrder,
+  };
+}

--- a/frontend/app/src/modules/settings/use-setting-write-feedback.spec.ts
+++ b/frontend/app/src/modules/settings/use-setting-write-feedback.spec.ts
@@ -1,0 +1,82 @@
+import type { Ref } from 'vue';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSettingWriteFeedback } from '@/modules/settings/use-setting-write-feedback';
+
+describe('useSettingWriteFeedback', () => {
+  let model: Ref<string[]>;
+  let success: Ref<boolean>;
+  let error: Ref<string>;
+
+  function create(message: () => string = () => 'saved the order'): ReturnType<typeof useSettingWriteFeedback> {
+    return useSettingWriteFeedback({ error, model, success }, message);
+  }
+
+  beforeEach(() => {
+    model = ref<string[]>([]);
+    success = ref<boolean>(false);
+    error = ref<string>('');
+  });
+
+  it('should start with no message', () => {
+    const feedback = create();
+
+    expect(get(feedback.success)).toBe('');
+    expect(get(feedback.error)).toBe('');
+  });
+
+  it('should report the success message once the write lands', async () => {
+    const feedback = create();
+
+    set(success, true);
+    await nextTick();
+
+    expect(get(feedback.success)).toContain('saved the order');
+  });
+
+  it('should read the success message at fire time', async () => {
+    let chain = 'optimism';
+    const feedback = create(() => `saved ${chain}`);
+
+    chain = 'base';
+    set(success, true);
+    await nextTick();
+
+    expect(get(feedback.success)).toContain('saved base');
+  });
+
+  it('should report the write error', async () => {
+    const feedback = create();
+
+    set(error, 'the backend said no');
+    await nextTick();
+
+    expect(get(feedback.error)).toContain('the backend said no');
+  });
+
+  it('should clear both messages when the draft changes again', async () => {
+    const feedback = create();
+
+    set(success, true);
+    set(error, 'the backend said no');
+    await nextTick();
+
+    set(model, ['etherscan']);
+    await nextTick();
+
+    expect(get(feedback.success)).toBe('');
+    expect(get(feedback.error)).toBe('');
+  });
+
+  it('should ignore a write flag that resets to its idle value', async () => {
+    const feedback = create();
+
+    set(success, true);
+    await nextTick();
+    set(success, false);
+    set(error, '');
+    await nextTick();
+
+    expect(get(feedback.success)).toContain('saved the order');
+    expect(get(feedback.error)).toBe('');
+  });
+});

--- a/frontend/app/src/modules/settings/use-setting-write-feedback.ts
+++ b/frontend/app/src/modules/settings/use-setting-write-feedback.ts
@@ -1,0 +1,44 @@
+import type { Ref } from 'vue';
+import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
+
+/** The parts of a {@link useSettingModel} return this needs; extra fields are ignored. */
+interface SettingWriteState<T> {
+  readonly model: Ref<T>;
+  readonly error: Readonly<Ref<string>>;
+  readonly success: Readonly<Ref<boolean>>;
+}
+
+interface UseSettingWriteFeedbackReturn {
+  readonly error: Readonly<Ref<string>>;
+  readonly success: Readonly<Ref<string>>;
+}
+
+/**
+ * Turns a setting model's `{ success, error }` flags into the transient message pair a form row
+ * renders, and clears both as soon as the draft changes again.
+ *
+ * `successMessage` is read at fire time rather than passed as a string, so it can name whatever the
+ * write was about (for example the chain whose order was just saved).
+ */
+export function useSettingWriteFeedback<T>(
+  state: SettingWriteState<T>,
+  successMessage: () => string,
+): UseSettingWriteFeedbackReturn {
+  const { clearAll, error, setError, setSuccess, success } = useClearableMessages();
+
+  watch(state.model, () => {
+    clearAll();
+  });
+
+  watch(state.success, (saved) => {
+    if (saved)
+      setSuccess(successMessage(), true);
+  });
+
+  watch(state.error, (message) => {
+    if (message)
+      setError(message, true);
+  });
+
+  return { error, success };
+}

--- a/frontend/app/src/modules/wallet/send/TradeSendCard.spec.ts
+++ b/frontend/app/src/modules/wallet/send/TradeSendCard.spec.ts
@@ -1,0 +1,371 @@
+import type { ComponentPublicInstance, ComputedRef } from 'vue';
+import type { TransactionParams } from '@/modules/wallet/types';
+import { bigNumberify } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import TradeSendCard from '@/modules/wallet/send/TradeSendCard.vue';
+
+const RECIPIENT = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65';
+const CONNECTED = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+const ETHEREUM_CHAIN_ID = 1;
+
+const connected = ref<boolean>(true);
+const connectedAddress = ref<string | undefined>(CONNECTED);
+const connectedChainId = ref<number | undefined>(ETHEREUM_CHAIN_ID);
+const isDisconnecting = ref<boolean>(false);
+const isWalletConnect = ref<boolean>(false);
+const preparing = ref<boolean>(false);
+const supportedChainsForConnectedAccount = ref<string[]>(['ethereum']);
+const waitingForWalletConfirmation = ref<boolean>(false);
+const walletMode = ref<string>('local-bridge');
+const switchNetwork = vi.fn();
+
+const useQueryingBalances = ref<boolean>(false);
+const warnUntrackedAddress = ref<boolean>(false);
+
+const estimatingGas = ref<boolean>(false);
+const assetBalance = ref(bigNumberify('2'));
+const max = ref<string>('2');
+const errorMessage = ref<string>('');
+const send = vi.fn<(params: TransactionParams) => Promise<boolean>>();
+const clearError = vi.fn();
+const refreshAssetBalance = vi.fn();
+const push = vi.fn();
+
+vi.mock('@/modules/wallet/use-wallet-store', () => ({
+  useWalletStore: vi.fn(() => ({
+    connected,
+    connectedAddress,
+    connectedChainId,
+    isDisconnecting,
+    isWalletConnect,
+    preparing,
+    supportedChainsForConnectedAccount,
+    switchNetwork,
+    waitingForWalletConfirmation,
+    walletMode,
+  })),
+}));
+
+vi.mock('@/modules/wallet/use-wallet-helper', () => ({
+  useWalletHelper: vi.fn(() => ({
+    getChainFromChainId: (chainId: number): string => (chainId === ETHEREUM_CHAIN_ID ? 'ethereum' : 'optimism'),
+    getChainIdFromChain: (): number => ETHEREUM_CHAIN_ID,
+  })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({ getNativeAsset: (): string => 'ETH' })),
+}));
+
+vi.mock('@/modules/wallet/send/use-balance-queries', () => ({
+  useBalanceQueries: vi.fn(() => ({ useQueryingBalances, warnUntrackedAddress })),
+}));
+
+vi.mock('@/modules/wallet/use-tradable-asset', async () => {
+  const mod = await vi.importActual<typeof import('@/modules/wallet/use-tradable-asset')>(
+    '@/modules/wallet/use-tradable-asset',
+  );
+  const { computed } = await import('vue');
+  return {
+    ...mod,
+    useTradableAsset: vi.fn(() => ({
+      getAssetDetail: (): ComputedRef<{ symbol: string }> => computed(() => ({ symbol: 'ETH' })),
+    })),
+  };
+});
+
+vi.mock('@/modules/wallet/providers/use-unified-providers', () => ({
+  useUnifiedProviders: vi.fn(() => ({
+    availableProviders: ref([]),
+    isDetecting: ref(false),
+    showProviderSelection: ref(false),
+  })),
+}));
+
+vi.mock('@/modules/wallet/send/use-trade-wallet-actions', () => ({
+  useTradeWalletActions: vi.fn(() => ({
+    clearError,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    errorMessage,
+    selectProvider: vi.fn(),
+    send,
+    toggleConnection: vi.fn(),
+  })),
+}));
+
+vi.mock('@/modules/wallet/send/use-trade-gas-estimation', () => ({
+  useTradeGasEstimation: vi.fn(() => ({
+    estimatedGasFee: ref('0'),
+    estimatingGas,
+    gasEstimable: ref(true),
+  })),
+}));
+
+vi.mock('@/modules/wallet/send/use-trade-asset-balance', () => ({
+  useTradeAssetBalance: vi.fn(() => ({
+    assetBalance,
+    max,
+    refreshAssetBalance,
+    resetMax: vi.fn(),
+  })),
+}));
+
+vi.mock('@/modules/wallet/send/use-trade-recipient-warning', () => ({
+  useTradeRecipientWarning: vi.fn(() => ({ showNeverInteractedWarning: ref(false) })),
+}));
+
+vi.mock('vue-router', async () => {
+  const mod = await vi.importActual<typeof import('vue-router')>('vue-router');
+  return { ...mod, useRouter: vi.fn(() => ({ push })) };
+});
+
+describe('tradeSendCard', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TradeSendCard>>;
+
+  function createWrapper(): VueWrapper<InstanceType<typeof TradeSendCard>> {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    return mount(TradeSendCard, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          ProviderSelectionDialog: true,
+          TradeAmountInput: true,
+          TradeAssetSelector: true,
+          TradeConnectedAddressBadge: true,
+          TradeHistoryView: true,
+          TradeRecipientAddress: true,
+          WalletConnectionButton: true,
+        },
+      },
+      provide: libraryDefaults,
+    });
+  }
+
+  /** Fill the form the way the child inputs would. */
+  async function enterTransfer(amount: string, recipient: string): Promise<void> {
+    wrapper.findComponent({ name: 'TradeAmountInput' }).vm.$emit('update:modelValue', amount);
+    wrapper.findComponent({ name: 'TradeAssetSelector' }).vm.$emit('update:modelValue', 'ETH');
+    wrapper.findComponent({ name: 'TradeRecipientAddress' }).vm.$emit('update:modelValue', recipient);
+    await nextTick();
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    set(connected, true);
+    set(connectedAddress, CONNECTED);
+    set(connectedChainId, ETHEREUM_CHAIN_ID);
+    set(isDisconnecting, false);
+    set(isWalletConnect, false);
+    set(preparing, false);
+    set(supportedChainsForConnectedAccount, ['ethereum']);
+    set(waitingForWalletConfirmation, false);
+    set(useQueryingBalances, false);
+    set(warnUntrackedAddress, false);
+    set(estimatingGas, false);
+    set(assetBalance, bigNumberify('2'));
+    set(max, '2');
+    set(errorMessage, '');
+    send.mockResolvedValue(true);
+
+    wrapper = createWrapper();
+    await flushPromises();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  describe('which action the footer offers', () => {
+    it('should offer to connect while no wallet is connected', async () => {
+      set(connected, false);
+      set(connectedAddress, undefined);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=connect-action]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=send-action]').exists()).toBe(false);
+    });
+
+    it('should offer to connect while disconnecting, even though still connected', async () => {
+      set(isDisconnecting, true);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=connect-action]').exists()).toBe(true);
+    });
+
+    it('should offer to track an untracked address instead of sending', async () => {
+      set(warnUntrackedAddress, true);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=track-action]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=send-action]').exists()).toBe(false);
+    });
+
+    it('should offer to switch network when the wallet is on another chain', async () => {
+      set(connectedChainId, 10);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=switch-network-action]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=send-action]').exists()).toBe(false);
+    });
+
+    it('should offer to send once connected, tracked and on the right chain', () => {
+      expect(wrapper.find('[data-testid=send-action]').exists()).toBe(true);
+    });
+  });
+
+  describe('when the send button is usable', () => {
+    it('should stay disabled until an amount and recipient are entered', async () => {
+      expect(wrapper.find('[data-testid=send-action]').attributes('disabled')).toBeDefined();
+
+      await enterTransfer('1', RECIPIENT);
+
+      expect(wrapper.find('[data-testid=send-action]').attributes('disabled')).toBeUndefined();
+    });
+
+    it('should stay disabled for an amount over the available max', async () => {
+      await enterTransfer('3', RECIPIENT);
+
+      expect(wrapper.find('[data-testid=send-action]').attributes('disabled')).toBeDefined();
+    });
+
+    it('should stay disabled while gas is still being estimated', async () => {
+      await enterTransfer('1', RECIPIENT);
+      set(estimatingGas, true);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=send-action]').attributes('disabled')).toBeDefined();
+    });
+
+    it('should stay disabled while the balance is unknown', async () => {
+      await enterTransfer('1', RECIPIENT);
+      set(assetBalance, undefined);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=send-action]').attributes('disabled')).toBeDefined();
+    });
+  });
+
+  describe('sending', () => {
+    it('should send what was entered', async () => {
+      await enterTransfer('1', RECIPIENT);
+
+      await wrapper.find('[data-testid=send-action]').trigger('click');
+      await flushPromises();
+
+      expect(send).toHaveBeenCalledWith({
+        amount: '1',
+        assetIdentifier: 'ETH',
+        chain: 'ethereum',
+        native: true,
+        to: RECIPIENT,
+      });
+    });
+
+    it('should clear the form once the transaction is accepted', async () => {
+      await enterTransfer('1', RECIPIENT);
+
+      await wrapper.find('[data-testid=send-action]').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.findComponent({ name: 'TradeAmountInput' }).props('modelValue')).toBe('');
+      expect(wrapper.findComponent({ name: 'TradeRecipientAddress' }).props('modelValue')).toBe('');
+    });
+
+    it('should keep the form when the transaction is refused', async () => {
+      send.mockResolvedValue(false);
+      await enterTransfer('1', RECIPIENT);
+
+      await wrapper.find('[data-testid=send-action]').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.findComponent({ name: 'TradeAmountInput' }).props('modelValue')).toBe('1');
+      expect(wrapper.findComponent({ name: 'TradeRecipientAddress' }).props('modelValue')).toBe(RECIPIENT);
+    });
+  });
+
+  describe('what the card reports', () => {
+    it('should warn that the connected address is not tracked', async () => {
+      set(warnUntrackedAddress, true);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=untracked-warning]').exists()).toBe(true);
+    });
+
+    it('should not warn about tracking while disconnecting', async () => {
+      set(warnUntrackedAddress, true);
+      set(isDisconnecting, true);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=untracked-warning]').exists()).toBe(false);
+    });
+
+    it('should warn while balances are being queried', async () => {
+      expect(wrapper.find('[data-testid=querying-balances-warning]').exists()).toBe(false);
+
+      set(useQueryingBalances, true);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=querying-balances-warning]').exists()).toBe(true);
+    });
+
+    it('should show a wallet error and clear it on dismissal', async () => {
+      set(errorMessage, 'insufficient funds');
+      await nextTick();
+      expect(wrapper.text()).toContain('insufficient funds');
+
+      wrapper.findComponent<ComponentPublicInstance>('[data-testid=trade-error]').vm.$emit('close');
+
+      expect(clearError).toHaveBeenCalledOnce();
+    });
+
+    it('should tell a wallet-connect user where to confirm', async () => {
+      set(waitingForWalletConfirmation, true);
+      set(isWalletConnect, true);
+      await nextTick();
+
+      expect(wrapper.text()).toContain('trade.waiting_for_confirmation.wallet_connect');
+    });
+
+    it('should tell a bridge user where to confirm', async () => {
+      set(waitingForWalletConfirmation, true);
+      await nextTick();
+
+      expect(wrapper.text()).toContain('trade.waiting_for_confirmation.not_wallet_connect');
+    });
+  });
+
+  describe('the other actions', () => {
+    it('should route to the account form with the connected address', async () => {
+      set(warnUntrackedAddress, true);
+      await nextTick();
+
+      await wrapper.find('[data-testid=track-action]').trigger('click');
+
+      expect(push).toHaveBeenCalledWith({
+        path: '/accounts/evm/accounts',
+        query: { add: 'true', addressToAdd: CONNECTED },
+      });
+    });
+
+    it('should ask the wallet to switch to the asset chain', async () => {
+      set(connectedChainId, 10);
+      await nextTick();
+
+      await wrapper.find('[data-testid=switch-network-action]').trigger('click');
+
+      expect(switchNetwork).toHaveBeenCalledWith(BigInt(ETHEREUM_CHAIN_ID));
+    });
+
+    it('should refresh the balance when the asset selector asks', async () => {
+      wrapper.findComponent({ name: 'TradeAssetSelector' }).vm.$emit('refresh');
+      await nextTick();
+
+      expect(refreshAssetBalance).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/send/TradeSendCard.vue
+++ b/frontend/app/src/modules/wallet/send/TradeSendCard.vue
@@ -1,45 +1,37 @@
 <script setup lang="ts">
-import type { EnhancedProviderDetail } from '@/modules/wallet/providers/provider-detection';
-import type { GasFeeEstimation, GetAssetBalancePayload } from '@/modules/wallet/types';
-import { type BigNumber, bigNumberify, Blockchain, isValidEthAddress, Zero } from '@rotki/common';
-import { logger } from '@/modules/core/common/logging/logging';
+import { Blockchain } from '@rotki/common';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { getWalletErrorMessage, isUserRejectedError, WALLET_MODES } from '@/modules/wallet/constants';
-import { useProviderSelection } from '@/modules/wallet/providers/use-provider-selection';
+import { WALLET_MODES } from '@/modules/wallet/constants';
 import { useUnifiedProviders } from '@/modules/wallet/providers/use-unified-providers';
 import ProviderSelectionDialog from '@/modules/wallet/ProviderSelectionDialog.vue';
+import { isAmountExceeded, isTradeValid } from '@/modules/wallet/send/trade-send-utils';
 import TradeAmountInput from '@/modules/wallet/send/TradeAmountInput.vue';
 import TradeAssetSelector from '@/modules/wallet/send/TradeAssetSelector.vue';
 import TradeConnectedAddressBadge from '@/modules/wallet/send/TradeConnectedAddressBadge.vue';
 import TradeHistoryView from '@/modules/wallet/send/TradeHistoryView.vue';
 import TradeRecipientAddress from '@/modules/wallet/send/TradeRecipientAddress.vue';
 import { useBalanceQueries } from '@/modules/wallet/send/use-balance-queries';
+import { useTradeAssetBalance } from '@/modules/wallet/send/use-trade-asset-balance';
+import { useTradeGasEstimation } from '@/modules/wallet/send/use-trade-gas-estimation';
+import { useTradeRecipientWarning } from '@/modules/wallet/send/use-trade-recipient-warning';
+import { useTradeWalletActions } from '@/modules/wallet/send/use-trade-wallet-actions';
 import { TradableAssetKey, useTradableAsset } from '@/modules/wallet/use-tradable-asset';
 import { useWalletHelper } from '@/modules/wallet/use-wallet-helper';
 import { useWalletStore } from '@/modules/wallet/use-wallet-store';
 import WalletConnectionButton from '@/modules/wallet/WalletConnectionButton.vue';
-import { useTradeApi } from './use-trade-api';
 
 const { t } = useI18n({ useScope: 'global' });
+const router = useRouter();
 
 const amount = ref<string>('');
 const asset = ref<string>('');
 const assetChain = ref<string>(Blockchain.ETH);
 const toAddress = ref<string>('');
 
-const max = ref<string>('0');
-const estimatedGasFee = ref<string>('0');
-const assetBalance = ref<BigNumber>();
-
-const estimatingGas = ref<boolean>(false);
-const showNeverInteractedWarning = ref<boolean>(false);
-const errorMessage = ref<string>('');
-const currentGasEstimationController = ref<AbortController>();
-
 const tradeAmountInputRef = useTemplateRef<InstanceType<typeof TradeAmountInput>>('tradeAmountInputRef');
 
 const { getChainFromChainId, getChainIdFromChain } = useWalletHelper();
-const { getEvmChainName, getNativeAsset } = useSupportedChains();
+const { getNativeAsset } = useSupportedChains();
 
 const walletStore = useWalletStore();
 const {
@@ -53,312 +45,121 @@ const {
   waitingForWalletConfirmation,
   walletMode,
 } = storeToRefs(walletStore);
-const { connect: connectWallet, disconnect: disconnectWallet, getGasFeeForChain, sendTransaction, switchNetwork } = walletStore;
+const { switchNetwork } = walletStore;
 const { useQueryingBalances, warnUntrackedAddress } = useBalanceQueries(connected, connectedAddress);
 
 const tradableAsset = useTradableAsset(connectedAddress);
 provide(TradableAssetKey, tradableAsset);
 const { getAssetDetail } = tradableAsset;
-const { getAssetBalance, getIsInteractedBefore } = useTradeApi();
-const router = useRouter();
 
-// Provider selection for wallet connection
-const unifiedProviders = useUnifiedProviders();
-const { availableProviders, isDetecting: detectingProviders, showProviderSelection } = unifiedProviders;
+const { availableProviders, isDetecting: detectingProviders, showProviderSelection } = useUnifiedProviders();
 
 const isConnecting = logicOr(preparing, detectingProviders);
 
-const { handleProviderSelection: handleProviderSelectionBase } = useProviderSelection();
+const assetDetail = getAssetDetail(asset, assetChain);
+const isAssetResolved = computed<boolean>(() => !!get(assetDetail));
 
-async function handleProviderSelection(provider: EnhancedProviderDetail): Promise<void> {
-  await handleProviderSelectionBase(provider, (message) => {
-    set(errorMessage, message);
-  });
-}
-
-const isNativeAsset = computed(() => {
+const isNativeAsset = computed<boolean>(() => {
   const chain = get(assetChain);
   const assetVal = get(asset);
-  if (!chain || !assetVal) {
+  if (!chain || !assetVal)
     return false;
-  }
 
-  const native = getNativeAsset(chain);
-  return assetVal === native;
+  return assetVal === getNativeAsset(chain);
 });
 
-const assetDetail = getAssetDetail(asset, assetChain);
+const {
+  clearError,
+  connect,
+  disconnect,
+  errorMessage,
+  selectProvider,
+  send: sendTransaction,
+  toggleConnection,
+} = useTradeWalletActions();
 
-const isWalletConnected = computed(() => get(connected) && !!get(connectedAddress));
+const { showNeverInteractedWarning } = useTradeRecipientWarning({
+  fromAddress: connectedAddress,
+  toAddress,
+});
 
-const wrongNetwork = computed(() => {
+const { estimatedGasFee, estimatingGas, gasEstimable } = useTradeGasEstimation({
+  asset,
+  chain: assetChain,
+  isAssetResolved,
+  isNativeAsset,
+});
+
+const { assetBalance, max, refreshAssetBalance, resetMax } = useTradeAssetBalance({
+  address: connectedAddress,
+  amount,
+  asset,
+  chain: assetChain,
+  estimatedGasFee,
+  gasEstimable,
+});
+
+const isWalletConnected = computed<boolean>(() => get(connected) && !!get(connectedAddress));
+
+const wrongNetwork = computed<boolean>(() => {
   const chainId = get(connectedChainId);
-  if (!get(connected) || !chainId) {
+  if (!get(connected) || !chainId)
     return false;
-  }
-  const chainIdOfConnectedNetwork = getChainFromChainId(chainId);
-  return get(assetChain) !== chainIdOfConnectedNetwork;
+
+  return get(assetChain) !== getChainFromChainId(chainId);
 });
 
-const amountExceeded = computed(() => {
-  const amountToBigNumber = bigNumberify(get(amount), Zero);
-  const maxToBigNumber = bigNumberify(get(max), Zero);
+const amountExceeded = computed<boolean>(() => isAmountExceeded(get(amount), get(max)));
 
-  return amountToBigNumber.gt(maxToBigNumber);
-});
+const valid = computed<boolean>(() => isTradeValid(get(amount), get(toAddress), get(max)));
 
-const valid = computed<boolean>(() => {
-  const amountToBigNumber = bigNumberify(get(amount), Zero);
-  const to = get(toAddress);
-
-  const amountValid = amountToBigNumber.gt(0);
-  const toAddressValid = !!to && isValidEthAddress(to);
-
-  return amountValid && toAddressValid && !get(amountExceeded);
-});
-
-function resetMax() {
-  set(max, '0');
-}
-
-function resetInput() {
+function resetInput(): void {
   set(toAddress, '');
   set(amount, '');
   resetMax();
 }
 
-function switchToDesireNetwork() {
-  const chainId = getChainIdFromChain(get(assetChain));
-  switchNetwork(BigInt(chainId));
+function switchToDesireNetwork(): void {
+  switchNetwork(BigInt(getChainIdFromChain(get(assetChain))));
 }
 
-async function trackAddress() {
-  await router.push(
-    {
-      path: '/accounts/evm/accounts',
-      query: {
-        add: 'true',
-        addressToAdd: get(connectedAddress),
-      },
+async function trackAddress(): Promise<void> {
+  await router.push({
+    path: '/accounts/evm/accounts',
+    query: {
+      add: 'true',
+      addressToAdd: get(connectedAddress),
     },
-  );
+  });
 }
 
-function setMax() {
+function setMax(): void {
   get(tradeAmountInputRef)?.setMax();
 }
 
-function updateMaxAmountForAsset() {
-  const balance = get(assetBalance);
-  if (balance) {
-    set(max, balance.minus(get(estimatedGasFee)).toFixed());
-  }
-  else {
-    resetMax();
-  }
-}
-
-async function estimateGas(currentAsset: string): Promise<GasFeeEstimation | undefined> {
-  // Create a new controller for this request
-  set(currentGasEstimationController, new AbortController());
-  set(estimatingGas, true);
-
-  const abortEstimationPromise = new Promise<GasFeeEstimation>((_, reject) => {
-    get(currentGasEstimationController)?.signal.addEventListener('abort', () => {
-      reject(new Error('Gas estimation cancelled'));
-    });
-  });
-  const gasFeeEstimation = await Promise.race([
-    getGasFeeForChain(),
-    abortEstimationPromise,
-  ]);
-
-  if (currentAsset !== get(asset)) {
-    return undefined;
-  }
-  return gasFeeEstimation;
-}
-
-async function send() {
-  const isNative = get(isNativeAsset);
-  const assetVal = get(asset);
-
-  const params = {
+async function send(): Promise<void> {
+  const sent = await sendTransaction({
     amount: get(amount),
-    assetIdentifier: assetVal,
+    assetIdentifier: get(asset),
     chain: get(assetChain),
-    native: isNative,
+    native: get(isNativeAsset),
     to: get(toAddress),
-  };
+  });
 
-  try {
-    set(errorMessage, '');
-    await sendTransaction(params);
+  if (sent)
     resetInput();
-  }
-  catch (error: unknown) {
-    if (isUserRejectedError(error)) {
-      set(errorMessage, 'Request is rejected by user');
-    }
-    else {
-      set(errorMessage, getWalletErrorMessage(error));
-    }
-  }
-}
-
-async function refreshAssetBalance() {
-  set(amount, '');
-  set(assetBalance, undefined);
-
-  const chain = get(assetChain);
-  const assetVal = get(asset);
-  const address = get(connectedAddress);
-
-  if (!chain || !assetVal || !address) {
-    return;
-  }
-
-  const evmChain = getEvmChainName(chain);
-
-  if (!evmChain) {
-    return;
-  }
-
-  const payload: GetAssetBalancePayload = {
-    address,
-    asset: assetVal,
-    evmChain,
-  };
-
-  try {
-    const response = await getAssetBalance(payload);
-    if (get(asset) === payload.asset) {
-      set(assetBalance, response);
-    }
-  }
-  catch (error) {
-    logger.error(error);
-  }
-}
-
-async function onConnectClicked() {
-  if (get(connected)) {
-    await disconnect();
-  }
-  else {
-    await connect();
-  }
-}
-
-async function connect() {
-  try {
-    set(errorMessage, '');
-    await connectWallet();
-  }
-  catch (error: unknown) {
-    logger.error(error);
-    set(errorMessage, getWalletErrorMessage(error));
-  }
-}
-
-async function disconnect() {
-  try {
-    set(errorMessage, '');
-    await disconnectWallet();
-  }
-  catch (error: unknown) {
-    logger.error(error);
-    set(errorMessage, getWalletErrorMessage(error));
-  }
 }
 
 watch([assetChain, supportedChainsForConnectedAccount], ([currentChain, chainOptions]) => {
-  if (!chainOptions.includes(currentChain)) {
+  if (!chainOptions.includes(currentChain))
     set(assetChain, chainOptions[0]);
-  }
-});
-
-watch([connectedAddress, toAddress], async ([fromAddress, toAddress]) => {
-  if (!fromAddress || !toAddress || !isValidEthAddress(toAddress)) {
-    set(showNeverInteractedWarning, false);
-    return;
-  }
-
-  try {
-    const result = await getIsInteractedBefore(fromAddress, toAddress);
-    set(showNeverInteractedWarning, !result);
-  }
-  catch (error: unknown) {
-    set(showNeverInteractedWarning, false);
-    logger.error(error);
-  }
-});
-
-watch([assetChain, asset, connectedAddress], async () => {
-  await refreshAssetBalance();
-});
-
-// calculate the gas fee estimation
-/** Gas can only be estimated once a wallet is connected and a resolvable asset is selected. */
-function canEstimateGas(chain: string | undefined, currentAsset: string | undefined): boolean {
-  return get(connected) && !!chain && !!currentAsset && !!get(assetDetail);
-}
-
-watchImmediate([
-  asset,
-  assetChain,
-  connectedChainId,
-], async ([currentAsset, chain, connectedChainId]) => {
-  if (!canEstimateGas(chain, currentAsset)) {
-    resetMax();
-    return;
-  }
-
-  // Cancel previous request if it exists
-  const controller = get(currentGasEstimationController);
-  if (controller) {
-    controller.abort();
-  }
-
-  if (!get(isNativeAsset)) {
-    set(estimatedGasFee, '0');
-    return;
-  }
-
-  try {
-    if (getChainIdFromChain(chain) === connectedChainId) {
-      const gasFeeEstimation = await estimateGas(currentAsset);
-      if (gasFeeEstimation) {
-        const { gasFee } = gasFeeEstimation;
-        set(estimatedGasFee, gasFee);
-        return;
-      }
-    }
-
-    set(estimatedGasFee, '0');
-  }
-  catch (error: unknown) {
-    if (getWalletErrorMessage(error) !== 'Gas estimation cancelled') {
-      set(estimatedGasFee, '0');
-      logger.error(error);
-    }
-  }
-  finally {
-    set(currentGasEstimationController, undefined);
-    set(estimatingGas, false);
-  }
 });
 
 watchImmediate(connectedChainId, (curr, prev) => {
-  if (!isDefined(curr) || curr === prev) {
+  if (!isDefined(curr) || curr === prev)
     return;
-  }
 
   set(assetChain, getChainFromChainId(curr));
-});
-
-watch([estimatedGasFee, assetBalance], () => {
-  updateMaxAmountForAsset();
 });
 </script>
 
@@ -454,7 +255,7 @@ watch([estimatedGasFee, assetBalance], () => {
         full-width
         :connected="isWalletConnected"
         :loading="isConnecting || isDisconnecting"
-        @click="onConnectClicked()"
+        @click="toggleConnection()"
       />
       <RuiButton
         v-else-if="warnUntrackedAddress"
@@ -492,7 +293,7 @@ watch([estimatedGasFee, assetBalance], () => {
     type="error"
     class="whitespace-break-spaces mt-4 overflow-hidden [&>div:first-child]:overflow-hidden [&>div:first-child>div:last-child]:overflow-hidden"
     closeable
-    @close="errorMessage = ''"
+    @close="clearError()"
   >
     <div class="overflow-hidden">
       {{ errorMessage }}
@@ -515,6 +316,6 @@ watch([estimatedGasFee, assetBalance], () => {
     v-model="showProviderSelection"
     :providers="availableProviders"
     :loading="detectingProviders"
-    @select-provider="handleProviderSelection($event)"
+    @select-provider="selectProvider($event)"
   />
 </template>

--- a/frontend/app/src/modules/wallet/send/TradeSendCard.vue
+++ b/frontend/app/src/modules/wallet/send/TradeSendCard.vue
@@ -172,6 +172,7 @@ watchImmediate(connectedChainId, (curr, prev) => {
       <RuiAlert
         v-if="warnUntrackedAddress && !isDisconnecting"
         type="warning"
+        data-testid="untracked-warning"
       >
         {{ t('trade.warning.not_tracked') }}
         <RuiButton
@@ -186,6 +187,7 @@ watchImmediate(connectedChainId, (curr, prev) => {
       <RuiAlert
         v-if="useQueryingBalances"
         type="warning"
+        data-testid="querying-balances-warning"
       >
         {{ t('trade.warning.query_on_progress') }}
       </RuiAlert>
@@ -253,6 +255,7 @@ watchImmediate(connectedChainId, (curr, prev) => {
         v-if="!isWalletConnected || isDisconnecting"
         size="lg"
         full-width
+        data-testid="connect-action"
         :connected="isWalletConnected"
         :loading="isConnecting || isDisconnecting"
         @click="toggleConnection()"
@@ -262,6 +265,7 @@ watchImmediate(connectedChainId, (curr, prev) => {
         color="primary"
         size="lg"
         class="!w-full"
+        data-testid="track-action"
         @click="trackAddress()"
       >
         {{ t('trade.actions.track') }}
@@ -271,6 +275,7 @@ watchImmediate(connectedChainId, (curr, prev) => {
         color="primary"
         size="lg"
         class="!w-full"
+        data-testid="switch-network-action"
         @click="switchToDesireNetwork()"
       >
         {{ t('trade.actions.change_network') }}
@@ -282,6 +287,7 @@ watchImmediate(connectedChainId, (curr, prev) => {
         class="!w-full"
         :disabled="!valid || estimatingGas || !assetBalance"
         :loading="preparing"
+        data-testid="send-action"
         @click="send()"
       >
         {{ t('trade.actions.send') }}
@@ -293,6 +299,7 @@ watchImmediate(connectedChainId, (curr, prev) => {
     type="error"
     class="whitespace-break-spaces mt-4 overflow-hidden [&>div:first-child]:overflow-hidden [&>div:first-child>div:last-child]:overflow-hidden"
     closeable
+    data-testid="trade-error"
     @close="clearError()"
   >
     <div class="overflow-hidden">

--- a/frontend/app/src/modules/wallet/send/trade-send-utils.spec.ts
+++ b/frontend/app/src/modules/wallet/send/trade-send-utils.spec.ts
@@ -15,12 +15,12 @@ describe('trade-send-utils', () => {
       expect(isAmountExceeded('2.0000001', '2')).toBe(true);
     });
 
-    it('should treat an unparseable amount as zero', () => {
+    it('should treat an unparsable amount as zero', () => {
       expect(isAmountExceeded('', '2')).toBe(false);
       expect(isAmountExceeded('not a number', '2')).toBe(false);
     });
 
-    it('should treat an unparseable max as zero', () => {
+    it('should treat an unparsable max as zero', () => {
       expect(isAmountExceeded('1', '')).toBe(true);
     });
   });

--- a/frontend/app/src/modules/wallet/send/trade-send-utils.spec.ts
+++ b/frontend/app/src/modules/wallet/send/trade-send-utils.spec.ts
@@ -1,0 +1,65 @@
+import { bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { isAmountExceeded, isTradeValid, maxSendableAmount } from '@/modules/wallet/send/trade-send-utils';
+
+const VALID_ADDRESS = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+
+describe('trade-send-utils', () => {
+  describe('isAmountExceeded', () => {
+    it('should allow an amount up to the max', () => {
+      expect(isAmountExceeded('1', '2')).toBe(false);
+      expect(isAmountExceeded('2', '2')).toBe(false);
+    });
+
+    it('should reject an amount above the max', () => {
+      expect(isAmountExceeded('2.0000001', '2')).toBe(true);
+    });
+
+    it('should treat an unparseable amount as zero', () => {
+      expect(isAmountExceeded('', '2')).toBe(false);
+      expect(isAmountExceeded('not a number', '2')).toBe(false);
+    });
+
+    it('should treat an unparseable max as zero', () => {
+      expect(isAmountExceeded('1', '')).toBe(true);
+    });
+  });
+
+  describe('isTradeValid', () => {
+    it('should accept a positive amount within the max to a valid address', () => {
+      expect(isTradeValid('1', VALID_ADDRESS, '2')).toBe(true);
+    });
+
+    it('should reject a zero or empty amount', () => {
+      expect(isTradeValid('0', VALID_ADDRESS, '2')).toBe(false);
+      expect(isTradeValid('', VALID_ADDRESS, '2')).toBe(false);
+    });
+
+    it('should reject a missing or malformed recipient', () => {
+      expect(isTradeValid('1', '', '2')).toBe(false);
+      expect(isTradeValid('1', '0xnope', '2')).toBe(false);
+    });
+
+    it('should reject an amount over the max', () => {
+      expect(isTradeValid('3', VALID_ADDRESS, '2')).toBe(false);
+    });
+  });
+
+  describe('maxSendableAmount', () => {
+    it('should leave the gas fee out of the sendable amount', () => {
+      expect(maxSendableAmount(bigNumberify('2'), '0.5')).toBe('1.5');
+    });
+
+    it('should offer the whole balance when gas is free', () => {
+      expect(maxSendableAmount(bigNumberify('2'), '0')).toBe('2');
+    });
+
+    it('should offer nothing when the balance is unknown', () => {
+      expect(maxSendableAmount(undefined, '0.5')).toBe('0');
+    });
+
+    it('should go negative rather than lie when gas exceeds the balance', () => {
+      expect(maxSendableAmount(bigNumberify('0.1'), '0.5')).toBe('-0.4');
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/send/trade-send-utils.ts
+++ b/frontend/app/src/modules/wallet/send/trade-send-utils.ts
@@ -1,0 +1,24 @@
+import { type BigNumber, bigNumberify, isValidEthAddress, Zero } from '@rotki/common';
+
+/** The amount the user asked to send is more than the balance left after gas. */
+export function isAmountExceeded(amount: string, max: string): boolean {
+  return bigNumberify(amount, Zero).gt(bigNumberify(max, Zero));
+}
+
+/** A send is only allowed for a positive amount to a well-formed address within the max. */
+export function isTradeValid(amount: string, toAddress: string, max: string): boolean {
+  const positive = bigNumberify(amount, Zero).gt(0);
+  const recipientValid = !!toAddress && isValidEthAddress(toAddress);
+  return positive && recipientValid && !isAmountExceeded(amount, max);
+}
+
+/**
+ * What is left to send once the estimated gas is set aside. Without a known balance there is
+ * nothing to offer, so the max collapses to zero rather than to the balance.
+ */
+export function maxSendableAmount(balance: BigNumber | undefined, estimatedGasFee: string): string {
+  if (!balance)
+    return '0';
+
+  return balance.minus(estimatedGasFee).toFixed();
+}

--- a/frontend/app/src/modules/wallet/send/use-trade-asset-balance.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-asset-balance.spec.ts
@@ -1,0 +1,152 @@
+import type { EffectScope, Ref } from 'vue';
+import type { GetAssetBalancePayload } from '@/modules/wallet/types';
+import { type BigNumber, bigNumberify } from '@rotki/common';
+import flushPromises from 'flush-promises';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTradeAssetBalance } from '@/modules/wallet/send/use-trade-asset-balance';
+
+const getAssetBalance = vi.fn<(payload: GetAssetBalancePayload) => Promise<BigNumber>>();
+
+vi.mock('@/modules/wallet/send/use-trade-api', () => ({
+  useTradeApi: vi.fn(() => ({ getAssetBalance })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({
+    getEvmChainName: (chain: string): string | undefined => (chain === 'unsupported' ? undefined : chain),
+  })),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+describe('useTradeAssetBalance', () => {
+  let scope: EffectScope;
+  let asset: Ref<string>;
+  let chain: Ref<string>;
+  let address: Ref<string | undefined>;
+  let amount: Ref<string>;
+  let estimatedGasFee: Ref<string>;
+  let gasEstimable: Ref<boolean>;
+
+  function create(): ReturnType<typeof useTradeAssetBalance> {
+    scope = effectScope();
+    const result = scope.run(() =>
+      useTradeAssetBalance({ address, amount, asset, chain, estimatedGasFee, gasEstimable }),
+    );
+    assert(result);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    asset = ref<string>('ETH');
+    chain = ref<string>('ethereum');
+    address = ref<string | undefined>('0x9531C059098e3d194fF87FebB587aB07B30B1306');
+    amount = ref<string>('');
+    estimatedGasFee = ref<string>('0');
+    gasEstimable = ref<boolean>(true);
+    getAssetBalance.mockResolvedValue(bigNumberify('2'));
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  it('should read the balance for the current asset, chain and address', async () => {
+    const { assetBalance, refreshAssetBalance } = create();
+    await refreshAssetBalance();
+
+    expect(getAssetBalance).toHaveBeenCalledWith({
+      address: '0x9531C059098e3d194fF87FebB587aB07B30B1306',
+      asset: 'ETH',
+      evmChain: 'ethereum',
+    });
+    expect(get(assetBalance)?.toFixed()).toBe('2');
+  });
+
+  it('should clear the entered amount on every refresh', async () => {
+    const { refreshAssetBalance } = create();
+    set(amount, '1.5');
+
+    await refreshAssetBalance();
+
+    expect(get(amount)).toBe('');
+  });
+
+  it('should not query without an address', async () => {
+    set(address, undefined);
+    const { assetBalance, refreshAssetBalance } = create();
+    await refreshAssetBalance();
+
+    expect(getAssetBalance).not.toHaveBeenCalled();
+    expect(get(assetBalance)).toBeUndefined();
+  });
+
+  it('should not query a chain with no evm name', async () => {
+    set(chain, 'unsupported');
+    const { refreshAssetBalance } = create();
+    await refreshAssetBalance();
+
+    expect(getAssetBalance).not.toHaveBeenCalled();
+  });
+
+  it('should keep the balance undefined when the query fails', async () => {
+    getAssetBalance.mockRejectedValue(new Error('backend is down'));
+    const { assetBalance, refreshAssetBalance } = create();
+    await refreshAssetBalance();
+
+    expect(get(assetBalance)).toBeUndefined();
+  });
+
+  it('should drop a balance that arrives after the asset changed', async () => {
+    let resolve: (value: BigNumber) => void;
+    getAssetBalance
+      .mockReturnValueOnce(new Promise<BigNumber>((res) => {
+        resolve = res;
+      }))
+      // The refresh the asset change triggers never settles, so only the stale answer could land.
+      .mockReturnValue(new Promise<BigNumber>(() => {}));
+    const { assetBalance, refreshAssetBalance } = create();
+    const pending = refreshAssetBalance();
+
+    set(asset, 'DAI');
+    resolve!(bigNumberify('99'));
+    await pending;
+
+    expect(get(assetBalance)).toBeUndefined();
+  });
+
+  it('should refresh when the asset changes', async () => {
+    create();
+    await flushPromises();
+    expect(getAssetBalance).not.toHaveBeenCalled();
+
+    set(asset, 'DAI');
+    await flushPromises();
+
+    expect(getAssetBalance).toHaveBeenCalledOnce();
+  });
+
+  it('should hold back the gas fee from the sendable max', async () => {
+    const { max, refreshAssetBalance } = create();
+    set(estimatedGasFee, '0.25');
+    await refreshAssetBalance();
+    await nextTick();
+
+    expect(get(max)).toBe('1.75');
+  });
+
+  it('should offer no max while gas cannot be estimated', async () => {
+    const { max, refreshAssetBalance } = create();
+    await refreshAssetBalance();
+    await nextTick();
+    expect(get(max)).toBe('2');
+
+    set(gasEstimable, false);
+    await nextTick();
+
+    expect(get(max)).toBe('0');
+  });
+});

--- a/frontend/app/src/modules/wallet/send/use-trade-asset-balance.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-asset-balance.ts
@@ -1,0 +1,104 @@
+import type { BigNumber } from '@rotki/common';
+import type { Ref } from 'vue';
+import type { GetAssetBalancePayload } from '@/modules/wallet/types';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { maxSendableAmount } from '@/modules/wallet/send/trade-send-utils';
+import { useTradeApi } from '@/modules/wallet/send/use-trade-api';
+
+interface UseTradeAssetBalanceOptions {
+  /** The asset whose balance is shown; a change while a request is pending invalidates it. */
+  readonly asset: Ref<string>;
+  /** The chain the balance is read on. */
+  readonly chain: Ref<string>;
+  /** The connected address the balance belongs to. */
+  readonly address: Readonly<Ref<string | undefined>>;
+  /** Cleared on every refresh: an amount entered against the previous balance is meaningless. */
+  readonly amount: Ref<string>;
+  /** Set aside from the balance when working out what can actually be sent. */
+  readonly estimatedGasFee: Readonly<Ref<string>>;
+  /** While no gas estimate is possible there is nothing to offer as a max. */
+  readonly gasEstimable: Readonly<Ref<boolean>>;
+}
+
+interface UseTradeAssetBalanceReturn {
+  readonly assetBalance: Readonly<Ref<BigNumber | undefined>>;
+  readonly max: Readonly<Ref<string>>;
+  readonly refreshAssetBalance: () => Promise<void>;
+  readonly resetMax: () => void;
+}
+
+/**
+ * The connected address's balance of the selected asset, and the amount of it that can actually be
+ * sent once gas is set aside.
+ *
+ * Like the gas estimate this is racy - the response is dropped when the asset changed while the
+ * request was in flight, so a slow answer for a previous asset cannot land as the current balance.
+ */
+export function useTradeAssetBalance(options: UseTradeAssetBalanceOptions): UseTradeAssetBalanceReturn {
+  const { address, amount, asset, chain, estimatedGasFee, gasEstimable } = options;
+
+  const assetBalance = shallowRef<BigNumber>();
+  const max = shallowRef<string>('0');
+
+  const { getEvmChainName } = useSupportedChains();
+  const { getAssetBalance } = useTradeApi();
+
+  function resetMax(): void {
+    set(max, '0');
+  }
+
+  async function refreshAssetBalance(): Promise<void> {
+    set(amount, '');
+    set(assetBalance, undefined);
+
+    const currentChain = get(chain);
+    const currentAsset = get(asset);
+    const currentAddress = get(address);
+
+    if (!currentChain || !currentAsset || !currentAddress)
+      return;
+
+    const evmChain = getEvmChainName(currentChain);
+
+    if (!evmChain)
+      return;
+
+    const payload: GetAssetBalancePayload = {
+      address: currentAddress,
+      asset: currentAsset,
+      evmChain,
+    };
+
+    try {
+      const response = await getAssetBalance(payload);
+      // Dropped when the selection moved on while the request was in flight.
+      if (get(asset) === payload.asset)
+        set(assetBalance, response);
+    }
+    catch (error) {
+      logger.error(error);
+    }
+  }
+
+  watch([chain, asset, address], async () => {
+    await refreshAssetBalance();
+  });
+
+  watch([estimatedGasFee, assetBalance], () => {
+    set(max, maxSendableAmount(get(assetBalance), get(estimatedGasFee)));
+  });
+
+  watchImmediate(gasEstimable, (estimable) => {
+    if (!estimable)
+      resetMax();
+  });
+
+  return {
+    // A computed rather than readonly(): deep-readonly would strip BigNumber's own type.
+    assetBalance: computed<BigNumber | undefined>(() => get(assetBalance)),
+    max: readonly(max),
+    refreshAssetBalance,
+    resetMax,
+  };
+}

--- a/frontend/app/src/modules/wallet/send/use-trade-gas-estimation.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-gas-estimation.spec.ts
@@ -1,0 +1,179 @@
+import type { EffectScope, Ref } from 'vue';
+import type { GasFeeEstimation } from '@/modules/wallet/types';
+import flushPromises from 'flush-promises';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTradeGasEstimation } from '@/modules/wallet/send/use-trade-gas-estimation';
+
+const ETHEREUM_CHAIN_ID = 1;
+const OPTIMISM_CHAIN_ID = 10;
+
+const connected = ref<boolean>(true);
+const connectedChainId = ref<number>();
+const getGasFeeForChain = vi.fn<() => Promise<GasFeeEstimation>>();
+
+vi.mock('@/modules/wallet/use-wallet-store', () => ({
+  useWalletStore: vi.fn(() => ({ connected, connectedChainId, getGasFeeForChain })),
+}));
+
+vi.mock('@/modules/wallet/use-wallet-helper', () => ({
+  useWalletHelper: vi.fn(() => ({
+    getChainIdFromChain: (chain: string): number => (chain === 'ethereum' ? ETHEREUM_CHAIN_ID : OPTIMISM_CHAIN_ID),
+  })),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+/** A gas estimate the test resolves by hand, to hold a request open across other changes. */
+function deferred(): { promise: Promise<GasFeeEstimation>; resolve: (gasFee: string) => void } {
+  let resolve: (value: GasFeeEstimation) => void;
+  const promise = new Promise<GasFeeEstimation>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve: (gasFee: string): void => resolve({ gasFee, maxAmount: '0' }) };
+}
+
+describe('useTradeGasEstimation', () => {
+  let scope: EffectScope;
+  let asset: Ref<string>;
+  let chain: Ref<string>;
+  let isNativeAsset: Ref<boolean>;
+  let isAssetResolved: Ref<boolean>;
+
+  function create(): ReturnType<typeof useTradeGasEstimation> {
+    scope = effectScope();
+    const result = scope.run(() => useTradeGasEstimation({ asset, chain, isAssetResolved, isNativeAsset }));
+    assert(result);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(connected, true);
+    set(connectedChainId, ETHEREUM_CHAIN_ID);
+    asset = ref<string>('ETH');
+    chain = ref<string>('ethereum');
+    isNativeAsset = ref<boolean>(true);
+    isAssetResolved = ref<boolean>(true);
+    getGasFeeForChain.mockResolvedValue({ gasFee: '0.01', maxAmount: '0' });
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  it('should estimate for a native asset on the connected chain', async () => {
+    const { estimatedGasFee } = create();
+    await flushPromises();
+
+    expect(getGasFeeForChain).toHaveBeenCalledOnce();
+    expect(get(estimatedGasFee)).toBe('0.01');
+  });
+
+  it('should not estimate while no wallet is connected', async () => {
+    set(connected, false);
+    const { estimatedGasFee, gasEstimable } = create();
+    await flushPromises();
+
+    expect(get(gasEstimable)).toBe(false);
+    expect(getGasFeeForChain).not.toHaveBeenCalled();
+    expect(get(estimatedGasFee)).toBe('0');
+  });
+
+  it('should not estimate until the asset resolves', async () => {
+    set(isAssetResolved, false);
+    const { gasEstimable } = create();
+    await flushPromises();
+
+    expect(get(gasEstimable)).toBe(false);
+    expect(getGasFeeForChain).not.toHaveBeenCalled();
+  });
+
+  it('should charge no gas for a non-native asset', async () => {
+    set(isNativeAsset, false);
+    const { estimatedGasFee } = create();
+    await flushPromises();
+
+    expect(getGasFeeForChain).not.toHaveBeenCalled();
+    expect(get(estimatedGasFee)).toBe('0');
+  });
+
+  it('should charge no gas while the wallet is on another chain', async () => {
+    set(connectedChainId, OPTIMISM_CHAIN_ID);
+    const { estimatedGasFee } = create();
+    await flushPromises();
+
+    expect(getGasFeeForChain).not.toHaveBeenCalled();
+    expect(get(estimatedGasFee)).toBe('0');
+  });
+
+  it('should report that it is estimating while a request is in flight', async () => {
+    const pending = deferred();
+    getGasFeeForChain.mockReturnValue(pending.promise);
+    const { estimatedGasFee, estimatingGas } = create();
+    await nextTick();
+
+    expect(get(estimatingGas)).toBe(true);
+
+    pending.resolve('0.02');
+    await flushPromises();
+
+    expect(get(estimatingGas)).toBe(false);
+    expect(get(estimatedGasFee)).toBe('0.02');
+  });
+
+  it('should drop an estimate that resolves after the asset changed', async () => {
+    const pending = deferred();
+    getGasFeeForChain.mockReturnValueOnce(pending.promise);
+    const { estimatedGasFee } = create();
+    await nextTick();
+
+    // Clearing the asset makes the next run bail before it aborts anything, so the first request
+    // is still live when it resolves - only the stale-asset check can discard it.
+    set(asset, '');
+    await nextTick();
+    pending.resolve('99');
+    await flushPromises();
+
+    expect(get(estimatedGasFee)).toBe('0');
+  });
+
+  it('should abort the previous request when the selection changes', async () => {
+    const pending = deferred();
+    getGasFeeForChain.mockReturnValueOnce(pending.promise);
+    const { estimatedGasFee } = create();
+    await nextTick();
+
+    getGasFeeForChain.mockResolvedValue({ gasFee: '0.05', maxAmount: '0' });
+    set(asset, 'DAI');
+    await flushPromises();
+
+    // The aborted request rejects, and that rejection must not clear the newer estimate.
+    pending.resolve('99');
+    await flushPromises();
+
+    expect(get(estimatedGasFee)).toBe('0.05');
+    expect(getGasFeeForChain).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reset the fee when the estimate fails', async () => {
+    getGasFeeForChain.mockRejectedValue(new Error('rpc is down'));
+    const { estimatedGasFee } = create();
+    await flushPromises();
+
+    expect(get(estimatedGasFee)).toBe('0');
+  });
+
+  it('should re-estimate when the connected chain changes', async () => {
+    create();
+    await flushPromises();
+    expect(getGasFeeForChain).toHaveBeenCalledOnce();
+
+    set(chain, 'optimism');
+    set(connectedChainId, OPTIMISM_CHAIN_ID);
+    await flushPromises();
+
+    expect(getGasFeeForChain).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/app/src/modules/wallet/send/use-trade-gas-estimation.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-gas-estimation.ts
@@ -1,0 +1,121 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { GasFeeEstimation } from '@/modules/wallet/types';
+import { logger } from '@/modules/core/common/logging/logging';
+import { getWalletErrorMessage } from '@/modules/wallet/constants';
+import { useWalletHelper } from '@/modules/wallet/use-wallet-helper';
+import { useWalletStore } from '@/modules/wallet/use-wallet-store';
+
+/** Rejection used to unwind an estimation the user has already moved past. */
+const CANCELLED = 'Gas estimation cancelled';
+
+interface UseTradeGasEstimationOptions {
+  /** The asset the estimate is about; a change while one is pending invalidates it. */
+  readonly asset: Ref<string>;
+  /** The chain the estimate is for; gas is only estimated on the connected chain. */
+  readonly chain: Ref<string>;
+  /** Whether the selected asset is the chain's native token; only then does gas apply. */
+  readonly isNativeAsset: Ref<boolean>;
+  /** Whether the selected asset resolved to a known one. Estimating before it does is pointless. */
+  readonly isAssetResolved: Ref<boolean>;
+}
+
+interface UseTradeGasEstimationReturn {
+  readonly estimatedGasFee: Readonly<Ref<string>>;
+  readonly estimatingGas: Readonly<Ref<boolean>>;
+  /** Whether a gas estimate can be produced at all for the current selection. */
+  readonly gasEstimable: ComputedRef<boolean>;
+}
+
+/**
+ * Keeps a gas estimate for the selected asset and chain.
+ *
+ * Estimation is inherently racy: the user can switch asset or chain while a request is in flight.
+ * Two guards keep a late answer from overwriting a newer selection - the previous request is
+ * aborted when a new one starts, and the resolved estimate is dropped if the asset changed while
+ * it was pending.
+ */
+export function useTradeGasEstimation(options: UseTradeGasEstimationOptions): UseTradeGasEstimationReturn {
+  const { asset, chain, isAssetResolved, isNativeAsset } = options;
+
+  const estimatedGasFee = shallowRef<string>('0');
+  const estimatingGas = shallowRef<boolean>(false);
+  const controller = shallowRef<AbortController>();
+
+  const { getChainIdFromChain } = useWalletHelper();
+  const { connected, connectedChainId } = storeToRefs(useWalletStore());
+  const { getGasFeeForChain } = useWalletStore();
+
+  function resetFee(): void {
+    set(estimatedGasFee, '0');
+  }
+
+  // Nothing should stay in flight once the card is gone.
+  onScopeDispose(() => {
+    get(controller)?.abort();
+  });
+
+  /** Gas can only be estimated once a wallet is connected and a resolvable asset is selected. */
+  const gasEstimable = computed<boolean>(() =>
+    get(connected) && !!get(chain) && !!get(asset) && get(isAssetResolved),
+  );
+
+  async function estimate(currentAsset: string): Promise<GasFeeEstimation | undefined> {
+    const abortController = new AbortController();
+    set(controller, abortController);
+    set(estimatingGas, true);
+
+    const aborted = new Promise<GasFeeEstimation>((_, reject) => {
+      abortController.signal.addEventListener('abort', () => {
+        reject(new Error(CANCELLED));
+      });
+    });
+
+    const estimation = await Promise.race([getGasFeeForChain(), aborted]);
+
+    // The selection moved on while this was in flight, so the answer is no longer about it.
+    if (currentAsset !== get(asset))
+      return undefined;
+
+    return estimation;
+  }
+
+  watchImmediate([asset, chain, connectedChainId], async ([currentAsset, currentChain, currentChainId]) => {
+    if (!get(gasEstimable))
+      return;
+
+    get(controller)?.abort();
+
+    if (!get(isNativeAsset)) {
+      resetFee();
+      return;
+    }
+
+    try {
+      if (getChainIdFromChain(currentChain) === currentChainId) {
+        const estimation = await estimate(currentAsset);
+        if (estimation) {
+          set(estimatedGasFee, estimation.gasFee);
+          return;
+        }
+      }
+
+      resetFee();
+    }
+    catch (error: unknown) {
+      if (getWalletErrorMessage(error) !== CANCELLED) {
+        resetFee();
+        logger.error(error);
+      }
+    }
+    finally {
+      set(controller, undefined);
+      set(estimatingGas, false);
+    }
+  });
+
+  return {
+    estimatedGasFee: readonly(estimatedGasFee),
+    estimatingGas: readonly(estimatingGas),
+    gasEstimable,
+  };
+}

--- a/frontend/app/src/modules/wallet/send/use-trade-recipient-warning.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-recipient-warning.spec.ts
@@ -1,0 +1,104 @@
+import type { EffectScope, Ref } from 'vue';
+import flushPromises from 'flush-promises';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTradeRecipientWarning } from '@/modules/wallet/send/use-trade-recipient-warning';
+
+const FROM = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+const TO = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65';
+
+const getIsInteractedBefore = vi.fn<(from: string, to: string) => Promise<boolean>>();
+
+vi.mock('@/modules/wallet/send/use-trade-api', () => ({
+  useTradeApi: vi.fn(() => ({ getIsInteractedBefore })),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+describe('useTradeRecipientWarning', () => {
+  let scope: EffectScope;
+  let fromAddress: Ref<string | undefined>;
+  let toAddress: Ref<string>;
+
+  function create(): ReturnType<typeof useTradeRecipientWarning> {
+    scope = effectScope();
+    const result = scope.run(() => useTradeRecipientWarning({ fromAddress, toAddress }));
+    assert(result);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fromAddress = ref<string | undefined>(FROM);
+    toAddress = ref<string>('');
+    getIsInteractedBefore.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  it('should warn about a recipient never transacted with', async () => {
+    const { showNeverInteractedWarning } = create();
+
+    set(toAddress, TO);
+    await flushPromises();
+
+    expect(getIsInteractedBefore).toHaveBeenCalledWith(FROM, TO);
+    expect(get(showNeverInteractedWarning)).toBe(true);
+  });
+
+  it('should stay quiet for a known recipient', async () => {
+    getIsInteractedBefore.mockResolvedValue(true);
+    const { showNeverInteractedWarning } = create();
+
+    set(toAddress, TO);
+    await flushPromises();
+
+    expect(get(showNeverInteractedWarning)).toBe(false);
+  });
+
+  it('should not ask about a half-typed address', async () => {
+    const { showNeverInteractedWarning } = create();
+
+    set(toAddress, '0xc37b40ABdB');
+    await flushPromises();
+
+    expect(getIsInteractedBefore).not.toHaveBeenCalled();
+    expect(get(showNeverInteractedWarning)).toBe(false);
+  });
+
+  it('should not ask without a connected address', async () => {
+    set(fromAddress, undefined);
+    const { showNeverInteractedWarning } = create();
+
+    set(toAddress, TO);
+    await flushPromises();
+
+    expect(getIsInteractedBefore).not.toHaveBeenCalled();
+    expect(get(showNeverInteractedWarning)).toBe(false);
+  });
+
+  it('should withdraw the warning when the recipient is cleared', async () => {
+    const { showNeverInteractedWarning } = create();
+    set(toAddress, TO);
+    await flushPromises();
+    expect(get(showNeverInteractedWarning)).toBe(true);
+
+    set(toAddress, '');
+    await flushPromises();
+
+    expect(get(showNeverInteractedWarning)).toBe(false);
+  });
+
+  it('should not raise a false alarm when the lookup fails', async () => {
+    getIsInteractedBefore.mockRejectedValue(new Error('backend is down'));
+    const { showNeverInteractedWarning } = create();
+
+    set(toAddress, TO);
+    await flushPromises();
+
+    expect(get(showNeverInteractedWarning)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/wallet/send/use-trade-recipient-warning.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-recipient-warning.ts
@@ -1,0 +1,49 @@
+import type { Ref } from 'vue';
+import { isValidEthAddress } from '@rotki/common';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useTradeApi } from '@/modules/wallet/send/use-trade-api';
+
+interface UseTradeRecipientWarningOptions {
+  /** The connected address the transaction would be sent from. */
+  readonly fromAddress: Readonly<Ref<string | undefined>>;
+  /** The recipient as typed, which may not be a well-formed address yet. */
+  readonly toAddress: Ref<string>;
+}
+
+interface UseTradeRecipientWarningReturn {
+  /** Whether to warn that the pair has never transacted before. */
+  readonly showNeverInteractedWarning: Readonly<Ref<boolean>>;
+}
+
+/**
+ * Warns when the connected address has never sent to the recipient before, which is the moment a
+ * mistyped address is most likely. The warning is withheld until the recipient parses as an
+ * address, and a failed lookup is treated as "no warning" rather than as a false alarm.
+ */
+export function useTradeRecipientWarning(
+  options: UseTradeRecipientWarningOptions,
+): UseTradeRecipientWarningReturn {
+  const { fromAddress, toAddress } = options;
+
+  const showNeverInteractedWarning = shallowRef<boolean>(false);
+
+  const { getIsInteractedBefore } = useTradeApi();
+
+  watch([fromAddress, toAddress], async ([from, to]) => {
+    if (!from || !to || !isValidEthAddress(to)) {
+      set(showNeverInteractedWarning, false);
+      return;
+    }
+
+    try {
+      const interacted = await getIsInteractedBefore(from, to);
+      set(showNeverInteractedWarning, !interacted);
+    }
+    catch (error: unknown) {
+      set(showNeverInteractedWarning, false);
+      logger.error(error);
+    }
+  });
+
+  return { showNeverInteractedWarning: readonly(showNeverInteractedWarning) };
+}

--- a/frontend/app/src/modules/wallet/send/use-trade-wallet-actions.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-wallet-actions.spec.ts
@@ -1,0 +1,153 @@
+import type { EffectScope } from 'vue';
+import type { EnhancedProviderDetail } from '@/modules/wallet/providers/provider-detection';
+import { createMock } from '@test/utils/create-mock';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTradeWalletActions } from '@/modules/wallet/send/use-trade-wallet-actions';
+
+const connected = ref<boolean>(false);
+const connectWallet = vi.fn<() => Promise<void>>();
+const disconnectWallet = vi.fn<() => Promise<void>>();
+const sendTransaction = vi.fn<() => Promise<string>>();
+const handleProviderSelection = vi.fn<
+  (provider: unknown, onError: (message: string) => void) => Promise<void>
+>();
+
+vi.mock('@/modules/wallet/use-wallet-store', () => ({
+  useWalletStore: vi.fn(() => ({
+    connect: connectWallet,
+    connected,
+    disconnect: disconnectWallet,
+    sendTransaction,
+  })),
+}));
+
+vi.mock('@/modules/wallet/providers/use-provider-selection', () => ({
+  useProviderSelection: vi.fn(() => ({ handleProviderSelection })),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const PARAMS = {
+  amount: '1',
+  assetIdentifier: 'ETH',
+  chain: 'ethereum',
+  native: true,
+  to: '0x9531C059098e3d194fF87FebB587aB07B30B1306',
+};
+
+describe('useTradeWalletActions', () => {
+  let scope: EffectScope;
+
+  function create(): ReturnType<typeof useTradeWalletActions> {
+    scope = effectScope();
+    const result = scope.run(() => useTradeWalletActions());
+    assert(result);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(connected, false);
+    connectWallet.mockResolvedValue();
+    disconnectWallet.mockResolvedValue();
+    sendTransaction.mockResolvedValue('0xhash');
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  it('should report a failed connection', async () => {
+    connectWallet.mockRejectedValue(new Error('no provider found'));
+    const { connect, errorMessage } = create();
+
+    await connect();
+
+    expect(get(errorMessage)).toBe('no provider found');
+  });
+
+  it('should report a failed disconnection', async () => {
+    disconnectWallet.mockRejectedValue(new Error('still busy'));
+    const { disconnect, errorMessage } = create();
+
+    await disconnect();
+
+    expect(get(errorMessage)).toBe('still busy');
+  });
+
+  it('should clear a previous error on the next attempt', async () => {
+    connectWallet.mockRejectedValueOnce(new Error('no provider found'));
+    const { connect, errorMessage } = create();
+    await connect();
+    expect(get(errorMessage)).toBe('no provider found');
+
+    await connect();
+
+    expect(get(errorMessage)).toBe('');
+  });
+
+  it('should connect when disconnected and disconnect when connected', async () => {
+    const { toggleConnection } = create();
+
+    await toggleConnection();
+    expect(connectWallet).toHaveBeenCalledOnce();
+    expect(disconnectWallet).not.toHaveBeenCalled();
+
+    set(connected, true);
+    await toggleConnection();
+
+    expect(disconnectWallet).toHaveBeenCalledOnce();
+  });
+
+  it('should report a sent transaction so the form can be cleared', async () => {
+    const { errorMessage, send } = create();
+
+    const sent = await send(PARAMS);
+
+    expect(sent).toBe(true);
+    expect(sendTransaction).toHaveBeenCalledWith(PARAMS);
+    expect(get(errorMessage)).toBe('');
+  });
+
+  it('should not report a failed transaction as sent', async () => {
+    sendTransaction.mockRejectedValue(new Error('insufficient funds'));
+    const { errorMessage, send } = create();
+
+    const sent = await send(PARAMS);
+
+    expect(sent).toBe(false);
+    expect(get(errorMessage)).toBe('insufficient funds');
+  });
+
+  it('should name a user rejection rather than call it a wallet error', async () => {
+    sendTransaction.mockRejectedValue(new Error('User rejected the request.'));
+    const { errorMessage, send } = create();
+
+    await send(PARAMS);
+
+    expect(get(errorMessage)).toBe('trade.errors.rejected');
+  });
+
+  it('should surface a provider selection failure', async () => {
+    handleProviderSelection.mockImplementation(async (_provider, onError) => {
+      onError('that provider is unavailable');
+    });
+    const { errorMessage, selectProvider } = create();
+
+    await selectProvider(createMock<EnhancedProviderDetail>());
+
+    expect(get(errorMessage)).toBe('that provider is unavailable');
+  });
+
+  it('should clear the error on request', async () => {
+    connectWallet.mockRejectedValue(new Error('no provider found'));
+    const { clearError, connect, errorMessage } = create();
+    await connect();
+
+    clearError();
+
+    expect(get(errorMessage)).toBe('');
+  });
+});

--- a/frontend/app/src/modules/wallet/send/use-trade-wallet-actions.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-wallet-actions.ts
@@ -1,0 +1,99 @@
+import type { Ref } from 'vue';
+import type { EnhancedProviderDetail } from '@/modules/wallet/providers/provider-detection';
+import type { TransactionParams } from '@/modules/wallet/types';
+import { logger } from '@/modules/core/common/logging/logging';
+import { getWalletErrorMessage, isUserRejectedError } from '@/modules/wallet/constants';
+import { useProviderSelection } from '@/modules/wallet/providers/use-provider-selection';
+import { useWalletStore } from '@/modules/wallet/use-wallet-store';
+
+interface UseTradeWalletActionsReturn {
+  readonly errorMessage: Readonly<Ref<string>>;
+  readonly clearError: () => void;
+  readonly connect: () => Promise<void>;
+  readonly disconnect: () => Promise<void>;
+  readonly toggleConnection: () => Promise<void>;
+  readonly send: (params: TransactionParams) => Promise<boolean>;
+  readonly selectProvider: (provider: EnhancedProviderDetail) => Promise<void>;
+}
+
+/**
+ * The wallet operations a send can trigger, each funnelling its failure into one message the card
+ * shows. A user-rejected transaction is reported as a rejection rather than as a wallet error,
+ * since it is a choice and not a fault.
+ */
+export function useTradeWalletActions(): UseTradeWalletActionsReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const errorMessage = shallowRef<string>('');
+
+  function clearError(): void {
+    set(errorMessage, '');
+  }
+
+  const walletStore = useWalletStore();
+  const { connected } = storeToRefs(walletStore);
+  const { connect: connectWallet, disconnect: disconnectWallet, sendTransaction } = walletStore;
+  const { handleProviderSelection } = useProviderSelection();
+
+  /** Runs a wallet call, reporting any failure through {@link errorMessage}. */
+  async function guarded(action: () => Promise<void>): Promise<boolean> {
+    try {
+      clearError();
+      await action();
+      return true;
+    }
+    catch (error: unknown) {
+      logger.error(error);
+      set(errorMessage, getWalletErrorMessage(error));
+      return false;
+    }
+  }
+
+  async function connect(): Promise<void> {
+    await guarded(async () => {
+      await connectWallet();
+    });
+  }
+
+  async function disconnect(): Promise<void> {
+    await guarded(async () => {
+      await disconnectWallet();
+    });
+  }
+
+  async function toggleConnection(): Promise<void> {
+    if (get(connected))
+      await disconnect();
+    else
+      await connect();
+  }
+
+  /** Resolves to whether the transaction was accepted, so the caller can clear the form. */
+  async function send(params: TransactionParams): Promise<boolean> {
+    try {
+      clearError();
+      await sendTransaction(params);
+      return true;
+    }
+    catch (error: unknown) {
+      set(errorMessage, isUserRejectedError(error) ? t('trade.errors.rejected') : getWalletErrorMessage(error));
+      return false;
+    }
+  }
+
+  async function selectProvider(provider: EnhancedProviderDetail): Promise<void> {
+    await handleProviderSelection(provider, (message) => {
+      set(errorMessage, message);
+    });
+  }
+
+  return {
+    clearError,
+    connect,
+    disconnect,
+    errorMessage: readonly(errorMessage),
+    selectProvider,
+    send,
+    toggleConnection,
+  };
+}


### PR DESCRIPTION
Part of #11252. The coverage plan's top two targets: the two largest untested SFCs. Both held a lot of logic inline, so the extraction comes first and the tests follow.

## IndexerOrderSetting.vue — 291 → 53 script lines
Extracted into `evm-indexer-utils.ts`, `use-evm-indexer-order.ts` and `use-setting-write-feedback.ts`.

The first spec pass only exercised add-chain and the read/derive side, which left the component reading as 80% covered while `removeChain`, `updateDefaultOrder`, `updateChainOrder` and `navigateToApiKeys` were all at zero. Those reorder/remove paths are the feature, so the spec now covers all four: 95.6% lines on the component, 100% on the composable.

Behaviour change, deliberate: blockscout's api key is now read reactively via `useApiKey`, the same way etherscan's already was.

## TradeSendCard.vue — 361 → 162 script lines
Four unrelated concerns split out:

- `trade-send-utils.ts` — the amount/recipient validity rules and the balance-minus-gas max
- `use-trade-gas-estimation.ts` — the estimate, its AbortController, and the guards that keep a late answer off a newer selection
- `use-trade-asset-balance.ts` — the balance query, its stale-response guard, the sendable max
- `use-trade-wallet-actions.ts` — connect/disconnect/send
- `use-trade-recipient-warning.ts` — the never-interacted-before lookup

The SFC is left with wiring, back under the 20-import ceiling it was over. A separate component spec covers what the composables can't reach: which action button renders per wallet state, the two warning alerts, the send/track/switch-network handlers and the error alert.

Behaviour change, deliberate: a user-rejected transaction reported a hardcoded English string; it is now `trade.errors.rejected`.

## Coverage
Full run green: 878 files, 8810 tests. Lines 60.32% → 61.14%.

## Not fixed here
`use-trade-gas-estimation.ts` keeps a pre-existing bug verbatim: the `finally` clears `estimatingGas` and drops the controller even when a newer estimation is already in flight, so a fast selection change can kill the spinner early. Moving it out makes it testable; worth a follow-up.