### PR TITLE
Map a model form's state, and retire refOptional

### DIFF
--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.spec.ts
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.spec.ts
@@ -224,6 +224,75 @@ describe('managedAssetForm', () => {
     expect(messages('symbol-input')).toEqual(['already taken']);
   });
 
+  // The form edits its own state and the dialog saves what it reads off the model, so an edit that
+  // never reaches the model is an edit that never gets persisted. Before the fields bound to
+  // `form.state` this direction was the one thing nothing here covered.
+  describe('writing back to the model', () => {
+    function lastModel(): SupportedAsset {
+      const emitted = wrapper.emitted<[SupportedAsset]>('update:modelValue');
+      const last = emitted?.at(-1);
+      assert(last);
+      return last[0];
+    }
+
+    it('should carry a typed name into the model', async () => {
+      wrapper = createWrapper();
+      await vi.advanceTimersToNextTimerAsync();
+
+      field('name-input').vm.$emit('update:modelValue', 'Circle USD');
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(lastModel().name).toBe('Circle USD');
+    });
+
+    it('should not report an edit the form never made', async () => {
+      wrapper = createWrapper();
+      await vi.advanceTimersToNextTimerAsync();
+
+      // The negative control for the test above: opening the form is not an edit, so a passing
+      // assertion there cannot be the model simply echoing what it was seeded with.
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+      expect(wrapper.emitted('update:stateUpdated')).toBeUndefined();
+    });
+
+    it('should keep a cleared optional field empty rather than absent', async () => {
+      wrapper = createWrapper();
+      await vi.advanceTimersToNextTimerAsync();
+
+      // The state holds '' rather than clearing the key, and `buildManagedAssetPayload` is what
+      // turns it back into an absent field. Clearing it here must not produce null.
+      field('symbol-input').vm.$emit('update:modelValue', '');
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(lastModel().symbol).toBe('');
+    });
+
+    it('should flag the dialog once a field is edited', async () => {
+      wrapper = createWrapper();
+      await vi.advanceTimersToNextTimerAsync();
+
+      field('symbol-input').vm.$emit('update:modelValue', 'USDC2');
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(wrapper.emitted<[boolean]>('update:stateUpdated')?.at(-1)).toEqual([true]);
+    });
+
+    it('should re-derive which fields apply from the edited type', async () => {
+      wrapper = createWrapper();
+      await vi.advanceTimersToNextTimerAsync();
+
+      // The chain select belongs to an evm token alone, and the rules that ask for an address read
+      // the same answer, so this is what proves the kind follows the state the fields write into.
+      expect(field('chain-select').exists()).toBe(true);
+
+      field('type-select').vm.$emit('update:modelValue', CUSTOM_ASSET);
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(lastModel().assetType).toBe(CUSTOM_ASSET);
+      expect(wrapper.find('[data-testid=chain-select]').exists()).toBe(false);
+    });
+  });
+
   it('should clear the server errors when the asset type changes', async () => {
     const errorMessages: ValidationErrors = { symbol: ['already taken'] };
     wrapper = createWrapper(evmToken(), { errorMessages });

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.vue
@@ -6,7 +6,11 @@ import ChainDisplay from '@/modules/accounts/blockchain/ChainDisplay.vue';
 import { decimalsTextModel, startedEpochModel } from '@/modules/assets/admin/asset-field-models';
 import AssetIconForm from '@/modules/assets/admin/AssetIconForm.vue';
 import { toAssetTypeOptions, useAssetKind } from '@/modules/assets/admin/managed/asset-kind';
-import { managedAssetSchema } from '@/modules/assets/admin/managed/managed-asset-form';
+import {
+  type ManagedAssetFormState,
+  managedAssetSchema,
+  toManagedAssetFormState,
+} from '@/modules/assets/admin/managed/managed-asset-form';
 import ManagedAssetOracleFields from '@/modules/assets/admin/managed/ManagedAssetOracleFields.vue';
 import { useManagedAssetErrors } from '@/modules/assets/admin/managed/use-managed-asset-errors';
 import { useManagedAssetSave } from '@/modules/assets/admin/managed/use-managed-asset-save';
@@ -14,8 +18,7 @@ import { useManagedTokenLookup } from '@/modules/assets/admin/managed/use-manage
 import UnderlyingTokenManager from '@/modules/assets/admin/UnderlyingTokenManager.vue';
 import { evmTokenKindsData, solanaTokenKindsData } from '@/modules/core/common/chains';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { refOptional, useRefPropVModel } from '@/modules/core/common/validation/model';
-import { useModelForm } from '@/modules/core/form/use-model-form';
+import { useMappedModelForm } from '@/modules/core/form/use-model-form';
 import CopyButton from '@/modules/shell/components/CopyButton.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
 import DateTimePicker from '@/modules/shell/components/inputs/DateTimePicker.vue';
@@ -30,46 +33,17 @@ const { editMode = false, assetTypes } = defineProps<{
   assetTypes: string[];
 }>();
 
+const { t } = useI18n({ useScope: 'global' });
+
 const underlyingTokens = ref<UnderlyingToken[]>([]);
 const assetIconFormRef = useTemplateRef<InstanceType<typeof AssetIconForm>>('assetIconFormRef');
 
-const identifier = computed<string>(() => get(modelValue).identifier);
-const address = refOptional(useRefPropVModel(modelValue, 'address'), '');
-const name = refOptional(useRefPropVModel(modelValue, 'name'), '');
-const symbol = refOptional(useRefPropVModel(modelValue, 'symbol'), '');
-const decimals = useRefPropVModel(modelValue, 'decimals');
-const coingecko = refOptional(useRefPropVModel(modelValue, 'coingecko'), '');
-const cryptocompare = refOptional(useRefPropVModel(modelValue, 'cryptocompare'), '');
-const assetType = useRefPropVModel(modelValue, 'assetType');
-const evmChain = useRefPropVModel(modelValue, 'evmChain');
-const tokenKind = useRefPropVModel(modelValue, 'tokenKind');
-const protocol = refOptional(useRefPropVModel(modelValue, 'protocol'), '');
-const swappedFor = refOptional(useRefPropVModel(modelValue, 'swappedFor'), '');
-const forked = refOptional(useRefPropVModel(modelValue, 'forked'), '');
-const isRebasing = refOptional(useRefPropVModel(modelValue, 'isRebasing'), false);
-const started = useRefPropVModel(modelValue, 'started');
-const collectibleId = refOptional(useRefPropVModel(modelValue, 'collectibleId'), '');
-
-const startedModel = startedEpochModel(started);
-const decimalsModel = decimalsTextModel(decimals);
-
-const { t } = useI18n({ useScope: 'global' });
 const { allEvmChains } = useSupportedChains();
 
-const { saveAsset } = useManagedAssetSave({
-  asset: modelValue,
-  editMode: () => editMode,
-  underlyingTokens,
-});
-
-const { clearFields } = useManagedAssetErrors(errors, assetType);
-
-const { fetching, refreshTokenData, suppressNextLookup } = useManagedTokenLookup({
-  address,
-  asset: modelValue,
-  evmChain,
-  onFilled: clearFields,
-});
+// Read off the payload rather than the form state below, which keeps this side of the form free of
+// the state it has not created yet. Every edit is mirrored into the payload on a pre-flush watcher,
+// so what these answer is current by the time anything renders or validates.
+const identifier = computed<string>(() => get(modelValue).identifier);
 
 const {
   isEvmToken,
@@ -77,7 +51,15 @@ const {
   isNft,
   isSolanaToken,
   requiresAddress: isTokenRequiresAddress,
-} = useAssetKind(assetType, tokenKind);
+} = useAssetKind(() => get(modelValue).assetType, () => get(modelValue).tokenKind);
+
+const { saveAsset } = useManagedAssetSave({
+  asset: modelValue,
+  editMode: () => editMode,
+  underlyingTokens,
+});
+
+const { clearFields } = useManagedAssetErrors(errors, () => get(modelValue).assetType);
 
 const schema = computed<ZodType>(() => managedAssetSchema({
   addressInvalid: t('asset_form.validation.valid_address'),
@@ -89,11 +71,27 @@ const schema = computed<ZodType>(() => managedAssetSchema({
   requiresAddress: get(isTokenRequiresAddress),
 }));
 
-const form = useModelForm<SupportedAsset>({
+// The inputs bind into `form.state` directly. Mapping the optional text fields to a string once,
+// here, is what saves every one of them a writable computed of its own.
+const form = useMappedModelForm<SupportedAsset, ManagedAssetFormState>({
   model: modelValue,
   schema,
   serverErrors: errors,
   stateUpdated,
+  toModel: (state, asset): SupportedAsset => ({ ...asset, ...state }),
+  toState: toManagedAssetFormState,
+});
+
+const startedModel = startedEpochModel(toRef(form.state, 'started'));
+const decimalsModel = decimalsTextModel(toRef(form.state, 'decimals'));
+
+// The lookup writes what it found into the payload, which the mirroring brings back into the state,
+// so a filled-in name lands in the input the same way a typed one does.
+const { fetching, refreshTokenData, suppressNextLookup } = useManagedTokenLookup({
+  address: () => form.state.address,
+  asset: modelValue,
+  evmChain: () => get(modelValue).evmChain,
+  onFilled: clearFields,
 });
 
 function saveIcon(identifier: string) {
@@ -147,7 +145,7 @@ defineExpose({
         data-testid="type-select"
       >
         <RuiMenuSelect
-          v-model="assetType"
+          v-model="form.state.assetType"
           :label="t('asset_form.labels.asset_type')"
           :options="types"
           :disabled="types.length === 1 || editMode"
@@ -161,7 +159,7 @@ defineExpose({
       <template v-if="isEvmToken">
         <div data-testid="chain-select">
           <RuiAutoComplete
-            v-model="evmChain"
+            v-model="form.state.evmChain"
             :label="t('asset_form.labels.chain')"
             :options="allEvmChains"
             :disabled="editMode"
@@ -188,7 +186,7 @@ defineExpose({
 
         <div data-testid="token-select">
           <RuiMenuSelect
-            v-model="tokenKind"
+            v-model="form.state.tokenKind"
             :label="t('asset_form.labels.token_kind')"
             :options="evmTokenKindsData"
             :disabled="editMode"
@@ -203,7 +201,7 @@ defineExpose({
           data-testid="address-input"
         >
           <RuiTextField
-            v-model="address"
+            v-model="form.state.address"
             class="flex-1"
             variant="outlined"
             color="primary"
@@ -230,7 +228,7 @@ defineExpose({
 
           <RuiTextField
             v-if="isNft"
-            v-model="collectibleId"
+            v-model="form.state.collectibleId"
             data-testid="collectible-id-input"
             class="sm:w-1/4"
             variant="outlined"
@@ -249,7 +247,7 @@ defineExpose({
           data-testid="token-select"
         >
           <RuiMenuSelect
-            v-model="tokenKind"
+            v-model="form.state.tokenKind"
             :label="t('asset_form.labels.token_kind')"
             :options="solanaTokenKindsData"
             :disabled="editMode"
@@ -264,7 +262,7 @@ defineExpose({
           data-testid="address-input"
         >
           <RuiTextField
-            v-model="address"
+            v-model="form.state.address"
             variant="outlined"
             color="primary"
             :loading="fetching"
@@ -282,7 +280,7 @@ defineExpose({
         data-testid="address-input"
       >
         <RuiTextField
-          v-model="address"
+          v-model="form.state.address"
           variant="outlined"
           color="primary"
           :error-messages="form.errors('address')"
@@ -294,7 +292,7 @@ defineExpose({
 
       <div class="col-span-2 grid md:grid-cols-2 lg:grid-cols-4 gap-x-4 gap-y-3">
         <RuiTextField
-          v-model="name"
+          v-model="form.state.name"
           data-testid="name-input"
           class="md:col-span-2"
           variant="outlined"
@@ -306,7 +304,7 @@ defineExpose({
         />
 
         <RuiTextField
-          v-model="symbol"
+          v-model="form.state.symbol"
           :class="isTokenRequiresAddress ? 'md:col-span-1' : 'md:col-span-2'"
           data-testid="symbol-input"
           variant="outlined"
@@ -334,8 +332,8 @@ defineExpose({
           />
         </div>
         <ManagedAssetOracleFields
-          v-model:coingecko="coingecko"
-          v-model:cryptocompare="cryptocompare"
+          v-model:coingecko="form.state.coingecko"
+          v-model:cryptocompare="form.state.cryptocompare"
           :coingecko-errors="form.errors('coingecko')"
           :cryptocompare-errors="form.errors('cryptocompare')"
           :disabled="loading"
@@ -370,7 +368,7 @@ defineExpose({
               <div class="grid md:grid-cols-2 gap-x-4 gap-y-2">
                 <RuiTextField
                   v-if="isEvmToken"
-                  v-model="protocol"
+                  v-model="form.state.protocol"
                   variant="outlined"
                   color="primary"
                   clearable
@@ -381,7 +379,7 @@ defineExpose({
                   @update:model-value="form.touch('protocol')"
                 />
                 <AssetSelect
-                  v-model="swappedFor"
+                  v-model="form.state.swappedFor"
                   variant="outlined"
                   clearable
                   :label="t('asset_form.labels.swapped_for')"
@@ -389,8 +387,8 @@ defineExpose({
                   :disabled="loading"
                 />
                 <AssetSelect
-                  v-if="!isEvmToken && assetType"
-                  v-model="forked"
+                  v-if="!isEvmToken && form.state.assetType"
+                  v-model="form.state.forked"
                   variant="outlined"
                   clearable
                   :label="t('asset_form.labels.forked')"
@@ -399,7 +397,7 @@ defineExpose({
                 />
                 <RuiSwitch
                   v-if="isEvmToken && !isNft"
-                  v-model="isRebasing"
+                  v-model="form.state.isRebasing"
                   class="md:col-span-2"
                   :disabled="loading"
                   :hint="t('asset_form.labels.rebasing_hint')"

--- a/frontend/app/src/modules/assets/admin/managed/managed-asset-form.spec.ts
+++ b/frontend/app/src/modules/assets/admin/managed/managed-asset-form.spec.ts
@@ -1,5 +1,6 @@
+import { EvmTokenKind, type SupportedAsset } from '@rotki/common';
 import { describe, expect, it } from 'vitest';
-import { managedAssetSchema } from '@/modules/assets/admin/managed/managed-asset-form';
+import { managedAssetSchema, toManagedAssetFormState } from '@/modules/assets/admin/managed/managed-asset-form';
 import { CUSTOM_ASSET, EVM_TOKEN, HYPERLIQUID_TOKEN, SOLANA_TOKEN } from '@/modules/assets/types';
 
 const messages = {
@@ -101,5 +102,57 @@ describe('managedAssetSchema', () => {
       .safeParse({ ...token, decimals: 6, underlyingTokens: [] });
 
     expect(result.success && result.data).toEqual({ ...token, decimals: 6, underlyingTokens: [] });
+  });
+});
+
+describe('toManagedAssetFormState', () => {
+  const asset: SupportedAsset = {
+    address: EVM_ADDRESS,
+    assetType: EVM_TOKEN,
+    identifier: 'test-asset',
+    isRebasing: false,
+  };
+
+  it('should open an unset optional field as an empty string', () => {
+    const state = toManagedAssetFormState(asset);
+
+    // The inputs need something to write into, and null is not it.
+    expect(state.name).toBe('');
+    expect(state.symbol).toBe('');
+    expect(state.coingecko).toBe('');
+    expect(state.collectibleId).toBe('');
+    expect(state.forked).toBe('');
+  });
+
+  it('should keep the value an optional field already has', () => {
+    const state = toManagedAssetFormState({ ...asset, name: 'USD Coin', protocol: 'aave' });
+
+    expect(state.name).toBe('USD Coin');
+    expect(state.protocol).toBe('aave');
+  });
+
+  it('should leave the fields with their own converters alone', () => {
+    // `decimals` and `started` keep the difference between unset and zero, which the payload
+    // records as null and their converters read on the way to the input.
+    const state = toManagedAssetFormState(asset);
+
+    expect(state.decimals).toBeUndefined();
+    expect(state.started).toBeUndefined();
+  });
+
+  it('should carry the rest of the payload through untouched', () => {
+    const state = toManagedAssetFormState({ ...asset, decimals: 6, ended: 42, tokenKind: EvmTokenKind.ERC20 });
+
+    expect(state.identifier).toBe('test-asset');
+    expect(state.decimals).toBe(6);
+    expect(state.ended).toBe(42);
+    expect(state.tokenKind).toBe(EvmTokenKind.ERC20);
+  });
+
+  // The mirroring in `useMappedModelForm` compares the mapped payload against the state to decide
+  // whether an outside edit is news. A mapper that answered differently for the same input would
+  // report every pass as a change and the two directions would never settle.
+  it('should answer the same for the same payload', () => {
+    expect(toManagedAssetFormState(asset)).toEqual(toManagedAssetFormState(asset));
   });
 });

--- a/frontend/app/src/modules/assets/admin/managed/managed-asset-form.ts
+++ b/frontend/app/src/modules/assets/admin/managed/managed-asset-form.ts
@@ -1,7 +1,56 @@
-import { isValidEthAddress, isValidHyperliquidTokenAddress, isValidSolanaAddress } from '@rotki/common';
+import { isValidEthAddress, isValidHyperliquidTokenAddress, isValidSolanaAddress, type SupportedAsset } from '@rotki/common';
 import { z, type ZodType } from 'zod';
 import { EVM_TOKEN, HYPERLIQUID_TOKEN, SOLANA_TOKEN } from '@/modules/assets/types';
 import { requiredField } from '@/modules/core/form/fields';
+
+/**
+ * The fields the payload admits as null and an input has to hold as a string.
+ *
+ * Not every nullable field is one of these: `decimals` and `started` are nullable too, and are
+ * bound through their own converters, which have a use for the difference between empty and zero.
+ */
+type OptionalTextField =
+  | 'address'
+  | 'coingecko'
+  | 'collectibleId'
+  | 'cryptocompare'
+  | 'forked'
+  | 'name'
+  | 'protocol'
+  | 'swappedFor'
+  | 'symbol';
+
+/**
+ * The asset as the form's inputs hold it: the optional text fields are always a string, empty where
+ * the payload has nothing.
+ *
+ * Derived from the payload rather than spelled out, so a field added to `SupportedAsset` reaches
+ * the form without anyone having to add it here too.
+ */
+export type ManagedAssetFormState =
+  Omit<SupportedAsset, OptionalTextField> & Record<OptionalTextField, string>;
+
+/**
+ * Widens the payload into what the inputs can bind to.
+ *
+ * The empty string survives as far as `buildManagedAssetPayload`, which is where it turns back into
+ * an absent field. That is deliberate: the api reads an absent field as "leave it alone" and an
+ * empty one as "clear it", and only the payload builder knows which of the two each field wants.
+ */
+export function toManagedAssetFormState(asset: SupportedAsset): ManagedAssetFormState {
+  return {
+    ...asset,
+    address: asset.address ?? '',
+    coingecko: asset.coingecko ?? '',
+    collectibleId: asset.collectibleId ?? '',
+    cryptocompare: asset.cryptocompare ?? '',
+    forked: asset.forked ?? '',
+    name: asset.name ?? '',
+    protocol: asset.protocol ?? '',
+    swappedFor: asset.swappedFor ?? '',
+    symbol: asset.symbol ?? '',
+  };
+}
 
 export interface ManagedAssetMessages {
   addressInvalid: string;

--- a/frontend/app/src/modules/core/common/validation/model.spec.ts
+++ b/frontend/app/src/modules/core/common/validation/model.spec.ts
@@ -1,14 +1,5 @@
-import type { WritableComputedRef } from 'vue';
 import { describe, expect, it } from 'vitest';
-import { refOptional, useRefPropVModel } from '@/modules/core/common/validation/model';
-
-function writable<T>(initial: T): WritableComputedRef<T> {
-  const state = shallowRef<T>(initial);
-  return computed<T>({
-    get: () => get(state),
-    set: (value: T) => set(state, value),
-  });
-}
+import { useRefPropVModel } from '@/modules/core/common/validation/model';
 
 describe('model-utils', () => {
   it('should properly map computed property to parent ref', () => {
@@ -23,20 +14,6 @@ describe('model-utils', () => {
     set(prop, 'newValue');
     expect(get(prop)).toBe('newValue');
     expect(get(objRef).value).toBe('newValue');
-  });
-});
-
-describe('refOptional', () => {
-  it('should fall back to the default value when null', () => {
-    const model = refOptional(writable<number | null | undefined>(null), 10);
-    expect(get(model)).toBe(10);
-  });
-
-  it('should store undefined when set to a nullish value', () => {
-    const source = writable<number | null | undefined>(3);
-    const model = refOptional(source, 10);
-    set(model, undefined);
-    expect(get(source)).toBeUndefined();
   });
 });
 

--- a/frontend/app/src/modules/core/common/validation/model.ts
+++ b/frontend/app/src/modules/core/common/validation/model.ts
@@ -1,16 +1,13 @@
 import type { Ref, WritableComputedRef } from 'vue';
 
-export function refOptional<T>(comp: WritableComputedRef<T | undefined | null>, defaultValue: T): WritableComputedRef<T> {
-  return computed<T>({
-    get() {
-      return get(comp) ?? defaultValue;
-    },
-    set(value?: T) {
-      set(comp, value ?? undefined);
-    },
-  });
-}
-
+/**
+ * One field of an object the parent owns, as a writable computed.
+ *
+ * For a component that holds a payload it does not own and has no form of its own: an account's
+ * chain, an accounting rule's value, a set of table toggles. A component that does have a form
+ * binds `form.state` directly instead, and one whose inputs cannot hold the payload as it stands
+ * maps it once with `useMappedModelForm` rather than wrapping each field here.
+ */
 export function useRefPropVModel<
   P extends object,
   K extends keyof P,

--- a/frontend/app/src/modules/core/form/use-model-form.spec.ts
+++ b/frontend/app/src/modules/core/form/use-model-form.spec.ts
@@ -1,9 +1,10 @@
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import type { FormApi } from '@/modules/core/form/use-form';
 import { startPromise } from '@shared/utils';
 import { describe, expect, it } from 'vitest';
-import { customRef, nextTick, type Ref, ref } from 'vue';
+import { customRef, nextTick, type Ref, ref, type UnwrapNestedRefs } from 'vue';
 import { z } from 'zod';
-import { useModelForm } from '@/modules/core/form/use-model-form';
+import { useMappedModelForm, useModelForm } from '@/modules/core/form/use-model-form';
 
 interface PriceState {
   fromAsset: string;
@@ -225,6 +226,117 @@ describe('useModelForm', () => {
       await nextTick();
 
       expect(form.errors('price')).toEqual([]);
+    });
+  });
+
+  describe('mapped state', () => {
+    /** The payload admits null where the input needs a string, which is the usual reason to map. */
+    interface PriceModel {
+      fromAsset: string;
+      price: string | null;
+      sourceType: string;
+      tags: string[] | null;
+    }
+
+    interface MappedOverrides {
+      model?: Ref<PriceModel>;
+      stateUpdated?: Ref<boolean>;
+    }
+
+    function baseMapped(): PriceModel {
+      return { fromAsset: 'ETH', price: null, sourceType: 'manual', tags: null };
+    }
+
+    function createMapped(overrides: MappedOverrides = {}): FormApi<PriceState, UnwrapNestedRefs<PriceState>> {
+      return useMappedModelForm<PriceModel, PriceState>({
+        model: overrides.model ?? ref<PriceModel>(baseMapped()),
+        schema: PriceSchema,
+        stateUpdated: overrides.stateUpdated,
+        toModel: (state, model): PriceModel => ({ ...model, ...state }),
+        // A new array every call on purpose: the mirroring has to notice that it holds the same
+        // values rather than that it is the same reference.
+        toState: (model): PriceState => ({
+          fromAsset: model.fromAsset,
+          price: model.price ?? '',
+          sourceType: model.sourceType,
+          tags: [...(model.tags ?? [])],
+        }),
+      });
+    }
+
+    it('should open on the mapped state rather than the payload', () => {
+      const form = createMapped();
+
+      expect(form.state.price).toBe('');
+      expect(form.state.tags).toEqual([]);
+    });
+
+    it('should write an edit back through the payload mapper', async () => {
+      const model = ref<PriceModel>(baseMapped());
+      const form = createMapped({ model });
+
+      form.state.price = '3000';
+      await nextTick();
+
+      expect(get(model).price).toBe('3000');
+    });
+
+    it('should leave the payload fields the state does not carry alone', async () => {
+      const model = ref<PriceModel>({ ...baseMapped(), fromAsset: 'BTC' });
+      const form = createMapped({ model });
+
+      form.state.price = '3000';
+      await nextTick();
+
+      // `toModel` is handed the payload precisely so a form editing part of one can fold over it.
+      expect(get(model).fromAsset).toBe('BTC');
+    });
+
+    it('should map an edit made outside the form on the way in', async () => {
+      const model = ref<PriceModel>(baseMapped());
+      const form = createMapped({ model });
+
+      set(model, { ...baseMapped(), price: null, sourceType: 'oracle' });
+      await nextTick();
+
+      expect(form.state.sourceType).toBe('oracle');
+      expect(form.state.price).toBe('');
+    });
+
+    /*
+     * Unlike the unmapped case above, this one does pin the equality guard rather than merely
+     * documenting it. `toState` answers with a new array every call, so without the comparison the
+     * mirroring would assign a fresh reference each pass, the write-back would answer with a fresh
+     * payload, and the two would trade writes until the test timed out.
+     */
+    it('should settle even though the mapper answers with a new object each time', async () => {
+      const model = ref<PriceModel>({ ...baseMapped(), tags: ['manual'] });
+      const form = createMapped({ model });
+
+      let writes = 0;
+      watch(model, () => {
+        writes += 1;
+      }, { deep: true });
+
+      form.state.price = '3000';
+      await nextTick();
+      await nextTick();
+      await nextTick();
+
+      expect(writes).toBe(1);
+      expect(form.state.price).toBe('3000');
+      expect(get(model).price).toBe('3000');
+      expect(form.state.tags).toEqual(['manual']);
+    });
+
+    it('should not read the mapping itself as an edit', async () => {
+      const stateUpdated = ref<boolean>(false);
+      const form = createMapped({ stateUpdated });
+      await nextTick();
+
+      // Opening on '' where the payload holds null is the mapper doing its job, not the user typing.
+      expect(get(form.dirty)).toBe(false);
+      expect(get(stateUpdated)).toBe(false);
     });
   });
 

--- a/frontend/app/src/modules/core/form/use-model-form.ts
+++ b/frontend/app/src/modules/core/form/use-model-form.ts
@@ -5,9 +5,7 @@ import { isEqual } from 'es-toolkit';
 import { toServerErrors } from '@/modules/core/form/server-errors';
 import { type FormApi, useForm } from '@/modules/core/form/use-form';
 
-export interface ModelFormOptions<TState extends object> {
-  /** The payload the parent dialog owns, saves, and reseeds. Edits are mirrored back into it. */
-  readonly model: Ref<TState>;
+interface SharedModelFormOptions<TState extends object> {
   /** The single validation source of truth. A getter for rules that depend on props. */
   readonly schema: MaybeRefOrGetter<ZodType>;
   /**
@@ -27,26 +25,59 @@ export interface ModelFormOptions<TState extends object> {
   readonly transientKeys?: readonly string[];
 }
 
+export interface ModelFormOptions<TState extends object> extends SharedModelFormOptions<TState> {
+  /** The payload the parent dialog owns, saves, and reseeds. Edits are mirrored back into it. */
+  readonly model: Ref<TState>;
+}
+
+export interface MappedModelFormOptions<
+  TModel extends object,
+  TState extends object,
+> extends SharedModelFormOptions<TState> {
+  /** The payload the parent dialog owns, saves, and reseeds. Edits are mirrored back into it. */
+  readonly model: Ref<TModel>;
+  /**
+   * The payload as the inputs need to hold it. Called for the opening state and again for every
+   * edit made outside the form.
+   *
+   * 🔴 It has to be stable: the same payload in must give a deep-equal state out. The mirroring
+   * below compares the two to decide whether an outside edit is news, and a mapper that invents a
+   * fresh value each call - a timestamp, a generated id - reports every pass as a change and the
+   * two directions then write to each other without settling.
+   */
+  readonly toState: (model: TModel) => TState;
+  /**
+   * The state as the payload wants it. Handed the payload the dialog is currently holding as well,
+   * so a form that edits part of a larger payload can fold its fields over it and leave the rest
+   * alone.
+   */
+  readonly toModel: (state: UnwrapNestedRefs<TState>, model: TModel) => TModel;
+}
+
 /**
- * A form whose state belongs to the dialog above it.
+ * A form whose state belongs to the dialog above it, and whose fields are shaped differently from
+ * the payload.
  *
- * These forms validate and edit, but never persist: the dialog reads the payload straight off the
- * model when its save button is pressed. That makes the model and the form state two copies of the
- * same data which have to be kept in step, which is the boilerplate this removes.
+ * The shapes disagree whenever the api's idea of a field is not the input's. A text input needs a
+ * string to write into where the payload admits null; a key is masked while it is not being edited;
+ * one payload field is edited through two inputs. Left to each field, that gap becomes a writable
+ * computed per input, wrapping and unwrapping the same value on every keystroke. Given here, it is
+ * two pure functions with the whole payload in view, which can be tested on their own.
  *
- * For a form that owns its own state and submits it, use `useForm` directly.
+ * For a form whose state is the payload, use `useModelForm`, which is this with both mappers set to
+ * a copy.
  */
-export function useModelForm<TState extends object>(
-  options: ModelFormOptions<TState>,
+export function useMappedModelForm<TModel extends object, TState extends object>(
+  options: MappedModelFormOptions<TModel, TState>,
 ): FormApi<TState, UnwrapNestedRefs<TState>> {
-  const { model, schema, seed, serverErrors, stateUpdated, transientKeys } = options;
+  const { model, schema, seed, serverErrors, stateUpdated, toModel, toState, transientKeys } = options;
 
   const form = useForm<TState, UnwrapNestedRefs<TState>>({
     // Seeded here rather than by the caller writing the model first: a write to the model is only
     // readable back on the next tick, so a caller doing it by hand takes its baseline from the
     // payload as it was before the write, and the seeding then counts as the first edit.
     initial: (): TState => {
-      const current = { ...get(model) };
+      const current = toState(get(model));
       return seed ? seed(current) : current;
     },
     schema,
@@ -58,17 +89,15 @@ export function useModelForm<TState extends object>(
 
   // Every edit is written back, because the dialog saves what it reads off the model, not what the
   // form holds.
-  // Spread over the current payload rather than the state alone: it keeps the result typed as the
-  // payload, which the reactive state is not, without an assertion to bridge the two.
   watch(() => form.state, (state) => {
-    set(model, { ...get(model), ...state });
+    set(model, toModel(state, get(model)));
   }, { deep: true });
 
   if (seed) {
     // The dialog saves what it reads off the model, so the opening state has to land there too. It
     // is not readable back on this tick, which is why the sync below skips its immediate run: the
     // state is already the newer of the two, and reading the model now would undo the seeding.
-    set(model, { ...get(model), ...form.state });
+    set(model, toModel(form.state, get(model)));
   }
 
   if (serverErrors) {
@@ -80,15 +109,16 @@ export function useModelForm<TState extends object>(
   // And an edit made outside the form - a reset, a different row seeded while it stays mounted - is
   // pulled back in.
   //
-  // The equality guard is defence, not the thing that makes this terminate: measured, the echo dies
-  // on its own, because the copy above is shallow, so both sides end up holding the same nested
-  // references and assigning them back is not a reactive change. That argument stops holding the
-  // day the copy deep-clones, and the failure mode then is an endless update loop, so the guard
-  // stays. `syncRef` handles the same problem by pausing the opposing watcher, but it needs two
-  // refs and a sync flush, and this state is reactive and watched deep.
+  // 🔴 The equality guard is what makes this terminate. `toState` answers with a new object every
+  // time, so assigning it back unconditionally would count as a change even when nothing moved, and
+  // the write-back above would then answer that with a new payload, forever. Comparing first means
+  // a pass that found nothing new stops here. `syncRef` handles the same problem by pausing the
+  // opposing watcher, but it needs two refs of one type and a sync flush, and these two are neither
+  // the same shape nor plain refs.
   watch(model, (value) => {
-    if (!isEqual(value, form.state))
-      Object.assign(form.state, value);
+    const next = toState(value);
+    if (!isEqual(next, form.state))
+      Object.assign(form.state, next);
   }, { deep: true, immediate: !seed });
 
   if (stateUpdated) {
@@ -97,4 +127,26 @@ export function useModelForm<TState extends object>(
   }
 
   return form;
+}
+
+/**
+ * A form whose state belongs to the dialog above it.
+ *
+ * These forms validate and edit, but never persist: the dialog reads the payload straight off the
+ * model when its save button is pressed. That makes the model and the form state two copies of the
+ * same data which have to be kept in step, which is the boilerplate this removes.
+ *
+ * For a form that owns its own state and submits it, use `useForm` directly. For one whose inputs
+ * cannot hold the payload as it stands, use `useMappedModelForm`.
+ */
+export function useModelForm<TState extends object>(
+  options: ModelFormOptions<TState>,
+): FormApi<TState, UnwrapNestedRefs<TState>> {
+  return useMappedModelForm<TState, TState>({
+    ...options,
+    // Spread over the current payload rather than the state alone: it keeps the result typed as the
+    // payload, which the reactive state is not, without an assertion to bridge the two.
+    toModel: (state, model): TState => ({ ...model, ...state }),
+    toState: (model): TState => ({ ...model }),
+  });
 }

--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -6,9 +6,7 @@ import { useConnectedExchangesStore } from '@/modules/balances/exchanges/use-con
 import { type ExchangeFormData, GateLocation, KrakenAccountType, OkxLocation } from '@/modules/balances/types/exchanges';
 import { useLocationStore } from '@/modules/core/common/use-location-store';
 import { useLocations } from '@/modules/core/common/use-locations';
-import { refOptional, useRefPropVModel } from '@/modules/core/common/validation/model';
-import { toServerErrors } from '@/modules/core/form/server-errors';
-import { useForm } from '@/modules/core/form/use-form';
+import { useMappedModelForm } from '@/modules/core/form/use-model-form';
 import BinancePairsSelector from '@/modules/settings/api-keys/BinancePairsSelector.vue';
 import BinanceHistoryStartDate from '@/modules/settings/api-keys/exchange/BinanceHistoryStartDate.vue';
 import {
@@ -69,18 +67,41 @@ const showBinanceHistoryImport = computed<boolean>(() => {
   return showsBinanceHistoryImport(location, mode);
 });
 
-const nameProp = useRefPropVModel(modelValue, 'name');
-const newNameProp = useRefPropVModel(modelValue, 'newName');
-const apiKey = useRefPropVModel(modelValue, 'apiKey');
-const apiSecret = useRefPropVModel(modelValue, 'apiSecret', {
-  transform(value) {
-    return normalizeApiSecret(get(location), value);
+/**
+ * The dialog owns the entry, so the form mirrors it: the inputs write `form.state`, and every edit
+ * is folded back over the entry the dialog is about to save.
+ */
+const form = useMappedModelForm<ExchangeFormData, ExchangeKeysFormState>({
+  model: modelValue,
+  schema: computed(() => exchangeKeysSchema({
+    capabilities: get(capabilities),
+    editingFutures: get(editFuturesKeys),
+    editingKeys: get(editKeys),
+    location: get(location),
+    mode: get(modelValue).mode,
+  })),
+  serverErrors: errorMessages,
+  stateUpdated,
+  toModel: (state, entry): ExchangeFormData => ({ ...entry, ...state }),
+  toState: toExchangeKeysFormState,
+});
+
+// Coinbase pastes its secret with literal `\n`. Normalised as it is written rather than on the way
+// to the entry, so the field shows what will actually be sent instead of correcting itself a tick
+// after the paste.
+const apiSecret = computed<string>({
+  get: () => form.state.apiSecret,
+  set: (value: string) => {
+    form.state.apiSecret = normalizeApiSecret(get(location), value);
   },
 });
 
 const asteriskPlaceholder = '*'.repeat(30);
 
-function createRefWithAsterisk(comp: WritableComputedRef<string>, editFlag: Ref<boolean>): WritableComputedRef<string> {
+function createRefWithAsterisk(
+  comp: Ref<string> | WritableComputedRef<string>,
+  editFlag: Ref<boolean>,
+): WritableComputedRef<string> {
   return computed({
     get() {
       if (get(editMode) && !get(editFlag)) {
@@ -103,36 +124,36 @@ function createSensitiveInputComponent(editFlag: Ref<boolean>) {
   });
 }
 
-const apiKeyModel = createRefWithAsterisk(apiKey, editKeys);
+const apiKeyModel = createRefWithAsterisk(toRef(form.state, 'apiKey'), editKeys);
 const apiSecretModel = createRefWithAsterisk(apiSecret, editKeys);
 const sensitiveInputComponent = createSensitiveInputComponent(editKeys);
 
-const passphrase = useRefPropVModel(modelValue, 'passphrase');
-const krakenAccountType = useRefPropVModel(modelValue, 'krakenAccountType');
-const krakenFuturesApiKey = useRefPropVModel(modelValue, 'krakenFuturesApiKey');
-const krakenFuturesApiSecret = useRefPropVModel(modelValue, 'krakenFuturesApiSecret');
-const binanceHistoryStartTs = useRefPropVModel(modelValue, 'binanceHistoryStartTs');
-const gateLocation = useRefPropVModel(modelValue, 'gateLocation');
-const okxLocation = useRefPropVModel(modelValue, 'okxLocation');
-
+// An edit renames the connection through a second field, so that the name it is currently stored
+// under stays readable while the new one is being typed.
 const name = computed<string>({
   get() {
-    return get(editMode) ? (get(newNameProp) || '') : get(nameProp);
+    return get(editMode) ? (form.state.newName ?? '') : form.state.name;
   },
-  set(value?: string) {
+  set(value: string) {
     if (get(editMode)) {
-      set(newNameProp, value);
+      form.state.newName = value;
     }
     else {
-      set(nameProp, value);
+      form.state.name = value;
     }
   },
 });
 
-const binanceHistoryStartTsModel = refOptional(
-  binanceHistoryStartTs,
-  Math.floor(Date.now() / 1000),
-);
+// Captured once rather than read per call: the picker opens on "now" for an entry that has no start
+// date yet, and a default that moved on every read would make the form look edited by itself.
+const defaultHistoryStart = Math.floor(Date.now() / 1000);
+
+const binanceHistoryStartTsModel = computed<number>({
+  get: () => form.state.binanceHistoryStartTs ?? defaultHistoryStart,
+  set: (value: number) => {
+    form.state.binanceHistoryStartTs = value;
+  },
+});
 
 function suggestedName(exchange: string): string {
   const location = getLocationData(exchange);
@@ -143,12 +164,10 @@ function suggestedName(exchange: string): string {
 function toggleEdit() {
   set(editKeys, !get(editKeys));
 
+  // Backing out of a key replacement drops whatever was typed, so the stored pair stands.
   if (!get(editKeys)) {
-    set(modelValue, {
-      ...get(modelValue),
-      apiKey: '',
-      apiSecret: '',
-    });
+    form.state.apiKey = '';
+    form.state.apiSecret = '';
   }
 }
 
@@ -187,36 +206,6 @@ const okxLocations = OkxLocation.options.map(item => ({
   identifier: item,
   label: t(OKX_LOCATION_KEYS[item]),
 }));
-
-/**
- * The dialog owns the entry, so the form mirrors it rather than holding its own copy: the fields
- * keep writing where they always did, and the rules always read what is on screen.
- */
-const form = useForm<ExchangeKeysFormState, ExchangeKeysFormState>({
-  initial: (): ExchangeKeysFormState => toExchangeKeysFormState(get(modelValue)),
-  schema: computed(() => exchangeKeysSchema({
-    capabilities: get(capabilities),
-    editingFutures: get(editFuturesKeys),
-    editingKeys: get(editKeys),
-    location: get(location),
-    mode: get(modelValue).mode,
-  })),
-  // The dialog persists; there is nothing to submit from here.
-  submit: async (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
-  transform: (state): ExchangeKeysFormState => ({ ...state }),
-});
-
-watchDeep(modelValue, (value) => {
-  Object.assign(form.state, toExchangeKeysFormState(value));
-});
-
-watch(errorMessages, (value) => {
-  form.setServerErrors(toServerErrors(value));
-}, { deep: true, immediate: true });
-
-watch(form.dirty, (dirty) => {
-  set(stateUpdated, dirty);
-});
 
 // The dialog keeps its prompt-on-close flag across opens, so hand it back disarmed.
 onUnmounted(() => {
@@ -312,7 +301,7 @@ defineExpose({
 
     <RuiMenuSelect
       v-if="isKraken"
-      v-model="krakenAccountType"
+      v-model="form.state.krakenAccountType"
       data-testid="account-type"
       :options="krakenAccountTypes"
       :label="t('exchange_settings.inputs.kraken_account')"
@@ -323,7 +312,7 @@ defineExpose({
 
     <RuiMenuSelect
       v-if="isGate"
-      v-model="gateLocation"
+      v-model="form.state.gateLocation"
       data-testid="gate-location"
       :options="gateLocations"
       :label="t('exchange_keys_form.region')"
@@ -347,7 +336,7 @@ defineExpose({
 
     <RuiMenuSelect
       v-if="isOkx"
-      v-model="okxLocation"
+      v-model="form.state.okxLocation"
       data-testid="okx-location"
       :options="okxLocations"
       :label="t('exchange_keys_form.region')"
@@ -438,7 +427,7 @@ defineExpose({
         <Component
           :is="sensitiveInputComponent"
           v-if="requiresPassphrase"
-          v-model.trim="passphrase"
+          v-model.trim="form.state.passphrase"
           :disabled="editMode && !editKeys"
           variant="outlined"
           color="primary"
@@ -486,8 +475,8 @@ defineExpose({
     </RuiAlert>
     <KrakenFuturesKeys
       v-if="isKraken"
-      v-model:api-key="krakenFuturesApiKey"
-      v-model:api-secret="krakenFuturesApiSecret"
+      v-model:api-key="form.state.krakenFuturesApiKey"
+      v-model:api-secret="form.state.krakenFuturesApiSecret"
       v-model:editing="editFuturesKeys"
       :edit-mode="editMode"
       :key-errors="form.errors('krakenFuturesApiKey')"
@@ -499,7 +488,7 @@ defineExpose({
       :edit="editMode"
       :location="modelValue.location"
       :error-messages="form.errors('binanceMarkets')"
-      @update:selection="modelValue = { ...modelValue, binanceMarkets: $event }"
+      @update:selection="form.state.binanceMarkets = $event"
     />
   </div>
 

--- a/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-form.ts
+++ b/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-form.ts
@@ -1,5 +1,6 @@
 import { z, type ZodType } from 'zod';
 import { type MessageKey, msg } from '@/message-key';
+import { GateLocation, KrakenAccountType, OkxLocation } from '@/modules/balances/types/exchanges';
 
 /**
  * Which fields the exchange key form demands, and which parts of it render, is decided entirely by
@@ -85,44 +86,44 @@ export function acceptsSensitiveEdit(mode: string, editing: boolean): boolean {
   return !isEditing(mode) || editing;
 }
 
-/** The fields the form validates. The rest of the entry is carried but never rejected. */
+/**
+ * The fields the form's inputs bind to. The rest of the entry — the location, the mode — is carried
+ * by the entry itself and never edited here.
+ *
+ * The three enum-typed fields keep the entry's own types rather than widening to `string`, so the
+ * state can be folded back over the entry without anything having to re-narrow it.
+ */
 export interface ExchangeKeysFormState {
   apiKey: string;
   apiSecret: string;
   binanceHistoryStartTs?: number;
   binanceMarkets?: string[];
-  gateLocation?: string;
+  gateLocation?: GateLocation;
+  krakenAccountType?: KrakenAccountType;
   krakenFuturesApiKey?: string;
   krakenFuturesApiSecret?: string;
   name: string;
   newName?: string;
-  okxLocation?: string;
+  okxLocation?: OkxLocation;
   passphrase?: string;
 }
 
 /**
- * The validated fields, taken out of the entry the dialog owns. The entry carries more than this —
- * the location, the mode, the kraken account type — none of which can be wrong on its own.
+ * The editable fields, taken out of the entry the dialog owns. The entry carries more than this —
+ * the location and the mode — which the form reads but never writes.
+ *
+ * 🔴 It has to answer the same for the same entry: `useMappedModelForm` compares what this returns
+ * against the state it already holds to decide whether an outside edit is news, so a value invented
+ * here would report every pass as a change and the two directions would never settle.
  */
-export function toExchangeKeysFormState(entry: {
-  apiKey: string;
-  apiSecret: string;
-  binanceHistoryStartTs?: number;
-  binanceMarkets?: string[];
-  gateLocation?: string;
-  krakenFuturesApiKey?: string;
-  krakenFuturesApiSecret?: string;
-  name: string;
-  newName?: string;
-  okxLocation?: string;
-  passphrase?: string;
-}): ExchangeKeysFormState {
+export function toExchangeKeysFormState(entry: ExchangeKeysFormState): ExchangeKeysFormState {
   return {
     apiKey: entry.apiKey,
     apiSecret: entry.apiSecret,
     binanceHistoryStartTs: entry.binanceHistoryStartTs,
     binanceMarkets: entry.binanceMarkets,
     gateLocation: entry.gateLocation,
+    krakenAccountType: entry.krakenAccountType,
     krakenFuturesApiKey: entry.krakenFuturesApiKey,
     krakenFuturesApiSecret: entry.krakenFuturesApiSecret,
     name: entry.name,
@@ -175,12 +176,15 @@ export function exchangeKeysSchema(context: ExchangeKeysContext): ZodType<Exchan
     apiSecret: z.string(),
     binanceHistoryStartTs: z.number().optional(),
     binanceMarkets: z.array(z.string()).optional(),
-    gateLocation: z.string().optional(),
+    // The three region/tier fields take their own enums rather than a bare string: none of them
+    // carries a rule, but naming the type here is what lets the state fold back over the entry.
+    gateLocation: GateLocation.optional(),
+    krakenAccountType: KrakenAccountType.optional(),
     krakenFuturesApiKey: z.string().optional(),
     krakenFuturesApiSecret: z.string().optional(),
     name: z.string(),
     newName: z.string().optional(),
-    okxLocation: z.string().optional(),
+    okxLocation: OkxLocation.optional(),
     passphrase: z.string().optional(),
   }).superRefine((state, ctx) => {
     const demand = (required: boolean, path: keyof ExchangeKeysFormState, message: MessageKey): void => {


### PR DESCRIPTION
Follow-up to #12933. Takes the two forms that held their data twice, and removes the wrapper they leaned on.

### The problem

Both `ManagedAssetForm` and `ExchangeKeysForm` held two copies of the same data: `form.state`, and a writable computed per field over the payload. A keystroke wrote the payload, a watcher copied it into `form.state`, and `form.state` was then only read back for `form.errors(...)`.

They kept the wrappers because their inputs cannot hold the payload as it stands. A `RuiTextField` needs a `string` where `SupportedAsset` is nullish; a key is masked while it is not being edited. `useModelForm` required the state to *be* the payload, so there was nowhere to say that once, and it got said per field instead.

### The design

`useMappedModelForm` takes the two directions as pure functions:

```ts
useMappedModelForm<TModel, TState>({
  model,
  toState,  // the payload as the inputs need it
  toModel,  // the state, folded back over the payload the dialog holds
  ...
})
```

`useModelForm` becomes this with both mappers set to a copy, so the 24 components using it are untouched.

`ExchangeKeysForm` is the evidence that this is the right seam: it already had the whole shape hand-rolled — its own state type, `toExchangeKeysFormState`, and then `useForm` plus a watcher pulling one way while the fields wrote the other. It hands both directions over now, and three watchers go with them.

### What goes

- 28 `useRefPropVModel` calls across the two forms.
- `refOptional` entirely, and its module drops to just `useRefPropVModel`, whose remaining callers are components with no form at all that hold one field of a payload their parent owns. That is the case it was written for, so it stays.

### Two things worth a look

**The equality guard in the mirroring is now load-bearing, not defensive.** `toState` answers with a fresh object every call, so assigning it back unconditionally reads as a change even when nothing moved, and the two directions then trade writes until Vue's recursion limit. The old comment said the guard was belt-and-braces because the shallow copy shared nested references; that stops being true with a mapper. Pinned by a test with a mapper that rebuilds an array each call, checked to fail without the guard.

**Mappers have to be stable** — same payload in, deep-equal state out — for the same reason. That is why the binance start date keeps its "now" default as a value captured once in the component rather than moving into `toState`: a default read per call would report every pass as a change. Documented on both mappers.

`ExchangeKeysFormState`'s three region/tier fields now take the entry's own enums rather than a bare string, so the state folds back over the entry without re-narrowing. Neither carries a rule.

The coinbase secret is still normalised as it is written rather than on the way to the entry, so the field shows what will be sent instead of correcting itself a tick after the paste.

### Checks

`typecheck`, `lint` (0 errors), `knip`, and the full `test:unit` (877 files / 8824 tests) green. E2E `assets.spec.ts` + `api-keys.spec.ts` across two shards, 15 tests, all passed — those drive both forms end to end.

`ManagedAssetForm.spec.ts` covered validation only, so the direction this rewires — an edit reaching the model, which is what the dialog saves — had no coverage. Five cases added, including a negative control that opening the form emits no edit, each checked against a broken binding rather than assumed.
