### PR TITLE
chore: bump @rotki/ui-library to 2.23.5

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.5.1
       version: 1.5.1
     '@rotki/ui-library':
-      specifier: 2.23.4
-      version: 2.23.4
+      specifier: 2.23.5
+      version: 2.23.5
     '@tsconfig/node24':
       specifier: 24.0.4
       version: 24.0.4
@@ -345,7 +345,7 @@ importers:
         version: link:../common
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.23.4(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+        version: 2.23.5(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -2183,8 +2183,8 @@ packages:
     peerDependencies:
       eslint: ^9.20.0 || ^10.0.0
 
-  '@rotki/ui-library@2.23.4':
-    resolution: {integrity: sha512-TE2AT//RknlAO7Sw1EqzRiPZMElCIJXRCtR8jis8IAo45ol7JFI9gRIYe+TWZyQZ+SlGPPZaVO0vHh22z81Zlw==}
+  '@rotki/ui-library@2.23.5':
+    resolution: {integrity: sha512-a4Rji4O9lSE1GZbWOCNI5Icf2mvawfqvCy9Yz11C2Xu9er1lnS1A58uoL8BYrOhCqs0y8G9p5CyJs1jTSf5F+w==}
     engines: {node: '>=24 <25', pnpm: '>=11 <12'}
     peerDependencies:
       dayjs: '>=1.11.13 <12'
@@ -7905,7 +7905,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@2.23.4(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
+  '@rotki/ui-library@2.23.5(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
   '@playwright/test': 1.62.1
   '@rotki/eslint-config': 7.0.0
   '@rotki/eslint-plugin': 1.5.1
-  '@rotki/ui-library': 2.23.4
+  '@rotki/ui-library': 2.23.5
   '@tsconfig/node24': 24.0.4
   '@types/node': 24.13.3
   '@types/qrcode': 1.5.6


### PR DESCRIPTION
Bumps the `@rotki/ui-library` catalog entry in `frontend/pnpm-workspace.yaml` from 2.23.4 to 2.23.5.

### What this picks up

- **data-table honours an empty `#item.expand` slot** (rotki/ui-library#576). Since ui-library 2.22.0 the data-table cell fell back to rendering the library's own expand toggle whenever the consumer's `#item.expand` slot rendered nothing. Vue treats an all-comment slot as empty, so the `v-if="isRowExpandable(row)"` gate we use was a no-op: every row got an expander, and the ones that had no breakdown opened an empty white panel. Reported against the dashboard asset table (OCEAN, an ERC20 at a single address).
- **auto-complete keeps a value set before its options arrive** (rotki/ui-library#577).

### Verification

Ran against a local dev instance with real balances:

- `pnpm run typecheck` clean, `pnpm run test:unit` green (877 files, 8802 tests).
- Dashboard asset table: 14 rows, 3 expanders, all owned by `DashboardAssetTable`, none by `RuiDataTableCell`. OCEAN no longer renders an expander. (`RuiTableRowExpander` is an alias export of `RuiExpandButton`, so app and library expanders are indistinguishable by name or DOM; they were told apart via the owning component on the vnode.)

### Not covered by this bump

`AssetDetailsLayout`'s `hasBreakdown` requires a non-empty breakdown, while `isRowExpandable` / `shouldShowRowExpander` still return true for any native token, so ETH with a single protocol and no breakdown can still show an expander over an empty panel. That is a separate issue on this side and did not reproduce on the account used here (its ETH has a genuine four-location breakdown).