### PR TITLE
fix(frontend): keep chain-keyed settings keyed by chain id

### DIFF
--- a/frontend/app/src/modules/core/api/constants.ts
+++ b/frontend/app/src/modules/core/api/constants.ts
@@ -11,6 +11,19 @@ export const TASKS_TIMEOUT = 90_000;
  */
 export const DOWNLOAD_TIMEOUT = 600_000;
 
+/**
+ * Response fields whose value is a map keyed by chain id rather than a record of fields.
+ *
+ * Passed as `skipCamelCaseKeys` so the response transformer leaves their contents as the backend
+ * sent them. It cannot tell a field name from a chain id, so otherwise it rewrites the ids:
+ * `polygon_pos` arrives as `polygonPos` while single-word ids like `base` are untouched, and every
+ * lookup by chain id then matches some entries and misses the rest.
+ *
+ * Named in their wire spelling, and shared, because these settings reach the app on more than one
+ * endpoint: a request that reads them without this gets its own mangled copy.
+ */
+export const CHAIN_KEYED_SETTINGS: string[] = ['disabled_chain_queries', 'evm_indexers_order'];
+
 /** Default maximum number of retry attempts after the initial request fails */
 export const DEFAULT_MAX_RETRIES = 2;
 

--- a/frontend/app/src/modules/core/api/response-handlers.ts
+++ b/frontend/app/src/modules/core/api/response-handlers.ts
@@ -5,6 +5,11 @@ import { HTTPStatus } from '@/modules/core/api/types/http';
 export interface ResponseParserOptions {
   skipCamelCase?: boolean;
   skipRootCamelCase?: boolean;
+  /**
+   * Fields whose nested object is left exactly as the backend sent it, for a value that is a map
+   * rather than a record of fields. The field's own key is still camelCased.
+   */
+  camelCaseSkipKeys?: string[];
 }
 
 /**
@@ -22,12 +27,12 @@ export function createResponseParser(
   if (options.skipRootCamelCase) {
     return (text: string): unknown => {
       const json = tryParseJson(text);
-      return json === null ? null : noRootCamelCaseTransformer(json);
+      return json === null ? null : noRootCamelCaseTransformer(json, options.camelCaseSkipKeys);
     };
   }
   return (text: string): unknown => {
     const json = tryParseJson(text);
-    return json === null ? null : camelCaseTransformer(json);
+    return json === null ? null : camelCaseTransformer(json, options.camelCaseSkipKeys);
   };
 }
 

--- a/frontend/app/src/modules/core/api/rotki-api.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.ts
@@ -158,9 +158,7 @@ export class RotkiApi {
     if (skipQueue)
       return this.fetchDirect<T>(url, restOptions);
 
-    const queue = restOptions.target === RequestTarget.COLIBRI
-      ? this._colibriRequestQueue
-      : this._requestQueue;
+    const queue = restOptions.target === RequestTarget.COLIBRI ? this._colibriRequestQueue : this._requestQueue;
 
     return queue.enqueue<T>(url, {
       ...restOptions,
@@ -236,6 +234,7 @@ export class RotkiApi {
       target,
       validStatuses,
       skipCamelCase,
+      skipCamelCaseKeys,
       skipRootCamelCase,
       skipSnakeCase,
       skipResultUnwrap,
@@ -261,7 +260,7 @@ export class RotkiApi {
         ignoreResponseError: true,
         body,
         query,
-        parseResponse: createResponseParser({ skipCamelCase, skipRootCamelCase }),
+        parseResponse: createResponseParser({ camelCaseSkipKeys: skipCamelCaseKeys, skipCamelCase, skipRootCamelCase }),
       }).finally(dispose);
 
       this.checkResponseStatus<T>(response, { validStatuses, skipAuthHandler });

--- a/frontend/app/src/modules/core/api/transformers.spec.ts
+++ b/frontend/app/src/modules/core/api/transformers.spec.ts
@@ -81,6 +81,20 @@ describe('transformers', () => {
     });
   });
 
+  it('should skip nested transformation for specified keys on the way in', () => {
+    const json = {
+      disabled_chain_queries: { base: [], binance_sc: [], polygon_pos: [] },
+      other_setting: { nested_key: 'test' },
+    };
+
+    const result = camelCaseTransformer(json, ['disabled_chain_queries']);
+
+    expect(result).toEqual({
+      disabledChainQueries: { base: [], binance_sc: [], polygon_pos: [] },
+      otherSetting: { nestedKey: 'test' },
+    });
+  });
+
   it('should handle transformer with no root', () => {
     const json = '{"_amount_": { "a_cbc": "1", "a_abc": "2"}}';
     const parsed = JSON.parse(json);

--- a/frontend/app/src/modules/core/api/transformers.ts
+++ b/frontend/app/src/modules/core/api/transformers.ts
@@ -69,12 +69,12 @@ export function snakeCaseTransformer<T>(data: T, skipKeys?: string[]): T {
   return convertKeys(data, { camelCase: false, skipKeys });
 }
 
-export function camelCaseTransformer<T>(data: T): T {
-  return convertKeys(data, { camelCase: true });
+export function camelCaseTransformer<T>(data: T, skipKeys?: string[]): T {
+  return convertKeys(data, { camelCase: true, skipKeys });
 }
 
-export function noRootCamelCaseTransformer<T>(data: T): T {
-  return convertKeys(data, { camelCase: true, skipRoot: true });
+export function noRootCamelCaseTransformer<T>(data: T, skipKeys?: string[]): T {
+  return convertKeys(data, { camelCase: true, skipKeys, skipRoot: true });
 }
 
 /**

--- a/frontend/app/src/modules/core/api/types.ts
+++ b/frontend/app/src/modules/core/api/types.ts
@@ -25,6 +25,15 @@ export interface RotkiFetchOptions<R extends ResponseType = 'json', T = unknown>
   skipCamelCase?: boolean;
   /** Use noRootCamelCaseTransformer instead of camelCaseTransformer (skips root keys transformation) */
   skipRootCamelCase?: boolean;
