### PR TITLE
fix(frontend): stop the wallet store leaking across sessions

### DIFF
--- a/frontend/app/src/modules/auth/login/LoginUsernameField.spec.ts
+++ b/frontend/app/src/modules/auth/login/LoginUsernameField.spec.ts
@@ -1,0 +1,61 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import LoginUsernameField from './LoginUsernameField.vue';
+
+const savedUsernames = ref<string[]>([]);
+const loadProfiles = vi.fn();
+
+vi.mock('@/modules/auth/use-saved-profiles', () => ({
+  useSavedProfiles: (): { loadProfiles: () => void; savedUsernames: typeof savedUsernames } => ({
+    loadProfiles,
+    savedUsernames,
+  }),
+}));
+
+interface FieldProps {
+  modelValue?: string;
+  search?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  isDocker?: boolean;
+}
+
+// under test the component always renders the plain text field (VITE_TEST is set), so the
+// input control is addressed by name rather than by branch.
+function mountField(props: FieldProps = {}): VueWrapper<InstanceType<typeof LoginUsernameField>> {
+  return mount(LoginUsernameField, {
+    props: { disabled: false, loading: false, modelValue: '', search: '', ...props },
+  });
+}
+
+describe('modules/auth/login/LoginUsernameField', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(savedUsernames, ['alice', 'bob']);
+  });
+
+  it('should normalize a cleared value to an empty string', async () => {
+    // RuiAutoComplete resets its selection to `undefined` whenever the options change and the
+    // current value is not among them, which happens while the profiles are still loading.
+    // The parent's model must stay a string.
+    const wrapper = mountField({ modelValue: 'alice' });
+
+    wrapper.findComponent({ name: 'RuiTextField' }).vm.$emit('update:modelValue', undefined);
+    await nextTick();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['']);
+  });
+
+  it('should render an undefined model value as an empty string', () => {
+    const wrapper = mountField({ modelValue: undefined });
+
+    expect(wrapper.findComponent({ name: 'RuiTextField' }).props('modelValue')).toBe('');
+  });
+
+  it('should pass a set value through to the input', () => {
+    const wrapper = mountField({ modelValue: 'alice' });
+
+    expect(wrapper.findComponent({ name: 'RuiTextField' }).props('modelValue')).toBe('alice');
+  });
+});

--- a/frontend/app/src/modules/auth/login/LoginUsernameField.vue
+++ b/frontend/app/src/modules/auth/login/LoginUsernameField.vue
@@ -4,7 +4,10 @@ import LoginNoProfilesMessage from '@/modules/auth/login/LoginNoProfilesMessage.
 import { sortUsernamesByKeyword } from '@/modules/auth/login/sort-usernames';
 import { useSavedProfiles } from '@/modules/auth/use-saved-profiles';
 
