### PR TITLE
Add job timeouts to the nightly and release builds

### DIFF
--- a/.github/workflows/rotki_dev_builds.yml
+++ b/.github/workflows/rotki_dev_builds.yml
@@ -24,6 +24,7 @@ jobs:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 30  # observed max 13m
     permissions:
       contents: read
     steps:
@@ -101,6 +102,9 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=4096
     environment: macos_sign
     runs-on: ${{ matrix.os.runner }}
+    # observed max: arm64 18m, x86_64 29m. x86_64 intermittently hangs forever in
+    # PyInstaller's codesign --timestamp (network call, no subprocess timeout).
+    timeout-minutes: 45
     permissions:
       contents: read
     steps:
@@ -181,6 +185,7 @@ jobs:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: windows-latest
+    timeout-minutes: 45  # observed max 24m
     environment: windows_sign
     permissions:
       contents: read
@@ -242,6 +247,7 @@ jobs:
     name: Build docker images
     if: ${{ github.repository == 'rotki/rotki' || github.event_name != 'schedule' }}
     runs-on: ${{ matrix.platform.runner }}
+    timeout-minutes: 30  # observed max 9m warm; extra air for a cold build cache
     environment: docker
     permissions:
       contents: read
@@ -325,6 +331,7 @@ jobs:
 
   docker-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # observed max 36s; the prune step lives here
     needs:
       - build-docker
     environment: docker
@@ -770,6 +777,7 @@ jobs:
     if: ${{ always() && (github.repository == 'rotki/rotki' || github.event_name != 'schedule') }}
     needs: [ 'build-linux', 'build-windows', 'build-macos', 'docker-merge' ]
     runs-on: ubuntu-latest
+    timeout-minutes: 10  # observed max 42s
     environment: nightly_notify
     steps:
       - name: Checkout

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -18,6 +18,7 @@ jobs:
   create_draft:
     name: Create Draft
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # observed max 24s
     permissions:
       contents: write
     outputs:
@@ -112,6 +113,7 @@ jobs:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 30  # observed max 14m
     needs: create_draft
     permissions:
       id-token: write
@@ -207,6 +209,11 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=4096
     environment: macos_sign
     runs-on: ${{ matrix.os.runner }}
+    # observed max: arm64 34m, x86_64 58m, over a 26-58m spread. Release builds
+    # deliberately run without the dependency cache, and the whole gap against
+    # the nightly build lands inside the Package step. Signing waits on Apple
+    # services on top of that, so keep the headroom generous.
+    timeout-minutes: 120
     needs: create_draft
     permissions:
       id-token: write
@@ -298,6 +305,7 @@ jobs:
     name: Merge latest-mac.yml
     needs: macos
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # observed max 42s
     permissions:
       contents: write
     steps:
@@ -339,6 +347,7 @@ jobs:
       CI: true
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: windows-latest
+    timeout-minutes: 60  # observed max 33m; signing waits on a timestamp server
     environment: windows_sign
     needs: create_draft
     permissions:
@@ -414,6 +423,7 @@ jobs:
   docker:
     name: 'Build docker images'
     runs-on: ${{ matrix.platform.runner }}
+    timeout-minutes: 30  # observed max 8m warm; extra air for a cold build cache
     environment: docker
     strategy:
       fail-fast: false
@@ -492,6 +502,7 @@ jobs:
 
   docker-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 15  # observed max 30s
     needs:
       - docker
     environment: docker


### PR DESCRIPTION
No job in the nightly or release build workflows declared `timeout-minutes`, so
every one of them inherited GitHub's 360-minute default.

That is not theoretical. `Build macOS binary x86_64` in the nightly hangs
intermittently and sat idle for the full 6 hours in **7 of the last 20 scheduled
runs** (08-03, 08-05, 08-11, 08-15, 08-16, 08-18, 08-19), holding a shared runner
that was doing no work.

## Where it hangs

Every hung run stops at the same line and leaves the same orphan behind:

```
199451 INFO: Re-signing the EXE            <- last output, then 5h43m of silence
##[error]The operation was canceled.
Terminate orphan process: pid (67787) (codesign)
```

On a healthy run that step completes in **0.8 seconds**.

The cause is in `PyInstaller/utils/osx.py::sign_binary`, called from
`building/api.py:907` immediately after the `Re-signing the EXE` log line:

```python
cmd_args = ['/usr/bin/codesign', '-s', identity, '--force',
            '--all-architectures', '--timestamp', *extra_args, filename]
p = subprocess.run(cmd_args, stdout=..., stderr=...)   # no timeout=
```

`--timestamp` is passed unconditionally, so codesign contacts Apple's timestamp
server on every signature, and the subprocess call has no timeout. A stalled
connection therefore blocks forever. That explains the intermittency: it is a
network dependency, not a build input.

`utils/osx.py` is byte-identical in the newest PyInstaller (6.22.2), so there is
no upstream release to move to. **This PR does not fix the hang**, it only stops
a hung job from occupying a runner slot until the default cap. A local fix is
possible (the spec file can bound and retry the call) and can follow separately.

## The limits

Sized from the observed maxima of successful runs, with roughly 2x headroom.

`rotki_dev_builds.yml`, 20 most recent nightly runs:

| Job | n | avg | max | limit |
|---|---|---|---|---|
| Build linux binary | 20 | 11.9 | 13.4 | 30 |
| Build macOS arm64 | 20 | 13.1 | 17.6 | 45 |
| Build macOS x86_64 | 12 | 22.7 | 28.5 | 45 |
| Build windows binary | 20 | 23.0 | 24.4 | 45 |
| Build docker amd64 | 20 | 7.5 | 9.2 | 30 |
| Build docker arm64 | 20 | 5.9 | 6.2 | 30 |
| docker-merge | 17 | 0.3 | 0.6 | 15 |
| Success check | 17 | 0.3 | 0.3 | 10 |

`rotki_release.yaml`, 12 most recent release runs:

| Job | n | avg | max | limit |
|---|---|---|---|---|
| Create Draft | 12 | 0.4 | 0.4 | 15 |
| Build linux binary | 12 | 12.7 | 14.2 | 30 |
| Build macOS arm64 | 12 | 19.8 | 33.5 | 120 |
| Build macOS x86_64 | 12 | 35.1 | 58.0 | 120 |
| Merge latest-mac.yml | 12 | 0.6 | 0.7 | 15 |
| Build windows binary | 12 | 23.1 | 32.8 | 60 |
| Build docker images | 12 | 7.6 | 8.1 | 30 |
| docker-merge | 12 | 0.3 | 0.5 | 15 |

Release limits are sized off release history rather than reused from the nightly.
Release builds run without the dependency cache on purpose, and macOS x86_64
spreads 26.2 to 58.0 minutes across those 12 runs, so a tight cap there would turn
a slow day into a failed release. The macOS limit covers both matrix legs, so
arm64 carries x86_64's more generous cap.

Values are minutes. Docker jobs get proportionally more air than their maxima
suggest because every one of those measurements had a warm build cache.

## Notes

- Every job in both workflows is covered; verified by parsing the YAML rather than
  by reading the diff.
- No behaviour changes, so there is nothing to see beyond CI staying green. A job
  that now exceeds its limit would be one that previously ran toward the 6-hour
  default.
- Still uncovered by this PR: `rotki_ci.yml` (12 of 16 jobs), `rotki_nightly.yml`
  (2 jobs) and `rotki_docker_publish.yaml` (1 job). Those need their own
  measurements rather than these numbers reused.
