### PR TITLE
Fix two snapshot editor display bugs

### DIFF
--- a/frontend/app/src/modules/dashboard/ConfirmSnapshotConflictReplacementDialog.vue
+++ b/frontend/app/src/modules/dashboard/ConfirmSnapshotConflictReplacementDialog.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import type { BalanceSnapshot } from '@/modules/dashboard/snapshots';
+import { AssetAmountDisplay } from '@/modules/assets/amount-display/components';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { isNft } from '@/modules/assets/nft-utils';
 import NftDetails from '@/modules/balances/nft/NftDetails.vue';
+import SnapshotFiatDisplay from '@/modules/dashboard/snapshots/components/SnapshotFiatDisplay.vue';
 import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
-import BalanceDisplay from '@/modules/shell/components/display/BalanceDisplay.vue';
 
 const { snapshot } = defineProps<{
   snapshot: BalanceSnapshot | null;
@@ -31,12 +32,21 @@ const asset = computed<string>(() => snapshot?.assetIdentifier ?? '');
     @confirm="emit('confirm')"
   >
     <div class="flex justify-center items-center gap-4 mt-4 border border-default rounded px-4">
-      <BalanceDisplay
-        :asset="asset"
-        :value="snapshot"
-        class="mr-4"
-        no-icon
-      />
+      <div
+        v-if="snapshot"
+        class="flex flex-col items-end mr-4 py-1"
+      >
+        <AssetAmountDisplay
+          :asset="asset"
+          :amount="snapshot.amount"
+          class="block font-medium"
+        />
+        <SnapshotFiatDisplay
+          :value="snapshot.usdValue"
+          :timestamp="snapshot.timestamp"
+          class="block text-rui-text-secondary"
+        />
+      </div>
 
       <NftDetails
         v-if="isNft(asset)"

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.spec.ts
@@ -55,6 +55,15 @@ describe('modules/dashboard/snapshots/components/SnapshotListTable', () => {
     expect(wrapper.emitted('delete')).toEqual([[1_600_000_000]]);
   });
 
+  it('should render the delta when the row has a predecessor', () => {
+    // Negative control for the dash test below: the delta column is wired through
+    // `previous-usd-value`, and a misspelled binding leaves every row dashed.
+    wrapper = createWrapper([createRow()]);
+
+    expect(wrapper.text()).not.toContain('—');
+    expect(wrapper.text()).toContain('10');
+  });
+
   it('should render a dash in the delta column for the oldest snapshot', () => {
     // No predecessor => no delta to show (currency defaults to USD in the test
     // harness, so no historic lookup is involved).

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.vue
@@ -92,7 +92,7 @@ const cols = computed<DataTableColumn<SnapshotListRow>[]>(() => [
       <SnapshotDeltaDisplay
         :value="row.usdValue"
         :timestamp="row.timestamp"
-        :previous-value="row.previousUsdValue"
+        :previous-usd-value="row.previousUsdValue"
         :previous-timestamp="row.previousTimestamp"
       />
     </template>


### PR DESCRIPTION
Two display bugs in the snapshot editor, both found from screenshots.

## The conflict dialog always showed `0.00`

`ConfirmSnapshotConflictReplacementDialog` passed a whole `BalanceSnapshot` as
`BalanceDisplay`'s `value`. `BalanceDisplay` reads `value?.value` (`Balance` is
`{ amount, value }` after the rename) while a `BalanceSnapshot` carries
`{ amount, usdValue }`, so the lookup missed and `useValueOrDefault` returned
`Zero` for every asset.

Typecheck could not catch it: the prop is `Partial<Balance>`, which makes the
missing `value` legal, and `usdValue` is only rejected as an excess property when
the argument is a fresh object literal.

Replaced with `AssetAmountDisplay` + `SnapshotFiatDisplay`, the latter because
snapshot values are USD and need the historic rate rather than the current one.

## The snapshot list's change column was a dash on every row

`SnapshotListTable` bound `:previous-value` while `SnapshotDeltaDisplay` declares
`previousUsdValue`. The prop was therefore always `undefined`, the delta never
computed, and every row fell through to the placeholder.

Nothing caught this either: **an unknown attribute on a component is not a type
error**, it just lands in `$attrs`. The existing spec only asserted the dash for
the *oldest* row, which is dashed with or without the bug.

So the added test is a negative control rather than another happy-path case, and
it was verified by reverting the binding: with `:previous-value` back, only the
new test fails and the pre-existing dash test still passes.

## Verified in the running app

Against real snapshot data in EUR, not just unit tests:

- conflict dialog now renders `< 1.603 ETH` / `2,226.280 €`, previously `0.00`
- change column now renders `-2,747.106 €`, `86,116.297 €`, `-324.253 €`,
  previously `—` on every row

## Not included

A third symptom from the same screenshots, the add-balance location preview
rendering `TO - €`, turned out to be already fixed by #12953 (`parseNumericInput`
now rejects `"NaN"`/`"Infinity"`, which parse without throwing and so slipped the
old catch-based fallback). Nothing to do here; noting it so the screenshot set is
fully accounted for.