+  /**
+   * Response fields whose nested object must reach the caller exactly as the backend sent it.
+   *
+   * For a field that is a map (keyed by chain id, asset identifier, location) the camelCase
+   * conversion has no field names to rename and rewrites the data instead: `polygon_pos` becomes
+   * `polygonPos` while single-word keys like `base` are untouched, so a lookup by chain id matches
+   * some entries and misses the rest. The field's own key is still converted.
+   */
+  skipCamelCaseKeys?: string[];
   /** Skip snake_case transformation on request body/query. Can be boolean or array of property names to skip. */
   skipSnakeCase?: boolean | string[];
   /** Valid HTTP status codes. Defaults to [200, 400, 409]. 401 is always handled separately. */

--- a/frontend/app/src/modules/core/common/chains.ts
+++ b/frontend/app/src/modules/core/common/chains.ts
@@ -16,6 +16,19 @@ export function isBlockchain(chain: string): chain is Blockchain {
   return isBlockchainValue(chain);
 }
 
+/**
+ * The canonical, snake_case chain id, for keying or comparing chains that arrive from producers
+ * spelling them differently: `polygon_pos` in the app, `POLYGON_POS` over the websocket (the
+ * `SupportedBlockchain` value), `polygonPos` from anything that has been through the camelCase
+ * response transformer.
+ *
+ * Splits only on a lower-to-upper boundary, so an id that is already snake_case or upper snake is
+ * left intact and merely lower-cased.
+ */
+export function toChainKey(chain: string): string {
+  return chain.replace(/([a-z\d])([A-Z])/gu, '$1_$2').toLowerCase();
+}
+
 interface EvmTokenData {
   identifier: EvmTokenKind;
   label: string;

--- a/frontend/app/src/modules/core/tasks/use-task-api.spec.ts
+++ b/frontend/app/src/modules/core/tasks/use-task-api.spec.ts
@@ -92,6 +92,29 @@ describe('composables/api/task', () => {
       expect(result.message).toBe('');
     });
 
+    it('should keep chain-keyed settings keyed by the chain id', async () => {
+      // Login and account creation return the user's settings as a task result, so this fetch is
+      // the only place the exemption can be declared for them.
+      server.use(
+        http.get(`${backendUrl}/api/1/tasks/123`, () =>
+          HttpResponse.json({
+            result: {
+              outcome: {
+                result: { settings: { disabled_chain_queries: { base: [], polygon_pos: [] } } },
+                message: '',
+              },
+              status: 'completed',
+            },
+            message: '',
+          })),
+      );
+
+      const { queryTaskResult } = useTaskApi();
+      const result = await queryTaskResult<{ settings: { disabledChainQueries: Record<string, string[]> } }>(123);
+
+      expect(Object.keys(result.result.settings.disabledChainQueries).sort()).toStrictEqual(['base', 'polygon_pos']);
+    });
+
     it('should throw TaskNotFoundError on 404', async () => {
       server.use(
         http.get(`${backendUrl}/api/1/tasks/999`, () =>

--- a/frontend/app/src/modules/core/tasks/use-task-api.ts
+++ b/frontend/app/src/modules/core/tasks/use-task-api.ts
@@ -2,7 +2,7 @@ import type { ActionResult } from '@rotki/common';
 import { isEmpty } from 'es-toolkit/compat';
 import { ofetch } from 'ofetch';
 import { IncompleteUpgradeError, SyncConflictError, SyncConflictPayload } from '@/modules/auth/login';
-import { DEFAULT_TIMEOUT, TASKS_TIMEOUT } from '@/modules/core/api/constants';
+import { CHAIN_KEYED_SETTINGS, DEFAULT_TIMEOUT, TASKS_TIMEOUT } from '@/modules/core/api/constants';
 import { api } from '@/modules/core/api/rotki-api';
 import { camelCaseTransformer } from '@/modules/core/api/transformers';
 import { ApiKeyMissingError, ApiValidationError } from '@/modules/core/api/types/errors';
@@ -74,7 +74,11 @@ export function useTaskApi(): UseTaskApiReturn {
       baseURL: api.baseURL,
       timeout: TASKS_TIMEOUT,
       ignoreResponseError: true,
-      parseResponse: (text: string) => camelCaseTransformer(JSON.parse(text)),
+      // Declared here rather than on a request: login and account creation return the user's
+      // settings as a task result, and this is the one fetch every task result comes through, so
+      // there is no settings request to hang the exemption on. The named fields always carry a
+      // chain-keyed map, whichever task they arrive in.
+      parseResponse: (text: string) => camelCaseTransformer(JSON.parse(text), CHAIN_KEYED_SETTINGS),
     });
 
     const status = response.status;

--- a/frontend/app/src/modules/settings/api/use-settings-api.spec.ts
+++ b/frontend/app/src/modules/settings/api/use-settings-api.spec.ts
@@ -123,6 +123,24 @@ describe('composables/api/settings/settings-api', () => {
       expect(result.accounting.includeCrypto2crypto).toBe(true);
     });
 
+    it('should keep chain-keyed settings keyed by the chain id', async () => {
+      // The response transformer renames every key of every nested object, and these two settings
+      // are maps keyed by chain id rather than by field name. Multi-word ids are the ones it
+      // mangles (`polygon_pos` -> `polygonPos`), which left the skip rules for exactly those chains
+      // matching nothing while `base` kept working.
+      server.use(
+        http.get(`${backendUrl}/api/1/settings`, () => HttpResponse.json(createSettingsResponse({
+          disabled_chain_queries: { base: [], binance_sc: [], polygon_pos: [] },
+          evm_indexers_order: { polygon_pos: ['etherscan'] },
+        }))),
+      );
+
+      const { general } = await useSettingsApi().getSettings();
+
+      expect(Object.keys(general.disabledChainQueries).sort()).toStrictEqual(['base', 'binance_sc', 'polygon_pos']);
+      expect(general.evmIndexersOrder).toStrictEqual({ polygon_pos: ['etherscan'] });
+    });
+
     it('should throw error when result is null', async () => {
       server.use(
         http.get(`${backendUrl}/api/1/settings`, () =>
@@ -185,6 +203,18 @@ describe('composables/api/settings/settings-api', () => {
 
       // Verify response was transformed and parsed correctly
       expect(result.general.uiFloatingPrecision).toBe(4);
+    });
+
+    it('should keep chain-keyed settings keyed by the chain id', async () => {
+      server.use(
+        http.put(`${backendUrl}/api/1/settings`, () => HttpResponse.json(createSettingsResponse({
+          disabled_chain_queries: { base: [], polygon_pos: [] },
+        }))),
+      );
+
+      const { general } = await useSettingsApi().setSettings({ disabledChainQueries: { polygon_pos: [] } });
+
+      expect(Object.keys(general.disabledChainQueries).sort()).toStrictEqual(['base', 'polygon_pos']);
     });
 
     it('should throw ApiValidationError on 400 response', async () => {
@@ -259,6 +289,19 @@ describe('composables/api/settings/settings-api', () => {
       expect(result).toHaveProperty('uiFloatingPrecision');
       expect(result).not.toHaveProperty('general');
       expect(result).not.toHaveProperty('accounting');
+    });
+
+    it('should keep chain-keyed settings keyed by the chain id', async () => {
+      // The path a resumed session reads its settings on.
+      server.use(
+        http.get(`${backendUrl}/api/1/settings`, () => HttpResponse.json(createSettingsResponse({
+          disabled_chain_queries: { base: [], polygon_pos: [] },
+        }))),
+      );
+
+      const result = await useSettingsApi().getRawSettings();
+
+      expect(Object.keys(result.disabledChainQueries!).sort()).toStrictEqual(['base', 'polygon_pos']);
     });
   });
 

--- a/frontend/app/src/modules/settings/api/use-settings-api.ts
+++ b/frontend/app/src/modules/settings/api/use-settings-api.ts
@@ -1,4 +1,4 @@
-import { RequestTarget } from '@/modules/core/api/constants';
+import { CHAIN_KEYED_SETTINGS, RequestTarget } from '@/modules/core/api/constants';
 import { api } from '@/modules/core/api/rotki-api';
 import { VALID_WITH_SESSION_STATUS } from '@/modules/core/api/utils';
 import { type SettingsUpdate, UserSettingsModel } from '@/modules/settings/types/user-settings';
@@ -19,12 +19,14 @@ export function useSettingsApi(): UseSettingsApiReturn {
     const response = await api.put<UserSettingsModel>(
       '/settings',
       { settings },
+      { skipCamelCaseKeys: CHAIN_KEYED_SETTINGS },
     );
     return UserSettingsModel.parse(response);
   };
 
   const getSettings = async (): Promise<UserSettingsModel> => {
     const response = await api.get<UserSettingsModel>('/settings', {
+      skipCamelCaseKeys: CHAIN_KEYED_SETTINGS,
       validStatuses: VALID_WITH_SESSION_STATUS,
     });
 
@@ -32,6 +34,7 @@ export function useSettingsApi(): UseSettingsApiReturn {
   };
 
   const getRawSettings = async (): Promise<SettingsUpdate> => api.get<SettingsUpdate>('/settings', {
+    skipCamelCaseKeys: CHAIN_KEYED_SETTINGS,
     validStatuses: VALID_WITH_SESSION_STATUS,
   });
 

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.spec.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.spec.ts
@@ -37,6 +37,20 @@ describe('useDisabledChains', () => {
       setDisabled({ polygon_pos: [] });
       expect(composable.isChainExcluded('POLYGON_POS')).toBe(true);
     });
+
+    it('should match a camelCased key against the snake_case chain id', () => {
+      // `camelCaseTransformer` renames every key of the settings response, and this setting is a
+      // map keyed by chain id, so a multi-word id reaches us as `polygonPos`. Matching only on case
+      // left exactly those chains unfiltered while `base` and `scroll` worked.
+      setDisabled({ binanceSc: [], polygonPos: [] });
+      expect(composable.isChainExcluded('polygon_pos')).toBe(true);
+      expect(composable.isChainExcluded('binance_sc')).toBe(true);
+    });
+
+    it('should not match a different chain that shares a prefix', () => {
+      setDisabled({ polygonPos: [] });
+      expect(composable.isChainExcluded('polygon')).toBe(false);
+    });
   });
 
   describe('isAddressExcluded', () => {
@@ -61,6 +75,12 @@ describe('useDisabledChains', () => {
       // the websocket, so a case-only difference must not silently defeat the rule.
       setDisabled({ eth: [ETH_ADDRESS.toLowerCase()] });
       expect(composable.isAddressExcluded('eth', ETH_ADDRESS)).toBe(true);
+    });
+
+    it('should apply a camelCased key to the addresses of that chain', () => {
+      setDisabled({ zksyncLite: [ETH_ADDRESS] });
+      expect(composable.isAddressExcluded('zksync_lite', ETH_ADDRESS)).toBe(true);
+      expect(composable.isAddressExcluded('zksync_lite', OTHER_ETH_ADDRESS)).toBe(false);
     });
   });
 

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/use-disabled-chains.ts
@@ -1,4 +1,5 @@
 import { get } from '@vueuse/core';
+import { toChainKey } from '@/modules/core/common/chains';
 import { useSetting } from '@/modules/settings/use-setting';
 
 interface AccountLike {
@@ -30,8 +31,9 @@ export interface UseDisabledChainsReturn {
  * different parties: the rule comes from the settings dialog, while what it is matched against
  * arrives over the websocket. Addresses are the case that bites - nothing normalizes them on the
  * way in, so a checksummed address on the wire against a lower-cased one in the rule would silently
- * defeat a rule the user did set. Chains are already lower-cased by `useTxQueryStatusStore`, so
- * normalizing them here is only belt-and-braces for callers that do not.
+ * defeat a rule the user did set. Chains go through {@link toChainKey}, which also folds the
+ * separator, since the same chain is spelled `polygon_pos`, `POLYGON_POS` or `polygonPos`
+ * depending on who wrote it.
  *
  * No two distinct addresses differ only by case in any chain rotki supports, so folding case cannot
  * over-match.
@@ -42,14 +44,14 @@ export function useDisabledChains(): UseDisabledChainsReturn {
   const rules = computed<Record<string, Set<string>>>(() => {
     const entries = Object.entries(get(disabledChainQueries)).map(
       ([chain, addresses]): [string, Set<string>] => [
-        chain.toLowerCase(),
+        toChainKey(chain),
         new Set(addresses.map(address => address.toLowerCase())),
       ],
     );
     return Object.fromEntries(entries);
   });
 
-  const ruleFor = (chain: string): Set<string> | undefined => get(rules)[chain.toLowerCase()];
+  const ruleFor = (chain: string): Set<string> | undefined => get(rules)[toChainKey(chain)];
 
   const isChainExcluded = (chain: string): boolean => ruleFor(chain)?.size === 0;
 


### PR DESCRIPTION
## Problem

A "skip chain" rule was silently inert for `polygon_pos` and `binance_sc`, while the same rule worked for `base` and `scroll`.

`camelCaseTransformer` renames every key of every nested object in a response and cannot tell a field name from a data key. `disabled_chain_queries` and `evm_indexers_order` are maps keyed by chain id, so their keys get rewritten: `polygon_pos` arrives as `polygonPos`, `binance_sc` as `binanceSc`, while single-word ids pass through untouched.

Every consumer looks these up by chain id, so a rule for a multi-word chain matched nothing:

- the settings page still rendered every rule correctly, because that path resolves keys through `matchChain`, which strips separators;
- but `useDisabledChains` matched on case alone, so the runtime filters treated the chain as enabled;
- its accounts were therefore seeded into the sync panel and submitted, and the backend, which deserializes the setting correctly, dropped those chains before querying;
- no `TRANSACTION_STATUS` message is ever emitted for them, so the rows never reach a terminal state and the history sync indicator sits below complete, unable to dismiss.

Balance queries and token detection were also querying the skipped chains for the same reason.

## Fix

Avoid mangling the keys rather than converting them back.

- `camelCaseTransformer` / `noRootCamelCaseTransformer` accept `skipKeys`. The recursive implementation always supported it; only the response path could not reach it.
- `skipCamelCaseKeys?: string[]` on `RotkiFetchOptions`, threaded to `createResponseParser`, mirroring the request side's existing `skipSnakeCase`.
- `CHAIN_KEYED_SETTINGS` names the two fields once, applied on `getSettings`, `setSettings`, `getRawSettings` and on the shared task-result fetch. That last one cannot be scoped to a request: login and account creation return the settings as a task result, and every task result comes through one `parseResponse`.
- `toChainKey` in `modules/core/common/chains.ts`, used by `useDisabledChains` as a backstop, since the websocket sends the same chain as `POLYGON_POS`.

## Tests

Five tests, one per path the settings arrive on plus a transformer unit test. Each was negative-controlled: removing the fix reproduces the bug verbatim as `['base', 'binanceSc', 'polygonPos']`.

Full unit suite (8810 tests), typecheck and lint are green.

## Notes for the reviewer

Two things I deliberately left out of scope, both worth an opinion:

1. Nothing forces a *future* settings endpoint to pass the flag. Defaulting `CHAIN_KEYED_SETTINGS` inside `createResponseParser` would make it structural instead of remembered. Happy to add it here if preferred.
2. This class of bug is wider than settings, and the codebase already copes with it in four different ways: `isEvmIdentifier` is special-cased inside the transformer for asset ids, `use-balances-store.ts` indexes the mangled spelling on purpose (`perAccount[camelCase(chain)]`), the decoding store re-canonicalizes through `matchChain`, and now `skipCamelCaseKeys`. There are ~55 `z.record(...)` schemas. A single policy for map-valued fields would be the real fix, but that is a much bigger change than this bug warranted.

Separately, and not addressed here: a seeded address that never receives a terminal status pins the sync panel at `SYNCING` permanently, since `stopSyncing()` only flips a flag and nothing reconciles the rows. This PR removes one trigger, not the fragility.