### PR TITLE
Make the pill bar's typed filter syntax discoverable

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5969,7 +5969,12 @@
       "narrow": "Filter…",
       "narrow_empty": "No matches",
       "remove": "Remove filter",
-      "search": "Filter by…"
+      "search": "Filter by…",
+      "syntax": {
+        "date_keywords": "date time when period since after before until",
+        "label": "Type directly:",
+        "range_keywords": "amount number value range more less over under above below at least at most"
+      }
     },
     "saved_views": {
       "actions": {

--- a/frontend/app/src/modules/core/table/pill/PillFilterBar.spec.ts
+++ b/frontend/app/src/modules/core/table/pill/PillFilterBar.spec.ts
@@ -2,7 +2,7 @@ import type { MatchedKeyword } from '@/modules/core/table/filtering';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { createCustomPinia } from '@test/utils/create-pinia';
 import { mount, type VueWrapper } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 import { defineComponent } from 'vue';
 import EnumValueEditor from '@/modules/core/table/pill/EnumValueEditor.vue';
 import FilterPill from '@/modules/core/table/pill/FilterPill.vue';
@@ -86,6 +86,9 @@ const fields = [protocol, account];
 // What a range field carries in the real adapter: it reads a typed amount into whole filters.
 const typedAmount: FieldDef = {
   ...amount,
+  // Set alongside `parseTyped`, the way the adapter builds a real range field: it is what gates
+  // the footer's syntax examples, so a fixture with only the parser advertises nothing to type.
+  matchesTyped: (query: string): boolean => /^[\d<>]/.test(query),
   parseTyped: (query: string) => (/^>\d+$/.test(query)
     ? [{ op: 'gt' as const, range: { min: query.slice(1) }, values: [] }]
     : []),
@@ -99,6 +102,7 @@ const labels = {
   narrowEmpty: 'No matches',
   remove: 'Remove filter',
   search: 'Filter by…',
+  syntax: 'Type directly:',
 };
 
 function createWrapper(
@@ -402,6 +406,71 @@ describe('pillFilterBar', () => {
     await nextTick();
 
     expect(lastEmit(wrapper, 'update:matches')).toStrictEqual({ minAmount: '100' });
+  });
+
+  // The footer teaches by demonstration: its example goes into the input, and the row it produces
+  // shows up above it. Applying it outright would add a pill for an amount nobody asked for.
+  it('should put a clicked syntax example in the input without filtering', async () => {
+    const wrapper = createWrapper({}, {}, {}, [protocol, typedAmount]);
+
+    wrapper.findComponent(PillNarrowList).vm.$emit('example', '>100');
+    await nextTick();
+
+    expect(wrapper.get<HTMLInputElement>('[data-testid=pill-narrow-input]').element.value).toBe('>100');
+    expect(wrapper.emitted('update:matches')).toBeUndefined();
+  });
+
+  // The chip is a `button`, but nothing in the popover is ever focused and it is teleported out of
+  // the input's tab order, so Tab never arrives and the mouse was the only way in. The highlight
+  // therefore runs on past the last row into the footer, and Enter there does what a click does.
+  it('should reach a syntax example by arrowing past the last row', async () => {
+    const wrapper = createWrapper({}, {}, {}, [protocol, typedAmount]);
+    const input = wrapper.get('[data-testid=pill-narrow-input]');
+    await input.setValue('>100');
+
+    const list = wrapper.findComponent(PillNarrowList);
+    const rows = list.props('suggestions').length;
+    const examples = list.props('examples') ?? [];
+    assert(examples.length > 0, 'the footer must offer an example to arrow onto');
+
+    // Down off the end of the rows lands on the first chip and names it to the screen reader.
+    for (let step = 0; step < rows; step++)
+      await input.trigger('keydown', { key: 'ArrowDown' });
+
+    expect(list.props('highlighted')).toBe(rows);
+    expect(input.attributes('aria-activedescendant')).toBe('pill-narrow-example-0');
+
+    await input.trigger('keydown', { key: 'Enter' });
+
+    expect(wrapper.get<HTMLInputElement>('[data-testid=pill-narrow-input]').element.value).toBe(examples[0]);
+    expect(wrapper.emitted('update:matches')).toBeUndefined();
+  });
+
+  // Wrapping is what makes the footer escapable without a mouse: one Up from the top row is the
+  // last chip, and one Down from it is the first row again.
+  it('should wrap between the rows and the footer', async () => {
+    const wrapper = createWrapper({}, {}, {}, [protocol, typedAmount]);
+    const input = wrapper.get('[data-testid=pill-narrow-input]');
+    await input.setValue('>100');
+
+    const list = wrapper.findComponent(PillNarrowList);
+    const total = list.props('suggestions').length + (list.props('examples') ?? []).length;
+
+    await input.trigger('keydown', { key: 'ArrowUp' });
+    expect(list.props('highlighted')).toBe(total - 1);
+
+    await input.trigger('keydown', { key: 'ArrowDown' });
+    expect(list.props('highlighted')).toBe(0);
+  });
+
+  // The example is only a starting point, so the rows it produces have to be there to pick from.
+  it('should offer the filter a clicked example reads as', async () => {
+    const wrapper = createWrapper({}, {}, {}, [protocol, typedAmount]);
+
+    wrapper.findComponent(PillNarrowList).vm.$emit('example', '>100');
+    await nextTick();
+
+    expect(wrapper.findComponent(PillNarrowList).props('suggestions')[0]).toMatchObject({ kind: 'filter' });
   });
   // Picking a field and then thinking better of it used to leave an empty pill: it filters
   // nothing, shows nothing, and the only way out was to find its remove button.

--- a/frontend/app/src/modules/core/table/pill/PillFilterBar.vue
+++ b/frontend/app/src/modules/core/table/pill/PillFilterBar.vue
@@ -76,7 +76,7 @@ const availableFields = computed<FieldDef[]>(() => {
   return fields.filter(field => !used.has(field.key) && !excluded.has(field.key));
 });
 
-const { loading: searching, suggestions } = useNarrowSuggestions(query, availableFields);
+const { examples: syntaxExamples, loading: searching, suggestions } = useNarrowSuggestions(query, availableFields);
 
 // external wire form <-> model (the model's self-echo guard breaks the round-trip loop)
 watchImmediate(matches, value => model.setFromMatches(value, get(params)));
@@ -229,21 +229,56 @@ function applySuggestion(suggestion: NarrowSuggestion): void {
   remember(suggestion.field, [suggestion.value]);
 }
 
+/**
+ * A footer example was clicked: it goes into the input, it is not applied.
+ *
+ * The footer exists to teach a syntax nothing else on screen mentions, and watching the text land
+ * in the bar and turn into a filter row is the lesson. Applying it outright would add a pill for a
+ * date the user has no interest in and teach them only that the footer is a set of odd shortcuts.
+ * The caret goes back to the input so the obvious next move, editing the date, just works.
+ */
+function applyExample(example: string): void {
+  set(query, example);
+  set(narrowOpen, true);
+  get(narrowInput)?.focus();
+}
+
 // The caret never leaves the input, so the highlighted row has to be named rather than focused.
 // `RuiMenu` gives its popover `role="menu"`, which is why the rows are menuitems and this input
 // says `aria-haspopup="menu"`: a combobox may only own a listbox, tree, grid or dialog, so calling
 // it one while pointing at a menu would be a promise the markup does not keep.
+// The rows and the footer chips form one navigable sequence, chips last. Nothing in the popover is
+// ever focused and Tab cannot reach it (it is teleported, and `disable-auto-focus` keeps the caret
+// here), so arrowing on past the last row is the only way a chip is reachable without a mouse.
+const navigableCount = computed<number>(() => get(suggestions).length + get(syntaxExamples).length);
+
 const activeSuggestionId = computed<string | undefined>(() => {
-  if (!get(narrowOpen) || get(suggestions).length === 0)
+  if (!get(narrowOpen) || get(navigableCount) === 0)
     return undefined;
 
-  return `pill-narrow-row-${get(highlighted)}`;
+  const index = get(highlighted);
+  const rows = get(suggestions).length;
+  return index < rows ? `pill-narrow-row-${index}` : `pill-narrow-example-${index - rows}`;
 });
 
 function moveHighlight(step: number): void {
-  const count = get(suggestions).length;
+  const count = get(navigableCount);
   if (count > 0)
     set(highlighted, (get(highlighted) + step + count) % count);
+}
+
+/** What Enter does to whatever the highlight is on, row or footer chip. */
+function applyHighlighted(items: NarrowSuggestion[]): void {
+  const index = get(highlighted);
+  // Past the last row is a footer chip: it writes its example into the input rather than applying
+  // anything, the same as clicking it does.
+  const example = get(syntaxExamples)[index - items.length];
+  if (example !== undefined) {
+    applyExample(example);
+    return;
+  }
+  // The list can shrink under the highlight (a search returning less than the last one).
+  applySuggestion(items[index] ?? items[0]);
 }
 
 function onNarrowKeydown(event: KeyboardEvent): void {
@@ -262,7 +297,7 @@ function onNarrowKeydown(event: KeyboardEvent): void {
   }
 
   const items = get(suggestions);
-  if (items.length === 0)
+  if (get(navigableCount) === 0)
     return;
 
   if (event.key === 'ArrowDown') {
@@ -275,8 +310,7 @@ function onNarrowKeydown(event: KeyboardEvent): void {
   }
   else if (event.key === 'Enter') {
     event.preventDefault();
-    // The list can shrink under the highlight (a search returning less than the last one).
-    applySuggestion(items[get(highlighted)] ?? items[0]);
+    applyHighlighted(items);
   }
 }
 
@@ -393,6 +427,9 @@ function focusInput(event: MouseEvent): void {
         :loading="searching"
         :highlighted="highlighted"
         :empty-text="labels.narrowEmpty"
+        :examples="syntaxExamples"
+        :examples-label="labels.syntax"
+        @example="applyExample($event)"
         @select="applySuggestion($event)"
         @update:highlighted="highlighted = $event"
       />

--- a/frontend/app/src/modules/core/table/pill/PillNarrowList.spec.ts
+++ b/frontend/app/src/modules/core/table/pill/PillNarrowList.spec.ts
@@ -70,4 +70,82 @@ describe('pillNarrowList', () => {
 
     expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' });
   });
+
+  // The footer is the only place the typed syntax is ever stated: nothing else on screen says a
+  // date or an amount can be written into the bar at all.
+  it('should show the typeable examples in the footer', () => {
+    const wrapper = mount(PillNarrowList, {
+      props: {
+        examples: ['after 15/01/2024', '>100'],
+        examplesLabel: 'Type directly:',
+        suggestions,
+      },
+    });
+
+    const footer = wrapper.find('[data-testid=pill-narrow-syntax]');
+    expect(footer.text()).toContain('Type directly:');
+    // As `code`, so they read as text to type rather than as a sentence about typing.
+    expect(footer.findAll('code').map(chip => chip.text())).toStrictEqual(['after 15/01/2024', '>100']);
+  });
+
+  // The footer demonstrates rather than describes: clicking an example is what puts it in the bar,
+  // where the row it produces appears directly above it.
+  it('should emit the example that was clicked', async () => {
+    const wrapper = mount(PillNarrowList, {
+      props: { examples: ['after 15/01/2024', '>100'], suggestions },
+    });
+
+    await wrapper.findAll('[data-testid=pill-narrow-syntax-chip]')[1].trigger('click');
+
+    expect(wrapper.emitted('example')).toStrictEqual([['>100']]);
+  });
+
+  // A chip is an action, so it has to be reachable and announced as one rather than being text
+  // that happens to respond to a click.
+  it('should render each example as a button', () => {
+    const wrapper = mount(PillNarrowList, {
+      props: { examples: ['>100'], suggestions },
+    });
+
+    const chip = wrapper.find('[data-testid=pill-narrow-syntax-chip]');
+    expect(chip.element.tagName).toBe('BUTTON');
+    expect(chip.attributes('type')).toBe('button');
+  });
+
+  // Being a `button` is what the tag says, not what the user can do: nothing in the popover is ever
+  // focused (the caret stays in the bar's input) and the popover is teleported, so Tab never
+  // arrives here and a chip was mouse-only. It is reachable because the highlight runs on past the
+  // last row into the footer, which means the chip has to carry the id the input points its
+  // `aria-activedescendant` at, and be a `menuitem` like the rows in the same `role="menu"`.
+  it('should highlight the example the index past the last row names', () => {
+    const wrapper = mount(PillNarrowList, {
+      props: { examples: ['after 15/01/2024', '>100'], highlighted: suggestions.length + 1, suggestions },
+    });
+
+    const chips = wrapper.findAll('[data-testid=pill-narrow-syntax-chip]');
+    expect(chips[1].attributes('id')).toBe('pill-narrow-example-1');
+    expect(chips[1].attributes('role')).toBe('menuitem');
+    expect(chips[1].classes()).toContain('text-rui-primary');
+    // And only that one: a highlight in two places names neither.
+    expect(chips[0].classes()).not.toContain('text-rui-primary');
+    const rowHighlights = wrapper.findAll('[data-testid=pill-narrow-row]')
+      .map(row => row.classes().includes('text-rui-primary'));
+    expect(rowHighlights).not.toContain(true);
+  });
+
+  it('should show no footer when there is nothing typeable to offer', () => {
+    expect(createWrapper().find('[data-testid=pill-narrow-syntax]').exists()).toBe(false);
+  });
+
+  // The rows scroll and the footer does not: a hint that scrolls out of sight is one you have to
+  // already know about in order to find.
+  it('should keep the footer outside the scrolling row area', () => {
+    const wrapper = mount(PillNarrowList, {
+      props: { examples: ['>100'], suggestions },
+    });
+
+    const scroller = wrapper.find('.overflow-y-auto');
+    expect(scroller.find('[data-testid=pill-narrow-syntax]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=pill-narrow-syntax]').exists()).toBe(true);
+  });
 });

--- a/frontend/app/src/modules/core/table/pill/PillNarrowList.vue
+++ b/frontend/app/src/modules/core/table/pill/PillNarrowList.vue
@@ -4,19 +4,36 @@ import { resolveText } from '@/modules/core/table/pill/core/text';
 import PillValueIcon from '@/modules/core/table/pill/PillValueIcon.vue';
 import EvmChainIcon from '@/modules/shell/components/EvmChainIcon.vue';
 
-const { suggestions, highlighted = 0, emptyText = '', loading = false } = defineProps<{
+const { suggestions, highlighted = 0, emptyText = '', loading = false, examples = [], examplesLabel = '' } = defineProps<{
   /** Cross-field narrowing results for what the user typed in the bar. */
   suggestions: NarrowSuggestion[];
-  /** Index of the keyboard-highlighted row; the bar owns it, since the input lives there. */
+  /**
+   * Index of the keyboard-highlighted item; the bar owns it, since the input lives there.
+   *
+   * One index over the rows and the footer chips in sequence, chips last: the caret stays in the
+   * input, so nothing here is ever focused and Tab never reaches the footer (the popover is
+   * teleported and the bar sets `disable-auto-focus`). Arrowing through both is what makes a chip
+   * reachable without a mouse at all; an index past the last row highlights the chip beneath it.
+   */
   highlighted?: number;
   emptyText?: string;
   /** An asset search is still running; its rows will be appended to what is already shown. */
   loading?: boolean;
+  /**
+   * Verbatim things that can be typed into the bar (`after 15/01/2024`, `>100`), shown in the
+   * footer. Drawn as code rather than prose: the whole point is that they are literal text the
+   * user types, which a sentence describing them cannot convey.
+   */
+  examples?: string[];
+  /** Lead-in for the footer, e.g. `Type directly:`. */
+  examplesLabel?: string;
 }>();
 
 const emit = defineEmits<{
   'select': [suggestion: NarrowSuggestion];
   'update:highlighted': [index: number];
+  /** A footer example was clicked; the bar puts it in the input rather than applying it. */
+  'example': [example: string];
 }>();
 
 function keyOf(suggestion: NarrowSuggestion): string {
@@ -55,82 +72,114 @@ watch(() => highlighted, (index) => {
 </script>
 
 <template>
-  <div class="flex flex-col gap-0.5 p-1.5 min-w-[16rem] max-w-[20rem] max-h-[17rem] overflow-y-auto">
-    <button
-      v-for="(suggestion, index) in suggestions"
-      :id="`pill-narrow-row-${index}`"
-      :key="keyOf(suggestion)"
-      ref="rows"
-      type="button"
-      role="menuitem"
-      class="flex items-center gap-2.5 w-full px-2.5 py-1.5 rounded-md text-sm text-left transition-colors"
-      :class="index === highlighted
-        ? 'bg-rui-primary/10 text-rui-primary'
-        : 'text-rui-text-primary hover:bg-rui-grey-100 dark:hover:bg-rui-grey-800'"
-      data-testid="pill-narrow-row"
-      :data-key="keyOf(suggestion)"
-      @mousemove="highlightFromPointer(index)"
-      @click="emit('select', suggestion)"
-    >
-      <!-- A value row carries the same icon its pill will: the asset's mark up front, its chain
+  <!-- The scroll area and the footer are siblings, so the footer stays put while the rows scroll:
+       a syntax hint that scrolls out of sight is one the user has to already know about to find. -->
+  <div class="flex flex-col min-w-[16rem] max-w-[20rem]">
+    <div class="flex flex-col gap-0.5 p-1.5 max-h-[17rem] overflow-y-auto">
+      <button
+        v-for="(suggestion, index) in suggestions"
+        :id="`pill-narrow-row-${index}`"
+        :key="keyOf(suggestion)"
+        ref="rows"
+        type="button"
+        role="menuitem"
+        class="flex items-center gap-2.5 w-full px-2.5 py-1.5 rounded-md text-sm text-left transition-colors"
+        :class="index === highlighted
+          ? 'bg-rui-primary/10 text-rui-primary'
+          : 'text-rui-text-primary hover:bg-rui-grey-100 dark:hover:bg-rui-grey-800'"
+        data-testid="pill-narrow-row"
+        :data-key="keyOf(suggestion)"
+        @mousemove="highlightFromPointer(index)"
+        @click="emit('select', suggestion)"
+      >
+        <!-- A value row carries the same icon its pill will: the asset's mark up front, its chain
            after it, so `USDC` on five chains reads as five distinct rows. -->
-      <PillValueIcon
-        v-if="suggestion.kind === 'value' && (suggestion.field.display || suggestion.field.resolveIcon || suggestion.field.resolveSwatch)"
-        :display="suggestion.field.display"
-        :icon="suggestion.field.resolveIcon?.(suggestion.value)"
-        :swatch="suggestion.field.resolveSwatch?.(suggestion.value)"
-        :value="suggestion.value"
-        size="18px"
-      />
-      <span class="flex-1 min-w-0 truncate">
-        {{ suggestion.label }}
-        <span
-          v-if="suggestion.kind === 'value' && suggestion.caption"
-          class="text-rui-text-secondary"
-        >
-          {{ suggestion.caption }}
+        <PillValueIcon
+          v-if="suggestion.kind === 'value' && (suggestion.field.display || suggestion.field.resolveIcon || suggestion.field.resolveSwatch)"
+          :display="suggestion.field.display"
+          :icon="suggestion.field.resolveIcon?.(suggestion.value)"
+          :swatch="suggestion.field.resolveSwatch?.(suggestion.value)"
+          :value="suggestion.value"
+          size="18px"
+        />
+        <span class="flex-1 min-w-0 truncate">
+          {{ suggestion.label }}
+          <span
+            v-if="suggestion.kind === 'value' && suggestion.caption"
+            class="text-rui-text-secondary"
+          >
+            {{ suggestion.caption }}
+          </span>
         </span>
-      </span>
-      <EvmChainIcon
-        v-if="suggestion.kind === 'value' && suggestion.chain"
-        :chain="suggestion.chain"
-        size="14px"
-        tooltip
-      />
-      <!-- A value or a read-out filter is tagged with the field it belongs to, so `ETH` reads as
+        <EvmChainIcon
+          v-if="suggestion.kind === 'value' && suggestion.chain"
+          :chain="suggestion.chain"
+          size="14px"
+          tooltip
+        />
+        <!-- A value or a read-out filter is tagged with the field it belongs to, so `ETH` reads as
            an Asset value and `greater than 100` as an Amount one. A field row needs no tag: its
            label already is the field. -->
-      <span
-        v-if="suggestion.kind !== 'field'"
-        class="text-xs text-rui-text-secondary shrink-0"
-      >
-        {{ resolveText(suggestion.field.label) }}
-      </span>
-    </button>
-    <!-- Announced: asset rows are appended when a remote search returns, so without a live region
+        <span
+          v-if="suggestion.kind !== 'field'"
+          class="text-xs text-rui-text-secondary shrink-0"
+        >
+          {{ resolveText(suggestion.field.label) }}
+        </span>
+      </button>
+      <!-- Announced: asset rows are appended when a remote search returns, so without a live region
          nothing tells a screen reader the list grew under it. -->
-    <div
-      v-if="loading"
-      class="flex justify-center py-2"
-      role="status"
-      aria-live="polite"
-      data-testid="pill-narrow-loading"
-    >
-      <RuiProgress
-        circular
-        variant="indeterminate"
-        size="16"
-        color="primary"
-      />
+      <div
+        v-if="loading"
+        class="flex justify-center py-2"
+        role="status"
+        aria-live="polite"
+        data-testid="pill-narrow-loading"
+      >
+        <RuiProgress
+          circular
+          variant="indeterminate"
+          size="16"
+          color="primary"
+        />
+      </div>
+      <div
+        v-else-if="suggestions.length === 0"
+        class="text-rui-text-secondary text-sm px-2.5 py-3 text-center"
+        role="status"
+        aria-live="polite"
+        data-testid="pill-narrow-empty"
+      >
+        {{ emptyText }}
+      </div>
     </div>
+
+    <!-- Drawn as code chips, not prose: `after 15/01/2024` is text the user types verbatim, and a
+         sentence about it would leave them guessing which words are the literal ones. Each one is a
+         button, so the footer demonstrates the syntax instead of describing it: clicking puts the
+         text in the input and the row it produces appears above, which is the actual lesson. -->
     <div
-      v-else-if="suggestions.length === 0"
-      class="text-rui-text-secondary text-sm px-2.5 py-3 text-center"
-      role="status"
-      aria-live="polite"
-      data-testid="pill-narrow-empty"
+      v-if="examples.length > 0"
+      class="flex flex-wrap items-center gap-1.5 px-3 py-2 border-t border-rui-grey-200 dark:border-rui-grey-700"
+      data-testid="pill-narrow-syntax"
     >
-      {{ emptyText }}
+      <span class="text-xs text-rui-text-secondary shrink-0">{{ examplesLabel }}</span>
+      <button
+        v-for="(example, index) in examples"
+        :id="`pill-narrow-example-${index}`"
+        :key="example"
+        type="button"
+        role="menuitem"
+        class="px-1.5 py-0.5 rounded transition-colors"
+        :class="suggestions.length + index === highlighted
+          ? 'bg-rui-primary/10 text-rui-primary'
+          : 'bg-rui-grey-100 dark:bg-rui-grey-800 text-rui-text-primary hover:bg-rui-primary/10 hover:text-rui-primary'"
+        data-testid="pill-narrow-syntax-chip"
+        @mousemove="highlightFromPointer(suggestions.length + index)"
+        @click="emit('example', example)"
+      >
+        <code class="font-mono text-[11px] leading-4">{{ example }}</code>
+      </button>
     </div>
   </div>
 </template>

--- a/frontend/app/src/modules/core/table/pill/composables/use-narrow-suggestions.ts
+++ b/frontend/app/src/modules/core/table/pill/composables/use-narrow-suggestions.ts
@@ -4,8 +4,14 @@ import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { startPromise } from '@shared/utils';
 import { assetDisplayCaption, assetDisplayLabel } from '@/modules/core/common/display/assets';
 import { useOperatorLabels } from '@/modules/core/table/pill/composables/use-operator-labels';
+import { usePillSyntaxHints } from '@/modules/core/table/pill/composables/use-pill-syntax-hints';
 import { useRecentFilterValues } from '@/modules/core/table/pill/composables/use-recent-filter-values';
-import { fieldSuggestions, type NarrowSuggestion, searchFieldsAndValues } from '@/modules/core/table/pill/core/narrowing';
+import {
+  fieldSuggestions,
+  type NarrowSuggestion,
+  searchFieldsAndValues,
+  syntaxExamples,
+} from '@/modules/core/table/pill/core/narrowing';
 
 /** Asset matches offered at once, so a broad query cannot bury the rest of the list. */
 const ASSET_RESULT_CAP = 5;
@@ -17,6 +23,8 @@ interface NarrowSuggestionsReturn {
   suggestions: ComputedRef<NarrowSuggestion[]>;
   /** An asset search is in flight; the list is usable meanwhile. */
   loading: Readonly<Ref<boolean>>;
+  /** Verbatim examples of what can be typed, for the fields currently on offer. */
+  examples: ComputedRef<string[]>;
 }
 
 /**
@@ -37,6 +45,7 @@ export function useNarrowSuggestions(
 ): NarrowSuggestionsReturn {
   const { recentFor } = useRecentFilterValues();
   const operatorLabels = useOperatorLabels();
+  const syntaxHints = usePillSyntaxHints();
   const assetSuggestions = ref<NarrowSuggestion[]>([]);
   const loading = shallowRef<boolean>(false);
   // Only the newest search may publish: an earlier, slower response would otherwise overwrite it.
@@ -97,10 +106,12 @@ export function useNarrowSuggestions(
     // An asset field that already has a pill is no longer offered, and neither are its assets.
     const offersAssets = available.some(field => field.searchAsset);
     return [
-      ...searchFieldsAndValues(toValue(query), available, get(operatorLabels), undefined, recentFor),
+      ...searchFieldsAndValues(toValue(query), available, get(operatorLabels), undefined, recentFor, get(syntaxHints)),
       ...(offersAssets ? get(assetSuggestions) : []),
     ];
   });
 
-  return { loading: readonly(loading), suggestions };
+  const examples = computed<string[]>(() => syntaxExamples(toValue(fields), get(syntaxHints)));
+
+  return { examples, loading: readonly(loading), suggestions };
 }

--- a/frontend/app/src/modules/core/table/pill/composables/use-pill-bar-labels.ts
+++ b/frontend/app/src/modules/core/table/pill/composables/use-pill-bar-labels.ts
@@ -18,5 +18,6 @@ export function usePillBarLabels(): ComputedRef<PillBarLabels> {
     narrowEmpty: t('table_filter.pill.narrow_empty'),
     remove: t('table_filter.pill.remove'),
     search: t('table_filter.pill.search'),
+    syntax: t('table_filter.pill.syntax.label'),
   }));
 }

--- a/frontend/app/src/modules/core/table/pill/composables/use-pill-syntax-hints.spec.ts
+++ b/frontend/app/src/modules/core/table/pill/composables/use-pill-syntax-hints.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DateFormat } from '@/modules/core/common/date-format';
+import { usePillSyntaxHints } from '@/modules/core/table/pill/composables/use-pill-syntax-hints';
+
+const dateInputFormat = ref<DateFormat>(DateFormat.DateMonthYearHourMinuteSecond);
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: vi.fn((key: string) => (key === 'dateInputFormat' ? dateInputFormat : ref(undefined))),
+}));
+
+describe('usePillSyntaxHints', () => {
+  // Asserted whole, not by substring: the formatter appends a time of day to any timestamp that is
+  // not on local midnight, and an example reading `after 15/01/2024 14:00` teaches a syntax nobody
+  // asked for. A `toContain` check passes straight through that.
+  const dates = (): readonly string[] => get(usePillSyntaxHints()).examples?.date ?? [];
+
+  // The example exists to state the field order, so writing it in a fixed order would teach the
+  // wrong one to everybody whose format is not that order.
+  it('should write the date examples in the user configured format', () => {
+    set(dateInputFormat, DateFormat.DateMonthYearHourMinuteSecond);
+    expect(dates()).toStrictEqual(['after 15/01/2024', 'before 15/01/2024', '15/01/2024 - 20/01/2024']);
+
+    set(dateInputFormat, DateFormat.MonthDateYearHourMinuteSecond);
+    expect(dates()).toStrictEqual(['after 01/15/2024', 'before 01/15/2024', '01/15/2024 - 01/20/2024']);
+
+    set(dateInputFormat, DateFormat.YearMonthDateHourMinuteSecond);
+    expect(dates()).toStrictEqual(['after 2024/01/15', 'before 2024/01/15', '2024/01/15 - 2024/01/20']);
+  });
+
+  // The operator words and the span separator are what the parser knows, in English. Translating
+  // them would hand the user an example the bar then refuses, so they are never passed through `t`.
+  // This is also why `before` needs its own chip: the bare-date rows that would otherwise show the
+  // word are labelled with the *translated* operator, which is not what the parser accepts.
+  it('should keep the operator words literal', () => {
+    expect(dates()[0]).toMatch(/^after /);
+    expect(dates()[1]).toMatch(/^before /);
+    expect(dates()[2]).toContain(' - ');
+  });
+
+  // A day inside the first twelve would read as the month to half the world, which is the one
+  // thing the example is there to settle.
+  it('should use a day past the twelfth so the order cannot be misread', () => {
+    set(dateInputFormat, DateFormat.DateMonthYearHourMinuteSecond);
+    const [day] = dates()[0].replace('after ', '').split('/');
+    expect(Number(day)).toBeGreaterThan(12);
+  });
+
+  it('should follow the format when it changes under an existing hint', () => {
+    set(dateInputFormat, DateFormat.DateMonthYearHourMinuteSecond);
+    const hints = usePillSyntaxHints();
+    expect(get(hints).examples?.date?.[0]).toBe('after 15/01/2024');
+
+    set(dateInputFormat, DateFormat.MonthDateYearHourMinuteSecond);
+    expect(get(hints).examples?.date?.[0]).toBe('after 01/15/2024');
+  });
+
+  // The span separator has to be spaced or `DATE_SPAN` will not split it, so an example copied
+  // out of the footer has to carry the spaces it needs.
+  it('should space the span separator so the example parses when copied', () => {
+    expect(dates()[2]).toMatch(/\d - \d/);
+  });
+
+  it('should offer keywords for the two typed-into value types', () => {
+    const hints = get(usePillSyntaxHints());
+    expect(hints.keywords?.date).toBeDefined();
+    expect(hints.keywords?.range).toBeDefined();
+  });
+
+  // One chip per shape, both types alike: a lower bound, an upper bound, a span. A single-direction
+  // chip reads as though that is the only direction the bar takes.
+  it('should cover both bounds and the span for an amount', () => {
+    expect(get(usePillSyntaxHints()).examples?.range).toStrictEqual(['>100', '<10', '10 - 50']);
+  });
+
+  it('should cover both bounds and the span for a date', () => {
+    set(dateInputFormat, DateFormat.DateMonthYearHourMinuteSecond);
+    expect(dates()).toStrictEqual(['after 15/01/2024', 'before 15/01/2024', '15/01/2024 - 20/01/2024']);
+  });
+});

--- a/frontend/app/src/modules/core/table/pill/composables/use-pill-syntax-hints.ts
+++ b/frontend/app/src/modules/core/table/pill/composables/use-pill-syntax-hints.ts
@@ -1,0 +1,66 @@
+import type { ComputedRef } from 'vue';
+import type { SyntaxHints } from '@/modules/core/table/pill/core/narrowing';
+import { convertFromTimestamp } from '@/modules/core/common/data/date';
+import { FilterValueTypes } from '@/modules/core/table/filtering';
+import { useSetting } from '@/modules/settings/use-setting';
+
+/**
+ * The date the syntax example is written with: a real, past date whose day is past the twelfth, so
+ * it cannot be misread as the month and the example states the user's field order unambiguously.
+ * Past, because the bound parser refuses a future date and an example nobody can copy is worse than
+ * none (`dateBoundParser`).
+ *
+ * Local midnight, not a fixed unix second: the formatter appends ` HH:mm` to any timestamp that is
+ * not on midnight *locally*, so a fixed instant would grow a time of day in most of the world and
+ * the example would read `15/01/2024 14:00`.
+ */
+const EXAMPLE_TIMESTAMP = new Date(2024, 0, 15).getTime() / 1000;
+
+/** The upper bound of the range example, five days on, so the two dates are visibly a span. */
+const EXAMPLE_END_TIMESTAMP = new Date(2024, 0, 20).getTime() / 1000;
+
+/**
+ * What the bar says about the fields that are typed into rather than picked from.
+ *
+ * These fields were undiscoverable: nothing on screen said a date or an amount could be written
+ * into the bar, the field is labelled `Period` rather than `Date`, and a half-written date matched
+ * nothing at all. The keywords make the fields reachable under the words people actually use, and
+ * the examples state the syntax on the field's own row.
+ *
+ * Per value type, not per table: `>100` reads the same everywhere, so no table restates it. The
+ * pure narrowing core takes these as a parameter, the same way it takes the operator labels.
+ */
+export function usePillSyntaxHints(): ComputedRef<SyntaxHints> {
+  const { t } = useI18n({ useScope: 'global' });
+  const dateInputFormat = useSetting('dateInputFormat');
+
+  // In the user's own format: an example reading `01/15/2024` to someone who writes dates
+  // day-first teaches the wrong order, and the order is the whole thing the example is for.
+  const exampleDate = computed<string>(() => convertFromTimestamp(EXAMPLE_TIMESTAMP, get(dateInputFormat)));
+  const exampleEndDate = computed<string>(() => convertFromTimestamp(EXAMPLE_END_TIMESTAMP, get(dateInputFormat)));
+
+  return computed<SyntaxHints>(() => ({
+    // Literal, and deliberately not translated: `after` and `to` are the words the parser knows,
+    // so a translated example would be one the user copies and the bar then refuses. The operator
+    // forms lead, because the bare date alone never showed that an operator was possible at all.
+    examples: {
+      // `before` earns its own chip even though `after` shows the shape: which words the parser
+      // knows is not guessable (`since` and `until` work, `from` and `to` do not), and its only
+      // other route was reading it off a bare date's result rows — which are *translated*, while
+      // the parser only knows the English words, so that route does not survive a locale change.
+      [FilterValueTypes.DATE]: [
+        `after ${get(exampleDate)}`,
+        `before ${get(exampleDate)}`,
+        `${get(exampleDate)} - ${get(exampleEndDate)}`,
+      ],
+      // One per shape, the same as the dates above: an upper bound, a lower bound, a span. Nothing
+      // else on screen distinguishes them, and a chip for only one direction reads as though that
+      // is the direction the bar supports.
+      [FilterValueTypes.RANGE]: ['>100', '<10', '10 - 50'],
+    },
+    keywords: {
+      [FilterValueTypes.DATE]: t('table_filter.pill.syntax.date_keywords'),
+      [FilterValueTypes.RANGE]: t('table_filter.pill.syntax.range_keywords'),
+    },
+  }));
+}

--- a/frontend/app/src/modules/core/table/pill/core/field-adapter.ts
+++ b/frontend/app/src/modules/core/table/pill/core/field-adapter.ts
@@ -3,7 +3,13 @@ import type { FieldText } from '@/modules/core/table/pill/core/text';
 import type { FieldDef, FilterOp, FilterValueType, TypedFilterDraft } from '@/modules/core/table/pill/core/types';
 import { FilterOps, FilterValueTypes } from '@/modules/core/table/filtering';
 import { DEFAULT_OPERATORS } from '@/modules/core/table/pill/core/operators';
-import { parseDateQuery, parseRangeQuery, type ParseTimestamp } from '@/modules/core/table/pill/core/typed-filters';
+import {
+  looksLikeDateQuery,
+  looksLikeRangeQuery,
+  parseDateQuery,
+  parseRangeQuery,
+  type ParseTimestamp,
+} from '@/modules/core/table/pill/core/typed-filters';
 
 /**
  * The pill editor a field renders in. `asset` is the dedicated asset picker (icon + symbol +
@@ -118,6 +124,7 @@ export function toRangeFieldDef(spec: BoundsFieldSpec): FieldDef {
     hint: spec.hint,
     key: spec.key,
     label: spec.label,
+    matchesTyped: looksLikeRangeQuery,
     multiple: false,
     operators: operatorsOf(FilterValueTypes.RANGE, spec.operators),
     // Every numeric field can read a typed amount; there is nothing table-specific about `>100`.
@@ -141,7 +148,14 @@ export function toDateFieldDef(spec: DateFieldSpec): FieldDef {
     label: spec.label,
     multiple: false,
     operators: operatorsOf(FilterValueTypes.DATE, spec.operators),
-    ...(parseBound ? { parseTyped: (query: string): TypedFilterDraft[] => parseDateQuery(query, parseBound) } : {}),
+    // Both gated on the parser: a field that cannot read a written date must not offer the syntax
+    // for one either, or its hint would point at something it then refuses.
+    ...(parseBound
+      ? {
+          matchesTyped: looksLikeDateQuery,
+          parseTyped: (query: string): TypedFilterDraft[] => parseDateQuery(query, parseBound),
+        }
+      : {}),
     serializer: spec.serializer,
     valueType: FilterValueTypes.DATE,
   };

--- a/frontend/app/src/modules/core/table/pill/core/narrowing.spec.ts
+++ b/frontend/app/src/modules/core/table/pill/core/narrowing.spec.ts
@@ -1,7 +1,7 @@
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { describe, expect, it } from 'vitest';
 import { FilterValueTypes } from '@/modules/core/table/filtering';
-import { fieldSuggestions, searchFieldsAndValues as search } from '@/modules/core/table/pill/core/narrowing';
+import { fieldSuggestions, searchFieldsAndValues as search, syntaxExamples } from '@/modules/core/table/pill/core/narrowing';
 
 // Operator words come from the Vue layer; these stand in for them.
 const operatorLabels = {
@@ -19,8 +19,9 @@ function searchFieldsAndValues(
   fields: Parameters<typeof search>[1],
   limits?: Parameters<typeof search>[3],
   recentValues?: Parameters<typeof search>[4],
+  syntaxHints?: Parameters<typeof search>[5],
 ): ReturnType<typeof search> {
-  return search(query, fields, operatorLabels, limits, recentValues);
+  return search(query, fields, operatorLabels, limits, recentValues, syntaxHints);
 }
 
 function field(overrides: Partial<FieldDef> & Pick<FieldDef, 'key' | 'label'>): FieldDef {
@@ -79,6 +80,7 @@ const amount = field({
   formatBound: (value: string): string => `${value} ETH`,
   key: 'amount',
   label: 'Amount',
+  matchesTyped: (query: string): boolean => /^[\d<>]/.test(query),
   operators: ['between', 'gt', 'lt'],
   parseTyped: (query: string) => (/^\d+$/.test(query)
     ? [
@@ -88,6 +90,26 @@ const amount = field({
     : []),
   valueType: FilterValueTypes.RANGE,
 });
+
+const period = field({
+  key: 'period',
+  label: 'Period',
+  // Claims `peri` too, so a query matching the label *and* the guidance is reachable: the two must
+  // not put the same field on screen twice.
+  matchesTyped: (query: string): boolean =>
+    query.startsWith('after') || query.startsWith('15/') || query.startsWith('peri'),
+  operators: ['between', 'after', 'before'],
+  parseTyped: (query: string) => (query === '15/01/2024'
+    ? [{ date: { from: '1705276800' }, op: 'after' as const, values: [] }]
+    : []),
+  valueType: FilterValueTypes.DATE,
+});
+
+// Stand in for the Vue layer's copy, which is where the real ones are built.
+const hints = {
+  examples: { date: ['after 15/01/2024', '15/01/2024 - 20/01/2024'], range: ['>100'] },
+  keywords: { date: 'date time when', range: 'amount number value' },
+};
 
 describe('fieldSuggestions', () => {
   it('should offer every field as itself', () => {
@@ -99,6 +121,34 @@ describe('fieldSuggestions', () => {
 
   it('should offer nothing when every field is in use', () => {
     expect(fieldSuggestions([])).toEqual([]);
+  });
+});
+
+describe('syntaxExamples', () => {
+  it('should offer the examples of every typed-into type on offer', () => {
+    expect(syntaxExamples([period, amount, protocol], hints)).toStrictEqual([
+      'after 15/01/2024',
+      '15/01/2024 - 20/01/2024',
+      '>100',
+    ]);
+  });
+
+  // Advertising a syntax for a field that is not there sends the user typing something the bar
+  // will refuse; a field whose pill is already set is no longer among those passed in.
+  it('should offer nothing for the types not on offer', () => {
+    expect(syntaxExamples([protocol], hints)).toStrictEqual([]);
+    expect(syntaxExamples([period], hints)).toStrictEqual(['after 15/01/2024', '15/01/2024 - 20/01/2024']);
+  });
+
+  // A field that cannot read what is typed must not advertise a syntax it would then refuse.
+  it('should ignore a field of a typed-into type that reads nothing typed', () => {
+    const bare = field({ key: 'bare', label: 'Bare', valueType: FilterValueTypes.DATE });
+    expect(syntaxExamples([bare], hints)).toStrictEqual([]);
+  });
+
+  it('should offer one set of examples for two fields of the same type', () => {
+    const second = field({ ...period, key: 'settled', label: 'Settled' });
+    expect(syntaxExamples([period, second], hints)).toStrictEqual(['after 15/01/2024', '15/01/2024 - 20/01/2024']);
   });
 });
 
@@ -304,6 +354,78 @@ describe('searchFieldsAndValues account keywords', () => {
 
     it('should offer nothing for a query the field cannot read', () => {
       expect(searchFieldsAndValues('uniswap', [amount])).toStrictEqual([]);
+    });
+
+    // A query heading for a filter it does not yet spell used to return an empty popover, which
+    // reads as "this field cannot be typed into" at exactly the moment the user is trying.
+    it('should offer the field with its example for a half-written value', () => {
+      expect(searchFieldsAndValues('after', [period], undefined, undefined, hints)).toStrictEqual([
+        { field: period, kind: 'field', label: 'Period' },
+      ]);
+    });
+
+    // Once the query says a whole filter, the filter itself is the answer; repeating the field
+    // under it adds a row that says nothing the two above it do not.
+    it('should not offer guidance once the query reads as a filter', () => {
+      const matches = searchFieldsAndValues('15/01/2024', [period], undefined, undefined, hints);
+      expect(matches).toHaveLength(1);
+      expect(matches[0]).toMatchObject({ kind: 'filter' });
+    });
+
+    // Guidance is the answer for a field with nothing to answer with, so anything that matched
+    // something concrete outranks it.
+    it('should rank guidance below every real match', () => {
+      const matches = searchFieldsAndValues('after', [period, field({
+        key: 'protocol',
+        label: 'Aftermath',
+        suggest: (): string[] => [],
+      })], undefined, undefined, hints);
+
+      expect(matches[0]).toMatchObject({ label: 'Aftermath' });
+      expect(matches[1]).toMatchObject({ label: 'Period' });
+    });
+
+    // The field is called `Period`, so the word people reach for found nothing at all.
+    it('should find a field by the words its value type is known by', () => {
+      expect(searchFieldsAndValues('time', [period], undefined, undefined, hints)).toStrictEqual([
+        { field: period, kind: 'field', label: 'Period' },
+      ]);
+    });
+
+    // The keyword blob is a bag of whole words, not a string to be searched inside: `in` sits in
+    // `since` and `an` in `range`, so a substring test hands back Period and Amount for a
+    // two-letter query and buries the real value matches under them. The fixture blobs above share
+    // no stem with the shipped ones, which is exactly why they never caught this — these are the
+    // strings the app actually passes in.
+    it('should not match a keyword on a fragment of one', () => {
+      const shipped = {
+        keywords: {
+          date: 'date time when period since after before until',
+          range: 'amount number value range more less over under above below at least at most',
+        },
+      };
+
+      expect(searchFieldsAndValues('in', [period], undefined, undefined, shipped)).toStrictEqual([]);
+      expect(searchFieldsAndValues('an', [amount], undefined, undefined, shipped)).toStrictEqual([]);
+      // The word itself still finds the field; only the fragment stops doing so.
+      expect(searchFieldsAndValues('since', [period], undefined, undefined, shipped)).toStrictEqual([
+        { field: period, kind: 'field', label: 'Period' },
+      ]);
+      // And a prefix of a keyword does too: the list narrows as the user types it out.
+      expect(searchFieldsAndValues('num', [amount], undefined, undefined, shipped)).toStrictEqual([
+        { field: amount, kind: 'field', label: 'Amount' },
+      ]);
+      // The two-word keywords are reachable as written, part-way through included.
+      expect(searchFieldsAndValues('at le', [amount], undefined, undefined, shipped)).toStrictEqual([
+        { field: amount, kind: 'field', label: 'Amount' },
+      ]);
+    });
+
+    it('should offer a field only once when its label and its guidance both match', () => {
+      const matches = searchFieldsAndValues('peri', [period], undefined, undefined, hints);
+      expect(matches).toStrictEqual([
+        { field: period, kind: 'field', label: 'Period' },
+      ]);
     });
 
     // It always matches, so like the typed free-text value it must never push a real match down.

--- a/frontend/app/src/modules/core/table/pill/core/narrowing.ts
+++ b/frontend/app/src/modules/core/table/pill/core/narrowing.ts
@@ -1,5 +1,5 @@
 import type { OperatorLabels } from '@/modules/core/table/pill/core/operators';
-import type { ActiveFilter, FieldDef } from '@/modules/core/table/pill/core/types';
+import type { ActiveFilter, FieldDef, FilterValueType } from '@/modules/core/table/pill/core/types';
 import { FilterValueTypes } from '@/modules/core/table/filtering';
 import { pillOperator, pillValueSummary } from '@/modules/core/table/pill/core/format';
 import { resolveText } from '@/modules/core/table/pill/core/text';
@@ -46,6 +46,36 @@ export type NarrowSuggestion = FieldSuggestion | ValueSuggestion | FilterSuggest
 /** Previously used values per field key, offered to fields that have no option list. */
 export type RecentValues = (field: FieldDef) => string[];
 
+/**
+ * What the bar says about the fields whose values are written rather than picked, keyed by value
+ * type rather than by field: `>100` and `after 15/01/2024` read the same on every table, so the
+ * copy belongs to the type and no table restates it.
+ *
+ * Already translated, and the date example is rendered in the user's own date format: a hint
+ * showing `01/15/2024` to someone whose format is day-first teaches the wrong order.
+ */
+export interface SyntaxHints {
+  /** Extra words a field of this type is findable by ("date time when"), beyond its own label. */
+  readonly keywords?: Partial<Record<FilterValueType, string>>;
+  /**
+   * Worked examples of what can be typed, shown verbatim in the popover's footer. Literal, never
+   * translated: the operator words the parser knows (`after`, `before`) are English, so a
+   * translated example would not work when the user copies it.
+   */
+  readonly examples?: Partial<Record<FilterValueType, readonly string[]>>;
+}
+
+/**
+ * The examples worth showing for the fields currently on offer.
+ *
+ * Only for the value types actually present: a table with no amount field must not advertise
+ * `>100`, and one whose period pill is already set has nothing left to say about dates.
+ */
+export function syntaxExamples(fields: FieldDef[], hints?: SyntaxHints): string[] {
+  const types = new Set(fields.filter(field => field.matchesTyped).map(field => field.valueType));
+  return [...types].flatMap(type => hints?.examples?.[type] ?? []);
+}
+
 export interface NarrowLimits {
   /** Values offered per field, so one long option list cannot crowd out the others. */
   readonly perField: number;
@@ -65,6 +95,9 @@ const RANK_FIELD_SUBSTRING = 2;
 const RANK_VALUE_SUBSTRING = 3;
 // A typed-value offer is ranked last: it always matches, so it must never crowd out a real one.
 const RANK_TYPED_VALUE = 4;
+// Below everything that matched something concrete: guidance is what a field offers when it has
+// nothing to answer with yet, so any real match is a better answer than telling the user the syntax.
+const RANK_GUIDANCE = 5;
 
 /**
  * How many filters one field may offer for a single query. Two is what an ambiguous bare number
@@ -135,7 +168,12 @@ function typedFilterMatches(field: FieldDef, typed: string, operatorLabels: Oper
  * than an empty state.
  */
 export function fieldSuggestions(fields: FieldDef[]): NarrowSuggestion[] {
-  return fields.map(field => ({ field, kind: 'field', label: resolveText(field.label) }));
+  return fields.map(field => fieldRow(field, resolveText(field.label)));
+}
+
+/** One field as a row. The typed syntax is stated by the popover's footer, not per row. */
+function fieldRow(field: FieldDef, label: string): FieldSuggestion {
+  return { field, kind: 'field', label };
 }
 
 /**
@@ -155,11 +193,47 @@ interface Ranked {
   readonly suggestion: NarrowSuggestion;
 }
 
-/** The field itself, when its label matches. */
-function fieldMatch(field: FieldDef, needle: string): Ranked | undefined {
+/**
+ * The field itself, when its label matches, or failing that when one of the words its value type
+ * is known by does. A period field is labelled `Period`, so `date`, `time` and `when` found nothing
+ * at all; the type keywords are what make it reachable under the word the user actually has in mind.
+ * A keyword hit ranks as a substring match, never a prefix one, so a visible label always wins.
+ *
+ * The blob is a bag of words and is matched only where a word begins: searched as one string it
+ * hands back the field for any fragment sitting inside a keyword, and `in` (in `since`) or `an`
+ * (in `range`) then put Period and Amount above every real value match on a two-letter query.
+ * From a word start rather than per token, so the multi-word keywords (`at least`, `at most`)
+ * stay reachable, and by prefix, so the list still narrows while the user types a keyword out.
+ */
+function keywordMatch(keywords: string | undefined, needle: string): boolean {
+  if (!keywords)
+    return false;
+  const blob = keywords.toLowerCase();
+  return [...blob.matchAll(/\S+/g)].some(word => blob.startsWith(needle, word.index));
+}
+
+function fieldMatch(field: FieldDef, needle: string, hints?: SyntaxHints): Ranked | undefined {
   const label = resolveText(field.label);
   const rank = rankOf(label, needle, RANK_FIELD_PREFIX, RANK_FIELD_SUBSTRING);
-  return rank === undefined ? undefined : { rank, suggestion: { field, kind: 'field', label } };
+  if (rank !== undefined)
+    return { rank, suggestion: fieldRow(field, label) };
+
+  return keywordMatch(hints?.keywords?.[field.valueType], needle)
+    ? { rank: RANK_FIELD_SUBSTRING, suggestion: fieldRow(field, label) }
+    : undefined;
+}
+
+/**
+ * The field offered for a query that is heading towards a filter on it but is not one yet.
+ *
+ * Typing `after`, `>` or `15/01` parses to nothing, and nothing is what the popover showed: an
+ * empty list, which says the bar does not take typed dates when in fact it does and the user was
+ * one keystroke away. Offering the field keeps the footer's syntax on screen beside it.
+ */
+function guidanceMatch(field: FieldDef, typed: string): Ranked | undefined {
+  if (!field.matchesTyped?.(typed))
+    return undefined;
+  return { rank: RANK_GUIDANCE, suggestion: fieldRow(field, resolveText(field.label)) };
 }
 
 /**
@@ -215,6 +289,40 @@ function recentMatches(field: FieldDef, needle: string, perField: number, recent
   return matches;
 }
 
+/** Everything one query is ranked against, gathered so the per-field pass takes one parameter. */
+interface RankContext {
+  readonly needle: string;
+  readonly typed: string;
+  readonly operatorLabels: OperatorLabels;
+  readonly limits: NarrowLimits;
+  readonly recentValues?: RecentValues;
+  readonly hints?: SyntaxHints;
+}
+
+/** Every way one field can answer the query, in one list. */
+function rankField(field: FieldDef, context: RankContext): Ranked[] {
+  const { hints, limits, needle, operatorLabels, recentValues, typed } = context;
+  const remembered = recentValues?.(field) ?? [];
+  const matched = fieldMatch(field, needle, hints);
+  // Read as a whole filter, for the fields whose values are written rather than picked.
+  const parsed = typedFilterMatches(field, typed, operatorLabels);
+  // Guidance only when the query yielded nothing on this field: a query that already reads as a
+  // filter gets the filter itself, and repeating the field beneath it says nothing new.
+  const guidance = parsed.length === 0 && !matched ? guidanceMatch(field, typed) : undefined;
+  const typedValue = typedValueSuggestion(field, typed);
+
+  return [
+    ...(matched ? [matched] : []),
+    ...listMatches(field, needle, limits.perField),
+    // A value used before beats the raw typed one: it is a value known to have been wanted.
+    ...recentMatches(field, needle, limits.perField, remembered),
+    ...parsed,
+    ...(guidance ? [guidance] : []),
+    // Already offered as a remembered value; do not repeat it as the typed one.
+    ...(typedValue && !remembered.includes(typed) ? [{ rank: RANK_TYPED_VALUE, suggestion: typedValue }] : []),
+  ];
+}
+
 /**
  * Cross-field narrowing for the bar's inline input: one query ranked against every field label,
  * every field's option labels, and every value the field was filtered by before, so typing `eth`
@@ -227,6 +335,7 @@ function recentMatches(field: FieldDef, needle: string, perField: number, recent
  * @param operatorLabels already-translated operator labels, for the rows read out of the query
  * @param limits caps on how many suggestions come back
  * @param recentValues previously used values per field, for the fields that have no option list
+ * @param hints per-value-type keywords and syntax examples for the fields that are typed into
  * @returns suggestions, best match first
  */
 export function searchFieldsAndValues(
@@ -235,32 +344,14 @@ export function searchFieldsAndValues(
   operatorLabels: OperatorLabels,
   limits: NarrowLimits = DEFAULT_LIMITS,
   recentValues?: RecentValues,
+  hints?: SyntaxHints,
 ): NarrowSuggestion[] {
   const needle = query.toLowerCase().trim();
   if (!needle)
     return [];
 
   const typed = query.trim();
-  const ranked: Ranked[] = [];
-
-  for (const field of fields) {
-    const remembered = recentValues?.(field) ?? [];
-    const matched = fieldMatch(field, needle);
-    if (matched)
-      ranked.push(matched);
-
-    ranked.push(...listMatches(field, needle, limits.perField));
-    // A value used before beats the raw typed one: it is a value known to have been wanted.
-    ranked.push(...recentMatches(field, needle, limits.perField, remembered));
-
-    // Read as a whole filter, for the fields whose values are written rather than picked.
-    ranked.push(...typedFilterMatches(field, typed, operatorLabels));
-
-    const typedValue = typedValueSuggestion(field, typed);
-    // Already offered as a remembered value; do not repeat it as the typed one.
-    if (typedValue && !remembered.includes(typed))
-      ranked.push({ rank: RANK_TYPED_VALUE, suggestion: typedValue });
-  }
+  const ranked = fields.flatMap(field => rankField(field, { hints, limits, needle, operatorLabels, recentValues, typed }));
 
   // Stable within a rank, so fields keep their declared order and values keep their option order.
   return ranked

--- a/frontend/app/src/modules/core/table/pill/core/typed-filters.spec.ts
+++ b/frontend/app/src/modules/core/table/pill/core/typed-filters.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { parseDateQuery, parseRangeQuery, type ParseTimestamp } from '@/modules/core/table/pill/core/typed-filters';
+import {
+  looksLikeDateQuery,
+  looksLikeRangeQuery,
+  parseDateQuery,
+  parseRangeQuery,
+  type ParseTimestamp,
+} from '@/modules/core/table/pill/core/typed-filters';
 
 // Stands in for the app's date reading: `DD/MM/YYYY`, with the wire value being the unix second.
 const parse: ParseTimestamp = (value: string): string | undefined => {
@@ -19,6 +25,46 @@ describe('parseRangeQuery', () => {
     expect(parseRangeQuery('>= 1.5')).toStrictEqual([{ op: 'gt', range: { min: '1.5' }, values: [] }]);
     expect(parseRangeQuery('<50')).toStrictEqual([{ op: 'lt', range: { max: '50' }, values: [] }]);
     expect(parseRangeQuery('=< 50')).toStrictEqual([{ op: 'lt', range: { max: '50' }, values: [] }]);
+  });
+
+  // The symbols were the only way in, while the rows the bar offers are labelled `greater than
+  // 100`: typing back what the row said did nothing.
+  it('should read a written lower bound', () => {
+    const gt = [{ op: 'gt', range: { min: '100' }, values: [] }];
+    expect(parseRangeQuery('over 100')).toStrictEqual(gt);
+    expect(parseRangeQuery('above 100')).toStrictEqual(gt);
+    expect(parseRangeQuery('more than 100')).toStrictEqual(gt);
+    expect(parseRangeQuery('greater than 100')).toStrictEqual(gt);
+    expect(parseRangeQuery('at least 100')).toStrictEqual(gt);
+    expect(parseRangeQuery('bigger 100')).toStrictEqual(gt);
+  });
+
+  it('should read a written upper bound', () => {
+    const lt = [{ op: 'lt', range: { max: '50' }, values: [] }];
+    expect(parseRangeQuery('under 50')).toStrictEqual(lt);
+    expect(parseRangeQuery('below 50')).toStrictEqual(lt);
+    expect(parseRangeQuery('less than 50')).toStrictEqual(lt);
+    expect(parseRangeQuery('smaller than 50')).toStrictEqual(lt);
+    expect(parseRangeQuery('at most 50')).toStrictEqual(lt);
+    expect(parseRangeQuery('up to 50')).toStrictEqual(lt);
+  });
+
+  it('should read a written bound whatever its casing', () => {
+    expect(parseRangeQuery('Over 100')).toStrictEqual([{ op: 'gt', range: { min: '100' }, values: [] }]);
+    expect(parseRangeQuery('LESS THAN 50')).toStrictEqual([{ op: 'lt', range: { max: '50' }, values: [] }]);
+  });
+
+  // `to` is the span separator as well as the tail of `up to`, and the two must not cross: a span
+  // always leads with its lower bound, which is what tells them apart.
+  it('should keep a span with a `to` separator a span', () => {
+    expect(parseRangeQuery('10 to 50')).toStrictEqual([{ op: 'between', range: { max: '50', min: '10' }, values: [] }]);
+    expect(parseRangeQuery('up to 50')).toStrictEqual([{ op: 'lt', range: { max: '50' }, values: [] }]);
+  });
+
+  it('should offer nothing for a word with no number after it', () => {
+    expect(parseRangeQuery('over')).toStrictEqual([]);
+    expect(parseRangeQuery('less than')).toStrictEqual([]);
+    expect(parseRangeQuery('overflow')).toStrictEqual([]);
   });
 
   it('should read a span as both bounds', () => {
@@ -91,5 +137,104 @@ describe('parseDateQuery', () => {
   // A date already carries separators, so a span has to be spaced to be told apart from one date.
   it('should not split a single hyphenated date', () => {
     expect(parseDateQuery('15-01-2024', parse)).toStrictEqual([]);
+  });
+});
+
+// The half-written counterpart of the parsers: what the bar offers guidance for. A query that
+// parses to nothing used to produce an empty popover, which reads as "this cannot be typed into".
+describe('looksLikeDateQuery', () => {
+  it('should claim an operator word with nothing after it yet', () => {
+    expect(looksLikeDateQuery('after')).toBe(true);
+    expect(looksLikeDateQuery('before ')).toBe(true);
+    expect(looksLikeDateQuery('since 15/')).toBe(true);
+    expect(looksLikeDateQuery('UNTIL')).toBe(true);
+  });
+
+  it('should claim a date that is still being written', () => {
+    expect(looksLikeDateQuery('15/')).toBe(true);
+    expect(looksLikeDateQuery('15/01')).toBe(true);
+    expect(looksLikeDateQuery('15/01/20')).toBe(true);
+    expect(looksLikeDateQuery('15.')).toBe(true);
+    expect(looksLikeDateQuery('15.01.')).toBe(true);
+    expect(looksLikeDateQuery('15-01-2024')).toBe(true);
+  });
+
+  it('should claim a span whose second bound is missing', () => {
+    expect(looksLikeDateQuery('15/01/2024 -')).toBe(true);
+    expect(looksLikeDateQuery('15/01/2024 to')).toBe(true);
+  });
+
+  // A bare marker says a bound is meant but not of what, so the amount fields claim it too and the
+  // user is shown both syntaxes, which is the ambiguity they are actually in.
+  it('should claim a bare comparison marker', () => {
+    expect(looksLikeDateQuery('>')).toBe(true);
+    expect(looksLikeDateQuery('<=')).toBe(true);
+  });
+
+  // A single dot or hyphen between digits is a decimal point or a span, not half a date: `1.5` is
+  // an amount and `10-50` is a range, and either claimed as a date would put a Period row under
+  // every amount the user types.
+  it('should leave an amount to the amount fields', () => {
+    expect(looksLikeDateQuery('100')).toBe(false);
+    expect(looksLikeDateQuery('>100')).toBe(false);
+    expect(looksLikeDateQuery('10 - 50')).toBe(false);
+    expect(looksLikeDateQuery('10-50')).toBe(false);
+    expect(looksLikeDateQuery('1.5')).toBe(false);
+  });
+
+  it('should claim nothing for text that is not heading anywhere', () => {
+    expect(looksLikeDateQuery('')).toBe(false);
+    expect(looksLikeDateQuery('   ')).toBe(false);
+    expect(looksLikeDateQuery('uniswap')).toBe(false);
+  });
+
+  // `to` and `-` are span separators, but only between two bounds: matching one wherever it fell
+  // put a Period row under every word that happens to end in it.
+  it('should not claim a word that merely ends in a span separator', () => {
+    expect(looksLikeDateQuery('auto')).toBe(false);
+    expect(looksLikeDateQuery('photo')).toBe(false);
+    expect(looksLikeDateQuery('uniswap -')).toBe(false);
+  });
+});
+
+describe('looksLikeRangeQuery', () => {
+  it('should claim a number being written, with or without a marker', () => {
+    expect(looksLikeRangeQuery('100')).toBe(true);
+    expect(looksLikeRangeQuery('1.')).toBe(true);
+    expect(looksLikeRangeQuery('>')).toBe(true);
+    expect(looksLikeRangeQuery('>= 1.5')).toBe(true);
+  });
+
+  it('should claim a span whose second bound is missing', () => {
+    expect(looksLikeRangeQuery('10 -')).toBe(true);
+    expect(looksLikeRangeQuery('10 to')).toBe(true);
+    expect(looksLikeRangeQuery('10 ..')).toBe(true);
+  });
+
+  it('should claim a written bound with nothing after it yet', () => {
+    expect(looksLikeRangeQuery('over')).toBe(true);
+    expect(looksLikeRangeQuery('less than')).toBe(true);
+    expect(looksLikeRangeQuery('at')).toBe(true);
+    expect(looksLikeRangeQuery('UNDER')).toBe(true);
+  });
+
+  it('should leave a date to the date fields', () => {
+    expect(looksLikeRangeQuery('15/01')).toBe(false);
+    expect(looksLikeRangeQuery('after')).toBe(false);
+    expect(looksLikeRangeQuery('15/01/2024')).toBe(false);
+  });
+
+  it('should claim nothing for text that is not heading anywhere', () => {
+    expect(looksLikeRangeQuery('')).toBe(false);
+    expect(looksLikeRangeQuery('uniswap')).toBe(false);
+  });
+
+  // The bound words are whole words: matching them as prefixes would put an Amount row under
+  // every query that merely opens with their letters.
+  it('should not claim a longer word that merely starts with a bound word', () => {
+    expect(looksLikeRangeQuery('overflow')).toBe(false);
+    expect(looksLikeRangeQuery('underlying')).toBe(false);
+    expect(looksLikeRangeQuery('atomic')).toBe(false);
+    expect(looksLikeRangeQuery('uphold')).toBe(false);
   });
 });

--- a/frontend/app/src/modules/core/table/pill/core/typed-filters.ts
+++ b/frontend/app/src/modules/core/table/pill/core/typed-filters.ts
@@ -29,6 +29,25 @@ const SPAN = new RegExp(String.raw`^(${NUMBER})\s*(?:\.\.|-|to)\s*(${NUMBER})$`,
 const BARE_NUMBER = new RegExp(String.raw`^${NUMBER}$`);
 
 /**
+ * The words an amount bound can be written with: `over 100`, `less than 50`, `at least 10`.
+ *
+ * A date has had `after`/`before` from the start while an amount had only the symbols, which left
+ * the bar contradicting itself: a typed `100` offers rows labelled `greater than 100` and
+ * `less than 100`, and typing back what the row said did nothing at all.
+ *
+ * `than` is optional because people leave it out, and the pairs are listed rather than built from a
+ * stem so that adding one is a decision rather than an accident of a regex.
+ */
+const RANGE_WORD = new RegExp(
+  String.raw`^((?:more|greater|larger|bigger)(?:\s+than)?|over|above|at\s+least`
+  + String.raw`|(?:less|smaller|lower|fewer)(?:\s+than)?|under|below|at\s+most|up\s+to)\s+(${NUMBER})$`,
+  'i',
+);
+
+/** Which of {@link RANGE_WORD}'s markers name the upper bound. */
+const RANGE_UPPER_WORDS = /^(?:less|smaller|lower|fewer|under|below|at\s+most|up\s+to)/i;
+
+/**
  * A date written out in full: two matching separators, so `1.5` and `2024` stay amounts rather
  * than being read as half a date. Which side is the day is the injected parser's business, not
  * this pattern's. An optional time may follow.
@@ -43,6 +62,32 @@ const DATE_WORD = /^(after|before|since|until)\s+(.+)$/i;
 const DATE_SPAN = /^(.+?)\s+(?:\.\.|-|to)\s+(.+)$/i;
 
 const UPPER_BOUND_MARKERS = /^(?:<=|=<|<|before|until)$/i;
+
+/** A comparison marker on its own, with nothing after it yet. */
+const BARE_MARKER = /^(?:>=|=>|>|<=|=<|<)$/;
+
+/** A comparison marker and whatever has been typed after it, which may be nothing. */
+const COMPARISON_MARKER = /^(?:>=|=>|>|<=|=<|<)\s*(.*)$/;
+
+/** A date word on its own, or one whose date is still being written. */
+const DATE_WORD_STARTED = /^(?:after|before|since|until)\b/i;
+
+/**
+ * A date on its way to being written. Looser than {@link WRITTEN_DATE}, which wants a whole date,
+ * but not loose enough to claim an amount: one separator counts only while nothing follows it
+ * (`15.`, `15-`) or when it is a slash, which no amount contains. So `1.5` stays an amount and
+ * `10-50` stays a span, while the second separator makes `15.01.` a date beyond doubt.
+ */
+const DATE_STARTED = /^\d{1,4}(?:[/.-]\d{0,4}[/.-]\d{0,4}|\/\d{0,2}|[.-])(?:\s.*)?$/;
+
+/** A number on its way to being written, including the trailing dot of `1.`. */
+const NUMBER_STARTED = /^\d+\.?\d*$/;
+
+/** An amount word on its own, or one whose number is still being written. */
+const RANGE_WORD_STARTED = /^(?:more|greater|larger|bigger|over|above|at|less|smaller|lower|fewer|under|below|up)\b/i;
+
+/** A span whose second bound is still missing: `10 -`, `10 to`, `15/01/2024 ..`. */
+const SPAN_STARTED = /\s*(?:\.\.|-|to)\s*$/i;
 
 function rangeDraft(op: ActiveFilter['op'], min?: string, max?: string): TypedFilterDraft {
   return { op, range: { ...(min ? { min } : {}), ...(max ? { max } : {}) }, values: [] };
@@ -66,6 +111,16 @@ export function parseRangeQuery(query: string): TypedFilterDraft[] {
   if (comparison) {
     const [, marker, amount] = comparison;
     return marker.includes('<')
+      ? [rangeDraft(FilterOps.LT, undefined, amount)]
+      : [rangeDraft(FilterOps.GT, amount)];
+  }
+
+  // After the symbols and before the span: a span always leads with its lower bound, so a query
+  // opening with a word cannot be one.
+  const worded = RANGE_WORD.exec(typed);
+  if (worded) {
+    const [, marker, amount] = worded;
+    return RANGE_UPPER_WORDS.test(marker)
       ? [rangeDraft(FilterOps.LT, undefined, amount)]
       : [rangeDraft(FilterOps.GT, amount)];
   }
@@ -111,6 +166,50 @@ export function parseDateQuery(query: string, parse: ParseTimestamp): TypedFilte
   if (!bound)
     return [];
   return [dateDraft(FilterOps.AFTER, bound), dateDraft(FilterOps.BEFORE, undefined, bound)];
+}
+
+/**
+ * Whether the query is on its way to a date filter, whether or not it is one yet.
+ *
+ * The counterpart of {@link parseDateQuery} for what has been typed *so far*. A half-written date
+ * parses to nothing, and nothing is what the bar used to show for it: typing `after` or `15/01`
+ * produced an empty popover, which reads as "this field cannot be typed into" rather than "keep
+ * going". A field that says yes here is offered with its syntax example instead.
+ *
+ * Wider than the parser on purpose, and narrower than "any text": it must not claim a bare number,
+ * which belongs to the amount fields.
+ */
+export function looksLikeDateQuery(query: string): boolean {
+  const typed = query.trim();
+  if (!typed)
+    return false;
+  if (DATE_WORD_STARTED.test(typed))
+    return true;
+  // A bare marker is ambiguous between a date and an amount, so both fields claim it and the user
+  // sees the two syntaxes side by side, which is exactly the ambiguity they are in.
+  if (BARE_MARKER.test(typed))
+    return true;
+
+  // A half-written span needs no case of its own: whatever follows the first date is swallowed by
+  // `DATE_STARTED`, and matching a trailing separator on its own would claim every word ending in
+  // `to` or `-`.
+  const prefixed = DATE_COMPARISON.exec(typed);
+  return DATE_STARTED.test((prefixed ? prefixed[2] : typed).trim());
+}
+
+/** {@link looksLikeDateQuery} for an amount: a marker, a partial number, or a half-written span. */
+export function looksLikeRangeQuery(query: string): boolean {
+  const typed = query.trim();
+  if (!typed)
+    return false;
+  if (BARE_MARKER.test(typed) || RANGE_WORD_STARTED.test(typed))
+    return true;
+
+  const prefixed = COMPARISON_MARKER.exec(typed);
+  const rest = (prefixed ? prefixed[1] : typed).trim();
+  // A span still missing its upper bound (`10 -`) keeps the number in front of the separator.
+  const head = rest.replace(SPAN_STARTED, '').trim();
+  return NUMBER_STARTED.test(head);
 }
 
 /**

--- a/frontend/app/src/modules/core/table/pill/core/types.ts
+++ b/frontend/app/src/modules/core/table/pill/core/types.ts
@@ -227,6 +227,13 @@ export interface FieldDef {
    */
   readonly parseTyped?: (query: string) => TypedFilterDraft[];
   /**
+   * Whether what has been typed is on its way to a filter on this field, even though it does not
+   * parse into one yet. The half-written counterpart of {@link parseTyped}: `after` and `15/01` are
+   * both headed for a date, and answering yes here has the bar offer this field with its
+   * {@link hint} rather than the empty popover a non-parsing query used to get.
+   */
+  readonly matchesTyped?: (query: string) => boolean;
+  /**
    * Message shown when `validate` rejects what was typed. Says what the field wants ("Enter a
    * valid transaction hash"), which a generic "Invalid value" cannot. Absent = the editor's
    * generic message.

--- a/frontend/app/src/modules/core/table/pill/core/types.ts
+++ b/frontend/app/src/modules/core/table/pill/core/types.ts
@@ -264,6 +264,8 @@ export interface PillBarLabels {
   readonly narrowEmpty: string;
   /** Accessible name for a pill's remove control, which is an icon with no text of its own. */
   readonly remove: string;
+  /** Lead-in for the narrowing popover's footer of typeable examples. */
+  readonly syntax: string;
 }
 
 /** One active filter, agnostic of presentation. */


### PR DESCRIPTION
The pill bar reads a date or an amount typed straight into it (`after
15/01/2024`, `>100`), but nothing on screen ever said so. There was no
hint anywhere, the field is labelled "Period" rather than "Date", and a
half-written date matched nothing at all, so probing with `after` or
`15/01` returned an empty popover: the one thing that reads as "this
field cannot be typed into".

## What changed

**A syntax footer in the narrowing popover.** Worked examples, one per
shape on each side: a lower bound, an upper bound, a span. They are
buttons, so the footer demonstrates rather than describes: clicking one
puts it in the input and the row it produces appears directly above.
Deliberately not applied, since watching the text turn into a filter is
the lesson, and applying it outright would add a pill nobody asked for.
The footer sits outside the scroll area, because a hint that scrolls
away is one you must already know about to find.

**Guidance rows.** A query heading towards a filter it does not yet
spell now returns the field instead of nothing. `FieldDef.matchesTyped`
is the half-written counterpart of `parseTyped`, ranked below every real
match and suppressed once the query reads as a whole filter.

**Keywords per value type.** A period field is labelled "Period", so
`date`, `time` and `when` found nothing. Declared per value type rather
than per field, so no table restates them, and ranked as a substring
match so a visible label always wins.

**Written amount bounds.** Amounts accepted only symbols, while the rows
the bar offers for one are labelled "greater than 100" -- typing back
what the row said did nothing. `over`, `above`, `more/greater than`, `at
least`, `under`, `below`, `less/smaller than`, `at most` and `up to` now
parse, with `than` optional.

## Notes for review

- The examples are literal and never translated. The operator words the
  parser knows are English, so a translated example would be one the
  user copies and the bar then refuses. Only the lead-in goes through
  `t`. This is also why `before` earns a chip of its own: its only other
  route was reading it off a bare date's result rows, and those are
  labelled with the *translated* operator.
- The example date renders in the user's own format, on a day past the
  twelfth so the field order cannot be misread, and at local midnight
  so the formatter does not append a time of day.
- `to` is both the span separator and the tail of `up to`. They are told
  apart by anchoring: a span always leads with its lower bound.
- The bound words match as whole words. Without that, `overflow`,
  `underlying`, `atomic` and `uphold` each put an Amount row on screen.
- Still not advertised, by choice: `since`/`until`, the `..` and `to`
  separators, and the optional time component. All still parse.

## Testing

24 new specs. Full frontend suite green (889 files, 9037 tests), plus
typecheck, eslint and knip. Verified in the running app: the footer, the
chips, click-to-fill, and each new amount word.
