### PR TITLE
feat(frontend): identify the session

### DIFF
--- a/frontend/app/src/modules/core/sigil/types.ts
+++ b/frontend/app/src/modules/core/sigil/types.ts
@@ -65,16 +65,24 @@ export type SigilEvent = keyof SigilEventMap;
 
 /** A queued entry stored in IndexedDB before being flushed via the batch endpoint. */
 export interface SigilQueueEntry {
+  /** IndexedDB key, not sent. */
   id?: number;
+  /**
+   * `identify` links the session to the client value; everything else is an event. Queued with the
+   * rest rather than sent apart, so it keeps its place in the batch and survives being offline.
+   */
+  kind?: 'identify';
   url: string;
   /** Set for custom events (chronicle calls), absent for page views. */
   name?: string;
-  /** Custom event data payload. */
+  /** Custom event data, or session data on an identify. */
   data?: Record<string, unknown>;
+  /** The value to link the session to. Identify only. */
+  clientId?: string;
   timestamp: number;
 }
 
-/** Payload shape for a single event sent to the analytics backend. */
+/** Payload shape for a single entry sent to the analytics backend. */
 interface SigilEventPayload {
   website: string;
   hostname: string;
@@ -85,9 +93,11 @@ interface SigilEventPayload {
   referrer: string;
   name?: string;
   data?: Record<string, unknown>;
+  /** The distinct id, capped at 50 characters upstream. Identify only. */
+  id?: string;
 }
 
 export interface SigilBatchEntry {
-  type: 'event';
+  type: 'event' | 'identify';
   payload: SigilEventPayload;
 }

--- a/frontend/app/src/modules/core/sigil/use-sigil-identity.spec.ts
+++ b/frontend/app/src/modules/core/sigil/use-sigil-identity.spec.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const INSTANCE_KEY = 'rotki.sigil.instance_id';
+
+describe('use-sigil-identity', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+
+  describe('instance id', () => {
+    it('should mint and persist one on first use', async () => {
+      const { getInstanceId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      const id = getInstanceId();
+
+      expect(id).toEqual(expect.any(String));
+      expect(id).not.toBe('');
+      expect(localStorage.getItem(INSTANCE_KEY)).toBe(id);
+    });
+
+    it('should return the same value on a second call', async () => {
+      const { getInstanceId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      expect(getInstanceId()).toBe(getInstanceId());
+    });
+
+    it('should reuse a stored value rather than minting a new one', async () => {
+      localStorage.setItem(INSTANCE_KEY, 'stored-instance');
+      const { getInstanceId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      expect(getInstanceId()).toBe('stored-instance');
+    });
+
+    it('should keep one value for the session when storage throws', async () => {
+      const { getInstanceId } = await import('@/modules/core/sigil/use-sigil-identity');
+      vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('storage unavailable');
+      });
+
+      const first = getInstanceId();
+
+      expect(first).not.toBe('');
+      expect(getInstanceId()).toBe(first);
+    });
+  });
+
+  describe('client id cache', () => {
+    it('should return nothing for an account it has never seen', async () => {
+      const { readCachedClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      expect(readCachedClientId('bob')).toBeUndefined();
+    });
+
+    it('should return what was cached for that account', async () => {
+      const { cacheClientId, readCachedClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      cacheClientId('bob', 'bob-id');
+
+      expect(readCachedClientId('bob')).toBe('bob-id');
+    });
+
+    it('should keep accounts apart', async () => {
+      const { cacheClientId, readCachedClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      cacheClientId('bob', 'bob-id');
+      cacheClientId('alice', 'alice-id');
+
+      expect(readCachedClientId('bob')).toBe('bob-id');
+      expect(readCachedClientId('alice')).toBe('alice-id');
+    });
+
+    it('should overwrite an earlier value for the same account', async () => {
+      const { cacheClientId, readCachedClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+      cacheClientId('bob', 'old-id');
+
+      cacheClientId('bob', 'new-id');
+
+      expect(readCachedClientId('bob')).toBe('new-id');
+    });
+
+    it('should ignore a corrupt store rather than throw', async () => {
+      localStorage.setItem('rotki.sigil.client_ids', '{not json');
+      const { readCachedClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      expect(readCachedClientId('bob')).toBeUndefined();
+    });
+
+    it('should ignore entries of the wrong shape', async () => {
+      localStorage.setItem('rotki.sigil.client_ids', JSON.stringify({ bob: { nested: true } }));
+      const { readCachedClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      expect(readCachedClientId('bob')).toBeUndefined();
+    });
+
+    it('should do nothing without a username, so entries cannot collide under an empty key', async () => {
+      const { cacheClientId, readCachedClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      cacheClientId('', 'orphan-id');
+
+      expect(localStorage.getItem('rotki.sigil.client_ids')).toBeNull();
+      expect(readCachedClientId('')).toBeUndefined();
+    });
+  });
+
+  describe('createClientId', () => {
+    it('should return a distinct value each call', async () => {
+      const { createClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+
+      expect(createClientId()).not.toBe(createClientId());
+    });
+
+    /**
+     * `crypto.randomUUID` is only defined in a secure context, so it is missing exactly where this
+     * matters most: a Docker instance reached over plain http on a LAN IP.
+     */
+    it('should still mint without crypto.randomUUID', async () => {
+      const { createClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+      vi.stubGlobal('crypto', { getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto) });
+
+      const id = createClientId();
+
+      expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+      expect(createClientId()).not.toBe(id);
+    });
+
+    it('should still mint with no crypto at all', async () => {
+      const { createClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+      vi.stubGlobal('crypto', undefined);
+
+      const id = createClientId();
+
+      expect(id).not.toBe('');
+      expect(createClientId()).not.toBe(id);
+    });
+  });
+
+  describe('resetSigilIdentity', () => {
+    it('should drop everything stored, so the next call starts over', async () => {
+      const { cacheClientId, getInstanceId, readCachedClientId, resetSigilIdentity } = await import('@/modules/core/sigil/use-sigil-identity');
+      const first = getInstanceId();
+      cacheClientId('bob', 'bob-id');
+
+      resetSigilIdentity();
+
+      expect(localStorage.getItem(INSTANCE_KEY)).toBeNull();
+      expect(readCachedClientId('bob')).toBeUndefined();
+      expect(getInstanceId()).not.toBe(first);
+    });
+  });
+});

--- a/frontend/app/src/modules/core/sigil/use-sigil-identity.ts
+++ b/frontend/app/src/modules/core/sigil/use-sigil-identity.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod';
+import { logger } from '@/modules/core/common/logging/logging';
+
+const INSTANCE_KEY = 'rotki.sigil.instance_id';
+const CLIENT_KEY = 'rotki.sigil.client_ids';
+
+const ClientIdCache = z.record(z.string(), z.string());
+
+let instanceId: string | undefined;
+let currentClientId: string | undefined;
+
+/**
+ * Stamped on every entry, not just the identify: upstream stores it per row, and a session covers
+ * every account used on that machine that day, so a session-only link cannot tell them apart.
+ */
+export function getCurrentClientId(): string | undefined {
+  return currentClientId;
+}
+
+export function setCurrentClientId(id: string): void {
+  currentClientId = id;
+}
+
+export function clearCurrentClientId(): void {
+  currentClientId = undefined;
+}
+
+/**
+ * `crypto.randomUUID` needs a secure context, which a Docker instance reached over plain http on a
+ * LAN IP is not, so it is only the first choice of three. `getRandomValues` has no such
+ * restriction; the last resort keeps a weaker value working rather than throwing.
+ */
+function randomId(): string {
+  if (typeof crypto !== 'undefined') {
+    if (typeof crypto.randomUUID === 'function')
+      return crypto.randomUUID();
+
+    if (typeof crypto.getRandomValues === 'function') {
+      const bytes = crypto.getRandomValues(new Uint8Array(16));
+      // the v4 version and variant bits
+      bytes[6] = (bytes[6] & 0x0F) | 0x40;
+      bytes[8] = (bytes[8] & 0x3F) | 0x80;
+      const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    }
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function createClientId(): string {
+  return randomId();
+}
+
+/**
+ * Storage can throw (private mode, a quota), in which case the value lives only in memory for this
+ * session, which is enough to keep one session's events consistent.
+ */
+export function getInstanceId(): string {
+  if (instanceId)
+    return instanceId;
+
+  try {
+    const stored = localStorage.getItem(INSTANCE_KEY);
+    if (stored) {
+      instanceId = stored;
+      return stored;
+    }
+
+    const minted = randomId();
+    localStorage.setItem(INSTANCE_KEY, minted);
+    instanceId = minted;
+    return minted;
+  }
+  catch {
+    logger.debug('[sigil] storage unavailable, using an in-memory value');
+    instanceId ??= randomId();
+    return instanceId;
+  }
+}
+
+function readCache(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(CLIENT_KEY);
+    if (!raw)
+      return {};
+
+    const parsed = ClientIdCache.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : {};
+  }
+  catch {
+    return {};
+  }
+}
+
+/**
+ * A fallback, never the source of truth: only read when the settings hold nothing. Keyed by
+ * username so two accounts on one machine do not read each other's.
+ */
+export function readCachedClientId(username: string): string | undefined {
+  if (!username)
+    return undefined;
+
+  return readCache()[username];
+}
+
+export function cacheClientId(username: string, id: string): void {
+  if (!username)
+    return;
+
+  try {
+    localStorage.setItem(CLIENT_KEY, JSON.stringify({ ...readCache(), [username]: id }));
+  }
+  catch {
+    logger.debug('[sigil] storage unavailable, not caching');
+  }
+}
+
+export function resetSigilIdentity(): void {
+  instanceId = undefined;
+  try {
+    localStorage.removeItem(INSTANCE_KEY);
+    localStorage.removeItem(CLIENT_KEY);
+  }
+  catch {
+    logger.debug('[sigil] storage unavailable, nothing to clear');
+  }
+}

--- a/frontend/app/src/modules/core/sigil/use-sigil-queue.spec.ts
+++ b/frontend/app/src/modules/core/sigil/use-sigil-queue.spec.ts
@@ -91,6 +91,149 @@ describe('use-sigil-queue', () => {
     });
   });
 
+  describe('identify', () => {
+    interface FlushedEntry { type: string; payload: { id?: string; name?: string; data?: Record<string, unknown> } }
+
+    async function flushed(): Promise<FlushedEntry[]> {
+      const fetchSpy = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const { flush } = await import('@/modules/core/sigil/use-sigil-queue');
+      await flush();
+
+      const [, init] = fetchSpy.mock.calls[0];
+      return JSON.parse(init.body);
+    }
+
+    it('should send an identify entry with the value as the distinct id', async () => {
+      const { enqueue } = await import('@/modules/core/sigil/use-sigil-queue');
+      await enqueue({ kind: 'identify', clientId: 'client-1', data: { instance_id: 'instance-1' }, url: '/page', timestamp: 1000 });
+
+      const [entry] = await flushed();
+
+      expect(entry.type).toBe('identify');
+      expect(entry.payload.id).toBe('client-1');
+      expect(entry.payload.data).toEqual({ instance_id: 'instance-1' });
+      vi.unstubAllGlobals();
+    });
+
+    it('should keep its place ahead of the events queued after it', async () => {
+      const { enqueue } = await import('@/modules/core/sigil/use-sigil-queue');
+      await enqueue({ kind: 'identify', clientId: 'client-1', url: '/page', timestamp: 1000 });
+      await enqueue({ url: '/page', timestamp: 2000 });
+
+      const entries = await flushed();
+
+      expect(entries.map(entry => entry.type)).toEqual(['identify', 'event']);
+      vi.unstubAllGlobals();
+    });
+
+    /**
+     * Upstream classifies an entry by its name, so an identify must not carry one, and the
+     * identity must not be smuggled into event data: data on a nameless entry is dropped.
+     */
+    it('should not name the identify entry', async () => {
+      const { enqueue } = await import('@/modules/core/sigil/use-sigil-queue');
+      await enqueue({ kind: 'identify', clientId: 'client-1', url: '/page', timestamp: 1000 });
+
+      const [entry] = await flushed();
+
+      expect(entry.payload).not.toHaveProperty('name');
+      vi.unstubAllGlobals();
+    });
+
+    it('should leave a page view without data of its own', async () => {
+      const { enqueue } = await import('@/modules/core/sigil/use-sigil-queue');
+      await enqueue({ url: '/page', timestamp: 1000 });
+
+      const [entry] = await flushed();
+
+      expect(entry.type).toBe('event');
+      expect(entry.payload).not.toHaveProperty('data');
+      vi.unstubAllGlobals();
+    });
+
+    it('should leave a custom event data untouched', async () => {
+      const { enqueue } = await import('@/modules/core/sigil/use-sigil-queue');
+      await enqueue({ url: '/page', name: 'session_config', data: { premium: true }, timestamp: 1000 });
+
+      const [entry] = await flushed();
+
+      expect(entry.payload.data).toEqual({ premium: true });
+      vi.unstubAllGlobals();
+    });
+  });
+
+  /**
+   * Upstream stores it per row, and derives the session from ip, user agent and a daily salt, so
+   * one session covers every account used on that machine that day. Stamping only the identify
+   * would leave the events unattributed and the account switch invisible.
+   */
+  describe('per-entry distinct id', () => {
+    interface FlushedEntry { payload: { id?: string } }
+
+    async function flushed(): Promise<FlushedEntry[]> {
+      const fetchSpy = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const { flush } = await import('@/modules/core/sigil/use-sigil-queue');
+      await flush();
+
+      const [, init] = fetchSpy.mock.calls[0];
+      return JSON.parse(init.body);
+    }
+
+    it('should stamp a page view', async () => {
+      const { setCurrentClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+      const { enqueue } = await import('@/modules/core/sigil/use-sigil-queue');
+      setCurrentClientId('client-1');
+      await enqueue({ url: '/page', timestamp: 1000 });
+
+      const [entry] = await flushed();
+
+      expect(entry.payload.id).toBe('client-1');
+      vi.unstubAllGlobals();
+    });
+
+    it('should stamp a custom event', async () => {
+      const { setCurrentClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+      const { enqueue } = await import('@/modules/core/sigil/use-sigil-queue');
+      setCurrentClientId('client-1');
+      await enqueue({ url: '/page', name: 'session_config', timestamp: 1000 });
+
+      const [entry] = await flushed();
+
+      expect(entry.payload.id).toBe('client-1');
+      vi.unstubAllGlobals();
+    });
+
+    it('should stamp nothing once cleared, so nothing is attributed to the account that left', async () => {
+      const { clearCurrentClientId, setCurrentClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+      const { enqueue } = await import('@/modules/core/sigil/use-sigil-queue');
+      setCurrentClientId('client-1');
+      clearCurrentClientId();
+      await enqueue({ url: '/page', timestamp: 1000 });
+
+      const [entry] = await flushed();
+
+      expect(entry.payload.id).toBeUndefined();
+      vi.unstubAllGlobals();
+    });
+
+    it('should use the value current at flush, so a switch does not relabel the queue wrongly', async () => {
+      const { setCurrentClientId } = await import('@/modules/core/sigil/use-sigil-identity');
+      const { enqueue } = await import('@/modules/core/sigil/use-sigil-queue');
+      setCurrentClientId('client-1');
+      await enqueue({ url: '/page', timestamp: 1000 });
+      setCurrentClientId('client-2');
+
+      const [entry] = await flushed();
+
+      expect(entry.payload.id).toBe('client-2');
+      vi.unstubAllGlobals();
+    });
+  });
+
   describe('flush', () => {
     it('should not call fetch when queue is empty', async () => {
       const fetchSpy = vi.fn();

--- a/frontend/app/src/modules/core/sigil/use-sigil-queue.ts
+++ b/frontend/app/src/modules/core/sigil/use-sigil-queue.ts
@@ -1,6 +1,7 @@
 import type { SigilBatchEntry, SigilQueueEntry } from '@/modules/core/sigil/types';
 import { startPromise } from '@shared/utils';
 import { logger } from '@/modules/core/common/logging/logging';
+import { getCurrentClientId } from '@/modules/core/sigil/use-sigil-identity';
 
 const DB_NAME = 'sigil';
 const STORE_NAME = 'events';
@@ -119,11 +120,23 @@ function toBatchEntry(entry: SigilQueueEntry): SigilBatchEntry {
     referrer: '',
   };
 
+  // Identify carries the linkage on the session, so page views are covered without a name, which
+  // event data would need: upstream drops data on a nameless entry.
+  if (entry.kind === 'identify') {
+    payload.id = entry.clientId;
+    payload.data = entry.data;
+    return { type: 'identify', payload };
+  }
+
   if (entry.name)
     payload.name = entry.name;
 
   if (entry.data)
     payload.data = entry.data;
+
+  // Every entry carries it, as the upstream tracker does: it is stored per row, and the identify
+  // alone only links the session, which is shared by every account used on that machine that day.
+  payload.id = getCurrentClientId();
 
   return { type: 'event', payload };
 }
@@ -140,8 +153,9 @@ async function flush(): Promise<void> {
 
     const batch = entries.map(toBatchEntry);
 
+    // stringified: the logger joins its args, so an object would only ever print as [object Object]
     if (SIGIL_DEBUG)
-      logger.debug('[sigil] flushing batch', batch);
+      logger.debug(`[sigil] flushing batch ${JSON.stringify(batch, null, 2)}`);
 
     try {
       const response = await fetch(BATCH_ENDPOINT, {

--- a/frontend/app/src/modules/core/sigil/use-sigil.spec.ts
+++ b/frontend/app/src/modules/core/sigil/use-sigil.spec.ts
@@ -1,5 +1,7 @@
 import type { EffectScope } from 'vue';
+import type { ActionStatus } from '@/modules/core/common/action';
 import type { SigilEventMap, SigilQueueEntry } from '@/modules/core/sigil/types';
+import type { FrontendSettingsPayload } from '@/modules/settings/types/frontend-settings';
 import { flushPromises } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { sigilBus } from '@/modules/core/sigil/event-bus';
@@ -50,16 +52,52 @@ const mockLogged = ref<boolean>(false);
 const mockSubmitUsageAnalytics = ref<boolean>(false);
 const mockIsDevelop = ref<boolean>(false);
 
+const mockUsername = ref<string>('bob');
+
 vi.mock('@/modules/auth/use-session-auth-store', () => ({
   useSessionAuthStore: vi.fn(() => ({
     $id: 'session/auth',
     logged: mockLogged,
+    username: mockUsername,
   })),
 }));
 
+const mockClientId = ref<string>('');
+
 vi.mock('@/modules/settings/use-setting', () => ({
-  useSetting: vi.fn(() => mockSubmitUsageAnalytics),
+  useSetting: vi.fn((key: string) => (key === 'clientId' ? mockClientId : mockSubmitUsageAnalytics)),
 }));
+
+const mockUpdateFrontendSetting = vi
+  .fn<(payload: FrontendSettingsPayload) => Promise<ActionStatus>>()
+  .mockResolvedValue({ success: true });
+
+vi.mock('@/modules/settings/use-frontend-settings-writer', () => ({
+  useFrontendSettingsWriter: vi.fn(() => ({
+    updateFrontendSetting: async (payload: FrontendSettingsPayload): Promise<ActionStatus> =>
+      mockUpdateFrontendSetting(payload),
+  })),
+}));
+
+const mockCacheClientId = vi.fn<(username: string, id: string) => void>();
+const mockReadCachedClientId = vi.fn<(username: string) => string | undefined>();
+
+const mockSetCurrentClientId = vi.fn<(id: string) => void>();
+const mockClearCurrentClientId = vi.fn();
+
+vi.mock('@/modules/core/sigil/use-sigil-identity', () => ({
+  cacheClientId: (username: string, id: string): void => mockCacheClientId(username, id),
+  clearCurrentClientId: (): void => mockClearCurrentClientId(),
+  createClientId: (): string => 'minted-id',
+  getInstanceId: (): string => 'instance-1',
+  readCachedClientId: (username: string): string | undefined => mockReadCachedClientId(username),
+  setCurrentClientId: (id: string): void => mockSetCurrentClientId(id),
+}));
+
+/** The identify entries the composable queued, in order. */
+function identifyEntries(): Omit<SigilQueueEntry, 'id'>[] {
+  return mockEnqueue.mock.calls.map(call => call[0]).filter(entry => entry.kind === 'identify');
+}
 
 vi.mock('@/modules/core/common/use-main-store', () => ({
   useMainStore: vi.fn(() => ({
@@ -107,6 +145,14 @@ describe('useSigil', () => {
     mockStartQueue.mockClear();
     mockStopQueue.mockClear();
     mockRemoveHook.mockClear();
+    mockUpdateFrontendSetting.mockClear();
+    mockUpdateFrontendSetting.mockResolvedValue({ success: true });
+    mockCacheClientId.mockClear();
+    mockReadCachedClientId.mockReset();
+    mockSetCurrentClientId.mockClear();
+    mockClearCurrentClientId.mockClear();
+    set(mockClientId, '');
+    set(mockUsername, 'bob');
     set(mockLogged, false);
     set(mockSubmitUsageAnalytics, false);
     set(mockIsDevelop, false);
@@ -195,6 +241,158 @@ describe('useSigil', () => {
       await nextTick();
 
       expect(mockRemoveHook).toHaveBeenCalled();
+    });
+  });
+
+  describe('client id', () => {
+    it('should adopt the stored value without writing', async () => {
+      set(mockClientId, 'existing-id');
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(identifyEntries()).toHaveLength(1);
+      expect(identifyEntries()[0].clientId).toBe('existing-id');
+      expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
+    });
+
+    it('should mint and persist one when neither the settings nor the cache have one', async () => {
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ clientId: 'minted-id' });
+      expect(identifyEntries()[0].clientId).toBe('minted-id');
+    });
+
+    it('should recover the cached value rather than mint when the settings lost it', async () => {
+      mockReadCachedClientId.mockReturnValue('earlier-id');
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(mockReadCachedClientId).toHaveBeenCalledWith('bob');
+      expect(mockUpdateFrontendSetting).toHaveBeenCalledWith({ clientId: 'earlier-id' });
+      expect(identifyEntries()[0].clientId).toBe('earlier-id');
+    });
+
+    it('should let the settings beat a disagreeing cache, and refresh it', async () => {
+      set(mockClientId, 'settings-id');
+      mockReadCachedClientId.mockReturnValue('stale-id');
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(identifyEntries()[0].clientId).toBe('settings-id');
+      expect(mockCacheClientId).toHaveBeenCalledWith('bob', 'settings-id');
+      expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
+    });
+
+    it('should cache under the account that resolved it', async () => {
+      set(mockUsername, 'alice');
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(mockCacheClientId).toHaveBeenCalledWith('alice', 'minted-id');
+    });
+
+    it('should not cache a value the write failed to persist', async () => {
+      mockUpdateFrontendSetting.mockResolvedValue({ success: false, message: 'nope' });
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(mockCacheClientId).not.toHaveBeenCalled();
+    });
+
+    it('should not identify with a value the write failed to persist', async () => {
+      mockUpdateFrontendSetting.mockResolvedValue({ success: false, message: 'nope' });
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(identifyEntries()).toHaveLength(0);
+    });
+
+    it('should not resolve one while the gate is closed', async () => {
+      set(mockClientId, 'existing-id');
+      set(mockLogged, true);
+      set(mockSubmitUsageAnalytics, false);
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(identifyEntries()).toHaveLength(0);
+      expect(mockUpdateFrontendSetting).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('identify entry', () => {
+    it('should carry the instance value as session data', async () => {
+      set(mockClientId, 'existing-id');
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(identifyEntries()[0].data).toEqual({ instance_id: 'instance-1' });
+    });
+
+    /** Upstream classifies by name, so a named identify would be recorded as a custom event. */
+    it('should not be named', async () => {
+      set(mockClientId, 'existing-id');
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(identifyEntries()[0].name).toBeUndefined();
+    });
+
+    it('should set the value events are stamped with', async () => {
+      set(mockClientId, 'existing-id');
+      activateSigil();
+
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      expect(mockSetCurrentClientId).toHaveBeenCalledWith('existing-id');
+    });
+
+    it('should drop that value on deactivate, before the queue drains', async () => {
+      set(mockClientId, 'existing-id');
+      activateSigil();
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      set(mockLogged, false);
+      await nextTick();
+
+      expect(mockClearCurrentClientId).toHaveBeenCalled();
+      expect(mockClearCurrentClientId.mock.invocationCallOrder[0])
+        .toBeLessThan(mockStopQueue.mock.invocationCallOrder[0]);
+    });
+
+    it('should be queued before the events of that session', async () => {
+      set(mockClientId, 'existing-id');
+      activateSigil();
+      scope.run(() => useSigil());
+      await flushPromises();
+
+      sigilBus.emit('session:ready');
+      await flushPromises();
+
+      const kinds = mockEnqueue.mock.calls.map(call => call[0].kind ?? 'event');
+      expect(kinds[0]).toBe('identify');
+      expect(kinds).toContain('event');
     });
   });
 

--- a/frontend/app/src/modules/core/sigil/use-sigil.ts
+++ b/frontend/app/src/modules/core/sigil/use-sigil.ts
@@ -9,7 +9,9 @@ import { useBalancesSummaryHandler } from '@/modules/core/sigil/handlers/balance
 import { useExchangesSummaryHandler } from '@/modules/core/sigil/handlers/exchanges-summary';
 import { useHistorySyncHandler } from '@/modules/core/sigil/handlers/history-sync';
 import { useSessionConfigHandler } from '@/modules/core/sigil/handlers/session-config';
+import { cacheClientId, clearCurrentClientId, createClientId, getInstanceId, readCachedClientId, setCurrentClientId } from '@/modules/core/sigil/use-sigil-identity';
 import { enqueue, startQueue, stopQueue, WEBSITE_ID } from '@/modules/core/sigil/use-sigil-queue';
+import { useFrontendSettingsWriter } from '@/modules/settings/use-frontend-settings-writer';
 import { useSetting } from '@/modules/settings/use-setting';
 import { router } from '@/router';
 
@@ -45,8 +47,10 @@ function buildSafeUrl(to: { name?: string | symbol | null | undefined; params: R
 }
 
 export const useSigil = createPersistentSharedComposable(({ acquireBusy, releaseBusy }) => {
-  const { logged } = storeToRefs(useSessionAuthStore());
+  const { logged, username } = storeToRefs(useSessionAuthStore());
   const submitUsageAnalytics = useSetting('submitUsageAnalytics');
+  const clientId = useSetting('clientId');
+  const { updateFrontendSetting } = useFrontendSettingsWriter();
   const { isDevelop } = storeToRefs(useMainStore());
 
   // Initialize handlers in Vue context so they can resolve stores/composables.
@@ -84,6 +88,11 @@ export const useSigil = createPersistentSharedComposable(({ acquireBusy, release
     if (sessionReadyHandled)
       return;
     sessionReadyHandled = true;
+
+    // Here rather than in activate() to keep the dependency explicit: an empty read must mean
+    // unset, never not-loaded-yet. The unlock flow happens to land the settings before it flips
+    // `logged`, so today both are equivalent; this does not rely on that staying true.
+    await resolveUser();
 
     chronicle('session_config', collectSessionConfig());
     chronicle('exchanges_summary', collectExchangesSummary());
@@ -123,6 +132,44 @@ export const useSigil = createPersistentSharedComposable(({ acquireBusy, release
 
   let active = false;
 
+  /**
+   * The settings win whenever they hold a value, and are adopted synchronously, so only a session
+   * that has to write pays a round trip. A failed write is dropped rather than used, since a value
+   * that did not persist would differ next session.
+   */
+  async function resolveUser(): Promise<void> {
+    const user = get(username);
+    const existing = get(clientId);
+    if (existing) {
+      cacheClientId(user, existing);
+      setCurrentClientId(existing);
+      identify(existing);
+      return;
+    }
+
+    const resolved = readCachedClientId(user) ?? createClientId();
+    const status = await updateFrontendSetting({ clientId: resolved });
+    if (!status.success) {
+      logger.warn(`[sigil] could not persist the client id: ${status.message}`);
+      return;
+    }
+
+    cacheClientId(user, resolved);
+    setCurrentClientId(resolved);
+    identify(resolved);
+  }
+
+  /** Queued once per activation, ahead of the events it should apply to. */
+  function identify(id: string): void {
+    startPromise(enqueue({
+      kind: 'identify',
+      clientId: id,
+      data: { instance_id: getInstanceId() },
+      url: buildSafeUrl(router.currentRoute.value),
+      timestamp: Date.now(),
+    }));
+  }
+
   function activate(): void {
     if (active)
       return;
@@ -150,6 +197,8 @@ export const useSigil = createPersistentSharedComposable(({ acquireBusy, release
     sigilBus.off('balances:loaded', onBalancesLoaded);
     sigilBus.off('history:ready', onHistoryReady);
     unregisterPageTracking();
+    // before stopQueue, which drains what is left: nothing may go out under the account that just left
+    clearCurrentClientId();
     stopQueue();
     releaseBusy();
   }

--- a/frontend/app/src/modules/settings/settings-registry-frontend.ts
+++ b/frontend/app/src/modules/settings/settings-registry-frontend.ts
@@ -46,6 +46,7 @@ export const frontendRegistry = {
   autoRerunOnEdit: frontend('autoRerunOnEdit'),
   balanceValueThreshold: frontend('balanceValueThreshold'),
   blockchainRefreshButtonBehaviour: frontend('blockchainRefreshButtonBehaviour'),
+  clientId: frontend('clientId', { userFacing: false }),
   currencyLocation: frontend('currencyLocation', {
     anchor: SettingsHighlightIds.CURRENCY_LOCATION,
     search: { category: SettingsCategoryIds.AMOUNT, titleKey: msg.$t('general_settings.amount.label.currency_location') },

--- a/frontend/app/src/modules/settings/settings-repo.spec.ts
+++ b/frontend/app/src/modules/settings/settings-repo.spec.ts
@@ -51,6 +51,7 @@ describe('useSettingsRepo frontend channel', () => {
     const store = useSettingsRepo(pinia);
     const state: FrontendSettings = {
       schemaVersion: 2,
+      clientId: '',
       defiSetupDone: true,
       language: SupportedLanguage.EN,
       lastAppliedSettingsVersion: '0.0.0',

--- a/frontend/app/src/modules/settings/types/frontend-settings.ts
+++ b/frontend/app/src/modules/settings/types/frontend-settings.ts
@@ -214,6 +214,8 @@ export const FrontendSettings = z.object({
   blockchainRefreshButtonBehaviour: BlockchainRefreshButtonBehaviourEnum.default(
     BlockchainRefreshButtonBehaviour.ONLY_REFRESH_BALANCES,
   ),
+  /** Empty until first set. `.catch` so a corrupt value costs one reset, not the whole blob. */
+  clientId: z.string().default('').catch(''),
   currencyLocation: CurrencyLocationEnum.default(Defaults.DEFAULT_CURRENCY_LOCATION),
   darkTheme: ThemeColors.default(DARK_COLORS),
   dashboardTablesVisibleColumns: DashboardTablesVisibleColumns.default(() => ({

--- a/frontend/app/src/modules/settings/types/user-settings.spec.ts
+++ b/frontend/app/src/modules/settings/types/user-settings.spec.ts
@@ -83,6 +83,7 @@ describe('user-types', () => {
       enableAliasNames: true,
       enablePasswordConfirmation: true,
       blockchainRefreshButtonBehaviour: BlockchainRefreshButtonBehaviour.ONLY_REFRESH_BALANCES,
+      clientId: '',
       silentNotifications: false,
       subscriptDecimals: false,
       recentFilterValues: {},


### PR DESCRIPTION
Sigil entries carry no stable value today, so entries cannot be told apart
beyond a session, and a session is derived per machine per day.

This adds an identify entry to the queue and stamps every entry with a value
kept in the frontend settings, so it follows the account rather than the
browser. Stamping every entry is deliberate: the value is recorded per entry
upstream, and one session can span more than one account on the same machine.

A copy in local storage seeds the setting while it is empty. The setting wins
whenever it holds a value, so two machines converge instead of each pushing its
own value up and flip-flopping every login. The local copy is keyed by profile
name, so two profiles on one machine cannot read each other's.

Minting prefers `crypto.randomUUID`, falls back to `getRandomValues`, and then
to a timestamp-based value. `randomUUID` needs a secure context, which a Docker
instance reached over plain http on a LAN IP is not.

The value is not user-modifiable: no settings control writes it, and it is
cleared before the queue drains on deactivate so nothing goes out attributed to
the profile that just left.

Tested with unit specs over the identity, queue and gate paths, and run against
a dev instance: creating a profile, logging out and back in, and logging in with
the local copy cleared all keep one value, in the database and in local storage.
