### PR TITLE
fix(frontend): keep the accounts table honest after a delete

### DIFF
--- a/frontend/app/src/modules/accounts/blockchain/use-account-delete.removals.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-delete.removals.spec.ts
@@ -1,0 +1,309 @@
+import type {
+  AddressData,
+  BlockchainAccount,
+  BlockchainAccountGroupWithBalance,
+  XpubData,
+} from '@/modules/accounts/blockchain-accounts';
+import { bigNumberify } from '@rotki/common';
+import { err, ok, type Result } from 'plainfp/result';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Cancelled, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import '@test/i18n';
+
+/**
+ * The wiring `use-account-delete.spec.ts` cannot see: there `useAccountRemovals` is mocked away, so
+ * the real submission path — activity id, orchestrator, backend outcome — never runs, and the
+ * branch a single-chain group takes (`toPayload` returns `type: 'account'`) is not covered at all.
+ * That is the branch behind "deleting the only EVM account leaves the row in the table".
+ */
+
+const mocks = vi.hoisted(() => ({
+  cancelTaskById: vi.fn(async (): Promise<boolean> => true),
+  deleteEth2Validators: vi.fn(),
+  deleteXpub: vi.fn(async (): Promise<{ taskId: number }> => ({ taskId: 1 })),
+  notifyError: vi.fn(),
+  queryAccounts: vi.fn(),
+  removeAgnosticBlockchainAccount: vi.fn(async (): Promise<{ taskId: number }> => ({ taskId: 1 })),
+  removeBlockchainAccount: vi.fn(async (_chain: string, _accounts: string[]): Promise<{ taskId: number }> => ({ taskId: 1 })),
+  runTask: vi.fn(),
+}));
+
+vi.mock('@/modules/accounts/api/use-blockchain-accounts-api', () => ({
+  useBlockchainAccountsApi: vi.fn(() => ({
+    deleteXpub: mocks.deleteXpub,
+    queryAccounts: mocks.queryAccounts,
+    removeAgnosticBlockchainAccount: mocks.removeAgnosticBlockchainAccount,
+    removeBlockchainAccount: mocks.removeBlockchainAccount,
+  })),
+}));
+
+// The handler backs the runner the facade binds to each activity; the orchestrator stays real.
+vi.mock('@/modules/core/tasks/use-task-handler', () => ({
+  useTaskHandler: (): Record<string, unknown> => ({
+    cancelTaskById: mocks.cancelTaskById,
+    runTask: mocks.runTask,
+  }),
+}));
+
+vi.mock('@/modules/accounts/use-eth-staking', () => ({
+  useEthStaking: vi.fn(() => ({ deleteEth2Validators: mocks.deleteEth2Validators })),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn(() => ({ notifyError: mocks.notifyError })),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({
+    getChainName: (chain: string): string => chain,
+    getNativeAsset: (chain: string): string => chain.toUpperCase(),
+  })),
+}));
+
+const ADDRESS = '0x123';
+const XPUB = 'xpub123';
+
+const account: BlockchainAccount<AddressData> = {
+  chain: 'eth',
+  data: { address: ADDRESS, type: 'address' },
+  nativeAsset: 'ETH',
+};
+
+/** The row the EVM accounts table renders for an address tracked on one chain only. */
+function singleChainGroup(): BlockchainAccountGroupWithBalance<AddressData> {
+  return {
+    category: 'evm',
+    chains: ['eth'],
+    data: { address: ADDRESS, type: 'address' },
+    type: 'group',
+    value: bigNumberify(0),
+  };
+}
+
+/**
+ * Omitting `allChains` makes the group "showing all its chains", which deletes agnostically in one
+ * call; naming more chains than are shown makes it delete chain by chain.
+ */
+function multiChainGroup(chains: string[], allChains?: string[]): BlockchainAccountGroupWithBalance<AddressData> {
+  return {
+    allChains,
+    category: 'evm',
+    chains,
+    data: { address: ADDRESS, type: 'address' },
+    type: 'group',
+    value: bigNumberify(0),
+  };
+}
+
+function xpubGroup(): BlockchainAccountGroupWithBalance<XpubData> {
+  return {
+    category: 'btc',
+    chains: ['btc'],
+    data: { type: 'xpub', xpub: XPUB },
+    type: 'group',
+    value: bigNumberify(0),
+  };
+}
+
+/** What the backend task reports back for this removal. The API call itself always goes out. */
+function backendReports(outcome: Result<unknown, TaskError>): void {
+  mocks.runTask.mockImplementation(async (task: () => Promise<unknown>): Promise<Result<unknown, TaskError>> => {
+    await task();
+    return outcome;
+  });
+}
+
+/**
+ * Fails only the named chains. The verdict is derived from each task's own API call rather than
+ * from a shared variable, so the chain-by-chain removals — which are submitted together — cannot
+ * read each other's outcome.
+ */
+function backendFails(chains: string[]): void {
+  mocks.runTask.mockImplementation(async (task: () => Promise<unknown>): Promise<Result<unknown, TaskError>> => {
+    try {
+      await task();
+      return ok(undefined);
+    }
+    catch {
+      return err(TaskFailed({ message: 'boom' }));
+    }
+  });
+  mocks.removeBlockchainAccount.mockImplementation(async (chain: string): Promise<{ taskId: number }> => {
+    if (chains.includes(chain))
+      throw new Error('boom');
+    return { taskId: 1 };
+  });
+}
+
+function accountOn(chain: string): BlockchainAccount<AddressData> {
+  return { chain, data: { address: ADDRESS, type: 'address' }, nativeAsset: chain.toUpperCase() };
+}
+
+interface Harness {
+  accounts: ReturnType<typeof import('@/modules/accounts/use-blockchain-accounts-store')['useBlockchainAccountsStore']>;
+  confirmRemoval: (row: BlockchainAccountGroupWithBalance<AddressData> | BlockchainAccountGroupWithBalance<XpubData>) => Promise<void>;
+  /** The chain read the periodic balance tick performs, `use-balance-fetching.ts` one level up. */
+  fetchChain: (chain: string) => Promise<void>;
+}
+
+/**
+ * `useNativeTask` is a `createSharedComposable`, so every test needs its own module graph, or the
+ * orchestrator (and its in-flight map) leaks between them and the second submit of an id is deduped
+ * onto the first test's promise.
+ */
+async function setup(): Promise<Harness> {
+  vi.resetModules();
+  setActivePinia(createPinia());
+
+  const { useAccountDelete } = await import('@/modules/accounts/blockchain/use-account-delete');
+  const { useAccountFetching } = await import('@/modules/accounts/use-account-fetching');
+  const { useBlockchainAccountsStore } = await import('@/modules/accounts/use-blockchain-accounts-store');
+  const { useConfirmStore } = await import('@/modules/core/common/use-confirm-store');
+
+  const accounts = useBlockchainAccountsStore();
+  accounts.updateAccounts('eth', [account]);
+
+  const { showConfirmation } = useAccountDelete();
+
+  return {
+    accounts,
+    fetchChain: useAccountFetching().fetch,
+    confirmRemoval: async (row): Promise<void> => {
+      showConfirmation({ data: row, type: 'account' });
+      await useConfirmStore().confirm();
+    },
+  };
+}
+
+describe('useAccountDelete against the real removal wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backendReports(ok(undefined));
+  });
+
+  it('should delete the only account of a single-chain group and drop it from the store', async () => {
+    const { accounts, confirmRemoval } = await setup();
+
+    await confirmRemoval(singleChainGroup());
+
+    expect(mocks.removeBlockchainAccount).toHaveBeenCalledWith('eth', [ADDRESS]);
+    expect(accounts.accounts).toStrictEqual({ eth: [] });
+  });
+
+  // The removals return `Promise<void>` and swallow their `Result` after notifying, so the caller
+  // cannot tell a failed delete from a successful one and drops the row either way. The account
+  // still exists on the backend, and nothing on this path ever re-reads to put it back.
+  it('should keep the account when the backend removal fails', async () => {
+    const { accounts, confirmRemoval } = await setup();
+    backendReports(err(TaskFailed({ message: 'boom' })));
+
+    await confirmRemoval(singleChainGroup());
+
+    expect(mocks.notifyError).toHaveBeenCalledOnce();
+    expect(accounts.accounts).toStrictEqual({ eth: [account] });
+  });
+
+  it('should keep the account when the removal is cancelled', async () => {
+    const { accounts, confirmRemoval } = await setup();
+    backendReports(err(Cancelled({ message: 'cancelled' })));
+
+    await confirmRemoval(singleChainGroup());
+
+    expect(accounts.accounts).toStrictEqual({ eth: [account] });
+  });
+
+  it('should keep the account when an agnostic group removal fails', async () => {
+    const { accounts, confirmRemoval } = await setup();
+    accounts.updateAccounts('optimism', [accountOn('optimism')]);
+    mocks.removeAgnosticBlockchainAccount.mockRejectedValue(new Error('boom'));
+    backendFails([]);
+
+    // no `allChains`, so the group shows every chain it has and deletes in one agnostic call
+    await confirmRemoval(multiChainGroup(['eth', 'optimism']));
+
+    expect(mocks.removeAgnosticBlockchainAccount).toHaveBeenCalledOnce();
+    expect(accounts.accounts).toStrictEqual({ eth: [account], optimism: [accountOn('optimism')] });
+  });
+
+  it('should keep every chain when all of a chain-by-chain removal fails', async () => {
+    const { accounts, confirmRemoval } = await setup();
+    accounts.updateAccounts('optimism', [accountOn('optimism')]);
+    backendFails(['eth', 'optimism']);
+
+    await confirmRemoval(multiChainGroup(['eth', 'optimism'], ['eth', 'optimism', 'base']));
+
+    expect(accounts.accounts).toStrictEqual({ eth: [account], optimism: [accountOn('optimism')] });
+  });
+
+  it('should drop only the chains whose removal succeeded', async () => {
+    const { accounts, confirmRemoval } = await setup();
+    accounts.updateAccounts('optimism', [accountOn('optimism')]);
+    backendFails(['optimism']);
+
+    await confirmRemoval(multiChainGroup(['eth', 'optimism'], ['eth', 'optimism', 'base']));
+
+    // eth went through, optimism did not: dropping both would lose a row the backend still has
+    expect(accounts.accounts).toStrictEqual({ eth: [], optimism: [accountOn('optimism')] });
+  });
+
+  it('should drop the xpub when its removal succeeds', async () => {
+    const { accounts, confirmRemoval } = await setup();
+    accounts.updateAccounts('btc', [{
+      chain: 'btc',
+      data: { type: 'xpub', xpub: XPUB },
+      nativeAsset: 'BTC',
+    }]);
+
+    await confirmRemoval(xpubGroup());
+
+    expect(mocks.deleteXpub).toHaveBeenCalledOnce();
+    expect(accounts.accounts.btc).toStrictEqual([]);
+  });
+
+  it('should keep the xpub when its removal fails', async () => {
+    const { accounts, confirmRemoval } = await setup();
+    const xpubAccount: BlockchainAccount<XpubData> = {
+      chain: 'btc',
+      data: { type: 'xpub', xpub: XPUB },
+      nativeAsset: 'BTC',
+    };
+    accounts.updateAccounts('btc', [xpubAccount]);
+    backendReports(err(TaskFailed({ message: 'boom' })));
+
+    await confirmRemoval(xpubGroup());
+
+    expect(mocks.deleteXpub).toHaveBeenCalledOnce();
+    expect(accounts.accounts.btc).toStrictEqual([xpubAccount]);
+  });
+
+  // The reported symptom: the row survives the delete although the backend has dropped the account.
+  // The periodic balance tick walks every chain (`use-balance-fetching.ts:120`), and a walk that was
+  // already in flight answers with a pre-delete snapshot. `updateAccounts` replaces the chain
+  // wholesale, so the deleted account comes back, and the delete path has no re-read to correct it.
+  it('should not let a chain read that started before the delete resurrect the account', async () => {
+    const { accounts, confirmRemoval, fetchChain } = await setup();
+
+    let answer: () => void = () => {};
+    const inFlight = new Promise<void>((resolve) => {
+      answer = resolve;
+    });
+    // The response the backend produced *before* the delete, delivered after it.
+    mocks.queryAccounts.mockImplementation(async (): Promise<unknown[]> => {
+      await inFlight;
+      return [{ address: ADDRESS, label: null, tags: null }];
+    });
+
+    const periodicRead = fetchChain('eth');
+    await confirmRemoval(singleChainGroup());
+    expect(accounts.accounts.eth).toHaveLength(0);
+
+    answer();
+    await periodicRead;
+
+    expect(accounts.accounts.eth).toHaveLength(0);
+  });
+});

