### PR TITLE
Guard user-typed amounts against a throwing parse

### DIFF
--- a/frontend/app/src/modules/accounts/manual-balances/manual-balance-form.spec.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/manual-balance-form.spec.ts
@@ -76,6 +76,12 @@ describe('modules/accounts/manual-balances/manual-balance-form', () => {
       expect(toFormState(balance({ amount: bigNumberify(Number.NaN) })).amount).toBe('');
     });
 
+    // The payload is rebuilt on every change, so an amount that is not a number yet lands in the
+    // same not-a-number state a cleared one does, rather than throwing out of the parse.
+    it.each(['-', '1.2.3', '0,5', '1 000'])('should carry an amount of %s as not a number', (typed) => {
+      expect(toPayload(balance(), state({ amount: typed })).amount.isNaN()).toBe(true);
+    });
+
     it('should offer no tags as an empty list', () => {
       expect(toFormState(balance({ tags: null })).tags).toEqual([]);
     });

--- a/frontend/app/src/modules/accounts/manual-balances/manual-balance-form.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/manual-balance-form.ts
@@ -2,6 +2,7 @@ import type { BalanceType } from '@/modules/balances/types/balances';
 import type { ManualBalance, RawManualBalance } from '@/modules/balances/types/manual-balances';
 import { bigNumberify } from '@rotki/common';
 import { z, type ZodType } from 'zod';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
 import { requiredField } from '@/modules/core/form/fields';
 
 /**
@@ -34,12 +35,15 @@ export function toFormState(balance: RawManualBalance | ManualBalance): ManualBa
  * different value: a cleared amount becomes NaN rather than zero precisely so that reading it
  * returns the empty field the user left, instead of refilling it with a nought they never typed.
  * An amount in that state never reaches the api, because the dialog saves only what validates.
+ *
+ * A field holding something that is not a number yet lands in the same state, rather than in the
+ * throw a bare parse would raise on it.
  */
 export function toPayload<T extends RawManualBalance>(balance: T, state: ManualBalanceFormState): T {
   return {
     ...balance,
     ...state,
-    amount: state.amount ? bigNumberify(state.amount) : bigNumberify(Number.NaN),
+    amount: parseNumericInput(state.amount, bigNumberify(Number.NaN)),
     tags: state.tags.length > 0 ? state.tags : null,
   };
 }

--- a/frontend/app/src/modules/core/common/data/bignumbers.spec.ts
+++ b/frontend/app/src/modules/core/common/data/bignumbers.spec.ts
@@ -1,7 +1,7 @@
 import { bigNumberify, Zero } from '@rotki/common';
 import { describe, expect, it } from 'vitest';
 import { ref } from 'vue';
-import { bigNumberifyFromRef, sortDesc, zeroBalance } from '@/modules/core/common/data/bignumbers';
+import { bigNumberifyFromRef, parseNumericInput, sortDesc, zeroBalance } from '@/modules/core/common/data/bignumbers';
 
 describe('core/common/data/bignumbers', () => {
   describe('bigNumberifyFromRef', () => {
@@ -31,6 +31,49 @@ describe('core/common/data/bignumbers', () => {
 
       const value = bigNumberifyFromRef(ref(input));
       expect(value.value).toStrictEqual(Zero);
+    });
+  });
+
+  describe('parseNumericInput', () => {
+    it('should parse a numeric string', () => {
+      expect(parseNumericInput('1.5')?.toFixed()).toBe('1.5');
+    });
+
+    it('should parse a number', () => {
+      expect(parseNumericInput(2)?.toFixed()).toBe('2');
+    });
+
+    it('should keep zero apart from nothing typed', () => {
+      expect(parseNumericInput('0')).toStrictEqual(Zero);
+      expect(parseNumericInput('')).toBeUndefined();
+      expect(parseNumericInput('   ')).toBeUndefined();
+    });
+
+    // The first group throws in bignumber.js, the second parses into something unusable. A caller
+    // that has to reject a value cannot tell them apart, so neither may come back as a number.
+    it.each(['abc', '1.2.3', '-', '.', '0,5', '1 000'])('should reject %s, which throws', (input) => {
+      expect(() => bigNumberify(input)).toThrow();
+      expect(parseNumericInput(input)).toBeUndefined();
+    });
+
+    it.each(['NaN', 'Infinity', '-Infinity'])('should reject %s, which parses', (input) => {
+      expect(() => bigNumberify(input)).not.toThrow();
+      expect(parseNumericInput(input)).toBeUndefined();
+    });
+
+    it('should accept a partially typed decimal', () => {
+      expect(parseNumericInput('1.')?.toFixed()).toBe('1');
+      expect(parseNumericInput('.5')?.toFixed()).toBe('0.5');
+    });
+
+    // With a fallback the result is a number the caller can use straight away, so the parse and the
+    // "what does an unreadable field mean here" decision stay in one place.
+    it.each(['', '-', '1.2.3', 'NaN'])('should fall back on %s when given a fallback', (input) => {
+      expect(parseNumericInput(input, Zero)).toStrictEqual(Zero);
+    });
+
+    it('should ignore the fallback when the value reads', () => {
+      expect(parseNumericInput('1.5', Zero).toFixed()).toBe('1.5');
     });
   });
 

--- a/frontend/app/src/modules/core/common/data/bignumbers.ts
+++ b/frontend/app/src/modules/core/common/data/bignumbers.ts
@@ -14,6 +14,30 @@ export function bigNumberifyFromRef(value: MaybeRefOrGetter<string | number>): C
   });
 }
 