-const username = defineModel<string>({ required: true });
+// RuiAutoComplete clears its selection to `undefined` whenever the options change and the
+// current value is not one of them - which happens on mount, while the profiles are still
+// loading. The model therefore accepts `undefined` and normalizes it back to an empty string.
+const model = defineModel<string>({ default: '' });
 const search = defineModel<string>('search', { required: true });
 
 const {
@@ -34,6 +37,11 @@ const { loadProfiles, savedUsernames } = useSavedProfiles();
 // A plain text field is used on docker (where profiles are not enumerable) and under test,
 // where the autocomplete's overlay makes the input awkward to drive.
 const usePlainField = computed<boolean>(() => !!isDocker || !!isTest);
+
+const username = computed<string>({
+  get: () => get(model),
+  set: (value: string | undefined) => set(model, value ?? ''),
+});
 
 const orderedUsernames = computed<string[]>(() => sortUsernamesByKeyword(get(savedUsernames), get(search)));
 

--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.spec.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.spec.ts
@@ -83,7 +83,7 @@ vi.mock('@/modules/settings/use-settings-operations', () => ({
 }));
 
 vi.mock('@/modules/wallet/use-wallet-store', () => ({
-  useWalletStore: (): unknown => ({ disconnect: h.disconnectWallet }),
+  disconnectWalletIfActive: (): unknown => h.disconnectWallet(),
 }));
 
 vi.mock('@/modules/auth/use-remember-settings', () => ({

--- a/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.ts
+++ b/frontend/app/src/modules/auth/unlock-flow/use-unlock-flow-controller.ts
@@ -9,7 +9,7 @@ import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { api } from '@/modules/core/api/rotki-api';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
-import { useWalletStore } from '@/modules/wallet/use-wallet-store';
+import { disconnectWalletIfActive } from '@/modules/wallet/use-wallet-store';
 import { useSessionReady } from './use-session-ready';
 import {
   type Resolution,
@@ -73,7 +73,6 @@ export function createUnlockFlowController(): UseUnlockFlowControllerReturn {
     () => get(logged),
   );
   const { updateFrontendSetting } = useSettingsOperations();
-  const { disconnect: disconnectWallet } = useWalletStore();
   const { savedUsername } = useRememberSettings();
   const { checkIfPasswordConfirmationNeeded } = usePasswordConfirmation();
   const { restarting } = useRestartingStatus();
@@ -154,7 +153,7 @@ export function createUnlockFlowController(): UseUnlockFlowControllerReturn {
     if (resumed)
       await checkIfPasswordConfirmationNeeded(get(username));
     else
-      await disconnectWallet();
+      await disconnectWalletIfActive();
   }
 
   watch(flow.state, (current) => {

--- a/frontend/app/src/modules/auth/use-logout.spec.ts
+++ b/frontend/app/src/modules/auth/use-logout.spec.ts
@@ -37,9 +37,7 @@ vi.mock('@/modules/auth/use-users-api', () => ({
 }));
 
 vi.mock('@/modules/wallet/use-wallet-store', () => ({
-  useWalletStore: vi.fn(() => ({
-    disconnect: mockDisconnectWallet,
-  })),
+  disconnectWalletIfActive: async (): Promise<void> => mockDisconnectWallet(),
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({

--- a/frontend/app/src/modules/auth/use-logout.ts
+++ b/frontend/app/src/modules/auth/use-logout.ts
@@ -8,7 +8,7 @@ import { getErrorMessage, useNotifications } from '@/modules/core/notifications/
 import { useSchedulerState } from '@/modules/session/use-scheduler-state';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
 import { useAppNavigation } from '@/modules/shell/layout/use-navigation';
-import { useWalletStore } from '@/modules/wallet/use-wallet-store';
+import { disconnectWalletIfActive } from '@/modules/wallet/use-wallet-store';
 
 interface LogoutOptions {
   navigate?: boolean;
@@ -36,7 +36,6 @@ export function useLogout(): UseLogoutReturn {
   const { showErrorMessage } = useNotifications();
   const { notifyUserLogout, resetMcpSession, resetTray } = useInterop();
   const { loggedUsers: getLoggedUsers, logout: callLogout } = useUsersApi();
-  const { disconnect: disconnectWallet } = useWalletStore();
   const { reset: resetSchedulerState } = useSchedulerState();
 
   const logout = async (navigate: boolean = true, options: LogoutOptions = {}): Promise<void> => {
@@ -50,7 +49,7 @@ export function useLogout(): UseLogoutReturn {
     // Notify electron to cleanup wallet bridge connections BEFORE disconnecting
     notifyUserLogout();
 
-    await disconnectWallet();
+    await disconnectWalletIfActive();
     set(logged, false);
     const user = get(username); // save the username, after the await below, it is reset
     // allow some time for the components to leave the dom completely and show loading overlay
@@ -85,7 +84,7 @@ export function useLogout(): UseLogoutReturn {
     api.cancel();
 
     try {
-      await disconnectWallet();
+      await disconnectWalletIfActive();
       const loggedUsers = await getLoggedUsers();
       for (const user of loggedUsers)
         await callLogout(user);

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.shared.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.shared.spec.ts
@@ -1,0 +1,50 @@
+import { createMock } from '@test/utils/create-mock';
+import { withSetup } from '@test/utils/with-setup';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWalletBridge } from '@/modules/shell/app/use-wallet-bridge';
+
+// Deliberately does NOT stub createSharedComposable: this file is about the sharing itself.
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/modules/shell/app/use-wallet-bridge', () => ({ useWalletBridge: vi.fn() }));
+
+describe('modules/wallet/bridge/use-wallet-proxy sharing', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    // reports the client as gone, so any health check that is still running WILL fire
+    // onDisconnect - that is what makes the "stopped" assertion below discriminating
+    vi.mocked(useWalletBridge).mockReturnValue(createMock<ReturnType<typeof useWalletBridge>>({
+      isProxyClientConnected: vi.fn(async () => false),
+    }));
+  });
+
+  it('should hand every consumer the same instance', async () => {
+    const { useWalletProxy } = await import('./use-wallet-proxy');
+
+    // the wallet store builds one inside its own scope, useInjectedWallet builds another
+    const fromStore = withSetup(() => useWalletProxy()).result;
+    const fromInjectedWallet = withSetup(() => useWalletProxy()).result;
+
+    expect(fromInjectedWallet).toBe(fromStore);
+  });
+
+  it('should let one consumer stop a health check another consumer started', async () => {
+    vi.useFakeTimers();
+    const { useWalletProxy } = await import('./use-wallet-proxy');
+
+    const starter = withSetup(() => useWalletProxy()).result;
+    const stopper = withSetup(() => useWalletProxy()).result;
+
+    const onDisconnect = vi.fn();
+    starter.startConnectionHealthCheck(() => true, onDisconnect);
+    // the interval lives on the shared instance, so the other handle owns it too
+    stopper.stopConnectionHealthCheck();
+
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(onDisconnect).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.spec.ts
@@ -9,6 +9,12 @@ vi.mock('@/modules/core/common/logging/logging', () => ({
   logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
+// each test wants its own proxy instance, so the sharing wrapper is a pass-through here
+vi.mock('@vueuse/core', async (importOriginal): Promise<any> => ({
+  ...(await importOriginal<any>()),
+  createSharedComposable: <T>(fn: T): T => fn,
+}));
+
 vi.mock('@/modules/shell/app/use-wallet-bridge', () => ({ useWalletBridge: vi.fn() }));
 vi.mock('@/modules/core/common/async/async-utilities', () => ({ waitForCondition: vi.fn(async () => true) }));
 

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.ts
@@ -1,6 +1,6 @@
 import { startPromise } from '@shared/utils';
 import { get, isDefined, set } from '@vueuse/core';
-import { computed, onBeforeUnmount, ref } from 'vue';
+import { computed, onScopeDispose, ref } from 'vue';
 import { waitForCondition } from '@/modules/core/common/async/async-utilities';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -285,9 +285,11 @@ export function useWalletProxy(): UseWalletProxyReturn {
     }
   };
 
-  // Cleanup on component unmount
-  onBeforeUnmount(() => {
-    logger.debug('Component unmounting, cleaning up bridge resources...');
+  // Cleanup when the owning scope is disposed. This composable is created inside the wallet
+  // store, so a component hook would bind to whichever component happened to instantiate the
+  // store first and tear the bridge down when that unrelated component unmounted.
+  onScopeDispose(() => {
+    logger.debug('Scope disposed, cleaning up bridge resources...');
     cleanupResources();
   });
 

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.ts
@@ -1,5 +1,5 @@
 import { startPromise } from '@shared/utils';
-import { get, isDefined, set } from '@vueuse/core';
+import { createSharedComposable, get, isDefined, set } from '@vueuse/core';
 import { computed, getCurrentScope, onScopeDispose, ref } from 'vue';
 import { waitForCondition } from '@/modules/core/common/async/async-utilities';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
@@ -23,7 +23,7 @@ interface UseWalletProxyReturn {
   disconnectProxy: () => Promise<void>;
 }
 
-export function useWalletProxy(): UseWalletProxyReturn {
+function _useWalletProxy(): UseWalletProxyReturn {
   const { isProxyClientConnected, isProxyClientReady, isProxyHttpListening, isProxyWebSocketListening, openProxyPageInDefaultBrowser, proxyStopServers } = useWalletBridge();
   const { cleanupResources: cleanupActiveResources, resources: activeResources } = createResourceManager();
 
@@ -288,9 +288,6 @@ export function useWalletProxy(): UseWalletProxyReturn {
   // Cleanup when the owning scope is disposed. This composable is created inside the wallet
   // store, so a component hook would bind to whichever component happened to instantiate the
   // store first and tear the bridge down when that unrelated component unmounted.
-  //
-  // useInjectedWallet() builds a second instance from an async action, where there is no scope
-  // to attach to; that one is torn down explicitly by its disconnect() instead.
   if (getCurrentScope()) {
     onScopeDispose(() => {
       logger.debug('Scope disposed, cleaning up bridge resources...');
@@ -307,3 +304,13 @@ export function useWalletProxy(): UseWalletProxyReturn {
     waitForProxyConnection,
   };
 }
+
+/**
+ * Shared across every consumer on purpose. The proxy owns process-wide resources - the health
+ * check interval, the setup abort controller and its timeout - and two instances split that
+ * state: the wallet store held one (which ran `setupProxy`) while `useInjectedWallet` held
+ * another (which ran the health check and `disconnectProxy`). Disconnecting therefore could
+ * not abort a setup that was still in flight, because the abort controller belonged to the
+ * other instance.
+ */
+export const useWalletProxy = createSharedComposable(_useWalletProxy);

--- a/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-wallet-proxy.ts
@@ -1,6 +1,6 @@
 import { startPromise } from '@shared/utils';
 import { get, isDefined, set } from '@vueuse/core';
-import { computed, onScopeDispose, ref } from 'vue';
+import { computed, getCurrentScope, onScopeDispose, ref } from 'vue';
 import { waitForCondition } from '@/modules/core/common/async/async-utilities';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -288,10 +288,15 @@ export function useWalletProxy(): UseWalletProxyReturn {
   // Cleanup when the owning scope is disposed. This composable is created inside the wallet
   // store, so a component hook would bind to whichever component happened to instantiate the
   // store first and tear the bridge down when that unrelated component unmounted.
-  onScopeDispose(() => {
-    logger.debug('Scope disposed, cleaning up bridge resources...');
-    cleanupResources();
-  });
+  //
+  // useInjectedWallet() builds a second instance from an async action, where there is no scope
+  // to attach to; that one is torn down explicitly by its disconnect() instead.
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      logger.debug('Scope disposed, cleaning up bridge resources...');
+      cleanupResources();
+    });
+  }
 
   return {
     disconnectProxy,

--- a/frontend/app/src/modules/wallet/providers/use-unified-providers.spec.ts
+++ b/frontend/app/src/modules/wallet/providers/use-unified-providers.spec.ts
@@ -162,6 +162,31 @@ describe('useUnifiedProviders', () => {
     expect(listener).toHaveBeenCalledWith(undefined, expect.anything());
   });
 
+  it('should forget the remembered provider when clearing deliberately', async () => {
+    detectMock.mockResolvedValue([makeProvider('solo')]);
+    const { clearProvider, detectProviders } = useUnifiedProviders();
+    await detectProviders();
+    expect(JSON.parse(localStorage.getItem('rotki-provider-preferences') ?? '{}').lastSelectedUuid).toBe('solo');
+
+    clearProvider();
+    await nextTick(); // useLocalStorage flushes on 'pre'
+
+    expect(JSON.parse(localStorage.getItem('rotki-provider-preferences') ?? '{}').lastSelectedUuid).toBeUndefined();
+  });
+
+  it('should keep the remembered provider when clearing without forgetting', async () => {
+    detectMock.mockResolvedValue([makeProvider('solo')]);
+    const { clearProvider, detectProviders, hasSelectedProvider } = useUnifiedProviders();
+    await detectProviders();
+
+    clearProvider({ forget: false });
+    await nextTick(); // useLocalStorage flushes on 'pre'
+
+    // the active selection still goes away, only the persisted choice survives
+    expect(get(hasSelectedProvider)).toBe(false);
+    expect(JSON.parse(localStorage.getItem('rotki-provider-preferences') ?? '{}').lastSelectedUuid).toBe('solo');
+  });
+
   it('should clear the selection when selecting the empty uuid', async () => {
     detectMock.mockResolvedValue([makeProvider('solo')]);
     const { detectProviders, hasSelectedProvider, selectProvider } = useUnifiedProviders();

--- a/frontend/app/src/modules/wallet/providers/use-unified-providers.ts
+++ b/frontend/app/src/modules/wallet/providers/use-unified-providers.ts
@@ -12,6 +12,15 @@ interface ProviderPreferences {
   autoSelectSingle: boolean;
 }
 
+interface ClearProviderOptions {
+  /**
+   * Whether to also forget the persisted `lastSelectedUuid`. Defaults to `true`, which is
+   * what a deliberate disconnect wants; session teardown passes `false` so the remembered
+   * provider survives to the next login.
+   */
+  forget?: boolean;
+}
+
 // Extended options for detection
 interface UnifiedDetectionOptions extends ProviderDetectionOptions {
   maxRetries?: number;
@@ -48,7 +57,7 @@ interface UnifiedProvidersComposable {
   // Actions
   detectProviders: (options?: UnifiedDetectionOptions) => Promise<EnhancedProviderDetail[]>;
   selectProvider: (uuid: string) => Promise<boolean>;
-  clearProvider: () => void;
+  clearProvider: (options?: ClearProviderOptions) => void;
   checkIfSelectedProvider: () => Promise<boolean>;
 
   // Event system
@@ -310,16 +319,20 @@ function createUnifiedProvidersComposable(): UnifiedProvidersComposable {
   }
 
   // Clear provider selection
-  function clearProvider(): void {
+  function clearProvider({ forget = true }: ClearProviderOptions = {}): void {
     const previousProvider = get(selectedProvider);
 
     set(selectedProvider, undefined);
 
-    // Update preferences
-    set(preferences, {
-      ...get<ProviderPreferences>(preferences),
-      lastSelectedUuid: undefined,
-    });
+    // Only a deliberate disconnect forgets the choice. Tearing the session down (logout,
+    // switching user) clears the active selection but must keep the remembered provider,
+    // otherwise the next login has to pick one again.
+    if (forget) {
+      set(preferences, {
+        ...get<ProviderPreferences>(preferences),
+        lastSelectedUuid: undefined,
+      });
+    }
 
     // Notify change listeners
     notifyProviderChanged(undefined, previousProvider?.provider);

--- a/frontend/app/src/modules/wallet/use-transaction-manager.ts
+++ b/frontend/app/src/modules/wallet/use-transaction-manager.ts
@@ -14,6 +14,7 @@ export function useTransactionManager(): {
   getRecentTransactionByTxHash: (hash: string) => RecentTransaction | undefined;
   handleTransactionSuccess: (client: ViemWalletClient, hash: Hash, chainId: number, params: TransactionParams, initiatorAddress: string | undefined, getChainFromChainId: (chainId: number) => string) => Promise<void>;
   recentTransactions: Readonly<Ref<RecentTransaction[]>>;
+  reset: () => void;
   updateTransactionStatus: (hash: string, status: 'completed' | 'failed') => void;
 } {
   const recentTransactions = ref<RecentTransaction[]>([]);
@@ -93,11 +94,16 @@ export function useTransactionManager(): {
     startPromise(updateStatePostTransaction(getRecentTransactionByTxHash(hash)));
   };
 
+  const reset = (): void => {
+    set(recentTransactions, []);
+  };
+
   return {
     addRecentTransaction,
     getRecentTransactionByTxHash,
     handleTransactionSuccess,
     recentTransactions: shallowReadonly(recentTransactions),
+    reset,
     updateTransactionStatus,
   };
 }

--- a/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
@@ -133,6 +133,23 @@ describe('modules/wallet/use-wallet-store', () => {
     expect(get(store.isWalletConnect)).toBe(false);
   });
 
+  it('should not clear the selected provider when the store is created', async () => {
+    await getStore();
+    await nextTick();
+
+    expect(providers().clearProvider).not.toHaveBeenCalled();
+  });
+
+  it('should disconnect when the wallet mode changes', async () => {
+    const store = await getStore();
+
+    store.walletMode = WALLET_MODES.WALLET_CONNECT;
+    await nextTick();
+    // back to local bridge, the mode disconnect() clears the provider for
+    store.walletMode = WALLET_MODES.LOCAL_BRIDGE;
+    await vi.waitFor(() => expect(providers().clearProvider).toHaveBeenCalledTimes(1));
+  });
+
   it('should reflect walletconnect mode in isWalletConnect', async () => {
     const store = await getStore();
     store.walletMode = WALLET_MODES.WALLET_CONNECT;

--- a/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
@@ -235,6 +235,27 @@ describe('modules/wallet/use-wallet-store', () => {
     });
   });
 
+  describe('disconnectWalletIfActive', () => {
+    it('should not create the store when it does not exist yet', async () => {
+      const { disconnectWalletIfActive } = await import('./use-wallet-store');
+
+      await disconnectWalletIfActive();
+
+      expect(providers().clearProvider).not.toHaveBeenCalled();
+      expect(injected().disconnect).not.toHaveBeenCalled();
+    });
+
+    it('should disconnect when the store already exists', async () => {
+      const { disconnectWalletIfActive } = await import('./use-wallet-store');
+      const store = await getStore();
+      await store.connect(); // initialise the injected instance
+
+      await disconnectWalletIfActive();
+
+      expect(injected().disconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('reset', () => {
     it('should clear the connection state and the recent transactions', async () => {
       const store = await getStore();

--- a/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
@@ -102,6 +102,7 @@ describe('modules/wallet/use-wallet-store', () => {
       transactionManager: {
         handleTransactionSuccess: vi.fn(async () => {}),
         recentTransactions: ref([]),
+        reset: vi.fn(),
         updateTransactionStatus: vi.fn(),
       },
       unifiedProviders: {
@@ -214,6 +215,27 @@ describe('modules/wallet/use-wallet-store', () => {
       expect(providers().clearProvider).toHaveBeenCalled();
       expect(get(store.connected)).toBe(false);
       expect(get(store.isDisconnecting)).toBe(false);
+    });
+  });
+
+  describe('reset', () => {
+    it('should clear the connection state and the recent transactions', async () => {
+      const store = await getStore();
+      await store.connect();
+
+      store.reset();
+
+      expect(get(store.connected)).toBe(false);
+      expect(get(store.connectedAddress)).toBeUndefined();
+      expect(mocks.state.transactionManager.reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not expose the recent transactions as patchable state', async () => {
+      const store = await getStore();
+
+      // they are a getter over the transaction manager's readonly ref, so the store
+      // reset plugin must not try to `$patch` them
+      expect(store.$state).not.toHaveProperty('recentTransactions');
     });
   });
 

--- a/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
@@ -233,6 +233,15 @@ describe('modules/wallet/use-wallet-store', () => {
       expect(get(store.connected)).toBe(false);
       expect(get(store.isDisconnecting)).toBe(false);
     });
+
+    it('should forget the remembered provider on a deliberate disconnect', async () => {
+      const store = await getStore();
+      await store.connect();
+
+      await store.disconnect();
+
+      expect(providers().clearProvider).toHaveBeenCalledWith({ forget: true });
+    });
   });
 
   describe('disconnectWalletIfActive', () => {
@@ -253,6 +262,16 @@ describe('modules/wallet/use-wallet-store', () => {
       await disconnectWalletIfActive();
 
       expect(injected().disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should keep the remembered provider so the next login can restore it', async () => {
+      const { disconnectWalletIfActive } = await import('./use-wallet-store');
+      const store = await getStore();
+      await store.connect();
+
+      await disconnectWalletIfActive();
+
+      expect(providers().clearProvider).toHaveBeenCalledWith({ forget: false });
     });
   });
 

--- a/frontend/app/src/modules/wallet/use-wallet-store.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.ts
@@ -26,6 +26,14 @@ export { type WalletMode } from './constants';
 
 const STORE_ID = 'wallet';
 
+interface DisconnectOptions {
+  /**
+   * Whether to forget the remembered provider. Defaults to `true` for a deliberate
+   * user disconnect; session teardown passes `false`.
+   */
+  forgetProvider?: boolean;
+}
+
 // Lazy backend types
 type WalletConnectInstance = ReturnType<typeof import('./use-wallet-connect').useWalletConnect>;
 
@@ -211,14 +219,14 @@ export const useWalletStore = defineStore(STORE_ID, () => {
     resetTransactions();
   };
 
-  const disconnect = async (): Promise<void> => {
+  const disconnect = async ({ forgetProvider = true }: DisconnectOptions = {}): Promise<void> => {
     set(isDisconnecting, true);
     try {
       if (get(walletMode) === WALLET_MODES.LOCAL_BRIDGE) {
         if (injectedWalletInstance) {
           await injectedWalletInstance.disconnect();
         }
-        unifiedProviders.clearProvider();
+        unifiedProviders.clearProvider({ forget: forgetProvider });
       }
       else {
         if (walletConnectInstance) {
@@ -374,11 +382,14 @@ export const useWalletStore = defineStore(STORE_ID, () => {
  * `useWalletStore()` would build the whole wallet graph (bridge proxy, providers, transaction
  * manager) just to tear it down. The auth flows use this so the login screen no longer
  * instantiates the store.
+ *
+ * The remembered provider is kept: logging out is not the user saying they no longer want
+ * that wallet.
  */
 export async function disconnectWalletIfActive(): Promise<void> {
   const pinia = getActivePinia();
   if (!pinia || !Object.hasOwn(pinia.state.value, STORE_ID))
     return;
 
-  await useWalletStore().disconnect();
+  await useWalletStore().disconnect({ forgetProvider: false });
 }

--- a/frontend/app/src/modules/wallet/use-wallet-store.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.ts
@@ -335,9 +335,10 @@ export const useWalletStore = defineStore('wallet', () => {
     }
   };
 
-  // Watch for changes in wallet mode
+  // Watch for changes in wallet mode. The immediate run has no previous mode and nothing is
+  // connected yet, so disconnecting there would only clear the remembered provider.
   watch(walletMode, async (walletMode, previousWalletMode) => {
-    if (walletMode !== previousWalletMode) {
+    if (previousWalletMode !== undefined && walletMode !== previousWalletMode) {
       await disconnect();
       resetState();
     }

--- a/frontend/app/src/modules/wallet/use-wallet-store.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.ts
@@ -24,12 +24,14 @@ import { useTransactionManager } from './use-transaction-manager';
 
 export { type WalletMode } from './constants';
 
+const STORE_ID = 'wallet';
+
 // Lazy backend types
 type WalletConnectInstance = ReturnType<typeof import('./use-wallet-connect').useWalletConnect>;
 
 type InjectedWalletInstance = ReturnType<typeof import('./bridge/use-injected-wallet').useInjectedWallet>;
 
-export const useWalletStore = defineStore('wallet', () => {
+export const useWalletStore = defineStore(STORE_ID, () => {
   // Core wallet state - centralized instead of delegated
   const preparing = ref<boolean>(false);
   const waitingForWalletConfirmation = ref<boolean>(false);
@@ -364,3 +366,19 @@ export const useWalletStore = defineStore('wallet', () => {
     walletMode,
   };
 });
+
+/**
+ * Disconnects the wallet only when the store already exists.
+ *
+ * A session that never opened the wallet has nothing to disconnect, and calling
+ * `useWalletStore()` would build the whole wallet graph (bridge proxy, providers, transaction
+ * manager) just to tear it down. The auth flows use this so the login screen no longer
+ * instantiates the store.
+ */
+export async function disconnectWalletIfActive(): Promise<void> {
+  const pinia = getActivePinia();
+  if (!pinia || !Object.hasOwn(pinia.state.value, STORE_ID))
+    return;
+
+  await useWalletStore().disconnect();
+}

--- a/frontend/app/src/modules/wallet/use-wallet-store.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.ts
@@ -2,6 +2,7 @@ import type {
   GasFeeEstimation,
   PrepareERC20TransferResponse,
   PrepareNativeTransferResponse,
+  RecentTransaction,
   TransactionParams,
 } from '@/modules/wallet/types';
 import { assert } from '@rotki/common';
@@ -51,7 +52,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
   // Transaction management
   const transactionManager = useTransactionManager();
-  const { recentTransactions, updateTransactionStatus } = transactionManager;
+  const { recentTransactions, reset: resetTransactions, updateTransactionStatus } = transactionManager;
 
   const { getChainFromChainId, getChainIdFromNamespace } = useWalletHelper();
   const { prepareERC20Transfer, prepareNativeTransfer } = useTradeApi();
@@ -201,6 +202,13 @@ export const useWalletStore = defineStore('wallet', () => {
     set(supportedChainIds, []);
   };
 
+  // Called by the store reset plugin on logout. `$patch` cannot clear the recent
+  // transactions since they are exposed as a getter, so they are reset here.
+  const reset = (): void => {
+    resetState();
+    resetTransactions();
+  };
+
   const disconnect = async (): Promise<void> => {
     set(isDisconnecting, true);
     try {
@@ -346,7 +354,8 @@ export const useWalletStore = defineStore('wallet', () => {
     isDisconnecting,
     isWalletConnect,
     preparing: logicOr(preparing, isConnecting),
-    recentTransactions,
+    recentTransactions: computed<RecentTransaction[]>(() => get(recentTransactions)),
+    reset,
     sendTransaction,
     supportedChainsForConnectedAccount,
     switchNetwork,


### PR DESCRIPTION
The wallet store kept state across a logout and tore its bridge down at the wrong times. Each commit is independent.

### The one that matters

`recentTransactions` was exposed as a `shallowReadonly` ref, which pinia treats as **state**, not a getter. `StoreResetPlugin` therefore tried to clear it with `$patch`, Vue rejected the write, and the transactions survived the logout. `$patch` does not throw, so the plugin's `try/catch` never fired, and the wallet store had no `reset` action for the plugin's fallback to call. The only symptom was a dev-console warning:

```
[Vue warn] Set operation on key "recentTransactions" failed: target is readonly
```

Vue strips warnings from production builds, so in a release the previous user's transactions simply stayed in the store with nothing to indicate it. It is now a computed getter plus a `reset` action, which the plugin calls.

### The rest

- **Login screen no longer builds the wallet store.** `use-logout.ts` and `use-unlock-flow-controller.ts` called `useWalletStore()` at setup just to keep a reference to `disconnect`, which constructed the whole wallet graph (bridge proxy, providers, transaction manager) on the login screen. `disconnectWalletIfActive()` checks `Object.hasOwn(getActivePinia().state.value, 'wallet')` first, using public API rather than `_s` internals.
- **The bridge cleanup hook is scoped correctly.** `onBeforeUnmount` inside a pinia store binds to whichever component happened to instantiate the store first, so an unrelated component unmounting tore down the wallet bridge. Now `onScopeDispose`, guarded by `getCurrentScope()`.
- **No disconnect on store creation.** The `walletMode` watcher ran immediately with no previous mode and nothing connected, so it disconnected and dropped the remembered provider.
- **The remembered provider survives a logout.** `disconnect()` always cleared the persisted `lastSelectedUuid`, and logout routes through it, so every session teardown forgot the chosen provider. `clearProvider()` now takes a `forget` flag: a deliberate disconnect still forgets, while `disconnectWalletIfActive()` keeps the persisted choice.
- **One shared wallet proxy.** `useWalletProxy` was a plain composable built twice, once by the store (which ran `setupProxy`) and once by `useInjectedWallet` (which ran the health check and `disconnectProxy`). Each copy had its own health-check interval and resource manager, so disconnecting could not abort a setup still in flight. It is now a `createSharedComposable`, matching `useInjectedWallet` in the same directory.
- **The login username model accepts `undefined`.** `RuiAutoComplete` writes `undefined` back into its parent's v-model whenever the options change and the current value is not among them, which happens on mount while the saved profiles are still loading. The field is `clearable`, so `undefined` is a legitimate "nothing selected" and `defineModel<string>({ required: true })` was the wrong contract. The library-side half shipped separately in `@rotki/ui-library` 2.23.5.

### Testing

272 wallet specs pass; typecheck and lint are clean. The new tests were checked against inverted implementations to confirm they fail when the fix is removed.

Verified in the Electron app against a real bridged wallet (Sepolia), running a full connect → logout → login cycle with no console warnings:

- the remembered provider survived both the logout and the re-login;
- `$reset()` called `reset()` once with no readonly warning;
- `recentTransactions` is confirmed absent from `store.$state`;
- a proxy handle obtained fresh from the module stopped the health-check interval that `useInjectedWallet` had started, which the pre-fix split instances could not do.