### PR TITLE
refactor(frontend): extract the data issues panel logic and test it

### DIFF
--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.spec.ts
@@ -1,0 +1,244 @@
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { get, set } from '@vueuse/core';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { computed, type Ref, ref } from 'vue';
+import DataIssuePanelCard from '@/modules/history/data-issues/components/DataIssuePanelCard.vue';
+import DataIssuesPanelContent from '@/modules/history/data-issues/components/DataIssuesPanelContent.vue';
+import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
+
+interface MockState {
+  hasActiveSelection: boolean;
+  issues: DataIssue[];
+  loading: boolean;
+}
+
+const state = vi.hoisted((): MockState => ({
+  hasActiveSelection: false,
+  issues: [],
+  loading: false,
+}));
+
+const clearSelection = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const refreshList = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const reloadAll = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock('@/modules/history/data-issues/use-data-issues-panel-list', () => ({
+  useDataIssuesPanelList: (): Record<string, unknown> => ({
+    hasRemediatingRows: computed(() => false),
+    isEmpty: computed(() => state.issues.length === 0),
+    loading: computed(() => state.loading),
+    loadingMore: computed(() => false),
+    loadMore: vi.fn().mockResolvedValue(undefined),
+    refreshList,
+    reloadAll,
+    rows: computed(() => state.issues.map(issue => ({
+      description: { amounts: {}, messageKey: 'k', shortMessageKey: 'k' },
+      eventRoute: undefined,
+      issue,
+    }))),
+  }),
+}));
+
+vi.mock('@/modules/history/data-issues/use-data-issues-panel-selection', () => ({
+  useDataIssuesPanelSelection: (): Record<string, unknown> => ({
+    activeEventIdentifier: computed(() => undefined),
+    clearSelection,
+    goToEvent: vi.fn().mockResolvedValue(undefined),
+    hasActiveSelection: computed(() => state.hasActiveSelection),
+    isActiveRow: (): boolean => false,
+  }),
+}));
+
+vi.mock('@/modules/history/data-issues/use-data-issues-panel-polling', () => ({
+  useDataIssuesPanelPolling: vi.fn(),
+}));
+
+interface Actions {
+  modelDrawerOpen?: Ref<boolean>;
+  modelSelectedIssue?: Ref<DataIssue | undefined>;
+  onResolveRequest: Mock;
+}
+
+/** Filled in when the component mounts, so a test can drive the detail-action refs. */
+const actions = vi.hoisted((): Actions => ({ onResolveRequest: vi.fn() }));
+
+function mounted<T>(value: T | undefined): T {
+  if (value === undefined)
+    throw new Error('the component has not been mounted yet');
+  return value;
+}
+
+vi.mock('@/modules/history/data-issues/use-data-issue-detail-actions', () => ({
+  useDataIssueDetailActions: (): Record<string, unknown> => {
+    actions.modelDrawerOpen = ref<boolean>(false);
+    actions.modelSelectedIssue = ref<DataIssue>();
+    return {
+      modelActionBusy: ref(false),
+      modelDrawerOpen: actions.modelDrawerOpen,
+      modelResolveOpen: ref(false),
+      modelSelectedIssue: actions.modelSelectedIssue,
+      onDismiss: vi.fn(),
+      onResolveConfirm: vi.fn(),
+      onResolveRequest: actions.onResolveRequest,
+      onRetry: vi.fn(),
+      openDetail: vi.fn(),
+    };
+  },
+}));
+
+vi.mock('@/modules/history/data-issues/use-data-issue-fields', () => ({
+  useDataIssueFields: (): unknown[] => [],
+}));
+
+function createIssue(id: number): DataIssue {
+  return {
+    asset: 'ETH',
+    autoRemediationAttempts: [],
+    createdAt: 1710000100,
+    groupIdentifier: null,
+    id,
+    kind: IssueKind.NEGATIVE_BALANCE,
+    location: 'ethereum',
+    locationLabel: '0x0000000000000000000000000000000000000001',
+    payload: {},
+    protocol: null,
+    resolvedAt: null,
+    severity: IssueSeverity.WARNING,
+    state: IssueState.OPEN,
+    tsEnd: 1710000000,
+    tsStart: 1710000000,
+  };
+}
+
+async function createWrapper(): Promise<VueWrapper<InstanceType<typeof DataIssuesPanelContent>>> {
+  const wrapper = mount(DataIssuesPanelContent, {
+    global: {
+      plugins: [createPinia()],
+      stubs: {
+        DataIssueDetailContent: true,
+        DataIssuePanelCard: true,
+        PillFilterBar: true,
+        PinnedDetailSheet: true,
+        ResolveManuallyDialog: true,
+        RouterLink: { template: '<a><slot /></a>' },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('dataIssuesPanelContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+    state.hasActiveSelection = false;
+    state.issues = [];
+    state.loading = false;
+  });
+
+  it('should load the list and the summary on mount', async () => {
+    await createWrapper();
+
+    expect(reloadAll).toHaveBeenCalledOnce();
+  });
+
+  it('should show the all-clear shield when the inbox is empty and unfiltered', async () => {
+    const wrapper = await createWrapper();
+
+    expect(wrapper.text()).toContain('data_issues.empty.all_clear_title');
+    expect(wrapper.find('[data-testid=data-issues-panel-list]').exists()).toBe(false);
+  });
+
+  it('should show a spinner instead of the shield while the first load runs', async () => {
+    state.loading = true;
+    const wrapper = await createWrapper();
+
+    expect(wrapper.text()).not.toContain('data_issues.empty.all_clear_title');
+  });
+
+  // The list is virtualised, so the rendered card count reflects the window, not the
+  // issue count. Assert on the issue each card was handed instead.
+  it('should hand each rendered card its issue', async () => {
+    state.issues = [createIssue(1), createIssue(2), createIssue(3)];
+    const wrapper = await createWrapper();
+
+    expect(wrapper.find('[data-testid=data-issues-panel-list]').exists()).toBe(true);
+    const cards = wrapper.findAllComponents(DataIssuePanelCard);
+    expect(cards.length).toBeGreaterThan(0);
+    expect(cards.map(card => card.props('issue').id)).toStrictEqual(
+      state.issues.slice(0, cards.length).map(issue => issue.id),
+    );
+  });
+
+  it('should not show the all-clear shield once issues exist', async () => {
+    state.issues = [createIssue(1)];
+    const wrapper = await createWrapper();
+
+    expect(wrapper.text()).not.toContain('data_issues.empty.all_clear_title');
+  });
+
+  it('should hide the selection bar when no event is highlighted', async () => {
+    const wrapper = await createWrapper();
+
+    expect(wrapper.find('[data-testid=data-issues-panel-active-selection]').exists()).toBe(false);
+  });
+
+  it('should show the selection bar while an event is highlighted', async () => {
+    state.hasActiveSelection = true;
+    const wrapper = await createWrapper();
+
+    expect(wrapper.find('[data-testid=data-issues-panel-active-selection]').exists()).toBe(true);
+  });
+
+  it('should clear the highlight from the selection bar', async () => {
+    state.hasActiveSelection = true;
+    const wrapper = await createWrapper();
+
+    await wrapper.find('[data-testid=data-issues-panel-clear-selection]').trigger('click');
+
+    expect(clearSelection).toHaveBeenCalledOnce();
+  });
+
+  // The resolve dialog reads the selected issue, so a card-triggered resolve has to
+  // select before it opens, or it would resolve whatever was selected last.
+  it('should select the issue before opening the resolve dialog from a card', async () => {
+    state.issues = [createIssue(7)];
+    const wrapper = await createWrapper();
+
+    await wrapper.findComponent(DataIssuePanelCard).vm.$emit('resolve', createIssue(7));
+
+    expect(get(mounted(actions.modelSelectedIssue))?.id).toBe(7);
+    expect(actions.onResolveRequest).toHaveBeenCalledOnce();
+  });
+
+  it('should tell the host drawer when a stacked overlay opens', async () => {
+    const wrapper = await createWrapper();
+    expect(wrapper.props('subDialogOpen')).toBe(false);
+
+    set(mounted(actions.modelDrawerOpen), true);
+    await flushPromises();
+
+    expect(wrapper.emitted('update:subDialogOpen')?.at(-1)).toStrictEqual([true]);
+  });
+
+  it('should reload the list when the filters settle', async () => {
+    const wrapper = await createWrapper();
+    refreshList.mockClear();
+
+    wrapper.findComponent({ name: 'PillFilterBar' }).vm.$emit('update:matches', { asset: 'ETH' });
+    await vi.waitFor(() => {
+      expect(refreshList).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('should emit close when the view-all link is used', async () => {
+    const wrapper = await createWrapper();
+
+    await wrapper.find('[data-testid=data-issues-panel-view-all]').trigger('click');
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.vue
@@ -1,24 +1,20 @@
 <script setup lang="ts">
-import type { RouteLocationRaw } from 'vue-router';
-import type { FieldDef } from '@/modules/core/table/pill/core/types';
-import type { DataIssue, DataIssuesRequestPayload } from '@/modules/history/data-issues/schemas';
-import type { IssueDescription } from '@/modules/history/data-issues/types';
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import type { Filters } from '@/modules/history/data-issues/use-data-issues-filter';
 import { startPromise } from '@shared/utils';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import DataIssueDetailContent from '@/modules/history/data-issues/components/DataIssueDetailContent.vue';
 import DataIssuePanelCard from '@/modules/history/data-issues/components/DataIssuePanelCard.vue';
 import ResolveManuallyDialog from '@/modules/history/data-issues/components/ResolveManuallyDialog.vue';
-import { IssueState, NON_TERMINAL_STATES } from '@/modules/history/data-issues/constants';
-import { describeIssue, relatedEventRoute } from '@/modules/history/data-issues/transforms';
+import { panelFilterFields } from '@/modules/history/data-issues/data-issues-panel-utils';
 import { useDataIssueDetailActions } from '@/modules/history/data-issues/use-data-issue-detail-actions';
 import { useDataIssueFields } from '@/modules/history/data-issues/use-data-issue-fields';
-import { useDataIssues } from '@/modules/history/data-issues/use-data-issues';
-import { DataIssuesFilterKeys, type Filters } from '@/modules/history/data-issues/use-data-issues-filter';
-import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
-import { HighlightTargetTypes, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
+import { useDataIssuesPanelList } from '@/modules/history/data-issues/use-data-issues-panel-list';
+import { useDataIssuesPanelPolling } from '@/modules/history/data-issues/use-data-issues-panel-polling';
+import { useDataIssuesPanelSelection } from '@/modules/history/data-issues/use-data-issues-panel-selection';
+import { usePanelFilterEngagement } from '@/modules/history/data-issues/use-panel-filter-engagement';
 import PinnedDetailSheet from '@/modules/shell/pinned/PinnedDetailSheet.vue';
-import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
 
 /** Mirrors whether a stacked detail/resolve overlay is open, so the host drawer can stay stateless. */
 const subDialogOpen = defineModel<boolean>('subDialogOpen', { default: false });
@@ -29,112 +25,25 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const issues = ref<DataIssue[]>([]);
-const loading = ref<boolean>(false);
-
-const { fetchData } = useDataIssues();
-const { refreshSummary } = useDataIssuesSummary();
-
-// Reuse the full-page filter fields, but expose only the compact subset that fits the preview:
-// state, kind, asset and account. Keyed by wire key, which is what a field carries — the period
-// pill is left out because the preview is a glance at what needs attention now, not a search.
-const PANEL_FILTER_KEYS: readonly string[] = [
-  DataIssuesFilterKeys.STATE,
-  DataIssuesFilterKeys.KIND,
-  DataIssuesFilterKeys.ASSET,
-  DataIssuesFilterKeys.ACCOUNT,
-];
-const panelFields: FieldDef[] = useDataIssueFields()
-  .filter(field => PANEL_FILTER_KEYS.includes(field.key));
-const pillLabels = usePillBarLabels();
 const panelFilters = ref<Filters>({});
+
+const panelFields = panelFilterFields(useDataIssueFields());
+const pillLabels = usePillBarLabels();
 const hasPanelFilters = computed<boolean>(() => Object.keys(get(panelFilters)).length > 0);
 
-// The filter's suggestion dropdown is a RuiMenu teleported to <body>, so clicking a
-// suggestion (e.g. an asset) reads as a click outside the floating drawer and would
-// dismiss it. Keep the drawer stateless while the filter is engaged, and hold that
-// state for a short grace period after focus leaves so the trailing click on a
-// teleported suggestion (which fires after the input blurs) is still ignored.
 const filterWrapper = useTemplateRef<HTMLElement>('filterWrapper');
-const { focused: filterFocused } = useFocusWithin(filterWrapper);
-const filterEngaged = ref<boolean>(false);
-const { start: scheduleDisengage, stop: cancelDisengage } = useTimeoutFn(() => {
-  set(filterEngaged, false);
-}, 300, { immediate: false });
+const filterEngaged = usePanelFilterEngagement(filterWrapper);
 
-watch(filterFocused, (focused) => {
-  if (focused) {
-    cancelDisengage();
-    set(filterEngaged, true);
-  }
-  else {
-    scheduleDisengage();
-  }
-});
-
-// Filter values are typed `string | string[] | boolean`; these fields only ever
-// produce strings/arrays, so narrow to the shapes the request payload accepts.
-type FilterValue = string | string[] | boolean | undefined;
-
-function asMulti(value: FilterValue): string | string[] | undefined {
-  return value === undefined || typeof value === 'boolean' ? undefined : value;
-}
-
-function asSingle(value: FilterValue): string | undefined {
-  return typeof value === 'string' ? value : undefined;
-}
-
-// The panel is a glanceable inbox preview: it loads one page at a time and appends
-// more as the user scrolls, rather than mounting the entire (possibly 100+) list at
-// once (each card resolves an asset icon/avatar and runs observers).
-const PAGE_SIZE = 25;
-const offset = ref<number>(0);
-const total = ref<number>(0);
-const loadingMore = ref<boolean>(false);
-const canLoadMore = computed<boolean>(() => get(issues).length < get(total));
-
-function buildPayload(): DataIssuesRequestPayload {
-  const filters = get(panelFilters);
-  return {
-    asset: asSingle(filters.asset),
-    kind: asMulti(filters.kind),
-    limit: PAGE_SIZE,
-    locationLabel: asSingle(filters.locationLabel),
-    offset: get(offset),
-    state: asMulti(filters.state) ?? [...NON_TERMINAL_STATES],
-  };
-}
-
-async function loadList(append: boolean): Promise<void> {
-  const busy = append ? loadingMore : loading;
-  set(busy, true);
-  try {
-    const collection = await fetchData(buildPayload());
-    set(issues, append ? [...get(issues), ...collection.data] : collection.data);
-    set(total, collection.found);
-  }
-  finally {
-    set(busy, false);
-  }
-}
-
-/** Reloads from the first page, replacing the current list (on mount, filter change, refresh). */
-async function refreshList(): Promise<void> {
-  set(offset, 0);
-  await loadList(false);
-}
-
-/** Appends the next page; guarded so overlapping scroll events do not double-fetch. */
-async function loadMore(): Promise<void> {
-  if (get(loading) || get(loadingMore) || !get(canLoadMore))
-    return;
-  set(offset, get(offset) + PAGE_SIZE);
-  await loadList(true);
-}
-
-async function reloadAll(): Promise<void> {
-  await Promise.all([refreshList(), refreshSummary()]);
-}
+const {
+  hasRemediatingRows,
+  isEmpty,
+  loading,
+  loadingMore,
+  loadMore,
+  refreshList,
+  reloadAll,
+  rows,
+} = useDataIssuesPanelList(panelFilters);
 
 const {
   modelActionBusy,
@@ -148,62 +57,9 @@ const {
   openDetail,
 } = useDataIssueDetailActions(reloadAll);
 
-const isEmpty = computed<boolean>(() => get(issues).length === 0);
+const { clearSelection, goToEvent, hasActiveSelection, isActiveRow } = useDataIssuesPanelSelection();
 
-const hasRemediatingRows = computed<boolean>(() =>
-  get(issues).some(issue => issue.state === IssueState.AUTO_REMEDIATING));
-
-interface PanelRow {
-  issue: DataIssue;
-  description: IssueDescription;
-  eventRoute: RouteLocationRaw | undefined;
-}
-
-const rows = computed<PanelRow[]>(() => get(issues).map((issue) => {
-  const description = describeIssue(issue);
-  return {
-    description,
-    eventRoute: relatedEventRoute(issue.kind, description.eventIdentifier, issue.groupIdentifier, issue.asset),
-    issue,
-  };
-}));
-
-const router = useRouter();
-const route = useRoute();
-const { clearHighlightTarget } = useHistoryEventNavigation();
-const { syncCompleted } = useSyncCompleted();
-
-async function goToEvent(target: RouteLocationRaw): Promise<void> {
-  await router.push(target);
-}
-
-// The route query is the single source of truth for the highlighted history event,
-// so the "source" card mirrors it: the card whose event is currently highlighted is
-// shown as active. This stays in sync automatically when the highlight is cleared
-// from the events view (the card simply stops matching).
-const activeEventIdentifier = computed<number | undefined>(() => {
-  const raw = get(route).query.highlightedNegativeBalanceEvent;
-  const value = Number(Array.isArray(raw) ? raw[0] : raw);
-  return Number.isInteger(value) && value > 0 ? value : undefined;
-});
-
-const hasActiveSelection = computed<boolean>(() => get(activeEventIdentifier) !== undefined);
-
-function isActiveRow(row: PanelRow): boolean {
-  const identifier = row.description.eventIdentifier;
-  return identifier !== undefined && identifier === get(activeEventIdentifier);
-}
-
-// Clear the selection: strip the highlight query params (which un-highlights both the
-// history row and the source card) and drop the paging target so a later filter change
-// does not re-navigate to the stale event. Mirrors clearHighlight() in the movement
-// matching pinned panel.
-async function clearSelection(): Promise<void> {
-  clearHighlightTarget(HighlightTargetTypes.NEGATIVE_BALANCE);
-  const { highlightedNegativeBalanceEvent, targetGroupIdentifier, ...remainingQuery } = get(route).query;
-  if (highlightedNegativeBalanceEvent || targetGroupIdentifier)
-    await router.replace({ query: remainingQuery });
-}
+useDataIssuesPanelPolling(hasRemediatingRows, reloadAll);
 
 // Resolving needs the issue selected first (the resolve dialog reads the selected
 // issue), so a card-triggered resolve selects then opens the dialog.
@@ -211,46 +67,6 @@ function onResolveFromCard(issue: DataIssue): void {
   set(modelSelectedIssue, issue);
   onResolveRequest();
 }
-
-const { pause, resume } = useIntervalFn(reloadAll, 10_000, { immediate: false });
-
-// While the panel is backgrounded under <KeepAlive> its reactivity stays live, so
-// gate the poll and the sync-refetch on activation: a hidden inbox must not keep
-// hitting the network. Deferred sync refreshes are caught up once it is shown again.
-const active = ref<boolean>(true);
-const pendingRefresh = ref<boolean>(false);
-
-function syncPolling(): void {
-  if (get(active) && get(hasRemediatingRows))
-    resume();
-  else
-    pause();
-}
-
-watch(hasRemediatingRows, syncPolling);
-
-// Reload when the history sync finishes so the inbox reflects the freshly detected
-// issues (or the all-clear shield) without waiting for the slow poll or a manual refresh.
-watch(syncCompleted, () => {
-  if (get(active))
-    startPromise(reloadAll());
-  else
-    set(pendingRefresh, true);
-});
-
-onActivated(() => {
-  set(active, true);
-  syncPolling();
-  if (get(pendingRefresh)) {
-    set(pendingRefresh, false);
-    startPromise(reloadAll());
-  }
-});
-
-onDeactivated(() => {
-  set(active, false);
-  pause();
-});
 
 watch([modelDrawerOpen, modelResolveOpen, filterEngaged], ([drawer, resolve, filter]) => {
   set(subDialogOpen, drawer || resolve || filter);

--- a/frontend/app/src/modules/history/data-issues/data-issues-panel-utils.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/data-issues-panel-utils.spec.ts
@@ -1,0 +1,126 @@
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
+import { createMock } from '@test/utils/create-mock';
+import { describe, expect, it } from 'vitest';
+import { IssueKind, IssueState, NON_TERMINAL_STATES } from '@/modules/history/data-issues/constants';
+import {
+  asMulti,
+  asSingle,
+  buildPanelPayload,
+  PANEL_PAGE_SIZE,
+  panelFilterFields,
+} from '@/modules/history/data-issues/data-issues-panel-utils';
+import { DataIssuesFilterKeys } from '@/modules/history/data-issues/use-data-issues-filter';
+
+function field(key: string): FieldDef {
+  return createMock<FieldDef>({ key });
+}
+
+describe('panelFilterFields', () => {
+  it('should keep only the four fields that fit the preview', () => {
+    const fields = [
+      field(DataIssuesFilterKeys.STATE),
+      field(DataIssuesFilterKeys.KIND),
+      field(DataIssuesFilterKeys.ASSET),
+      field(DataIssuesFilterKeys.ACCOUNT),
+      field(DataIssuesFilterKeys.START),
+      field(DataIssuesFilterKeys.END),
+    ];
+
+    expect(panelFilterFields(fields).map(f => f.key)).toStrictEqual([
+      DataIssuesFilterKeys.STATE,
+      DataIssuesFilterKeys.KIND,
+      DataIssuesFilterKeys.ASSET,
+      DataIssuesFilterKeys.ACCOUNT,
+    ]);
+  });
+
+  it('should drop the period pills, which the preview does not offer', () => {
+    const keys = panelFilterFields([field(DataIssuesFilterKeys.START), field(DataIssuesFilterKeys.END)]);
+
+    expect(keys).toStrictEqual([]);
+  });
+
+  it('should preserve the order the caller supplied', () => {
+    const fields = [field(DataIssuesFilterKeys.ACCOUNT), field(DataIssuesFilterKeys.STATE)];
+
+    expect(panelFilterFields(fields).map(f => f.key)).toStrictEqual([
+      DataIssuesFilterKeys.ACCOUNT,
+      DataIssuesFilterKeys.STATE,
+    ]);
+  });
+});
+
+describe('asMulti', () => {
+  it('should pass a string through', () => {
+    expect(asMulti('ETH')).toBe('ETH');
+  });
+
+  it('should pass an array through', () => {
+    expect(asMulti(['a', 'b'])).toStrictEqual(['a', 'b']);
+  });
+
+  it('should drop a boolean, which the payload cannot carry', () => {
+    expect(asMulti(true)).toBeUndefined();
+    expect(asMulti(false)).toBeUndefined();
+  });
+
+  it('should drop undefined', () => {
+    expect(asMulti(undefined)).toBeUndefined();
+  });
+});
+
+describe('asSingle', () => {
+  it('should pass a string through', () => {
+    expect(asSingle('ETH')).toBe('ETH');
+  });
+
+  it('should drop an array, since the field takes one value', () => {
+    expect(asSingle(['a', 'b'])).toBeUndefined();
+  });
+
+  it('should drop a boolean and undefined', () => {
+    expect(asSingle(true)).toBeUndefined();
+    expect(asSingle(undefined)).toBeUndefined();
+  });
+});
+
+describe('buildPanelPayload', () => {
+  it('should default to the non-terminal states when no state filter is engaged', () => {
+    const payload = buildPanelPayload({}, 0);
+
+    expect(payload.state).toStrictEqual([...NON_TERMINAL_STATES]);
+  });
+
+  it('should not fall back once the user picks a state', () => {
+    const payload = buildPanelPayload({ state: [IssueState.RESOLVED] }, 0);
+
+    expect(payload.state).toStrictEqual([IssueState.RESOLVED]);
+  });
+
+  it('should carry the offset and a fixed page size', () => {
+    const payload = buildPanelPayload({}, 50);
+
+    expect(payload.offset).toBe(50);
+    expect(payload.limit).toBe(PANEL_PAGE_SIZE);
+  });
+
+  it('should map asset and account to single values and kind to a multi value', () => {
+    const payload = buildPanelPayload({
+      asset: 'ETH',
+      kind: [IssueKind.NEGATIVE_BALANCE, IssueKind.UNMATCHED_BRIDGE],
+      locationLabel: '0x01',
+    }, 0);
+
+    expect(payload.asset).toBe('ETH');
+    expect(payload.locationLabel).toBe('0x01');
+    expect(payload.kind).toStrictEqual([IssueKind.NEGATIVE_BALANCE, IssueKind.UNMATCHED_BRIDGE]);
+  });
+
+  it('should leave an unset filter off the payload rather than sending an empty value', () => {
+    const payload = buildPanelPayload({}, 0);
+
+    expect(payload.asset).toBeUndefined();
+    expect(payload.kind).toBeUndefined();
+    expect(payload.locationLabel).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/data-issues-panel-utils.ts
+++ b/frontend/app/src/modules/history/data-issues/data-issues-panel-utils.ts
@@ -1,0 +1,56 @@
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
+import type { DataIssuesRequestPayload } from '@/modules/history/data-issues/schemas';
+import { NON_TERMINAL_STATES } from '@/modules/history/data-issues/constants';
+import { DataIssuesFilterKeys, type Filters } from '@/modules/history/data-issues/use-data-issues-filter';
+
+/**
+ * The panel is a glanceable inbox preview: it loads one page at a time and appends
+ * more as the user scrolls, rather than mounting the entire (possibly 100+) list at
+ * once (each card resolves an asset icon/avatar and runs observers).
+ */
+export const PANEL_PAGE_SIZE = 25;
+
+/**
+ * The compact filter subset that fits the preview, keyed by wire key (which is what
+ * a field carries). The period pill is left out because the preview is a glance at
+ * what needs attention now, not a search.
+ */
+export const PANEL_FILTER_KEYS: readonly string[] = [
+  DataIssuesFilterKeys.STATE,
+  DataIssuesFilterKeys.KIND,
+  DataIssuesFilterKeys.ASSET,
+  DataIssuesFilterKeys.ACCOUNT,
+];
+
+/** Reuses the full-page filter fields, but exposes only the subset above. */
+export function panelFilterFields(fields: FieldDef[]): FieldDef[] {
+  return fields.filter(field => PANEL_FILTER_KEYS.includes(field.key));
+}
+
+// Filter values are typed `string | string[] | boolean`; these fields only ever
+// produce strings/arrays, so narrow to the shapes the request payload accepts.
+type FilterValue = string | string[] | boolean | undefined;
+
+export function asMulti(value: FilterValue): string | string[] | undefined {
+  return value === undefined || typeof value === 'boolean' ? undefined : value;
+}
+
+export function asSingle(value: FilterValue): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Builds the list request for a page of the panel. With no state filter engaged the
+ * panel falls back to the non-terminal states, so a resolved or dismissed issue never
+ * appears in the preview.
+ */
+export function buildPanelPayload(filters: Filters, offset: number): DataIssuesRequestPayload {
+  return {
+    asset: asSingle(filters.asset),
+    kind: asMulti(filters.kind),
+    limit: PANEL_PAGE_SIZE,
+    locationLabel: asSingle(filters.locationLabel),
+    offset,
+    state: asMulti(filters.state) ?? [...NON_TERMINAL_STATES],
+  };
+}

--- a/frontend/app/src/modules/history/data-issues/data-issues-panel-utils.ts
+++ b/frontend/app/src/modules/history/data-issues/data-issues-panel-utils.ts
@@ -15,7 +15,7 @@ export const PANEL_PAGE_SIZE = 25;
  * a field carries). The period pill is left out because the preview is a glance at
  * what needs attention now, not a search.
  */
-export const PANEL_FILTER_KEYS: readonly string[] = [
+const PANEL_FILTER_KEYS: readonly string[] = [
   DataIssuesFilterKeys.STATE,
   DataIssuesFilterKeys.KIND,
   DataIssuesFilterKeys.ASSET,

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-panel-list.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-panel-list.spec.ts
@@ -1,0 +1,222 @@
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import type { Filters } from '@/modules/history/data-issues/use-data-issues-filter';
+import { get, set } from '@vueuse/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
+import { PANEL_PAGE_SIZE } from '@/modules/history/data-issues/data-issues-panel-utils';
+import { useDataIssuesPanelList } from '@/modules/history/data-issues/use-data-issues-panel-list';
+
+const fetchData = vi.fn();
+const refreshSummary = vi.fn();
+
+vi.mock('@/modules/history/data-issues/use-data-issues', () => ({
+  useDataIssues: (): Record<string, unknown> => ({ fetchData }),
+}));
+
+vi.mock('@/modules/history/data-issues/use-data-issues-summary', () => ({
+  useDataIssuesSummary: (): Record<string, unknown> => ({ refreshSummary }),
+}));
+
+function createIssue(overrides: Partial<DataIssue> = {}): DataIssue {
+  return {
+    asset: 'ETH',
+    autoRemediationAttempts: [],
+    createdAt: 1710000100,
+    groupIdentifier: null,
+    id: 1,
+    kind: IssueKind.NEGATIVE_BALANCE,
+    location: 'ethereum',
+    locationLabel: '0x0000000000000000000000000000000000000001',
+    payload: {},
+    protocol: null,
+    resolvedAt: null,
+    severity: IssueSeverity.WARNING,
+    state: IssueState.OPEN,
+    tsEnd: 1710000000,
+    tsStart: 1710000000,
+    ...overrides,
+  };
+}
+
+/** A page of `count` issues out of `found` total, with ids offset so pages differ. */
+function page(count: number, found: number, startId = 1): { data: DataIssue[]; found: number; limit: number; total: number } {
+  return {
+    data: Array.from({ length: count }, (_, index) => createIssue({ id: startId + index })),
+    found,
+    limit: PANEL_PAGE_SIZE,
+    total: found,
+  };
+}
+
+describe('useDataIssuesPanelList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refreshSummary.mockResolvedValue(undefined);
+  });
+
+  it('should start empty before anything is loaded', () => {
+    const { isEmpty, rows } = useDataIssuesPanelList(ref<Filters>({}));
+
+    expect(get(rows)).toStrictEqual([]);
+    expect(get(isEmpty)).toBe(true);
+  });
+
+  it('should replace the list on refresh', async () => {
+    fetchData.mockResolvedValueOnce(page(2, 2));
+    const { isEmpty, refreshList, rows } = useDataIssuesPanelList(ref<Filters>({}));
+
+    await refreshList();
+
+    expect(get(rows)).toHaveLength(2);
+    expect(get(isEmpty)).toBe(false);
+  });
+
+  it('should request the current filters', async () => {
+    const filters = ref<Filters>({ asset: 'BTC' });
+    fetchData.mockResolvedValueOnce(page(1, 1));
+    const { refreshList } = useDataIssuesPanelList(filters);
+
+    await refreshList();
+
+    expect(fetchData).toHaveBeenCalledWith(expect.objectContaining({ asset: 'BTC', offset: 0 }));
+  });
+
+  it('should read the filters at request time, not at construction', async () => {
+    const filters = ref<Filters>({ asset: 'BTC' });
+    fetchData.mockResolvedValue(page(1, 1));
+    const { refreshList } = useDataIssuesPanelList(filters);
+
+    set(filters, { asset: 'ETH' });
+    await refreshList();
+
+    expect(fetchData).toHaveBeenLastCalledWith(expect.objectContaining({ asset: 'ETH' }));
+  });
+
+  it('should append the next page and advance the offset', async () => {
+    fetchData.mockResolvedValueOnce(page(PANEL_PAGE_SIZE, 40));
+    const { loadMore, refreshList, rows } = useDataIssuesPanelList(ref<Filters>({}));
+    await refreshList();
+
+    fetchData.mockResolvedValueOnce(page(15, 40, 100));
+    await loadMore();
+
+    expect(fetchData).toHaveBeenLastCalledWith(expect.objectContaining({ offset: PANEL_PAGE_SIZE }));
+    expect(get(rows)).toHaveLength(40);
+  });
+
+  it('should not fetch more once everything is loaded', async () => {
+    fetchData.mockResolvedValueOnce(page(2, 2));
+    const { loadMore, refreshList } = useDataIssuesPanelList(ref<Filters>({}));
+    await refreshList();
+    fetchData.mockClear();
+
+    await loadMore();
+
+    expect(fetchData).not.toHaveBeenCalled();
+  });
+
+  it('should reset the offset back to the first page on refresh', async () => {
+    fetchData.mockResolvedValueOnce(page(PANEL_PAGE_SIZE, 40));
+    const { loadMore, refreshList } = useDataIssuesPanelList(ref<Filters>({}));
+    await refreshList();
+    fetchData.mockResolvedValueOnce(page(15, 40, 100));
+    await loadMore();
+
+    fetchData.mockResolvedValueOnce(page(PANEL_PAGE_SIZE, 40));
+    await refreshList();
+
+    expect(fetchData).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 0 }));
+  });
+
+  it('should ignore an overlapping loadMore so a scroll burst cannot double-fetch', async () => {
+    fetchData.mockResolvedValueOnce(page(PANEL_PAGE_SIZE, 40));
+    const { loadMore, refreshList } = useDataIssuesPanelList(ref<Filters>({}));
+    await refreshList();
+
+    fetchData.mockClear();
+    fetchData.mockResolvedValue(page(15, 40, 100));
+    await Promise.all([loadMore(), loadMore()]);
+
+    expect(fetchData).toHaveBeenCalledOnce();
+  });
+
+  it('should expose the loading flag only while the first page is in flight', async () => {
+    fetchData.mockResolvedValueOnce(page(1, 1));
+    const { loading, refreshList } = useDataIssuesPanelList(ref<Filters>({}));
+
+    const pending = refreshList();
+    expect(get(loading)).toBe(true);
+    await pending;
+
+    expect(get(loading)).toBe(false);
+  });
+
+  it('should mark a page append with loadingMore, leaving loading untouched', async () => {
+    fetchData.mockResolvedValueOnce(page(PANEL_PAGE_SIZE, 40));
+    const { loading, loadingMore, loadMore, refreshList } = useDataIssuesPanelList(ref<Filters>({}));
+    await refreshList();
+
+    fetchData.mockResolvedValueOnce(page(15, 40, 100));
+    const pending = loadMore();
+    expect(get(loadingMore)).toBe(true);
+    expect(get(loading)).toBe(false);
+    await pending;
+
+    expect(get(loadingMore)).toBe(false);
+  });
+
+  it('should clear the loading flag when the request rejects', async () => {
+    fetchData.mockRejectedValueOnce(new Error('boom'));
+    const { loading, refreshList } = useDataIssuesPanelList(ref<Filters>({}));
+
+    await expect(refreshList()).rejects.toThrow('boom');
+
+    expect(get(loading)).toBe(false);
+  });
+
+  it('should report a remediating row so the caller can start polling', async () => {
+    fetchData.mockResolvedValueOnce({
+      ...page(1, 1),
+      data: [createIssue({ state: IssueState.AUTO_REMEDIATING })],
+    });
+    const { hasRemediatingRows, refreshList } = useDataIssuesPanelList(ref<Filters>({}));
+
+    await refreshList();
+
+    expect(get(hasRemediatingRows)).toBe(true);
+  });
+
+  it('should report no remediating rows when every issue is settled', async () => {
+    fetchData.mockResolvedValueOnce({
+      ...page(1, 1),
+      data: [createIssue({ state: IssueState.OPEN })],
+    });
+    const { hasRemediatingRows, refreshList } = useDataIssuesPanelList(ref<Filters>({}));
+
+    await refreshList();
+
+    expect(get(hasRemediatingRows)).toBe(false);
+  });
+
+  it('should describe each row so the card does not have to', async () => {
+    fetchData.mockResolvedValueOnce(page(1, 1));
+    const { refreshList, rows } = useDataIssuesPanelList(ref<Filters>({}));
+
+    await refreshList();
+
+    const [row] = get(rows);
+    expect(row.issue.id).toBe(1);
+    expect(row.description.messageKey).toBeTruthy();
+  });
+
+  it('should refresh the list and the badge summary together', async () => {
+    fetchData.mockResolvedValueOnce(page(1, 1));
+    const { reloadAll } = useDataIssuesPanelList(ref<Filters>({}));
+
+    await reloadAll();
+
+    expect(fetchData).toHaveBeenCalledOnce();
+    expect(refreshSummary).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-panel-list.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-panel-list.ts
@@ -1,0 +1,101 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { RouteLocationRaw } from 'vue-router';
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import type { IssueDescription } from '@/modules/history/data-issues/types';
+import type { Filters } from '@/modules/history/data-issues/use-data-issues-filter';
+import { IssueState } from '@/modules/history/data-issues/constants';
+import { buildPanelPayload, PANEL_PAGE_SIZE } from '@/modules/history/data-issues/data-issues-panel-utils';
+import { describeIssue, relatedEventRoute } from '@/modules/history/data-issues/transforms';
+import { useDataIssues } from '@/modules/history/data-issues/use-data-issues';
+import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
+
+/** One rendered card: the issue plus everything derived from it for display. */
+export interface PanelRow {
+  issue: DataIssue;
+  description: IssueDescription;
+  eventRoute: RouteLocationRaw | undefined;
+}
+
+interface UseDataIssuesPanelListReturn {
+  loading: Readonly<Ref<boolean>>;
+  loadingMore: Readonly<Ref<boolean>>;
+  rows: ComputedRef<PanelRow[]>;
+  isEmpty: ComputedRef<boolean>;
+  hasRemediatingRows: ComputedRef<boolean>;
+  refreshList: () => Promise<void>;
+  loadMore: () => Promise<void>;
+  reloadAll: () => Promise<void>;
+}
+
+/**
+ * The panel's paged issue list: one page at a time, appending as the user scrolls.
+ * `reloadAll` refreshes the list and the badge summary together, so every caller
+ * that changes an issue keeps both in step from a single place.
+ */
+export function useDataIssuesPanelList(filters: MaybeRefOrGetter<Filters>): UseDataIssuesPanelListReturn {
+  const { fetchData } = useDataIssues();
+  const { refreshSummary } = useDataIssuesSummary();
+
+  const issues = ref<DataIssue[]>([]);
+  const loading = shallowRef<boolean>(false);
+  const loadingMore = shallowRef<boolean>(false);
+  const offset = shallowRef<number>(0);
+  const total = shallowRef<number>(0);
+
+  const canLoadMore = computed<boolean>(() => get(issues).length < get(total));
+  const isEmpty = computed<boolean>(() => get(issues).length === 0);
+
+  const hasRemediatingRows = computed<boolean>(() =>
+    get(issues).some(issue => issue.state === IssueState.AUTO_REMEDIATING));
+
+  const rows = computed<PanelRow[]>(() => get(issues).map((issue) => {
+    const description = describeIssue(issue);
+    return {
+      description,
+      eventRoute: relatedEventRoute(issue.kind, description.eventIdentifier, issue.groupIdentifier, issue.asset),
+      issue,
+    };
+  }));
+
+  async function loadList(append: boolean): Promise<void> {
+    const busy = append ? loadingMore : loading;
+    set(busy, true);
+    try {
+      const collection = await fetchData(buildPanelPayload(toValue(filters), get(offset)));
+      set(issues, append ? [...get(issues), ...collection.data] : collection.data);
+      set(total, collection.found);
+    }
+    finally {
+      set(busy, false);
+    }
+  }
+
+  /** Reloads from the first page, replacing the current list (on mount, filter change, refresh). */
+  async function refreshList(): Promise<void> {
+    set(offset, 0);
+    await loadList(false);
+  }
+
+  /** Appends the next page; guarded so overlapping scroll events do not double-fetch. */
+  async function loadMore(): Promise<void> {
+    if (get(loading) || get(loadingMore) || !get(canLoadMore))
+      return;
+    set(offset, get(offset) + PANEL_PAGE_SIZE);
+    await loadList(true);
+  }
+
+  async function reloadAll(): Promise<void> {
+    await Promise.all([refreshList(), refreshSummary()]);
+  }
+
+  return {
+    hasRemediatingRows,
+    isEmpty,
+    loading: readonly(loading),
+    loadingMore: readonly(loadingMore),
+    loadMore,
+    refreshList,
+    reloadAll,
+    rows,
+  };
+}

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-panel-polling.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-panel-polling.spec.ts
@@ -1,0 +1,193 @@
+import { mount } from '@vue/test-utils';
+import { set } from '@vueuse/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, KeepAlive, type Ref, ref, shallowRef } from 'vue';
+import { useDataIssuesPanelPolling } from '@/modules/history/data-issues/use-data-issues-panel-polling';
+
+const syncCompleted = ref<boolean>(false);
+
+vi.mock('@/modules/shell/sync-progress/use-sync-completed', () => ({
+  useSyncCompleted: (): Record<string, unknown> => ({ syncCompleted }),
+}));
+
+const POLL_INTERVAL = 10_000;
+
+/**
+ * Mounts the composable inside a `<KeepAlive>` so it is deactivated rather than
+ * unmounted when hidden, which is how the panel actually behaves.
+ */
+function mountPanel(hasRemediatingRows: Ref<boolean>, reload: () => Promise<void>): {
+  show: (visible: boolean) => Promise<void>;
+  unmount: () => void;
+} {
+  const Panel = defineComponent({
+    name: 'Panel',
+    setup() {
+      useDataIssuesPanelPolling(hasRemediatingRows, reload);
+      return (): unknown => h('div');
+    },
+  });
+
+  const visible = shallowRef<boolean>(true);
+  const wrapper = mount(defineComponent({
+    setup() {
+      return (): unknown => h(KeepAlive, null, [visible.value ? h(Panel) : null]);
+    },
+  }));
+
+  return {
+    show: async (next: boolean): Promise<void> => {
+      set(visible, next);
+      await wrapper.vm.$nextTick();
+    },
+    unmount: (): void => {
+      wrapper.unmount();
+    },
+  };
+}
+
+describe('useDataIssuesPanelPolling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    set(syncCompleted, false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not poll while nothing is auto-remediating', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const panel = mountPanel(ref(false), reload);
+
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL * 3);
+
+    expect(reload).not.toHaveBeenCalled();
+    panel.unmount();
+  });
+
+  it('should poll once a row starts auto-remediating', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const remediating = ref<boolean>(false);
+    const panel = mountPanel(remediating, reload);
+
+    set(remediating, true);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL * 2);
+
+    expect(reload).toHaveBeenCalledTimes(2);
+    panel.unmount();
+  });
+
+  it('should stop polling when the last remediating row settles', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const remediating = ref<boolean>(true);
+    const panel = mountPanel(remediating, reload);
+    set(remediating, false);
+    await vi.advanceTimersByTimeAsync(0);
+    reload.mockClear();
+
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL * 3);
+
+    expect(reload).not.toHaveBeenCalled();
+    panel.unmount();
+  });
+
+  it('should stop polling while hidden, so a backgrounded panel makes no requests', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const remediating = ref<boolean>(true);
+    const panel = mountPanel(remediating, reload);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await panel.show(false);
+    reload.mockClear();
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL * 3);
+
+    expect(reload).not.toHaveBeenCalled();
+    panel.unmount();
+  });
+
+  // Under <KeepAlive> the panel's reactivity stays live while hidden, so a row that
+  // starts remediating in the background still fires the watcher. Without the
+  // activation gate that would restart the poll on a panel nobody is looking at.
+  it('should not start polling for a row that begins remediating while hidden', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const remediating = ref<boolean>(false);
+    const panel = mountPanel(remediating, reload);
+    await panel.show(false);
+
+    set(remediating, true);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL * 3);
+
+    expect(reload).not.toHaveBeenCalled();
+    panel.unmount();
+  });
+
+  it('should resume polling when shown again with rows still remediating', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const remediating = ref<boolean>(true);
+    const panel = mountPanel(remediating, reload);
+    await panel.show(false);
+    reload.mockClear();
+
+    await panel.show(true);
+    await vi.advanceTimersByTimeAsync(POLL_INTERVAL);
+
+    expect(reload).toHaveBeenCalled();
+    panel.unmount();
+  });
+
+  it('should reload when a sync completes while visible', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const panel = mountPanel(ref(false), reload);
+
+    set(syncCompleted, true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(reload).toHaveBeenCalledOnce();
+    panel.unmount();
+  });
+
+  it('should defer a sync that completes while hidden instead of dropping it', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const panel = mountPanel(ref(false), reload);
+    await panel.show(false);
+
+    set(syncCompleted, true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(reload).not.toHaveBeenCalled();
+    panel.unmount();
+  });
+
+  it('should catch up a deferred sync refresh once shown again', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const panel = mountPanel(ref(false), reload);
+    await panel.show(false);
+    set(syncCompleted, true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await panel.show(true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(reload).toHaveBeenCalledOnce();
+    panel.unmount();
+  });
+
+  it('should catch up only once, not on every later activation', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const panel = mountPanel(ref(false), reload);
+    await panel.show(false);
+    set(syncCompleted, true);
+    await vi.advanceTimersByTimeAsync(0);
+    await panel.show(true);
+    await vi.advanceTimersByTimeAsync(0);
+    reload.mockClear();
+
+    await panel.show(false);
+    await panel.show(true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(reload).not.toHaveBeenCalled();
+    panel.unmount();
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-panel-polling.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-panel-polling.ts
@@ -1,0 +1,60 @@
+import type { MaybeRefOrGetter } from 'vue';
+import { startPromise } from '@shared/utils';
+import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
+
+/** How often the panel re-reads the list while auto-remediation is running. */
+const POLL_INTERVAL = 10_000;
+
+/**
+ * Keeps the panel's list fresh without letting a backgrounded panel hit the network.
+ *
+ * Two triggers reload it: a slow poll while any row is auto-remediating, and the
+ * completion of a history sync (so the inbox reflects freshly detected issues, or
+ * the all-clear shield, without waiting for the poll or a manual refresh).
+ *
+ * Both are gated on activation, because under `<KeepAlive>` a hidden panel keeps its
+ * reactivity live. A sync that completes while hidden is not dropped: it is recorded
+ * and caught up the next time the panel is shown.
+ */
+export function useDataIssuesPanelPolling(
+  hasRemediatingRows: MaybeRefOrGetter<boolean>,
+  reload: () => Promise<void>,
+): void {
+  const { syncCompleted } = useSyncCompleted();
+  const { pause, resume } = useIntervalFn(() => {
+    startPromise(reload());
+  }, POLL_INTERVAL, { immediate: false });
+
+  const active = shallowRef<boolean>(true);
+  const pendingRefresh = shallowRef<boolean>(false);
+
+  function syncPolling(): void {
+    if (get(active) && toValue(hasRemediatingRows))
+      resume();
+    else
+      pause();
+  }
+
+  watch(() => toValue(hasRemediatingRows), syncPolling);
+
+  watch(syncCompleted, () => {
+    if (get(active))
+      startPromise(reload());
+    else
+      set(pendingRefresh, true);
+  });
+
+  onActivated(() => {
+    set(active, true);
+    syncPolling();
+    if (get(pendingRefresh)) {
+      set(pendingRefresh, false);
+      startPromise(reload());
+    }
+  });
+
+  onDeactivated(() => {
+    set(active, false);
+    pause();
+  });
+}

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-panel-selection.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-panel-selection.spec.ts
@@ -1,0 +1,140 @@
+import type { LocationQuery } from 'vue-router';
+import type { PanelRow } from '@/modules/history/data-issues/use-data-issues-panel-list';
+import { createMock } from '@test/utils/create-mock';
+import { get, set } from '@vueuse/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useDataIssuesPanelSelection } from '@/modules/history/data-issues/use-data-issues-panel-selection';
+import { HighlightTargetTypes } from '@/modules/history/events/use-history-event-navigation';
+
+const route = ref<{ query: LocationQuery }>({ query: {} });
+const push = vi.fn();
+const replace = vi.fn();
+const clearHighlightTarget = vi.fn();
+
+// The shared vue-router mock exposes no `replace`, which clearSelection needs.
+vi.mock('vue-router', () => ({
+  useRoute: (): unknown => route,
+  useRouter: (): unknown => ({ push, replace }),
+}));
+
+vi.mock('@/modules/history/events/use-history-event-navigation', () => ({
+  HighlightTargetTypes: { NEGATIVE_BALANCE: 'negativeBalance' },
+  useHistoryEventNavigation: (): Record<string, unknown> => ({ clearHighlightTarget }),
+}));
+
+/** A row whose card would be highlighted for `eventIdentifier`. */
+function row(eventIdentifier: number | undefined): PanelRow {
+  return createMock<PanelRow>({
+    description: { amounts: {}, eventIdentifier, messageKey: 'k', shortMessageKey: 'k' },
+  });
+}
+
+describe('useDataIssuesPanelSelection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(route, { query: {} });
+  });
+
+  it('should report no selection when the query carries no highlight', () => {
+    const { activeEventIdentifier, hasActiveSelection } = useDataIssuesPanelSelection();
+
+    expect(get(activeEventIdentifier)).toBeUndefined();
+    expect(get(hasActiveSelection)).toBe(false);
+  });
+
+  it('should read the highlighted event from the query', () => {
+    set(route, { query: { highlightedNegativeBalanceEvent: '42' } });
+    const { activeEventIdentifier, hasActiveSelection } = useDataIssuesPanelSelection();
+
+    expect(get(activeEventIdentifier)).toBe(42);
+    expect(get(hasActiveSelection)).toBe(true);
+  });
+
+  it('should take the first value when the query repeats the parameter', () => {
+    set(route, { query: { highlightedNegativeBalanceEvent: ['7', '9'] } });
+    const { activeEventIdentifier } = useDataIssuesPanelSelection();
+
+    expect(get(activeEventIdentifier)).toBe(7);
+  });
+
+  it('should reject a non-numeric highlight rather than selecting NaN', () => {
+    set(route, { query: { highlightedNegativeBalanceEvent: 'abc' } });
+    const { activeEventIdentifier, hasActiveSelection } = useDataIssuesPanelSelection();
+
+    expect(get(activeEventIdentifier)).toBeUndefined();
+    expect(get(hasActiveSelection)).toBe(false);
+  });
+
+  it('should reject zero and negative identifiers', () => {
+    set(route, { query: { highlightedNegativeBalanceEvent: '0' } });
+    const { activeEventIdentifier } = useDataIssuesPanelSelection();
+    expect(get(activeEventIdentifier)).toBeUndefined();
+
+    set(route, { query: { highlightedNegativeBalanceEvent: '-3' } });
+    expect(get(activeEventIdentifier)).toBeUndefined();
+  });
+
+  it('should follow the query, so clearing the highlight elsewhere deselects the card', () => {
+    set(route, { query: { highlightedNegativeBalanceEvent: '42' } });
+    const { hasActiveSelection } = useDataIssuesPanelSelection();
+    expect(get(hasActiveSelection)).toBe(true);
+
+    set(route, { query: {} });
+
+    expect(get(hasActiveSelection)).toBe(false);
+  });
+
+  it('should mark only the row whose event is highlighted', () => {
+    set(route, { query: { highlightedNegativeBalanceEvent: '42' } });
+    const { isActiveRow } = useDataIssuesPanelSelection();
+
+    expect(isActiveRow(row(42))).toBe(true);
+    expect(isActiveRow(row(43))).toBe(false);
+  });
+
+  it('should not mark a row that has no related event', () => {
+    set(route, { query: {} });
+    const { isActiveRow } = useDataIssuesPanelSelection();
+
+    expect(isActiveRow(row(undefined))).toBe(false);
+  });
+
+  it('should push the target when going to an event', async () => {
+    const { goToEvent } = useDataIssuesPanelSelection();
+
+    await goToEvent({ path: '/history/events' });
+
+    expect(push).toHaveBeenCalledWith({ path: '/history/events' });
+  });
+
+  it('should strip both highlight params and keep the rest of the query', async () => {
+    set(route, {
+      query: { highlightedNegativeBalanceEvent: '42', page: '2', targetGroupIdentifier: '0xabc' },
+    });
+    const { clearSelection } = useDataIssuesPanelSelection();
+
+    await clearSelection();
+
+    expect(clearHighlightTarget).toHaveBeenCalledWith(HighlightTargetTypes.NEGATIVE_BALANCE);
+    expect(replace).toHaveBeenCalledWith({ query: { page: '2' } });
+  });
+
+  it('should clear the paging target even when no event is highlighted', async () => {
+    set(route, { query: { targetGroupIdentifier: '0xabc' } });
+    const { clearSelection } = useDataIssuesPanelSelection();
+
+    await clearSelection();
+
+    expect(replace).toHaveBeenCalledWith({ query: {} });
+  });
+
+  it('should not navigate when there is nothing to clear', async () => {
+    const { clearSelection } = useDataIssuesPanelSelection();
+
+    await clearSelection();
+
+    expect(clearHighlightTarget).toHaveBeenCalledOnce();
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-panel-selection.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-panel-selection.ts
@@ -1,0 +1,64 @@
+import type { ComputedRef } from 'vue';
+import type { RouteLocationRaw } from 'vue-router';
+import type { PanelRow } from '@/modules/history/data-issues/use-data-issues-panel-list';
+import { HighlightTargetTypes, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
+
+interface UseDataIssuesPanelSelectionReturn {
+  activeEventIdentifier: ComputedRef<number | undefined>;
+  hasActiveSelection: ComputedRef<boolean>;
+  isActiveRow: (row: PanelRow) => boolean;
+  goToEvent: (target: RouteLocationRaw) => Promise<void>;
+  clearSelection: () => Promise<void>;
+}
+
+/**
+ * Which card is shown as the "source" of the currently highlighted history event.
+ *
+ * The route query is the single source of truth for the highlight, so the card
+ * mirrors it rather than holding its own selection state. That keeps it in sync
+ * automatically when the highlight is cleared from the events view: the card
+ * simply stops matching.
+ */
+export function useDataIssuesPanelSelection(): UseDataIssuesPanelSelectionReturn {
+  const router = useRouter();
+  const route = useRoute();
+  const { clearHighlightTarget } = useHistoryEventNavigation();
+
+  const activeEventIdentifier = computed<number | undefined>(() => {
+    const raw = get(route).query.highlightedNegativeBalanceEvent;
+    const value = Number(Array.isArray(raw) ? raw[0] : raw);
+    return Number.isInteger(value) && value > 0 ? value : undefined;
+  });
+
+  const hasActiveSelection = computed<boolean>(() => get(activeEventIdentifier) !== undefined);
+
+  function isActiveRow(row: PanelRow): boolean {
+    const identifier = row.description.eventIdentifier;
+    return identifier !== undefined && identifier === get(activeEventIdentifier);
+  }
+
+  async function goToEvent(target: RouteLocationRaw): Promise<void> {
+    await router.push(target);
+  }
+
+  /**
+   * Clears the selection: strips the highlight query params (which un-highlights both
+   * the history row and the source card) and drops the paging target so a later filter
+   * change does not re-navigate to the stale event. Mirrors clearHighlight() in the
+   * movement matching pinned panel.
+   */
+  async function clearSelection(): Promise<void> {
+    clearHighlightTarget(HighlightTargetTypes.NEGATIVE_BALANCE);
+    const { highlightedNegativeBalanceEvent, targetGroupIdentifier, ...remainingQuery } = get(route).query;
+    if (highlightedNegativeBalanceEvent || targetGroupIdentifier)
+      await router.replace({ query: remainingQuery });
+  }
+
+  return {
+    activeEventIdentifier,
+    clearSelection,
+    goToEvent,
+    hasActiveSelection,
+    isActiveRow,
+  };
+}

--- a/frontend/app/src/modules/history/data-issues/use-panel-filter-engagement.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-panel-filter-engagement.spec.ts
@@ -1,0 +1,96 @@
+import { get, set } from '@vueuse/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref, shallowRef } from 'vue';
+import { usePanelFilterEngagement } from '@/modules/history/data-issues/use-panel-filter-engagement';
+
+const focused = shallowRef<boolean>(false);
+
+// happy-dom never updates VueUse's active-element tracking (element.focus() moves
+// document.activeElement but fires no event it listens for), so driving real focus
+// here would test the DOM rather than the grace period this composable owns.
+vi.mock('@vueuse/core', async importOriginal => ({
+  ...await importOriginal<typeof import('@vueuse/core')>(),
+  useFocusWithin: (): { focused: Ref<boolean> } => ({ focused }),
+}));
+
+const DISENGAGE_DELAY = 300;
+
+function engagement(): Readonly<Ref<boolean>> {
+  return usePanelFilterEngagement(ref<HTMLElement>());
+}
+
+describe('usePanelFilterEngagement', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    set(focused, false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should start disengaged', () => {
+    expect(get(engagement())).toBe(false);
+  });
+
+  it('should engage as soon as the filter takes focus', async () => {
+    const engaged = engagement();
+
+    set(focused, true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(get(engaged)).toBe(true);
+  });
+
+  // The grace period is the whole point: a click on a teleported suggestion lands
+  // after the input blurs, and would otherwise dismiss the floating drawer.
+  it('should stay engaged for the grace period after focus leaves', async () => {
+    const engaged = engagement();
+    set(focused, true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    set(focused, false);
+    await vi.advanceTimersByTimeAsync(DISENGAGE_DELAY - 1);
+
+    expect(get(engaged)).toBe(true);
+  });
+
+  it('should disengage once the grace period elapses', async () => {
+    const engaged = engagement();
+    set(focused, true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    set(focused, false);
+    await vi.advanceTimersByTimeAsync(DISENGAGE_DELAY);
+
+    expect(get(engaged)).toBe(false);
+  });
+
+  it('should cancel the pending disengage when focus returns in time', async () => {
+    const engaged = engagement();
+    set(focused, true);
+    await vi.advanceTimersByTimeAsync(0);
+    set(focused, false);
+    await vi.advanceTimersByTimeAsync(DISENGAGE_DELAY / 2);
+
+    set(focused, true);
+    await vi.advanceTimersByTimeAsync(DISENGAGE_DELAY * 2);
+
+    expect(get(engaged)).toBe(true);
+  });
+
+  it('should disengage after a full grace period following the last blur', async () => {
+    const engaged = engagement();
+    set(focused, true);
+    await vi.advanceTimersByTimeAsync(0);
+    set(focused, false);
+    await vi.advanceTimersByTimeAsync(DISENGAGE_DELAY / 2);
+    set(focused, true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    set(focused, false);
+    await vi.advanceTimersByTimeAsync(DISENGAGE_DELAY);
+
+    expect(get(engaged)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/use-panel-filter-engagement.ts
+++ b/frontend/app/src/modules/history/data-issues/use-panel-filter-engagement.ts
@@ -1,0 +1,38 @@
+import type { MaybeElementRef } from '@vueuse/core';
+import type { Ref } from 'vue';
+
+/**
+ * How long after focus leaves the filter the panel keeps treating it as engaged.
+ * Long enough to cover the trailing click on a teleported suggestion, which fires
+ * after the input blurs.
+ */
+const DISENGAGE_DELAY = 300;
+
+/**
+ * Whether the user is currently interacting with the panel's filter.
+ *
+ * The filter's suggestion dropdown is a `RuiMenu` teleported to `<body>`, so clicking
+ * a suggestion (an asset, say) reads as a click outside the floating drawer and would
+ * dismiss it. The host drawer stays stateless while this is true, and it is held for a
+ * short grace period after focus leaves so that trailing click is still ignored.
+ */
+export function usePanelFilterEngagement(target: MaybeElementRef): Readonly<Ref<boolean>> {
+  const { focused } = useFocusWithin(target);
+  const engaged = shallowRef<boolean>(false);
+
+  const { start: scheduleDisengage, stop: cancelDisengage } = useTimeoutFn(() => {
+    set(engaged, false);
+  }, DISENGAGE_DELAY, { immediate: false });
+
+  watch(focused, (isFocused) => {
+    if (isFocused) {
+      cancelDisengage();
+      set(engaged, true);
+    }
+    else {
+      scheduleDisengage();
+    }
+  });
+
+  return readonly(engaged);
+}


### PR DESCRIPTION
Part of #11252, continuing the extract-then-test pass from #12932. This is the coverage plan's ranked target #4: `DataIssuesPanelContent.vue`, 284 script lines at zero coverage.

## The split — 284 → 100 script lines

Four unrelated concerns came out, none of which were testable without mounting the panel:

- `data-issues-panel-utils.ts` — the filter-value narrowing, the compact field subset and the paged request payload, all pure. This also clears the "8 inline type/helper declarations" the plan flagged for this file.
- `use-data-issues-panel-list.ts` — the paged list, its append/replace paging, the guard that stops overlapping scroll events double-fetching, and the derived rows
- `use-data-issues-panel-selection.ts` — the highlighted-event selection, which mirrors the route query rather than holding its own state
- `use-data-issues-panel-polling.ts` — the remediation poll, the sync-completed refetch, and the `<KeepAlive>` activation gating
- `use-panel-filter-engagement.ts` — the focus grace period that stops a click on a teleported suggestion from dismissing the drawer

The virtual list stays in the SFC: it is template plumbing, not logic. No behaviour change anywhere.

## Coverage

All five new modules are at 100%; the component goes from zero to 66.6% of its remaining 54 lines. Repo-wide **61.14% → 61.39% lines**, full suite green at 883 files / 8872 tests.

## Two notes on the tests

**The polling spec mounts under `<KeepAlive>`** so activation is real rather than simulated. All nine tests passed on the first run, so I gutted the activation gate as a negative control and they *still* passed: `onDeactivated` pauses the timer directly, so hiding the panel stops polling with or without the gate. The gate only matters when a row starts remediating *while the panel is hidden*, where reactivity is still live and the watcher fires anyway. That case now has its own test, and it fails when the gate is removed.

**The filter engagement spec stubs `useFocusWithin`.** happy-dom moves `document.activeElement` on `focus()` but fires no event VueUse listens for, so `focused` never flips; driving real focus there would assert on the DOM rather than on the grace period this composable owns.