### PR TITLE
Search chain-skip rule addresses by name

### DIFF
--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/DisabledChainQueryRuleDialog.spec.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/DisabledChainQueryRuleDialog.spec.ts
@@ -16,6 +16,7 @@ vi.mock('@/modules/settings/general/disabled-chain-queries/use-rule-editor-form'
     availableChainsForAddress: computed(() => []),
     buildDraft: (): RuleDraft | undefined => buildDraftMock(),
     canSave: computed<boolean>(() => get(canSave)),
+    filterAddressOption: (): boolean => true,
     modelAddress: ref<string | undefined>(undefined),
     modelChainId: ref<string | undefined>(undefined),
     modelKind: kind,

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/DisabledChainQueryRuleDialog.vue
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/DisabledChainQueryRuleDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Rule, RuleDraft } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chain-queries-state';
+import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
 import ChainDisplay from '@/modules/accounts/blockchain/ChainDisplay.vue';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -20,6 +21,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const { accounts } = storeToRefs(useBlockchainAccountsStore());
 const { supportedChains } = useSupportedChains();
+const { getAddressName } = useAddressNameResolution();
 
 const {
   modelAddress,
@@ -27,6 +29,7 @@ const {
   availableChainsForAddress,
   buildDraft,
   canSave,
+  filterAddressOption,
   modelChainId,
   modelKind,
   reset,
@@ -36,6 +39,7 @@ const {
   accounts,
   chains: supportedChains,
   editing: () => editing,
+  resolveName: getAddressName,
 });
 
 const chainOptionsForAddress = computed(() => get(supportedChains).filter(c => get(availableChainsForAddress).includes(c.id)));
@@ -119,6 +123,7 @@ watch(open, (value) => {
             variant="outlined"
             key-attr="address"
             text-attr="address"
+            :filter="filterAddressOption"
             hide-details
             auto-select-first
             data-testid="rule-address-picker"

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/use-rule-editor-form.spec.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/use-rule-editor-form.spec.ts
@@ -1,17 +1,20 @@
 import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
 import type { ChainInfo } from '@/modules/core/api/types/chains';
 import type { Rule } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chain-queries-state';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, assert, describe, expect, it } from 'vitest';
 import { effectScope, ref } from 'vue';
 import { useRuleEditorForm, type UseRuleEditorFormReturn } from '@/modules/settings/general/disabled-chain-queries/use-rule-editor-form';
+
+type AddressOption = UseRuleEditorFormReturn['addressOptions']['value'][number];
 
 const ADDR_A = '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c';
 const ADDR_B = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65';
 
-function addressAccount(chain: string, address: string): BlockchainAccount {
+function addressAccount(chain: string, address: string, label?: string): BlockchainAccount {
   return {
     chain,
     data: { address, type: 'address' },
+    label,
     nativeAsset: 'ETH',
   };
 }
@@ -45,6 +48,7 @@ function createHarness(initial: {
   editing?: Rule;
   accounts?: Record<string, BlockchainAccount[]>;
   chains?: ChainInfo[];
+  resolveName?: (address: string, chainId?: string) => string | undefined;
 } = {}): Harness {
   const editing = ref<Rule | undefined>(initial.editing);
   const scope = effectScope();
@@ -52,6 +56,7 @@ function createHarness(initial: {
     accounts: initial.accounts ?? defaultAccounts,
     chains: initial.chains ?? defaultChains,
     editing,
+    resolveName: initial.resolveName,
   }))!;
   return {
     dispose: (): void => scope.stop(),
@@ -113,6 +118,47 @@ describe('useRuleEditorForm', () => {
       harness = createHarness();
       const options = harness.form.addressOptions.value;
       expect(options.find(o => o.address === '0xpubkey')).toBeUndefined();
+    });
+  });
+
+  describe('filterAddressOption', () => {
+    function optionFor(address: string): AddressOption {
+      const option = harness.form.addressOptions.value.find(o => o.address === address);
+      assert(option);
+      return option;
+    }
+
+    it('should match a fragment of the address, case-insensitively', () => {
+      harness = createHarness();
+      const { filterAddressOption } = harness.form;
+      expect(filterAddressOption(optionFor(ADDR_A), ADDR_A.slice(10, 20).toUpperCase())).toBe(true);
+      expect(filterAddressOption(optionFor(ADDR_B), ADDR_A.slice(10, 20))).toBe(false);
+    });
+
+    it('should match the account label', () => {
+      harness = createHarness({
+        accounts: {
+          eth: [addressAccount('eth', ADDR_A, 'My Ledger'), addressAccount('eth', ADDR_B)],
+        },
+      });
+      const { filterAddressOption } = harness.form;
+      expect(filterAddressOption(optionFor(ADDR_A), 'ledger')).toBe(true);
+      expect(filterAddressOption(optionFor(ADDR_B), 'ledger')).toBe(false);
+    });
+
+    it('should match the resolved alias name', () => {
+      harness = createHarness({
+        resolveName: (address: string): string | undefined => address === ADDR_A ? 'rotki.eth' : undefined,
+      });
+      const { filterAddressOption } = harness.form;
+      expect(filterAddressOption(optionFor(ADDR_A), 'rotki')).toBe(true);
+      expect(filterAddressOption(optionFor(ADDR_B), 'rotki')).toBe(false);
+    });
+
+    it('should keep every option for an empty query', () => {
+      harness = createHarness();
+      const { filterAddressOption } = harness.form;
+      expect(filterAddressOption(optionFor(ADDR_A), '  ')).toBe(true);
     });
   });
 

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/use-rule-editor-form.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/use-rule-editor-form.ts
@@ -11,6 +11,7 @@ type AddressScope = 'all' | 'specific';
 interface AddressOption {
   readonly address: string;
   readonly chainIds: readonly string[];
+  /** Lowercased haystack: the address plus every name the option is displayed under. */
   readonly searchText: string;
 }
 
@@ -21,6 +22,11 @@ export interface UseRuleEditorFormOptions {
   chains: MaybeRefOrGetter<ChainInfo[]>;
   /** Rule being edited, or `undefined` for the create flow. */
   editing: MaybeRefOrGetter<Rule | undefined>;
+  /**
+   * Resolves the alias name (address book entry or ENS) an address is displayed
+   * under, so that the picker can be searched by it and not only by the address.
+   */
+  resolveName?: (address: string, chainId?: string) => string | undefined;
 }
 
 export interface UseRuleEditorFormReturn {
@@ -32,40 +38,65 @@ export interface UseRuleEditorFormReturn {
   addressOptions: ComputedRef<AddressOption[]>;
   availableChainsForAddress: ComputedRef<string[]>;
   canSave: ComputedRef<boolean>;
+  /** Search predicate for the address picker, matching address, label and alias name. */
+  filterAddressOption: (item: AddressOption, query: string) => boolean;
   /** Reset the form back to the current `editing` value (or empty/create state). */
   reset: () => void;
   /** Build the draft to emit on save, or `undefined` if the form is not yet valid. */
   buildDraft: () => RuleDraft | undefined;
 }
 
-function buildAddressOptions(accounts: Record<string, BlockchainAccount[]>): AddressOption[] {
-  const byAddress = new Map<string, Set<string>>();
+interface AddressEntry {
+  readonly chains: Set<string>;
+  readonly labels: Set<string>;
+}
+
+function buildAddressOptions(
+  accounts: Record<string, BlockchainAccount[]>,
+  resolveName?: (address: string, chainId?: string) => string | undefined,
+): AddressOption[] {
+  const byAddress = new Map<string, AddressEntry>();
   for (const [chain, list] of Object.entries(accounts)) {
     for (const account of list) {
       if (isValidatorAccount(account) || account.data.type !== 'address')
         continue;
       const addr = account.data.address;
-      const set = byAddress.get(addr);
-      if (set === undefined)
-        byAddress.set(addr, new Set([chain]));
-      else
-        set.add(chain);
+      let entry = byAddress.get(addr);
+      if (entry === undefined) {
+        entry = { chains: new Set(), labels: new Set() };
+        byAddress.set(addr, entry);
+      }
+      entry.chains.add(chain);
+      if (account.label)
+        entry.labels.add(account.label);
     }
   }
   const built: AddressOption[] = [];
-  for (const [address, chainSet] of byAddress) {
+  for (const [address, { chains, labels }] of byAddress) {
+    const chainIds = [...chains];
+    const aliasName = resolveName?.(address, chainIds[0]);
+    const keywords = [address, ...labels];
+    if (aliasName)
+      keywords.push(aliasName);
     built.push({
       address,
-      chainIds: [...chainSet],
-      searchText: address.toLowerCase(),
+      chainIds,
+      searchText: keywords.join(' ').toLowerCase(),
     });
   }
   built.sort((a, b) => a.address.localeCompare(b.address));
   return built;
 }
 
+function filterAddressOption(item: AddressOption, query: string): boolean {
+  const search = query.trim().toLowerCase();
+  if (!search)
+    return true;
+  return item.searchText.includes(search);
+}
+
 export function useRuleEditorForm(options: UseRuleEditorFormOptions): UseRuleEditorFormReturn {
-  const { accounts, chains, editing } = options;
+  const { accounts, chains, editing, resolveName } = options;
 
   // These refs are the form model, bound via v-model from the dialog template.
   // The `model` prefix marks them as writable by the consumer.
@@ -75,7 +106,7 @@ export function useRuleEditorForm(options: UseRuleEditorFormOptions): UseRuleEdi
   const modelScope = shallowRef<AddressScope>('all');
   const modelSelectedChainIds = ref<string[]>([]);
 
-  const addressOptions = computed<AddressOption[]>(() => buildAddressOptions(toValue(accounts)));
+  const addressOptions = computed<AddressOption[]>(() => buildAddressOptions(toValue(accounts), resolveName));
 
   const availableChainsForAddress = computed<string[]>(() => {
     const target = get(modelAddress);
@@ -153,6 +184,7 @@ export function useRuleEditorForm(options: UseRuleEditorFormOptions): UseRuleEdi
     availableChainsForAddress,
     buildDraft,
     canSave,
+    filterAddressOption,
     modelAddress,
     modelChainId,
     modelKind,


### PR DESCRIPTION
### Problem

In **Settings → Chains → Skip chains and addresses**, the address picker of the add/edit rule dialog can only be searched by the raw hex address.

`DisabledChainQueryRuleDialog.vue` renders a `RuiAutoComplete` with `key-attr="address"` and `text-attr="address"` and no custom `filter`, so the library's default predicate matches those two attributes only, which are the same string.

The rows show something else. The item slot renders `AccountDisplay`, which resolves an alias through `getAddressName()` (address book entry, ENS, or account label) and shows the address only when there is no alias. On an account with real data, 9 of 11 rows read as a name (`yabir.eth`, `lefteris.eth`, `compound`, `loop`, ...). Typing what you see returned "no data".

`AddressOption.searchText` already existed for this, populated with the lowercased address, but nothing read it.

### Change

- `use-rule-editor-form.ts`: new optional `resolveName` input; `buildAddressOptions` folds the account label(s) and the resolved alias into `searchText`; new `filterAddressOption` predicate returned from the composable.
- `DisabledChainQueryRuleDialog.vue`: passes `resolveName: getAddressName` and `:filter="filterAddressOption"`.

The chain picker needed no change, it already uses `text-attr="name"`.

### Verified

Unit: 4 new cases (address fragment case-insensitively, account label, resolved alias, empty query), each paired with a negative assertion on a second address. Stubbing the predicate to `return true` fails all three matching tests, so they are not passing for an unrelated reason.

In-app, against an account with 11 tracked addresses:

| typed | result |
|---|---|
| `yabir` | `yabir.eth` only (ENS) |
| `loop` / `compound` | that account only (label) |
| `c37b40` / `C37B40` | the matching address, whose row displays `yabir.eth` |
| `zzzznope` | no results |
| empty | all 11 |

`loop`, `yabir` and `compound` contain non-hex letters, so they cannot match an address substring. Saving still round-trips: picking `loop` persisted `0x3Ba6eB…CEF` across its 10 chains, and removing it cleared the setting.

`pnpm run test:unit` (folder), `lint:file:check`, `typecheck` and `knip` are all clean.