### PR TITLE
Split the model mirror out of the form

### DIFF
--- a/frontend/app/src/modules/core/form/use-model-form.ts
+++ b/frontend/app/src/modules/core/form/use-model-form.ts
@@ -1,9 +1,9 @@
 import type { MaybeRefOrGetter, Ref, UnwrapNestedRefs } from 'vue';
 import type { ZodType } from 'zod';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import { isEqual } from 'es-toolkit';
 import { toServerErrors } from '@/modules/core/form/server-errors';
 import { type FormApi, useForm } from '@/modules/core/form/use-form';
+import { type ModelMirrorOptions, useModelMirror } from '@/modules/core/form/use-model-mirror';
 
 interface SharedModelFormOptions<TState extends object> {
   /** The single validation source of truth. A getter for rules that depend on props. */
@@ -33,26 +33,10 @@ export interface ModelFormOptions<TState extends object> extends SharedModelForm
 export interface MappedModelFormOptions<
   TModel extends object,
   TState extends object,
-> extends SharedModelFormOptions<TState> {
-  /** The payload the parent dialog owns, saves, and reseeds. Edits are mirrored back into it. */
-  readonly model: Ref<TModel>;
-  /**
-   * The payload as the inputs need to hold it. Called for the opening state and again for every
-   * edit made outside the form.
-   *
-   * 🔴 It has to be stable: the same payload in must give a deep-equal state out. The mirroring
-   * below compares the two to decide whether an outside edit is news, and a mapper that invents a
-   * fresh value each call - a timestamp, a generated id - reports every pass as a change and the
-   * two directions then write to each other without settling.
-   */
-  readonly toState: (model: TModel) => TState;
-  /**
-   * The state as the payload wants it. Handed the payload the dialog is currently holding as well,
-   * so a form that edits part of a larger payload can fold its fields over it and leave the rest
-   * alone.
-   */
-  readonly toModel: (state: UnwrapNestedRefs<TState>, model: TModel) => TModel;
-}
+> extends
+  SharedModelFormOptions<TState>,
+  // The two mappers and the payload are the mirror's, described there.
+  Pick<ModelMirrorOptions<TModel, TState>, 'model' | 'toModel' | 'toState'> {}
 
 /**
  * A form whose state belongs to the dialog above it, and whose fields are shaped differently from
@@ -87,39 +71,21 @@ export function useMappedModelForm<TModel extends object, TState extends object>
     transientKeys,
   });
 
-  // Every edit is written back, because the dialog saves what it reads off the model, not what the
-  // form holds.
-  watch(() => form.state, (state) => {
-    set(model, toModel(state, get(model)));
-  }, { deep: true });
-
-  if (seed) {
-    // The dialog saves what it reads off the model, so the opening state has to land there too. It
-    // is not readable back on this tick, which is why the sync below skips its immediate run: the
-    // state is already the newer of the two, and reading the model now would undo the seeding.
-    set(model, toModel(form.state, get(model)));
-  }
+  // The two shapes are kept in step by the mirror, which is this without the validation: the form
+  // adds rules, errors and a dirty flag on top of state that is already being mapped both ways.
+  useModelMirror<TModel, TState>({
+    model,
+    seeded: Boolean(seed),
+    state: form.state,
+    toModel,
+    toState,
+  });
 
   if (serverErrors) {
     watchImmediate(serverErrors, (value) => {
       form.setServerErrors(toServerErrors(value));
     }, { deep: true });
   }
-
-  // And an edit made outside the form - a reset, a different row seeded while it stays mounted - is
-  // pulled back in.
-  //
-  // 🔴 The equality guard is what makes this terminate. `toState` answers with a new object every
-  // time, so assigning it back unconditionally would count as a change even when nothing moved, and
-  // the write-back above would then answer that with a new payload, forever. Comparing first means
-  // a pass that found nothing new stops here. `syncRef` handles the same problem by pausing the
-  // opposing watcher, but it needs two refs of one type and a sync flush, and these two are neither
-  // the same shape nor plain refs.
-  watch(model, (value) => {
-    const next = toState(value);
-    if (!isEqual(next, form.state))
-      Object.assign(form.state, next);
-  }, { deep: true, immediate: !seed });
 
   if (stateUpdated) {
     // Immediate, so reopening a dialog that kept its flag from the last edit starts disarmed.

--- a/frontend/app/src/modules/core/form/use-model-mirror.spec.ts
+++ b/frontend/app/src/modules/core/form/use-model-mirror.spec.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import { nextTick, reactive, type Ref, ref } from 'vue';
+import { useModelMirror } from '@/modules/core/form/use-model-mirror';
+
+/** The payload, as the api admits it: the optional half can be absent. */
+interface Rule {
+  name: string;
+  linkedSetting?: string;
+  tags?: string[];
+}
+
+/** The same rule as the inputs need it: a string to type into, and the link as its own flag. */
+interface RuleState {
+  name: string;
+  linked: boolean;
+  linkedSetting: string;
+  tags: string[];
+}
+
+function toState(rule: Rule): RuleState {
+  return {
+    linked: Boolean(rule.linkedSetting),
+    linkedSetting: rule.linkedSetting ?? '',
+    name: rule.name,
+    // A new array every call on purpose: the mirroring has to notice it holds the same values
+    // rather than that it is the same reference.
+    tags: [...(rule.tags ?? [])],
+  };
+}
+
+function toModel(state: RuleState, rule: Rule): Rule {
+  return {
+    ...rule,
+    linkedSetting: state.linked ? state.linkedSetting : undefined,
+    name: state.name,
+    tags: state.tags,
+  };
+}
+
+interface Mirrored {
+  model: Ref<Rule>;
+  state: RuleState;
+}
+
+function mirror(initial: Rule, seed?: (state: RuleState) => RuleState): Mirrored {
+  const model = ref<Rule>(initial);
+  const opening = toState(get(model));
+  const state = reactive<RuleState>(seed ? seed(opening) : opening);
+
+  useModelMirror<Rule, RuleState>({
+    model,
+    seeded: Boolean(seed),
+    state,
+    toModel,
+    toState,
+  });
+
+  return { model, state };
+}
+
+describe('useModelMirror', () => {
+  it('should open on the mapped state rather than the payload', () => {
+    const { state } = mirror({ name: 'gas' });
+
+    expect(state.linked).toBe(false);
+    expect(state.linkedSetting).toBe('');
+    expect(state.tags).toEqual([]);
+  });
+
+  it('should read an absent field as its mapped presence flag', () => {
+    const { state } = mirror({ linkedSetting: 'includeGasCosts', name: 'gas' });
+
+    expect(state.linked).toBe(true);
+  });
+
+  it('should write an edit back through the payload mapper', async () => {
+    const { model, state } = mirror({ name: 'gas' });
+
+    state.linked = true;
+    state.linkedSetting = 'includeGasCosts';
+    await nextTick();
+
+    expect(get(model).linkedSetting).toBe('includeGasCosts');
+  });
+
+  it('should drop the field again when its flag is turned off', async () => {
+    const { model, state } = mirror({ linkedSetting: 'includeGasCosts', name: 'gas' });
+
+    state.linked = false;
+    await nextTick();
+
+    // Absent, not empty: the api reads an absent field as "this rule has no link".
+    expect(get(model).linkedSetting).toBeUndefined();
+  });
+
+  it('should leave the payload fields the state does not carry alone', async () => {
+    const model = ref<Rule>({ name: 'gas' });
+    const state = reactive<RuleState>(toState(get(model)));
+    useModelMirror<Rule, RuleState>({
+      model,
+      state,
+      toModel: (next, rule): Rule => ({ ...rule, name: next.name }),
+      toState,
+    });
+
+    set(model, { ...get(model), linkedSetting: 'includeGasCosts' });
+    await nextTick();
+    state.name = 'renamed';
+    await nextTick();
+
+    expect(get(model).linkedSetting).toBe('includeGasCosts');
+  });
+
+  it('should map an edit made outside on the way in', async () => {
+    const { model, state } = mirror({ name: 'gas' });
+
+    set(model, { linkedSetting: 'includeGasCosts', name: 'gas' });
+    await nextTick();
+
+    expect(state.linked).toBe(true);
+    expect(state.linkedSetting).toBe('includeGasCosts');
+  });
+
+  /*
+   * The equality guard is what makes this terminate rather than being defensive: `toState` answers
+   * with a new array every call, so without the comparison the mirroring would assign a fresh
+   * reference each pass, the write-back would answer with a fresh payload, and the two would trade
+   * writes until Vue's recursion limit.
+   */
+  it('should settle even though the mapper answers with a new object each time', async () => {
+    const { model, state } = mirror({ name: 'gas', tags: ['manual'] });
+
+    let writes = 0;
+    watch(model, () => {
+      writes += 1;
+    }, { deep: true });
+
+    state.name = 'renamed';
+    await nextTick();
+    await nextTick();
+    await nextTick();
+
+    expect(writes).toBe(1);
+    expect(get(model).name).toBe('renamed');
+    expect(state.tags).toEqual(['manual']);
+  });
+
+  describe('seeded', () => {
+    it('should put the seeded value in the payload the parent saves', () => {
+      const { model } = mirror({ name: '' }, state => ({ ...state, name: 'suggested' }));
+
+      expect(get(model).name).toBe('suggested');
+    });
+
+    it('should not let the payload undo the seeding', async () => {
+      const { model, state } = mirror({ name: '' }, next => ({ ...next, name: 'suggested' }));
+      await nextTick();
+
+      // The immediate pull is skipped precisely so the older payload does not win this race.
+      expect(state.name).toBe('suggested');
+      expect(get(model).name).toBe('suggested');
+    });
+  });
+});

--- a/frontend/app/src/modules/core/form/use-model-mirror.ts
+++ b/frontend/app/src/modules/core/form/use-model-mirror.ts
@@ -1,0 +1,76 @@
+import type { Ref, UnwrapNestedRefs } from 'vue';
+import { isEqual } from 'es-toolkit';
+
+export interface ModelMirrorOptions<TModel extends object, TState extends object> {
+  /** The payload the parent owns, saves, and reseeds. Edits are mirrored back into it. */
+  readonly model: Ref<TModel>;
+  /** The reactive state the inputs bind to. Already holding `toState(model)`, or a seed of it. */
+  readonly state: UnwrapNestedRefs<TState>;
+  /**
+   * The payload as the inputs need to hold it. Called for every edit made outside the state.
+   *
+   * 🔴 It has to be stable: the same payload in must give a deep-equal state out. The mirroring
+   * compares the two to decide whether an outside edit is news, and a mapper that invents a fresh
+   * value each call - a timestamp, a generated id - reports every pass as a change, so the two
+   * directions write to each other without ever settling.
+   */
+  readonly toState: (model: TModel) => TState;
+  /**
+   * The state as the payload wants it. Handed the payload currently held as well, so a caller
+   * editing part of a larger payload can fold its fields over it and leave the rest alone.
+   */
+  readonly toModel: (state: UnwrapNestedRefs<TState>, model: TModel) => TModel;
+  /**
+   * Whether the state was already moved past what the payload says, by a caller that decides part
+   * of its opening value. It is then written to the payload instead of read from it, because the
+   * state is the newer of the two and reading the payload now would undo the choice.
+   */
+  readonly seeded?: boolean;
+}
+
+/**
+ * Two shapes of the same data, kept in step.
+ *
+ * A component that edits a payload its parent owns cannot always bind to the payload as it stands:
+ * a text input needs a string where the api admits null, a key is masked while it is not being
+ * edited, one field is edited through two controls. Left to each field that gap becomes a writable
+ * computed per input, wrapping and unwrapping the same value on every keystroke, and the shape the
+ * inputs actually want is never written down anywhere.
+ *
+ * Written down here it is two pure functions with the whole payload in view, testable on their own,
+ * and the inputs bind to plain reactive state.
+ *
+ * This is the half of `useMappedModelForm` that has nothing to do with validation, for a component
+ * that maps but does not validate. One that does both wants that instead.
+ */
+export function useModelMirror<TModel extends object, TState extends object>(
+  options: ModelMirrorOptions<TModel, TState>,
+): void {
+  const { model, seeded = false, state, toModel, toState } = options;
+
+  // Every edit is written back, because the parent saves what it reads off the payload, not what
+  // the state holds.
+  watch(() => state, (value) => {
+    set(model, toModel(value, get(model)));
+  }, { deep: true });
+
+  if (seeded) {
+    // The parent saves what it reads off the payload, so the opening state has to land there too.
+    set(model, toModel(state, get(model)));
+  }
+
+  // And an edit made outside - a reset, a different row seeded while the component stays mounted -
+  // is pulled back in.
+  //
+  // 🔴 The equality guard is what makes this terminate. `toState` answers with a new object every
+  // time, so assigning it back unconditionally would count as a change even when nothing moved, and
+  // the write-back above would answer that with a new payload, forever. Comparing first means a
+  // pass that found nothing new stops here. `syncRef` handles the same problem by pausing the
+  // opposing watcher, but it needs two refs of one type and a sync flush, and these two are neither
+  // the same shape nor plain refs.
+  watch(model, (value) => {
+    const next = toState(value);
+    if (!isEqual(next, state))
+      Object.assign(state, next);
+  }, { deep: true, immediate: !seeded });
+}

--- a/frontend/app/src/modules/history/events/HistoryEventsTableActions.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsTableActions.vue
@@ -8,7 +8,6 @@ import type { HistoryEventRequestPayload } from '@/modules/history/events/reques
 import type { IgnoreStatus } from '@/modules/history/events/use-history-events-selection-actions';
 import type { SelectionState } from '@/modules/history/events/use-selection-mode';
 import { arrayify } from '@/modules/core/common/data/array';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
 import { type MatchedKeywordWithBehaviour, SavedFilterLocations } from '@/modules/core/table/filtering';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
@@ -43,7 +42,9 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 // Not a pill: it constrains how the other filters apply instead of filtering anything itself.
-const matchExactEvents = useRefPropVModel(toggles, 'matchExactEvents');
+function toggleMatchExact(): void {
+  set(toggles, { ...get(toggles), matchExactEvents: !get(toggles).matchExactEvents });
+}
 
 const pillLabels = usePillBarLabels();
 
@@ -176,11 +177,11 @@ function handleToggleSelectAllMatching(): void {
                 icon
                 class="shrink-0"
                 :disabled="barDisabled"
-                :color="matchExactEvents ? 'primary' : 'secondary'"
-                :class="{ 'bg-rui-primary/10': matchExactEvents }"
-                :aria-pressed="matchExactEvents"
+                :color="toggles.matchExactEvents ? 'primary' : 'secondary'"
+                :class="{ 'bg-rui-primary/10': toggles.matchExactEvents }"
+                :aria-pressed="toggles.matchExactEvents"
                 data-testid="filter-match-exact"
-                @click="matchExactEvents = !matchExactEvents"
+                @click="toggleMatchExact()"
               >
                 <RuiIcon
                   name="lu-focus"
@@ -195,7 +196,7 @@ function handleToggleSelectAllMatching(): void {
               <!-- An icon toggle has no label to read its state from, so the tooltip says which
                    state it is in rather than only what the setting means. -->
               <div class="text-caption">
-                {{ matchExactEvents
+                {{ toggles.matchExactEvents
                   ? t('transactions.filter.match_exact_filter_enabled')
                   : t('transactions.filter.match_exact_filter_disabled') }}
               </div>

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleWithLinkedSetting.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleWithLinkedSetting.spec.ts
@@ -1,0 +1,150 @@
+import type {
+  AccountingRuleLinkedSettingMap,
+  AccountingRuleWithLinkedProperty,
+} from '@/modules/settings/types/accounting';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, describe, expect, it, vi } from 'vitest';
+import { type ComponentPublicInstance, nextTick, ref } from 'vue';
+import '@test/i18n';
+
+const options = ref<AccountingRuleLinkedSettingMap[]>([]);
+
+vi.mock('@/modules/settings/accounting/use-accounting-rule-mappings', () => ({
+  useAccountingRuleMappings: vi.fn().mockReturnValue({
+    accountingRuleLinkedMappingData: (): typeof options => options,
+  }),
+}));
+
+const AccountingRuleWithLinkedSetting = (
+  await import('@/modules/settings/accounting/rule/AccountingRuleWithLinkedSetting.vue')
+).default;
+
+describe('accountingRuleWithLinkedSetting', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AccountingRuleWithLinkedSetting>>;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    set(options, []);
+  });
+
+  function createWrapper(
+    modelValue: AccountingRuleWithLinkedProperty,
+  ): VueWrapper<InstanceType<typeof AccountingRuleWithLinkedSetting>> {
+    return mount(AccountingRuleWithLinkedSetting, {
+      global: {
+        stubs: {
+          ExternalLink: true,
+          RuiCheckbox: { emits: ['update:modelValue'], name: 'RuiCheckbox', props: ['modelValue'], template: '<div />' },
+          RuiMenuSelect: {
+            emits: ['update:modelValue'],
+            name: 'RuiMenuSelect',
+            props: ['modelValue', 'options'],
+            template: '<div />',
+          },
+          RuiSwitch: { emits: ['update:modelValue'], name: 'RuiSwitch', props: ['modelValue', 'disabled'], template: '<div />' },
+          SuccessDisplay: true,
+        },
+      },
+      props: { hint: 'hint', identifier: 'taxable', label: 'label', modelValue },
+    });
+  }
+
+  /** The stubs below declare their props at runtime, so their instances are typed loosely. */
+  function control(name: string): VueWrapper<ComponentPublicInstance<Record<string, unknown>>> {
+    return wrapper.findComponent<ComponentPublicInstance<Record<string, unknown>>>({ name });
+  }
+
+  function lastModel(): AccountingRuleWithLinkedProperty {
+    const last = wrapper.emitted<[AccountingRuleWithLinkedProperty]>('update:modelValue')?.at(-1);
+    assert(last);
+    return last[0];
+  }
+
+  it('should read an absent linked setting as unlinked', () => {
+    wrapper = createWrapper({ value: true });
+
+    expect(control('RuiCheckbox').props('modelValue')).toBe(false);
+    expect(control('RuiSwitch').props('modelValue')).toBe(true);
+  });
+
+  it('should read a present linked setting as linked', () => {
+    wrapper = createWrapper({ linkedSetting: 'includeGasCosts', value: false });
+
+    expect(control('RuiCheckbox').props('modelValue')).toBe(true);
+    expect(control('RuiMenuSelect').props('modelValue')).toBe('includeGasCosts');
+  });
+
+  it('should disable the value switch while the rule is linked', () => {
+    wrapper = createWrapper({ linkedSetting: 'includeGasCosts', value: false });
+
+    // The linked setting decides the value, so editing it by hand would be a lie.
+    expect(control('RuiSwitch').props('disabled')).toBe(true);
+  });
+
+  it('should carry an edited value into the model', async () => {
+    wrapper = createWrapper({ value: false });
+
+    control('RuiSwitch').vm.$emit('update:modelValue', true);
+    await nextTick();
+
+    expect(lastModel().value).toBe(true);
+  });
+
+  it('should adopt the first option when the link is ticked', async () => {
+    set(options, [{ identifier: 'includeGasCosts', label: 'Gas', state: true }]);
+    wrapper = createWrapper({ value: true });
+
+    control('RuiCheckbox').vm.$emit('update:modelValue', true);
+    await nextTick();
+
+    // The select below has to open on something, so ticking the box chooses for the user.
+    expect(lastModel().linkedSetting).toBe('includeGasCosts');
+  });
+
+  it('should drop the linked setting when the link is unticked', async () => {
+    set(options, [{ identifier: 'includeGasCosts', label: 'Gas', state: true }]);
+    wrapper = createWrapper({ linkedSetting: 'includeGasCosts', value: true });
+
+    control('RuiCheckbox').vm.$emit('update:modelValue', false);
+    await nextTick();
+
+    // Absent, not empty: the api reads an absent field as "this rule has no link".
+    expect(lastModel().linkedSetting).toBeUndefined();
+  });
+
+  // The mapping arrives over the api, so a rule opened before it lands has nothing to link to, and
+  // a link naming nothing is not a link. Refused outright rather than taken and undone, which would
+  // flash the select open on its way back out.
+  it('should refuse the link while there is nothing to link to', async () => {
+    wrapper = createWrapper({ value: true });
+
+    control('RuiCheckbox').vm.$emit('update:modelValue', true);
+    await nextTick();
+
+    expect(control('RuiCheckbox').props('modelValue')).toBe(false);
+    expect(wrapper.findComponent({ name: 'RuiMenuSelect' }).exists()).toBe(false);
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  it('should carry a chosen linked setting into the model', async () => {
+    set(options, [
+      { identifier: 'includeGasCosts', label: 'Gas', state: true },
+      { identifier: 'includeCrypto2crypto', label: 'Crypto', state: false },
+    ]);
+    wrapper = createWrapper({ linkedSetting: 'includeGasCosts', value: true });
+
+    control('RuiMenuSelect').vm.$emit('update:modelValue', 'includeCrypto2crypto');
+    await nextTick();
+
+    expect(lastModel().linkedSetting).toBe('includeCrypto2crypto');
+  });
+
+  it('should not report an edit the user never made', async () => {
+    set(options, [{ identifier: 'includeGasCosts', label: 'Gas', state: true }]);
+    wrapper = createWrapper({ linkedSetting: 'includeGasCosts', value: true });
+    await nextTick();
+
+    // The negative control: mapping the payload into three controls is not an edit of it.
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleWithLinkedSetting.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleWithLinkedSetting.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { AccountingRuleWithLinkedProperty } from '@/modules/settings/types/accounting';
-import { useRefPropVModel } from '@/modules/core/common/validation/model';
+import { useModelMirror } from '@/modules/core/form/use-model-mirror';
+import { type LinkedPropertyState, toLinkedProperty, toLinkedPropertyState } from '@/modules/settings/accounting/rule/accounting-rule-form';
 import { useAccountingRuleMappings } from '@/modules/settings/accounting/use-accounting-rule-mappings';
 import SuccessDisplay from '@/modules/shell/components/display/SuccessDisplay.vue';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
@@ -16,53 +17,44 @@ const { identifier, label, hint, learnMoreUrl } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const value = useRefPropVModel(modelValue, 'value');
+// Three controls over a payload of two fields, where the absence of one of them is what the
+// checkbox means. Mapped once here, so each control binds to plain state.
+const state = reactive<LinkedPropertyState>(toLinkedPropertyState(get(modelValue)));
 
-function updateModelValue(newValue: AccountingRuleWithLinkedProperty): void {
-  set(modelValue, newValue);
-}
+useModelMirror<AccountingRuleWithLinkedProperty, LinkedPropertyState>({
+  model: modelValue,
+  state,
+  toModel: toLinkedProperty,
+  toState: toLinkedPropertyState,
+});
 
 const { accountingRuleLinkedMappingData } = useAccountingRuleMappings();
 
 const linkableSettingOptions = accountingRuleLinkedMappingData(() => identifier);
 
-const linkedModel = computed<boolean>({
-  get() {
-    return !!get(modelValue).linkedSetting;
-  },
-  set(newValue: boolean) {
-    if (newValue) {
-      updateModelValue({
-        linkedSetting: get(linkableSettingOptions)[0]?.identifier || '',
-        value: get(modelValue).value,
-      });
-    }
-    else {
-      updateModelValue({
-        value: get(modelValue).value,
-      });
-    }
-  },
-});
+// Not a wrapper over the payload: ticking the box has to choose a setting for the select below it
+// to open on, and unticking has to let it go.
+//
+// The options arrive over the api, so a rule opened before they land has nothing to link to. The
+// tick is refused outright rather than taken and then undone, which would flash the select open
+// for a tick on its way back out.
+const linked = computed<boolean>({
+  get: () => state.linked,
+  set: (value: boolean) => {
+    const first = get(linkableSettingOptions)[0]?.identifier;
+    if (value && !first)
+      return;
 
-const linkedSettingModel = computed<string | undefined>({
-  get() {
-    return get(modelValue).linkedSetting;
-  },
-  set(newLinkedSetting: string | undefined) {
-    updateModelValue({
-      value: get(modelValue).value,
-      ...(newLinkedSetting ? { linkedSetting: newLinkedSetting } : {}),
-    });
+    state.linked = value;
+    state.linkedSetting = value && first ? first : '';
   },
 });
 
 const linkedPropertyValue = computed<boolean | null>(() => {
-  const property = get(modelValue).linkedSetting;
-  if (!property)
+  if (!state.linked || !state.linkedSetting)
     return null;
 
-  const item = get(linkableSettingOptions).find(item => item.identifier === property);
+  const item = get(linkableSettingOptions).find(item => item.identifier === state.linkedSetting);
 
   if (!item)
     return null;
@@ -77,9 +69,9 @@ const elemID = computed(() => `${identifier}-switch`);
   <div class="flex gap-4 py-4">
     <RuiSwitch
       :id="elemID"
-      v-model="value"
+      v-model="state.value"
       color="primary"
-      :disabled="linkedModel"
+      :disabled="state.linked"
     />
     <div class="w-full">
       <label
@@ -107,7 +99,7 @@ const elemID = computed(() => `${identifier}-switch`);
         </div>
       </label>
       <RuiCheckbox
-        v-model="linkedModel"
+        v-model="linked"
         size="sm"
         color="primary"
         hide-details
@@ -117,11 +109,11 @@ const elemID = computed(() => `${identifier}-switch`);
         </span>
       </RuiCheckbox>
       <div
-        v-if="linkedModel"
+        v-if="state.linked"
         class="ml-7 mt-1 md:w-1/2"
       >
         <RuiMenuSelect
-          v-model="linkedSettingModel"
+          v-model="state.linkedSetting"
           variant="outlined"
           hide-details
           dense

--- a/frontend/app/src/modules/settings/accounting/rule/accounting-rule-form.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/accounting-rule-form.ts
@@ -1,6 +1,10 @@
 import { z, type ZodType } from 'zod';
 import { requiredEventSubtype, requiredEventType } from '@/modules/history/management/forms/event-field-schemas';
-import { type AccountingRuleEntry, AccountingTreatment } from '@/modules/settings/types/accounting';
+import {
+  type AccountingRuleEntry,
+  type AccountingRuleWithLinkedProperty,
+  AccountingTreatment,
+} from '@/modules/settings/types/accounting';
 
 /**
  * The four identifying fields of a rule. The three linked toggles are deliberately absent: they can
@@ -49,5 +53,39 @@ export function applyAccountingRuleFormState(
     counterparty: state.counterparty,
     eventSubtype: state.eventSubtype,
     eventType: state.eventType,
+  };
+}
+
+/**
+ * A linked property as its control needs it: the link is a flag of its own, and the setting it
+ * names is always a string.
+ *
+ * The payload records "not linked" by leaving `linkedSetting` out, which the checkbox cannot bind
+ * to and the select below it cannot open on. Naming both here is what saves the component a
+ * writable computed per control.
+ */
+export interface LinkedPropertyState {
+  linked: boolean;
+  linkedSetting: string;
+  value: boolean;
+}
+
+export function toLinkedPropertyState(property: AccountingRuleWithLinkedProperty): LinkedPropertyState {
+  return {
+    linked: Boolean(property.linkedSetting),
+    linkedSetting: property.linkedSetting ?? '',
+    value: property.value,
+  };
+}
+
+/**
+ * ⭐ A link the user asked for but which names nothing yet reads back as no link at all, which is
+ * how an empty option list leaves the checkbox off. That is the behaviour the pair of writable
+ * computeds this replaced already had.
+ */
+export function toLinkedProperty(state: LinkedPropertyState): AccountingRuleWithLinkedProperty {
+  return {
+    value: state.value,
+    ...(state.linked && state.linkedSetting ? { linkedSetting: state.linkedSetting } : {}),
   };
 }


### PR DESCRIPTION
Follow-up to #12935. Splits the mapping seam out of the form so components that map but do not validate can use it too, and takes the first two.

### The seam was welded to the form

`useMappedModelForm` gave forms a way to say "my inputs cannot hold the payload as it stands". But keeping two shapes in step needs nothing from validation — `toState`, `toModel`, the two watchers and the equality guard between them are about mapping, not rules. Any component that maps without validating had no way to say it, so it said it per field instead, in writable computeds over the payload.

`useModelMirror` is that half on its own. It wires an existing reactive state to a payload; the form is now that plus a schema, server errors and a dirty flag. It takes the state rather than creating it, because a form's state belongs to `useForm`, which builds and resets it. The existing `useModelForm` spec passes untouched, which is the evidence the extraction is behaviour-preserving.

### `AccountingRuleWithLinkedSetting`

The payload records "not linked" by leaving `linkedSetting` out, and three controls sit over that: a switch for the value, a checkbox for whether it is linked, a select for what to. The absence of a field is not something a checkbox can bind to, so the component wrote that conversion by hand, twice, in a pair of writable computeds. Named now as `toLinkedPropertyState` / `toLinkedProperty` beside the rule schema, and mirrored.

One deliberate behaviour change: ticking the box while the option list has not arrived is now refused outright, rather than taken and then undone by the round trip. The old code reached the same end state — the box could not stay ticked naming nothing — but by a route that would flash the select open for a tick on its way back out.

### `HistoryEventsTableActions`

Smaller than it looked from the outside. Its `pillParams` bridges *three* separate models into one param bag, which the mirror (one payload, one state) does not cover, so that stays as it is. `matchExactEvents` was wrapping one field only to read it back three times and flip it once; the reads take the field directly, as the row below them already did, and the flip is a handler.

### Tests

`AccountingRuleWithLinkedSetting` had **no spec at all**, and neither the unit suite nor the accounting-rules e2e touched its linked toggle — nothing anywhere asserted what its three controls do to the payload. Nine cases added, checked against a deliberately broken mapper rather than assumed, plus a negative control that mapping a payload into three controls is not an edit of it. `useModelMirror` gets nine of its own, including the one that fails without the equality guard.

### Checks

`typecheck`, `lint` (0 errors, 0 warnings), `knip`, full `test:unit` (886 files / 8929 tests). E2E `accounting-rules.spec.ts` + `history-events.spec.ts` across two shards, 34 tests, all passed.

### What is left after this

Three call sites of `useRefPropVModel`, then the module goes: `AccountingRuleForm`'s three toggles (they can join the form state under `transientKeys`, which `useForm` already has, so they keep not marking it dirty), `ValidatorAccountForm` (a prop-contract narrowing, not a transform), and `AccountForm` (the hard one — `AccountManageState` is a discriminated union whose variants disagree about `chain` itself, so `toModel` has to reconstruct the variant rather than spread).