+/** The fallback for the parse below: a value bignumber.js accepts but nothing downstream can use. */
+const NOT_A_NUMBER = bigNumberify(Number.NaN);
+
+/**
+ * Reads a field the user is typing. Without a fallback an unusable value comes back as undefined,
+ * so the caller has to answer for it; with one, the result is a number the caller can just use.
+ *
+ * The callers that pass no fallback are the ones that must not invent a value: a save would
+ * otherwise write a nought nobody typed, and a check has to tell "not a number yet" apart from
+ * "zero". `''`, `'-'` and `'1.2.3'` are all unusable, as are `'NaN'` and `'Infinity'`, which parse
+ * but are no more usable than the ones that throw.
+ */
+export function parseNumericInput(value: string | number): BigNumber | undefined;
+
+export function parseNumericInput(value: string | number, fallback: BigNumber): BigNumber;
+
+export function parseNumericInput(value: string | number, fallback?: BigNumber): BigNumber | undefined {
+  if (typeof value === 'string' && value.trim() === '')
+    return fallback;
+
+  const parsed = bigNumberify(value, NOT_A_NUMBER);
+  return parsed.isFinite() ? parsed : fallback;
+}
+
 export function zeroBalance(): Balance {
   return {
     amount: Zero,

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalanceEntryDialog.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalanceEntryDialog.spec.ts
@@ -1,0 +1,173 @@
+import type { Snapshot } from '@/modules/dashboard/snapshots';
+import type { BalanceMutation } from '@/modules/dashboard/snapshots/utils/snapshot-math';
+import { type BigNumber, bigNumberify, One } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, type Ref, ref } from 'vue';
+import { BalanceType } from '@/modules/balances/types/balances';
+import SnapshotBalanceEntryDialog from '@/modules/dashboard/snapshots/components/SnapshotBalanceEntryDialog.vue';
+
+const TS = 1_600_000_000;
+
+vi.mock('@/modules/dashboard/snapshots/composables/use-historic-fiat-conversion', () => ({
+  useHistoricFiatConversion: (): { isUsd: Ref<boolean>; loading: Ref<boolean>; rate: Ref<BigNumber>; rateReady: Ref<boolean> } => ({
+    isUsd: ref(true),
+    loading: ref(false),
+    rate: ref(One),
+    rateReady: ref(true),
+  }),
+}));
+
+function createSnapshot(): Snapshot {
+  return {
+    balancesSnapshot: [
+      { amount: bigNumberify(1), assetIdentifier: 'ETH', category: BalanceType.ASSET, timestamp: TS, usdValue: bigNumberify(100) },
+    ],
+    locationDataSnapshot: [
+      { location: 'kraken', timestamp: TS, usdValue: bigNumberify(100) },
+      { location: 'total', timestamp: TS, usdValue: bigNumberify(100) },
+    ],
+  };
+}
+
+/** Stands in for the form, which owns the fields but not the parsing under test. */
+const FormStub = {
+  emits: ['update:modelValue', 'update:stateUpdated', 'update:asset'],
+  methods: {
+    submitPrice(): void {},
+    validate(): boolean {
+      return true;
+    },
+  },
+  name: 'EditBalancesSnapshotForm',
+  props: ['modelValue', 'edit', 'hideLocation', 'previewLocationBalance', 'disabledLocations', 'locations', 'timestamp', 'stateUpdated'],
+  // The split toggle lives in this slot, so the stub has to render it.
+  template: '<div><slot name="before-location" /></div>',
+};
+
+describe('modules/dashboard/snapshots/components/SnapshotBalanceEntryDialog', () => {
+  let wrapper: VueWrapper<InstanceType<typeof SnapshotBalanceEntryDialog>>;
+
+  /**
+   * What the dialog threw out of a handler. Vue routes those into its error handler, so a save that
+   * throws still emits nothing: without this, a test asserting "nothing was submitted" cannot tell
+   * a clean refusal from a crash, and stays green against the code it is meant to catch.
+   */
+  const handlerErrors: unknown[] = [];
+
+  function createWrapper(): VueWrapper<InstanceType<typeof SnapshotBalanceEntryDialog>> {
+    return mount(SnapshotBalanceEntryDialog, {
+      global: {
+        config: {
+          errorHandler: (error: unknown): void => {
+            handlerErrors.push(error);
+          },
+        },
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          BigDialog: {
+            emits: ['confirm', 'cancel'],
+            props: ['display', 'title', 'action', 'loading', 'promptOnClose'],
+            template: '<div v-if="display"><slot /><button data-testid="confirm" @click="$emit(\'confirm\')" /></div>',
+          },
+          ConfirmSnapshotConflictReplacementDialog: true,
+          EditBalancesSnapshotForm: FormStub,
+          SnapshotLocationSplit: {
+            emits: ['update:modelValue', 'update:valid'],
+            name: 'SnapshotLocationSplit',
+            props: ['modelValue', 'valid', 'total', 'locations', 'maxPerLocation', 'timestamp'],
+            template: '<div />',
+          },
+        },
+      },
+      props: { snapshot: createSnapshot(), timestamp: TS },
+    });
+  }
+
+  /** Opens the add dialog and puts the given fields in the form's model. */
+  async function openAddWith(amount: string, usdValue: string): Promise<void> {
+    wrapper.vm.openAdd();
+    await nextTick();
+
+    const form = wrapper.findComponent({ name: 'EditBalancesSnapshotForm' });
+    form.vm.$emit('update:modelValue', {
+      amount,
+      assetIdentifier: 'ETH',
+      category: BalanceType.ASSET,
+      location: 'kraken',
+      timestamp: TS,
+      usdValue,
+    });
+    await nextTick();
+  }
+
+  function submitted(): BalanceMutation[] {
+    const events = wrapper.emitted<[{ index: number | null; mutation: BalanceMutation }]>('submit');
+    return (events ?? []).map(([payload]) => payload.mutation);
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    handlerErrors.length = 0;
+    wrapper = createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should submit the entered amount and value', async () => {
+    await openAddWith('2', '250');
+    await wrapper.find('[data-testid=confirm]').trigger('click');
+
+    const [mutation] = submitted();
+    expect(mutation.balance.amount.toNumber()).toBe(2);
+    expect(mutation.balance.usdValue.toNumber()).toBe(250);
+  });
+
+  // The schema gates the category and the location only, so the save path is what has to hold the
+  // line on the two text fields. A cleared one used to throw on parse; a fallback would have
+  // written a nought nobody typed into the snapshot.
+  it.each([
+    ['a cleared amount', '', '250'],
+    ['a cleared value', '2', ''],
+    ['a half-typed amount', '-', '250'],
+    ['a half-typed value', '2', '1.2.3'],
+  ])('should not submit %s', async (_label, amount, usdValue) => {
+    await openAddWith(amount, usdValue);
+    await wrapper.find('[data-testid=confirm]').trigger('click');
+
+    expect(handlerErrors).toEqual([]);
+    expect(submitted()).toEqual([]);
+  });
+
+  it('should attribute the balance to the split rows in split mode', async () => {
+    await openAddWith('2', '250');
+    await wrapper.find('[data-testid=snapshot-balance-split-toggle] input').setValue(true);
+
+    const split = wrapper.findComponent({ name: 'SnapshotLocationSplit' });
+    split.vm.$emit('update:modelValue', [{ location: 'kraken', usdValue: bigNumberify(250) }]);
+    split.vm.$emit('update:valid', true);
+    await nextTick();
+
+    await wrapper.find('[data-testid=confirm]').trigger('click');
+
+    const [mutation] = submitted();
+    expect(mutation.location).toEqual([{ location: 'kraken', usdValue: bigNumberify(250) }]);
+  });
+
+  // The location preview and the overdrawn-location check read the same field on every keystroke,
+  // where a throw takes the dialog down rather than surfacing as a bad number.
+  it('should keep rendering while the value field holds no number', async () => {
+    await openAddWith('2', '1.2.3');
+
+    // Nothing readable was entered, so the location is previewed as unchanged.
+    const preview = wrapper.findComponent({ name: 'EditBalancesSnapshotForm' }).props('previewLocationBalance');
+    expect(preview.before.toNumber()).toBe(100);
+    expect(preview.after.toNumber()).toBe(100);
+    expect(wrapper.findComponent({ name: 'EditBalancesSnapshotForm' }).props('disabledLocations')).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalanceEntryDialog.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalanceEntryDialog.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { BalanceSnapshot, BalanceSnapshotPayload, Snapshot } from '@/modules/dashboard/snapshots';
 import type { BalanceMutation, LocationAttribution, LocationSplit } from '@/modules/dashboard/snapshots/utils/snapshot-math';
-import { assert, type BigNumber, bigNumberify, Zero } from '@rotki/common';
+import { assert, type BigNumber, Zero } from '@rotki/common';
 import { BalanceType } from '@/modules/balances/types/balances';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
 import ConfirmSnapshotConflictReplacementDialog
   from '@/modules/dashboard/ConfirmSnapshotConflictReplacementDialog.vue';
 import EditBalancesSnapshotForm from '@/modules/dashboard/edit-snapshot/EditBalancesSnapshotForm.vue';
@@ -57,14 +58,16 @@ const previousUsdValue = computed<BigNumber>(() => {
   return idx === null ? Zero : snapshot.balancesSnapshot[idx]?.usdValue ?? Zero;
 });
 
+/** What the value field holds, or Zero while it holds nothing a number can be read out of. */
+const enteredUsdValue = computed<BigNumber>(() => parseNumericInput(get(formModel)?.usdValue ?? '', Zero));
+
 /**
  * Signed change to the balance's USD value (`new − old`) — the amount the split
  * distributes across locations. On an add this is the whole new value; on an
  * edit it is only the difference, so each location moves by its own share rather
  * than the stale stored value being dumped on one row.
  */
-const valueDelta = computed<BigNumber>(() =>
-  bigNumberify(get(formModel)?.usdValue || '0').minus(get(previousUsdValue)));
+const valueDelta = computed<BigNumber>(() => get(enteredUsdValue).minus(get(previousUsdValue)));
 
 /** The magnitude the split rows must add up to (the amount added or removed). */
 const splitTotal = computed<BigNumber>(() => get(valueDelta).abs());
@@ -101,7 +104,7 @@ const disabledLocations = computed<string[]>(() => {
   const formVal = get(formModel);
   if (!formVal)
     return [];
-  const usdValue = bigNumberify(formVal.usdValue || '0');
+  const usdValue = get(enteredUsdValue);
   return overdrawnLocationIds(snapshot, formVal.category, location =>
     locationBalanceAfterEdit({ category: formVal.category, editIndex: get(editIndex), location, snapshot, usdValue }).after);
 });
@@ -119,7 +122,7 @@ const previewLocationBalance = computed<LocationBalancePreview | null>(() => {
     editIndex: get(editIndex),
     location: formVal.location,
     snapshot,
-    usdValue: bigNumberify(formVal.usdValue),
+    usdValue: get(enteredUsdValue),
   });
 });
 
@@ -234,6 +237,44 @@ function close(): void {
   resetSplit();
 }
 
+/**
+ * The row the form describes, or undefined while the amount or the value holds no number.
+ *
+ * The schema gates the category and the location; the amount and the value are free text, and the
+ * price sub-form's rules over them only decorate the fields. Reading them here is what keeps a
+ * cleared field from being saved as a nought nobody entered, or from reaching a parse that throws.
+ */
+function toBalance(formData: BalanceSnapshotPayload): BalanceSnapshot | undefined {
+  const amount = parseNumericInput(formData.amount);
+  const usdValue = parseNumericInput(formData.usdValue);
+  if (!amount || !usdValue)
+    return undefined;
+
+  return {
+    amount,
+    assetIdentifier: formData.assetIdentifier,
+    category: formData.category,
+    timestamp,
+    usdValue,
+  };
+}
+
+/**
+ * Where the balance is attributed: the split rows, or the single location the form holds.
+ *
+ * The split rows hold positive amounts; a removal moves the location subtotals down, so negate each
+ * portion into the signed delta the mutation applies.
+ */
+function toLocation(location: string): LocationAttribution {
+  if (!get(splitMode))
+    return location;
+
+  const splitEntries: LocationSplit[] = get(splitIsRemoval)
+    ? get(splits).map(entry => ({ ...entry, usdValue: entry.usdValue.negated() }))
+    : get(splits);
+  return splitEntries;
+}
+
 async function save(): Promise<void> {
   if (get(rateMissing))
     return;
@@ -252,24 +293,13 @@ async function save(): Promise<void> {
     return;
 
   set(submitting, true);
-
-  const balance: BalanceSnapshot = {
-    amount: bigNumberify(formData.amount),
-    assetIdentifier: formData.assetIdentifier,
-    category: formData.category,
-    timestamp,
-    usdValue: bigNumberify(formData.usdValue),
-  };
-
+  const balance = toBalance(formData);
   set(submitting, false);
 
-  // The split rows hold positive amounts; a removal moves the location subtotals
-  // down, so negate each portion into the signed delta the mutation applies.
-  const splitEntries: LocationSplit[] = get(splitIsRemoval)
-    ? get(splits).map(entry => ({ ...entry, usdValue: entry.usdValue.negated() }))
-    : get(splits);
-  const location: LocationAttribution = get(splitMode) ? splitEntries : formData.location;
-  emit('submit', { index: get(editIndex), mutation: { balance, location } });
+  if (!balance)
+    return;
+
+  emit('submit', { index: get(editIndex), mutation: { balance, location: toLocation(formData.location) } });
 
   formRef?.submitPrice();
   close();

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotFxOverrideControl.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotFxOverrideControl.spec.ts
@@ -34,9 +34,20 @@ vi.mock('@/modules/dashboard/snapshots/composables/use-snapshot-fx-override', ()
 describe('modules/dashboard/snapshots/components/SnapshotFxOverrideControl', () => {
   let wrapper: VueWrapper<InstanceType<typeof SnapshotFxOverrideControl>>;
 
+  /**
+   * What the component threw out of a handler. Vue swallows those into its error handler, so a
+   * throw would otherwise leave the assertions below intact and the test green.
+   */
+  const handlerErrors: unknown[] = [];
+
   function createWrapper(): VueWrapper<InstanceType<typeof SnapshotFxOverrideControl>> {
     return mount(SnapshotFxOverrideControl, {
       global: {
+        config: {
+          errorHandler: (error: unknown): void => {
+            handlerErrors.push(error);
+          },
+        },
         plugins: [createPinia()],
         provide: libraryDefaults,
         stubs: {
@@ -55,6 +66,7 @@ describe('modules/dashboard/snapshots/components/SnapshotFxOverrideControl', () 
     set(currentOverride, undefined);
     setOverride.mockClear();
     clearOverride.mockClear();
+    handlerErrors.length = 0;
   });
 
   afterEach(() => {
@@ -109,6 +121,20 @@ describe('modules/dashboard/snapshots/components/SnapshotFxOverrideControl', () 
 
     expect(setOverride).toHaveBeenCalledTimes(1);
     expect(setOverride.mock.calls[0][0].toNumber()).toBe(0.88);
+  });
+
+  // bignumber.js throws on a value it cannot parse, so applying a half-typed rate used to raise out
+  // of the click handler. A rate of nothing is refused for the same reason it always was.
+  it.each(['', '-', '1.2.3', '0'])('should refuse to apply %s as a rate', async (input) => {
+    wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=snapshot-fx-override-edit]').trigger('click');
+    await wrapper.find('[data-testid=snapshot-fx-override-input]').setValue(input);
+    await nextTick();
+    await wrapper.find('[data-testid=snapshot-fx-override-apply]').trigger('click');
+
+    expect(handlerErrors).toEqual([]);
+    expect(setOverride).not.toHaveBeenCalled();
   });
 
   it('should call clearOverride from the clear action', async () => {

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotFxOverrideControl.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotFxOverrideControl.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { bigNumberify } from '@rotki/common';
 import { startPromise } from '@shared/utils';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
 import { useSnapshotFxOverride } from '@/modules/dashboard/snapshots/composables/use-snapshot-fx-override';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 
@@ -34,8 +34,10 @@ function startEdit(): void {
 }
 
 async function apply(): Promise<void> {
-  const value = bigNumberify(get(input));
-  if (!value.isPositive())
+  // A rate the field does not hold a number for, and a rate of zero, are both unusable: the one
+  // would throw on parse and the other would price every balance at nothing.
+  const value = parseNumericInput(get(input));
+  if (!value?.isGreaterThan(0))
     return;
   const success = await setOverride(value);
   if (success)

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotLocationEntryDialog.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotLocationEntryDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { LocationDataSnapshot, LocationDataSnapshotPayload } from '@/modules/dashboard/snapshots';
-import { bigNumberify } from '@rotki/common';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
 import EditLocationDataSnapshotForm from '@/modules/dashboard/edit-snapshot/EditLocationDataSnapshotForm.vue';
 import { useHistoricFiatConversion } from '@/modules/dashboard/snapshots/composables/use-historic-fiat-conversion';
 import { convertFiatToUsd, convertUsdToFiat } from '@/modules/dashboard/snapshots/utils/snapshot-fx';
@@ -80,11 +80,15 @@ async function save(): Promise<void> {
   if (!formData)
     return;
 
+  // The field is free text, so a value that is not a number is not written into the row: the parse
+  // it would otherwise go through throws.
+  const entered = parseNumericInput(formData.usdValue);
+  if (!entered)
+    return;
+
   set(submitting, true);
 
-  const usdValue = get(isUsd)
-    ? bigNumberify(formData.usdValue)
-    : convertFiatToUsd(bigNumberify(formData.usdValue), get(rate));
+  const usdValue = get(isUsd) ? entered : convertFiatToUsd(entered, get(rate));
 
   set(submitting, false);
 

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotLocationSplit.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotLocationSplit.spec.ts
@@ -102,6 +102,22 @@ describe('modules/dashboard/snapshots/components/SnapshotLocationSplit', () => {
     expect(isValid(wrapper)).toBe(false);
   });
 
+  // The totals run through every row on each keystroke, so a row holding something bignumber.js
+  // cannot parse used to take the whole dialog down mid-render. It counts as nothing allocated.
+  it.each(['-', '1.2.3', '0,5'])('should read a row of %s as nothing allocated', async (typed) => {
+    const wrapper = mountSplit(100);
+    const locations = wrapper.findAll('.loc');
+    const amounts = wrapper.findAll('input:not(.loc)');
+
+    await locations[0].setValue('kraken');
+    await locations[1].setValue('ledger');
+    await amounts[0].setValue('100');
+    await amounts[1].setValue(typed);
+
+    expect(isValid(wrapper)).toBe(true);
+    expect(lastSplits(wrapper).map(split => split.usdValue.toNumber())).toEqual([100, 0]);
+  });
+
   it('should be valid when every row stays within its location cap', async () => {
     const wrapper = mountSplit(100, { kraken: bigNumberify(80), ledger: bigNumberify(80) });
     const locations = wrapper.findAll('.loc');

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotLocationSplit.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotLocationSplit.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { type BigNumber, bigNumberify, Zero } from '@rotki/common';
+import { type BigNumber, Zero } from '@rotki/common';
 import LocationSelector from '@/modules/balances/LocationSelector.vue';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
 import SnapshotFiatDisplay from '@/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue';
 import { useHistoricFiatConversion } from '@/modules/dashboard/snapshots/composables/use-historic-fiat-conversion';
 import { convertFiatToUsd, convertUsdToFiat } from '@/modules/dashboard/snapshots/utils/snapshot-fx';
@@ -40,9 +41,13 @@ const { isUsd, rate } = useHistoricFiatConversion(() => timestamp);
 
 const rows = ref<SplitRow[]>([{ amount: '', location: '' }, { amount: '', location: '' }]);
 
-/** Converts a display-currency input back into the stored USD value. */
+/**
+ * Converts a display-currency input back into the stored USD value. A row the user has not typed a
+ * number into yet counts as nothing allocated: this runs inside the totals, where a parse that
+ * throws takes the whole dialog down with it.
+ */
 function toUsd(amount: string): BigNumber {
-  const value = bigNumberify(amount || '0');
+  const value = parseNumericInput(amount, Zero);
   return get(isUsd) ? value : convertFiatToUsd(value, get(rate));
 }
 

--- a/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.spec.ts
+++ b/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.spec.ts
@@ -108,6 +108,21 @@ describe('assetMovementMatchingSettingsMenu', () => {
     expect(get(tolerance)).toBe('0.000001');
   });
 
+  // The schemas pass a field that holds nothing yet, since the menu writes on every keystroke, so
+  // clearing the tolerance used to convert `''` and throw, and clearing the time range wrote NaN
+  // seconds. Neither field is written until it holds a number again.
+  it.each(['', '-', '1.2.3'])('should not write a tolerance of %s', async (typed) => {
+    await edit(0, typed);
+
+    expect(get(tolerance)).toBe('0.05');
+  });
+
+  it.each(['', '-', '1.2.3'])('should not write a time range of %s', async (typed) => {
+    await edit(1, typed);
+
+    expect(get(timeRange)).toBe(7200);
+  });
+
   // Deliberately flipped in the zod swap. `callIfValid` asked the whole validator whether anything
   // was wrong rather than the field being written, so an out-of-range tolerance silently stopped
   // the time range from saving, and the two settings have nothing to do with each other.

--- a/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.vue
+++ b/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ZodType } from 'zod';
 import { bigNumberify } from '@rotki/common';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
 import {
   checkSetting,
   type MatchingSettingsMessages,
@@ -69,8 +70,15 @@ const timeRangeRuleErrors = computed<string[]>(
  * Each field answers for itself. The rule it replaces asked the whole validator whether anything
  * was wrong, so an out-of-range tolerance stopped the time range from saving too, and the two have
  * nothing to do with each other.
+ *
+ * The schemas deliberately pass a field that holds nothing yet, since the menu writes on every
+ * keystroke, so a value that is not a number is stopped here instead: converting one writes NaN
+ * seconds, or throws on the way to a decimal.
  */
 function writeIfValid(value: string, schema: ZodType<string>, write: (value: string) => void): void {
+  if (!parseNumericInput(value))
+    return;
+
   if (checkSetting(schema, value).length === 0)
     write(value);
 }

--- a/frontend/app/src/modules/history/events/PotentialMatchesContent.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesContent.vue
@@ -2,6 +2,7 @@
 import type { MatchingFlow, MatchSuggestions, PotentialMatchRow, UnmatchedEventGroup } from '@/modules/history/events/matching/types';
 import type { HistoryEventCollectionRow } from '@/modules/history/events/schemas';
 import { bigNumberify } from '@rotki/common';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
 import { logger } from '@/modules/core/common/logging/logging';
 import { getErrorMessage } from '@/modules/core/notifications/use-notifications';
 import { useAssetMovementMatchingApi } from '@/modules/history/api/events/use-asset-movement-matching-api';
@@ -62,8 +63,11 @@ const searchTimeRange = ref<string>(getDefaultHourRange().toString());
 const onlyExpectedAssets = ref<boolean>(true);
 const tolerancePercentage = ref<string>(getDefaultTolerancePercentage());
 
+// The tolerance is a free-text field, so a search started before it holds a number searches on the
+// default rather than on a parse that throws.
 function percentageToDecimal(percentage: string): string {
-  return bigNumberify(percentage).dividedBy(100).toString();
+  const value = parseNumericInput(percentage, bigNumberify(getDefaultTolerancePercentage()));
+  return value.dividedBy(100).toString();
 }
 const buttonSize = computed<'sm' | undefined>(() => isPinned ? 'sm' : undefined);
 

--- a/frontend/app/src/modules/history/events/prices/EventAssetPriceUpdateDialog.vue
+++ b/frontend/app/src/modules/history/events/prices/EventAssetPriceUpdateDialog.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import type { OraclePriceEntry } from '@/modules/assets/prices/price-types';
 import type { EventPriceUpdatePayload } from '@/modules/history/events/prices/use-event-price-update-trigger';
-import { bigNumberify, toSentenceCase } from '@rotki/common';
+import { type BigNumber, toSentenceCase } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -36,12 +37,11 @@ function close(): void {
 const existingIsManual = computed<boolean>(() => get(existingEntry)?.sourceType === PriceOracle.MANUAL);
 const showModeChoice = computed<boolean>(() => Boolean(get(existingEntry)) && !get(existingIsManual));
 
+const parsedPrice = computed<BigNumber | undefined>(() => parseNumericInput(get(price).trim()));
+
 const priceValid = computed<boolean>(() => {
-  const value = get(price).trim();
-  if (!value)
-    return false;
-  const parsed = bigNumberify(value);
-  return parsed.isFinite() && parsed.isGreaterThan(0);
+  const parsed = get(parsedPrice);
+  return parsed !== undefined && parsed.isGreaterThan(0);
 });
 
 const priceErrors = computed<string[]>(() => {
@@ -84,11 +84,15 @@ async function save(): Promise<void> {
   if (!payload)
     return;
 
+  const parsed = get(parsedPrice);
+  if (!parsed)
+    return;
+
   const entry = get(existingEntry);
   const nextPrice = get(price).trim();
   const selectedMode = get(mode);
   const unchanged = entry
-    && bigNumberify(nextPrice).isEqualTo(entry.price)
+    && parsed.isEqualTo(entry.price)
     && (selectedMode === 'oracle' || entry.sourceType === PriceOracle.MANUAL);
   if (unchanged) {
     close();

--- a/frontend/app/src/modules/wallet/send/TradeAmountInput.vue
+++ b/frontend/app/src/modules/wallet/send/TradeAmountInput.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { bigNumberify } from '@rotki/common';
 import { get, set } from '@vueuse/core';
 import { AssetAmountDisplay, FiatDisplay } from '@/modules/assets/amount-display/components';
-import { bigNumberifyFromRef } from '@/modules/core/common/data/bignumbers';
+import { bigNumberifyFromRef, parseNumericInput } from '@/modules/core/common/data/bignumbers';
 import { useSetting } from '@/modules/settings/use-setting';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import { useInjectedTradableAsset } from '@/modules/wallet/use-tradable-asset';
@@ -71,17 +70,21 @@ function swapInput(): void {
 function setMax(): void {
   set(model, max);
   const priceVal = get(price);
-  if (get(isAmountSelected) && priceVal) {
-    set(fiatValue, bigNumberify(max).multipliedBy(priceVal).toString());
+  const amount = parseNumericInput(max);
+  if (get(isAmountSelected) && priceVal && amount) {
+    set(fiatValue, amount.multipliedBy(priceVal).toString());
   }
 }
 
+// Both sides hold what the user is typing, so a value that is not a number yet reads as nothing
+// entered rather than being handed to a parse that throws.
 watch([model, price], ([value, price]) => {
   if (!get(isAmountSelected))
     return;
 
-  if (value && price) {
-    set(fiatValue, bigNumberify(value).multipliedBy(price).toString());
+  const amount = parseNumericInput(value);
+  if (amount && price) {
+    set(fiatValue, amount.multipliedBy(price).toString());
   }
   else {
     set(fiatValue, '0');
@@ -92,8 +95,9 @@ watch([fiatValue, price], ([fiatValue, price]) => {
   if (get(isAmountSelected))
     return;
 
-  if (fiatValue && price) {
-    set(model, bigNumberify(fiatValue).dividedBy(price).toString());
+  const value = parseNumericInput(fiatValue);
+  if (value && price) {
+    set(model, value.dividedBy(price).toString());
   }
   else {
     set(model, '0');


### PR DESCRIPTION
Since bignumber.js 11 the constructor throws on a value it cannot read, so every free-text amount field was one keystroke away from an exception: inside a computed it took the render down, inside a handler it silently dropped the action. This is the sweep that was left over from #12868.

## What this adds

`parseNumericInput` in `modules/core/common/data/bignumbers.ts`, overloaded so the call site says what an unreadable field means there:

- no fallback: `BigNumber | undefined`, for the callers that must not invent a value (a save, or a check that has to tell "not a number yet" apart from "zero");
- with a fallback: a non-nullable `BigNumber`, for the callers that just want to render something.

It rejects the values the constructor throws on (`''`, `'-'`, `'1.2.3'`, `'0,5'`, `'1 000'`) and also `'NaN'`/`'Infinity'`, which parse but are no more usable. Nine call sites go through it: `TradeAmountInput`, `EventAssetPriceUpdateDialog`, `SnapshotFxOverrideControl`, `AssetMovementMatchingSettingsMenu`, `PotentialMatchesContent`, `SnapshotBalanceEntryDialog`, `SnapshotLocationEntryDialog`, `SnapshotLocationSplit` and `manual-balance-form`.

## Two live defects it uncovered

- **The snapshot balance add dialog saved an empty amount straight into a throw.** `balanceSnapshotSchema` gates the category and the location only, `amount` and `usdValue` are bare `z.string()`, and the price sub-form's rules over them are display-only by design. The save path now refuses a row whose amount or value holds no number.
- **The asset-movement matching menu wrote `NaN` seconds** when its time range was cleared. `boundedNumber` deliberately passes an empty or non-numeric field, since the menu writes on every keystroke, so the guard went into `writeIfValid` rather than into the schema.

Also tightened: an FX override rate of `0` is now refused (`isPositive()` is true for zero, so it used to go through).

## Tests

Characterization tests on every fix that had an existing spec, plus a new spec for `SnapshotBalanceEntryDialog`, and unit tests for both overloads of the helper. Each was negative-controlled by reverting the fix.

One of those controls **passed** at first: asserting "nothing was submitted" is green whether the guard returned cleanly or the handler threw, because Vue routes a handler error to its error handler. The affected specs now capture `global.config.errorHandler` and assert it stayed empty; the same control then failed on every case.

Left unguarded on purpose, their inputs being validated or backend-sourced: `use-currency-update` (thresholds go through `numberSettingField`), `use-account-manage` (`isValidOwnershipPercentage`), `use-transaction-manager`, `store-debug-plugin`.