--- a/frontend/app/src/modules/accounts/blockchain/use-account-delete.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-delete.spec.ts
@@ -3,7 +3,9 @@ import type {
   BlockchainAccount,
   BlockchainAccountGroupWithBalance,
 } from '@/modules/accounts/blockchain-accounts';
+import type { TaskError } from '@/modules/core/tasks/task-result';
 import { bigNumberify } from '@rotki/common';
+import { ok, type Result } from 'plainfp/result';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccountDelete } from '@/modules/accounts/blockchain/use-account-delete';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
@@ -12,9 +14,9 @@ import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import '@test/i18n';
 
 const mocks = vi.hoisted(() => ({
-  deleteXpub: vi.fn(),
-  removeAccount: vi.fn(async (_payload: { accounts: string[]; chain: string }): Promise<void> => {}),
-  removeAgnosticAccount: vi.fn(async (): Promise<void> => {}),
+  deleteXpub: vi.fn(async (): Promise<Result<void, TaskError>> => ok(undefined)),
+  removeAccount: vi.fn(async (_payload: { accounts: string[]; chain: string }): Promise<Result<void, TaskError>> => ok(undefined)),
+  removeAgnosticAccount: vi.fn(async (): Promise<Result<void, TaskError>> => ok(undefined)),
 }));
 
 vi.mock('@/modules/accounts/use-account-removals', () => ({
@@ -160,9 +162,10 @@ describe('useAccountDelete', () => {
       const gate = new Promise<void>((resolve) => {
         release = resolve;
       });
-      mocks.removeAccount.mockImplementation(async ({ chain }: { chain: string }): Promise<void> => {
+      mocks.removeAccount.mockImplementation(async ({ chain }: { chain: string }): Promise<Result<void, TaskError>> => {
         started.push(chain);
-        return gate;
+        await gate;
+        return ok(undefined);
       });
 
       const removal = confirmRemoval(groupAccount(['eth', 'optimism'], ['eth', 'optimism', 'base']));

--- a/frontend/app/src/modules/accounts/blockchain/use-account-delete.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-delete.ts
@@ -4,6 +4,7 @@ import type {
   XpubData,
 } from '@/modules/accounts/blockchain-accounts';
 import { Blockchain } from '@rotki/common';
+import { isErr } from 'plainfp/result';
 import { getAccountAddress, isXpubAccount } from '@/modules/accounts/account-utils';
 import { useAccountRemovals } from '@/modules/accounts/use-account-removals';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
@@ -127,6 +128,7 @@ interface UseAccountDeleteReturn {
 export function useAccountDelete(): UseAccountDeleteReturn {
   const { accounts } = storeToRefs(useBlockchainAccountsStore());
   const { balances } = storeToRefs(useBalancesStore());
+  const { invalidateChain } = useBlockchainAccountsStore();
   const { deleteEth2Validators } = useEthStaking();
   const { deleteXpub, removeAccount, removeAgnosticAccount } = useAccountRemovals();
   const { t } = useI18n({ useScope: 'global' });
@@ -168,6 +170,10 @@ export function useAccountDelete(): UseAccountDeleteReturn {
 
     set(accounts, knownAccounts);
     set(balances, knownBalances);
+
+    // A chain read already in flight is carrying a pre-delete snapshot; marking the chain makes
+    // it drop its write instead of replacing the chain wholesale and resurrecting the account.
+    chains.forEach(chain => invalidateChain(chain));
   };
 
   async function removeValidator(publicKeys: string[]): Promise<void> {
@@ -180,27 +186,41 @@ export function useAccountDelete(): UseAccountDeleteReturn {
     { address, chains, includeAllChains }: EvmPayloadData,
   ): Promise<void> {
     if (includeAllChains) {
-      await removeAgnosticAccount(category, address);
+      const outcome = await removeAgnosticAccount(category, address);
+      if (isErr(outcome))
+        return;
+
       removeAccounts({ addresses: [address], chains });
     }
     else {
       // Submitted together, serialized by the removal lane rather than by a limiter here: one
       // per chain and one active chain at a time is the shape this call always had, now declared
       // once where the activity is, as the warning on `DECODE_LANE` requires.
-      await Promise.all(chains.map(async chain => removeAccount({ accounts: [address], chain })));
+      const outcomes = await Promise.all(chains.map(
+        async chain => [chain, await removeAccount({ accounts: [address], chain })] as const,
+      ));
+
+      // A partial failure keeps the chains it could not delete, rather than dropping the whole row.
+      const removed = outcomes.filter(([, outcome]) => !isErr(outcome)).map(([chain]) => chain);
+      if (removed.length === 0)
+        return;
 
       removeAccounts({
         addresses: [address],
-        chains,
+        chains: removed,
       });
     }
   }
 
   async function removeSingleAccount({ address, chain }: { address: string; chain: string }): Promise<void> {
-    await removeAccount({
+    const outcome = await removeAccount({
       accounts: [address],
       chain,
     });
+
+    // A failed or cancelled removal leaves the account on the backend, so the row has to stay.
+    if (isErr(outcome))
+      return;
 
     removeAccounts({
       addresses: [address],
@@ -209,7 +229,10 @@ export function useAccountDelete(): UseAccountDeleteReturn {
   }
 
   async function removeXpub(payload: XpubData & { chain: string }): Promise<void> {
-    await deleteXpub(payload);
+    const outcome = await deleteXpub(payload);
+    if (isErr(outcome))
+      return;
+
     removeAccounts({
       addresses: [getAccountAddress({ data: payload })],
       chains: [payload.chain],

--- a/frontend/app/src/modules/accounts/use-account-fetching.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-fetching.spec.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   notifyError: vi.fn(),
   queryAccounts: vi.fn(),
   queryBtcAccounts: vi.fn(),
+  revisionOf: vi.fn((_chain: string): number => 0),
   updateAccounts: vi.fn(),
 }));
 
@@ -29,7 +30,10 @@ vi.mock('@/modules/accounts/use-eth-staking', () => ({
 }));
 
 vi.mock('@/modules/accounts/use-blockchain-accounts-store', () => ({
-  useBlockchainAccountsStore: vi.fn(() => ({ updateAccounts: mocks.updateAccounts })),
+  useBlockchainAccountsStore: vi.fn(() => ({
+    revisionOf: mocks.revisionOf,
+    updateAccounts: mocks.updateAccounts,
+  })),
 }));
 
 vi.mock('@/modules/core/common/use-supported-chains', () => ({
@@ -67,6 +71,23 @@ describe('useAccountFetching', () => {
     await useAccountFetching().fetch('btc');
     expect(mocks.queryBtcAccounts).toHaveBeenCalledWith('btc');
     expect(mocks.updateAccounts).toHaveBeenCalledWith('btc', []);
+  });
+
+  // A delete bumps the chain's revision. A read that was already in flight is carrying a
+  // pre-delete snapshot, so writing it back would replace the chain wholesale and put the
+  // deleted account back.
+  it.each([
+    ['btc', async (): Promise<void> => { mocks.queryBtcAccounts.mockResolvedValue({ standalone: [], xpubs: [] }); }],
+    ['eth', async (): Promise<void> => { mocks.queryAccounts.mockResolvedValue([{ address: '0xabc', label: null, tags: null }]); }],
+  ])('should drop a %s read whose revision moved while it was in flight', async (chain, arrange) => {
+    await arrange();
+    // 0 when the read starts, 1 by the time it resolves
+    mocks.revisionOf.mockReturnValueOnce(0).mockReturnValue(1);
+
+    const { useAccountFetching } = await importModule();
+    await useAccountFetching().fetch(chain);
+
+    expect(mocks.updateAccounts).not.toHaveBeenCalled();
   });
 
   it('should fetch eth staking validators for eth2', async () => {

--- a/frontend/app/src/modules/accounts/use-account-fetching.ts
+++ b/frontend/app/src/modules/accounts/use-account-fetching.ts
@@ -18,7 +18,7 @@ interface UseAccountFetchingReturn {
 export function useAccountFetching(): UseAccountFetchingReturn {
   const { queryAccounts, queryBtcAccounts } = useBlockchainAccountsApi();
   const { fetchEthStakingValidators } = useEthStaking();
-  const { updateAccounts } = useBlockchainAccountsStore();
+  const { revisionOf, updateAccounts } = useBlockchainAccountsStore();
   const { notifyError } = useNotifications();
   const { t } = useI18n({ useScope: 'global' });
   const { getNativeAsset } = useSupportedChains();
@@ -45,8 +45,12 @@ export function useAccountFetching(): UseAccountFetchingReturn {
   };
 
   const fetchBlockchainAccounts = async (chain: string): Promise<void> => {
+    const revision = revisionOf(chain);
     try {
       const accounts = await queryAccounts(chain);
+      if (revisionOf(chain) !== revision)
+        return;
+
       const chainInfo = {
         chain,
         nativeAsset: getNativeAsset(chain),
@@ -60,8 +64,12 @@ export function useAccountFetching(): UseAccountFetchingReturn {
   };
 
   const fetchBtcAccounts = async (chain: BtcChains): Promise<void> => {
+    const revision = revisionOf(chain);
     try {
       const accounts = await queryBtcAccounts(chain);
+      if (revisionOf(chain) !== revision)
+        return;
+
       updateAccounts(chain, convertBtcAccounts(getNativeAsset, chain, accounts));
     }
     catch (error: unknown) {

--- a/frontend/app/src/modules/accounts/use-account-removals.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-removals.spec.ts
@@ -69,10 +69,12 @@ describe('useAccountRemovals', () => {
   // because no call site forwarded it — so the family caps were dead config and removals that used
   // to run one at a time all raced. Only reading what `submitTask` received can catch that.
   describe('lane', () => {
-    const cases: [string, (accounts: Removals) => Promise<void>, string][] = [
-      ['removeAccount', async (accounts): Promise<void> => accounts.removeAccount({ accounts: ['0xabc'], chain: 'eth' }), 'accounts-remove:eth'],
-      ['deleteXpub', async (accounts): Promise<void> => accounts.deleteXpub({ chain: 'btc', xpub: 'xpub123' }), 'accounts-remove:btc'],
-      ['removeAgnosticAccount', async (accounts): Promise<void> => accounts.removeAgnosticAccount('evm', '0xabc'), 'accounts-remove:evm'],
+    // The outcome is the caller's business (`use-account-delete` gates the local removal on it);
+    // here only the lane the submission carries is under test.
+    const cases: [string, (accounts: Removals) => Promise<unknown>, string][] = [
+      ['removeAccount', async (accounts): Promise<unknown> => accounts.removeAccount({ accounts: ['0xabc'], chain: 'eth' }), 'accounts-remove:eth'],
+      ['deleteXpub', async (accounts): Promise<unknown> => accounts.deleteXpub({ chain: 'btc', xpub: 'xpub123' }), 'accounts-remove:btc'],
+      ['removeAgnosticAccount', async (accounts): Promise<unknown> => accounts.removeAgnosticAccount('evm', '0xabc'), 'accounts-remove:evm'],
     ];
 
     it.each(cases)('should submit %s on its own removal lane', async (_name, act, lane) => {

--- a/frontend/app/src/modules/accounts/use-account-removals.ts
+++ b/frontend/app/src/modules/accounts/use-account-removals.ts
@@ -9,9 +9,9 @@ import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 
 interface UseAccountRemovalsReturn {
-  removeAccount: (payload: DeleteBlockchainAccountParams) => Promise<void>;
-  removeAgnosticAccount: (chainType: string, address: string) => Promise<void>;
-  deleteXpub: (params: DeleteXpubParams) => Promise<void>;
+  removeAccount: (payload: DeleteBlockchainAccountParams) => Promise<Result<void, TaskError>>;
+  removeAgnosticAccount: (chainType: string, address: string) => Promise<Result<void, TaskError>>;
+  deleteXpub: (params: DeleteXpubParams) => Promise<Result<void, TaskError>>;
 }
 
 export function useAccountRemovals(): UseAccountRemovalsReturn {
@@ -38,7 +38,7 @@ export function useAccountRemovals(): UseAccountRemovalsReturn {
     }));
   };
 
-  const removeAccount = async (payload: DeleteBlockchainAccountParams): Promise<void> => {
+  const removeAccount = async (payload: DeleteBlockchainAccountParams): Promise<Result<void, TaskError>> => {
     const { accounts, chain } = payload;
     const subject: AccountSubject = { chain, target: { addresses: accounts, kind: 'addresses' } };
     const outcome = await submitTask({
@@ -60,9 +60,11 @@ export function useAccountRemovals(): UseAccountRemovalsReturn {
       blockchain: chain,
       count: accounts.length,
     }));
+
+    return outcome;
   };
 
-  const removeAgnosticAccount = async (chainType: string, address: string): Promise<void> => {
+  const removeAgnosticAccount = async (chainType: string, address: string): Promise<Result<void, TaskError>> => {
     const subject = { address, category: chainType };
     const outcome = await submitTask({
       id: accountAgnosticRemoveActivity.id(subject),
@@ -80,9 +82,11 @@ export function useAccountRemovals(): UseAccountRemovalsReturn {
     });
 
     notifyRemovalFailure(outcome, t('actions.balances.blockchain_account_removal.agnostic.error.title', { address }));
+
+    return outcome;
   };
 
-  const deleteXpub = async (params: DeleteXpubParams): Promise<void> => {
+  const deleteXpub = async (params: DeleteXpubParams): Promise<Result<void, TaskError>> => {
     const subject: AccountSubject = {
       chain: params.chain,
       target: { derivationPath: params.derivationPath, kind: 'xpub', xpub: params.xpub },
@@ -110,6 +114,8 @@ export function useAccountRemovals(): UseAccountRemovalsReturn {
         xpub: params.xpub,
       }));
     }
+
+    return outcome;
   };
 
   return { deleteXpub, removeAccount, removeAgnosticAccount };

--- a/frontend/app/src/modules/accounts/use-blockchain-accounts-store.ts
+++ b/frontend/app/src/modules/accounts/use-blockchain-accounts-store.ts
@@ -5,6 +5,19 @@ import { removeTags, renameTags } from '@/modules/tags/tag-utils';
 export const useBlockchainAccountsStore = defineStore('blockchain/accounts', () => {
   const accounts = ref<Accounts>({});
   const recentlyAddedAddresses = ref<Set<string>>(new Set());
+  const revisions = ref<Record<string, number>>({});
+
+  const revisionOf = (chain: string): number => get(revisions)[chain] ?? 0;
+
+  /**
+   * Bumped whenever a chain's accounts are edited locally rather than read back from the backend,
+   * which today means a delete. A read that started before the bump is carrying a pre-delete
+   * snapshot, so `updateAccounts` would replace the chain wholesale and resurrect the account.
+   * Readers capture the revision before querying and drop their write if it moved.
+   */
+  const invalidateChain = (chain: string): void => {
+    set(revisions, { ...get(revisions), [chain]: revisionOf(chain) + 1 });
+  };
 
   const updateAccounts = (chain: string, data: BlockchainAccount[]): void => {
     set(accounts, { ...get(accounts), [chain]: data });
@@ -81,9 +94,11 @@ export const useBlockchainAccountsStore = defineStore('blockchain/accounts', () 
     accounts,
     getAccountByAddress,
     getAccounts,
+    invalidateChain,
     recentlyAddedAddresses,
     removeTag,
     renameTag,
+    revisionOf,
     trackAddedAddresses,
     updateAccountData,
     updateAccounts,


### PR DESCRIPTION
Deleting a blockchain account could leave the row in the EVM accounts table until a reload, while the backend had already dropped it. Investigating that turned up a second, deterministic defect that is worse than the reported one.

### Why the delete path drifts from the backend

The addition path re-reads from the backend after it completes. The delete path patched the accounts and balances stores by hand and never reconciled, so anything wrong in that local state stayed wrong. The table itself is not at fault: `AccountBalances.vue` already refreshes on any store write.

### A failed or cancelled delete dropped the row anyway

This one is deterministic and does not need a race. The removals returned `Promise<void>` and swallowed their `Result` after notifying, so the caller could not tell a failed delete from a successful one and ran the local removal either way. Rejecting a delete removed the account from the UI while it still existed on the backend.

They now return the outcome, and the local removal is applied only when it succeeded. A group deleted chain by chain keeps the chains whose removal failed, instead of dropping the whole row on a partial failure.

### The reported symptom was a race

The periodic balance tick walks every chain. A walk already in flight when the delete landed answered with a pre-delete snapshot, `updateAccounts` wrote it back wholesale, and the account reappeared with nothing left to correct it. That matches the measurements from the original report: the backend at `[]` and the task queue empty.

A local removal now bumps a per-chain revision. A read captures that revision before querying and drops its write if it moved while the request was in flight. This is preferred to re-reading after the delete, which only narrows the window: a read that was already in flight can still land afterwards.

Anything deriving from the accounts store was affected too, including `useTrackedEntities().tracksNothing`, so the "no tracked accounts" row did not come back after deleting the last account until a reload.

### Testing

The new spec drives the real `useAccountRemovals` and the real orchestrator, mocking only the API and the task handler. The existing `use-account-delete.spec.ts` mocks removals wholesale, so it cannot see any of this, and it never covered the branch a single-chain group takes.

Against the unfixed code, three of its cases fail. Every branch this PR adds is covered on both sides, and each fix was checked against an inverted implementation:

- neutering the `isErr` gates kills the four keep-on-failure cases (backend failure, cancellation, agnostic group, xpub);
- ignoring the per-chain outcomes kills the partial-failure and all-failed cases;
- neutering the revision guards kills both staleness cases.

678 accounts specs pass, 8961 across the suite; typecheck, eslint and knip are clean.

### Not included

Two things this deliberately leaves alone. `use-account-delete.ts` filters group chains through `isBlockchain`, the static `Blockchain` enum rather than the backend's supported chains, so a group on a chain outside the enum would be deleted on the backend but survive in the store — that is unproven and wants its own test first. And `removeValidator` keeps its unconditional removal, because `deleteEth2Validators` does not return a `Result`; gating it is a separate change.