### PR TITLE
Keep spam tokens out of the send form's default asset

### DIFF
--- a/frontend/app/src/modules/wallet/use-tradable-asset.spec.ts
+++ b/frontend/app/src/modules/wallet/use-tradable-asset.spec.ts
@@ -2,6 +2,7 @@ import type { Balances } from '@/modules/accounts/blockchain-accounts';
 import { bigNumberify, Zero } from '@rotki/common';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { useTradableAsset } from './use-tradable-asset';
 
@@ -25,6 +26,11 @@ vi.mock('@/modules/core/common/use-supported-chains', () => ({
 function seedBalances(data: Balances): void {
   const { balances } = storeToRefs(useBalancesStore());
   set(balances, data);
+}
+
+function seedIgnoredAssets(assets: string[]): void {
+  const { ignoredAssets } = storeToRefs(useAssetsStore());
+  set(ignoredAssets, assets);
 }
 
 describe('useTradableAsset', () => {
@@ -136,6 +142,89 @@ describe('useTradableAsset', () => {
     expect(result[0].asset).toBe('ETH');
     expect(result[0].amount.isZero()).toBe(true);
     expect(getAssetPrice).not.toHaveBeenCalled();
+  });
+
+  it('should drop ignored assets so a spam token cannot be the default selection', () => {
+    seedBalances({
+      eth: {
+        '0xabc': {
+          assets: {
+            HEX: { address: { amount: bigNumberify(1000000), value: Zero } },
+            USDC: { address: { amount: bigNumberify(50), value: Zero } },
+          },
+          liabilities: { HEX: { address: { amount: bigNumberify(1), value: Zero } } },
+        },
+      },
+    });
+    seedIgnoredAssets(['HEX']);
+
+    getAssetPrice.mockImplementation((asset: string) => {
+      if (asset === 'HEX')
+        return bigNumberify(10);
+      if (asset === 'USDC')
+        return bigNumberify(1);
+      return undefined;
+    });
+
+    const { allOwnedAssets } = useTradableAsset(ref('0xabc'));
+    const result = get(allOwnedAssets);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].asset).toBe('USDC');
+  });
+
+  it('should drop ignored assets from the deduplicated list as well', () => {
+    seedBalances({
+      eth: {
+        '0xa': { assets: { HEX: { address: { amount: bigNumberify(1), value: Zero } } }, liabilities: {} },
+        '0xb': { assets: { DAI: { address: { amount: bigNumberify(2), value: Zero } } }, liabilities: {} },
+      },
+    });
+    seedIgnoredAssets(['HEX']);
+
+    const { allOwnedAssets } = useTradableAsset(ref(undefined));
+    const result = get(allOwnedAssets);
+
+    expect(result.map(item => item.asset)).toEqual(['DAI']);
+  });
+
+  it('should order the unpriced list deterministically instead of by balance key order', () => {
+    seedBalances({
+      eth: {
+        '0xa': {
+          assets: {
+            ZRX: { address: { amount: bigNumberify(1), value: Zero } },
+            HEX: { address: { amount: bigNumberify(1), value: Zero } },
+            ETH: { address: { amount: bigNumberify(1), value: Zero } },
+            AAVE: { address: { amount: bigNumberify(1), value: Zero } },
+          },
+          liabilities: {},
+        },
+      },
+    });
+
+    const { allOwnedAssets } = useTradableAsset(ref(undefined));
+
+    expect(get(allOwnedAssets).map(item => item.asset)).toEqual(['ETH', 'AAVE', 'HEX', 'ZRX']);
+  });
+
+  it('should break a fiat value tie by identifier', () => {
+    seedBalances({
+      eth: {
+        '0xabc': {
+          assets: {
+            HEX: { address: { amount: bigNumberify(1), value: Zero } },
+            DAI: { address: { amount: bigNumberify(1), value: Zero } },
+          },
+          liabilities: {},
+        },
+      },
+    });
+    getAssetPrice.mockReturnValue(bigNumberify(1));
+
+    const { allOwnedAssets } = useTradableAsset(ref('0xabc'));
+
+    expect(get(allOwnedAssets).map(item => item.asset)).toEqual(['DAI', 'HEX']);
   });
 
   it('should skip address entries without an assets bag', () => {

--- a/frontend/app/src/modules/wallet/use-tradable-asset.ts
+++ b/frontend/app/src/modules/wallet/use-tradable-asset.ts
@@ -3,6 +3,7 @@ import type { BlockchainAssetBalances, EthBalance } from '@/modules/balances/typ
 import type { TradableAsset, TradableAssetWithoutValue } from '@/modules/wallet/types';
 import { Zero } from '@rotki/common';
 import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
+import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { sortDesc } from '@/modules/core/common/data/bignumbers';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -17,6 +18,7 @@ type UseInjectedTradableAssetReturn = UseTradableAssetReturn;
 
 export function useTradableAsset(address: MaybeRefOrGetter<string | undefined>): UseTradableAssetReturn {
   const { balances } = storeToRefs(useBalancesStore());
+  const { ignoredAssets } = storeToRefs(useAssetsStore());
   const { supportedChainsForConnectedAccount } = storeToRefs(useWalletStore());
   const { getAssetPrice } = usePriceUtils();
   const { getNativeAsset, isEvm } = useSupportedChains();
@@ -26,13 +28,14 @@ export function useTradableAsset(address: MaybeRefOrGetter<string | undefined>):
     chainBalances: BlockchainAssetBalances,
     addressVal: string,
     result: TradableAssetWithoutValue[],
+    ignored: Set<string>,
   ): void {
     const addressBalance: EthBalance | undefined = chainBalances[addressVal];
     if (!addressBalance?.assets)
       return;
 
     for (const [asset, balance] of Object.entries(addressBalance.assets)) {
-      if (balance.address?.amount) {
+      if (balance.address?.amount && !ignored.has(asset)) {
         result.push({ amount: balance.address.amount, asset, chain });
       }
     }
@@ -43,18 +46,37 @@ export function useTradableAsset(address: MaybeRefOrGetter<string | undefined>):
     chainBalances: BlockchainAssetBalances,
     result: TradableAssetWithoutValue[],
     seen: Set<string>,
+    ignored: Set<string>,
   ): void {
     for (const addressBalance of Object.values(chainBalances)) {
       if (!addressBalance?.assets)
         continue;
 
       for (const [asset, balance] of Object.entries(addressBalance.assets)) {
-        if (balance.address?.amount && !seen.has(asset)) {
+        if (balance.address?.amount && !seen.has(asset) && !ignored.has(asset)) {
           seen.add(asset);
           result.push({ amount: Zero, asset, chain });
         }
       }
     }
+  }
+
+  /**
+   * Orders the list the send form picks its default from: the chain's native asset first,
+   * then by fiat value, then by identifier so an unpriced list still has a stable head.
+   */
+  function compareByPriority(a: TradableAsset, b: TradableAsset): number {
+    const aNative = getNativeAsset(a.chain) === a.asset;
+    const bNative = getNativeAsset(b.chain) === b.asset;
+
+    if (aNative !== bNative)
+      return aNative ? -1 : 1;
+
+    const byValue = sortDesc(a.fiatValue ?? Zero, b.fiatValue ?? Zero);
+    if (byValue !== 0)
+      return byValue;
+
+    return a.asset.localeCompare(b.asset);
   }
 
   function enhanceWithPrices(assets: TradableAssetWithoutValue[]): TradableAsset[] {
@@ -68,23 +90,14 @@ export function useTradableAsset(address: MaybeRefOrGetter<string | undefined>):
         fiatValue: price.multipliedBy(item.amount),
         price,
       };
-    }).sort((a, b) => {
-      const aNative = getNativeAsset(a.chain) === a.asset;
-      const bNative = getNativeAsset(b.chain) === b.asset;
-
-      if (aNative && !bNative)
-        return -1;
-      if (!aNative && bNative)
-        return 1;
-
-      return sortDesc(a.fiatValue ?? Zero, b.fiatValue ?? Zero);
-    });
+    }).sort(compareByPriority);
   }
 
   const allOwnedAssets = computed<TradableAsset[]>(() => {
     const addressVal = toValue(address);
     const supportedChains = get(supportedChainsForConnectedAccount);
     const balancesData = get(balances);
+    const ignored = new Set(get(ignoredAssets));
 
     const result: TradableAssetWithoutValue[] = [];
     const seen = new Set<string>();
@@ -94,13 +107,13 @@ export function useTradableAsset(address: MaybeRefOrGetter<string | undefined>):
         continue;
 
       if (addressVal)
-        collectAddressBalances(chain, chainBalances, addressVal, result);
+        collectAddressBalances(chain, chainBalances, addressVal, result, ignored);
       else
-        collectDeduplicatedBalances(chain, chainBalances, result, seen);
+        collectDeduplicatedBalances(chain, chainBalances, result, seen, ignored);
     }
 
     if (!addressVal)
-      return result;
+      return result.sort(compareByPriority);
 
     return enhanceWithPrices(result);
   });


### PR DESCRIPTION
## Problem

The onchain send form opened with a spam token (HEX) preselected. Two independent
causes, both in the send flow itself.

**No ignore filter.** `useTradableAsset` kept only EVM chains the connected wallet
supports and non-zero amounts. It applied no ignore filter of its own and relied
entirely on the shared balances store having been scrubbed by `removeIgnoredAssets`,
which fires on ignore-list changes. A spam asset in rotki is one the backend put on
the ignored list, so anything that scrub missed stayed in the selector.

**The default is `list[0]`, and the list was not always ordered.** With a connected
address the sort is native first, then fiat value descending, but zero amounts are
filtered out before it, so on a chain whose native balance is zero the native
tiebreak never fires and a priced spam token floats above real holdings. With no
connected address the list was returned unsorted and unpriced, leaving the default
at raw `Object.entries` key order.

## Change

- Both collectors skip ignored identifiers, read from the assets store, so the filter
  no longer depends on another store's cleanup having run first.
- The comparator is extracted, gains an identifier tiebreak so an unpriced list still
  has a stable head, and is applied to the no-address branch too.

Filtering on the ignored list is sufficient to cover spam: the backend keeps spam as a
strict subset of ignored. `add_tokens_to_spam`, `check_token_impersonates_dangerous_tokens`
and `update_spam_assets` all set `protocol='spam'` and add to the ignored list;
`remove_token_from_spam` and `add_to_spam_assets_false_positive` clear both; and
`DBHandler.sync_globaldb_assets` mirrors every globalDB spam token into the user's
ignored list on asset updates.

## Tests

Four new cases in `use-tradable-asset.spec.ts`: ignored assets dropped from the
addressed list and from the deduplicated list, deterministic ordering of the unpriced
list, and the fiat-value tie broken by identifier.

Verified with a negative control: with the fix reverted, exactly those four fail and
the seven pre-existing tests still pass. 11/11 with the fix.

## Follow-ups, not in this PR

- The two overlapping `watchImmediate` blocks in `TradeAssetSelector.vue` still both
  assign the default asset and remain redundant.
- The selector dialog has no search and no virtualization, and mounts every option at
  once (83 rows for a single chain on a test account).
- With no wallet connected the list is unpriced, so the identifier tiebreak is the only
  active comparison and the displayed order reads as arbitrary. Sorting the displayed
  list by resolved symbol would fix the presentation without disturbing the default.
