### PR TITLE
Fix eth staking filter bar crash and withdrawal address matching

### DIFF
--- a/frontend/app/src/modules/core/table/pill/composables/use-filter-state.ts
+++ b/frontend/app/src/modules/core/table/pill/composables/use-filter-state.ts
@@ -56,7 +56,18 @@ export function useFilterState(fields: MaybeRefOrGetter<FieldDef[]>): UseFilterS
    * applied to all of them alike — an edit, a removal, and the route/saved-view restore below.
    */
   function commit(next: FilterState): void {
-    set(state, pruneInadmissible(next, toValue(fields)));
+    const pruned = pruneInadmissible(next, toValue(fields));
+    // A rebuild that changes nothing must not change identity. `matches`/`params` are derived from
+    // this ref, and the bar writes them back on every identity change, so an equal-but-new array is
+    // an update that produces another update. That is survivable while the two sides converge, but
+    // they cannot converge when a field is removed while its filter is still active: the codec
+    // skips a filter whose field is gone, so the derived bag permanently disagrees with the
+    // incoming one, `setFromMatches` rebuilds on every flush, and the bar recurses until Vue aborts
+    // the render. Comparing by value is what makes a no-op rebuild a no-op.
+    if (isEqual(pruned, get(state)))
+      return;
+
+    set(state, pruned);
   }
 
   function addFilter(filter: ActiveFilter): void {

--- a/frontend/app/src/modules/staking/eth/components/EthStakingFilterBar.spec.ts
+++ b/frontend/app/src/modules/staking/eth/components/EthStakingFilterBar.spec.ts
@@ -1,0 +1,134 @@
+import type { ValidatorData } from '@/modules/accounts/blockchain-accounts';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
+import { Blockchain, type EthStakingCombinedFilter, type EthStakingFilter } from '@rotki/common';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { defineComponent, h, type Ref } from 'vue';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
+import EnumValueEditor from '@/modules/core/table/pill/EnumValueEditor.vue';
+import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
+import PillMenu from '@/modules/core/table/pill/PillMenu.vue';
+import EthStakingFilterBar from './EthStakingFilterBar.vue';
+import '@test/i18n';
+
+const VALIDATOR: ValidatorData = {
+  index: 9,
+  ownershipPercentage: '100',
+  publicKey: '0xabc123',
+  status: 'active',
+  type: 'validator',
+  withdrawalAddress: '0x347AC2e04dD10cBF70F65c058Ac3a078D4D9E0e5',
+};
+
+// RuiMenu lazily teleports its content; stub it to render both slots inline so the activator and
+// the editor are always in the tree, as `PillFilterBar.spec.ts` does.
+const RuiMenuStub = defineComponent({
+  name: 'RuiMenu',
+  emits: ['update:modelValue'],
+  props: { disabled: { default: false, type: Boolean }, modelValue: { default: false, type: Boolean } },
+  template: '<div><slot name="activator" :attrs="{}" /><slot /></div>',
+});
+
+type BarWrapper = VueWrapper<InstanceType<typeof PillFilterBar>>;
+
+interface Harness {
+  bar: BarWrapper;
+  filter: Ref<EthStakingCombinedFilter | undefined>;
+  selection: Ref<EthStakingFilter>;
+  warnings: string[];
+}
+
+/**
+ * The bar wired the way the staking page wires it: both models held outside and written back, which
+ * is what makes the field list reactive to what the bar itself emits.
+ */
+function createHarness(): Harness {
+  const pinia = createCustomPinia();
+  setActivePinia(pinia);
+  useBlockchainAccountsStore().accounts[Blockchain.ETH2] = [{
+    chain: Blockchain.ETH2,
+    data: VALIDATOR,
+    label: 'Validator 9',
+    nativeAsset: 'ETH2',
+  }];
+
+  const selection = ref<EthStakingFilter>({ validators: [] });
+  const filter = ref<EthStakingCombinedFilter | undefined>({ status: 'active' });
+
+  const Host = defineComponent({
+    name: 'Host',
+    render: () => h(EthStakingFilterBar, {
+      'filter': get(filter),
+      'modelValue': get(selection),
+      'onUpdate:filter': (value: EthStakingCombinedFilter | undefined): void => set(filter, value),
+      'onUpdate:modelValue': (value: EthStakingFilter): void => set(selection, value),
+    }),
+  });
+
+  const warnings: string[] = [];
+  const wrapper = mount(Host, {
+    global: {
+      config: {
+        warnHandler: (message: string): void => {
+          warnings.push(message);
+        },
+      },
+      plugins: [pinia],
+      stubs: { AssetValueEditor: true, RuiAutoComplete: true, RuiMenu: RuiMenuStub },
+    },
+  });
+
+  return { bar: wrapper.findComponent(PillFilterBar), filter, selection, warnings };
+}
+
+/** Adds the validator pill and picks validator 9, the way the reported crash was triggered. */
+async function pickValidator(bar: BarWrapper): Promise<void> {
+  const fields: FieldDef[] = bar.props('fields');
+  bar.findComponent(PillMenu).vm.$emit('select', fields.find(field => field.key === 'validator'));
+  await nextTick();
+  await nextTick();
+
+  const editor = bar.findAllComponents(EnumValueEditor)
+    .find(candidate => candidate.props('field').key === 'validator');
+  expect(editor, 'the validator editor opens with its pill').toBeDefined();
+
+  editor!.vm.$emit('update', { fieldKey: 'validator', op: 'is', values: ['9'] });
+  await nextTick();
+  await nextTick();
+}
+
+describe('ethStakingFilterBar', () => {
+  // Picking a validator stops the status field from being offered, while the status filter it was
+  // picked alongside is still in the bar's state. The codec skips a filter whose field is gone, so
+  // the bag the bar derives and the bag the page holds disagree with no way to converge, and the
+  // round-trip watchers rebuild the state on every flush until Vue aborts the render. The
+  // `__vnode` TypeError the user actually sees is the half-patched tree, not the fault.
+  it('should not loop when a validator is picked while a status filter is active', async () => {
+    const { bar, warnings } = createHarness();
+    await nextTick();
+
+    await pickValidator(bar);
+
+    expect(warnings.filter(message => message.includes('Maximum recursive updates'))).toEqual([]);
+  });
+
+  // Hiding the status field has to take the status value with it: one left behind in the page model
+  // would go on filtering the view through a control the user can no longer see or undo.
+  it('should clear the status filter when a validator is picked', async () => {
+    const { bar, filter, selection } = createHarness();
+    await nextTick();
+
+    // The precondition is half the test: `status` reading as undefined at the end proves nothing
+    // if it could also read that way having never been set.
+    expect(get(filter)?.status).toBe('active');
+    expect(bar.props('fields').some((field: FieldDef) => field.key === 'status')).toBe(true);
+
+    await pickValidator(bar);
+
+    const picked = get(selection);
+    expect('validators' in picked && picked.validators.map(entry => entry.index)).toEqual([9]);
+    expect(get(filter)?.status).toBeUndefined();
+    expect(bar.props('fields').some((field: FieldDef) => field.key === 'status')).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-selection-fields.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-selection-fields.spec.ts
@@ -1,16 +1,42 @@
+import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
+import { Blockchain } from '@rotki/common';
 import { createCustomPinia } from '@test/utils/create-pinia';
 import { withSetup } from '@test/utils/with-setup';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
+import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { useEthStakingSelectionFields } from './use-eth-staking-selection-fields';
 import '@test/i18n';
 
-function selectionFields(): FieldDef[] {
+const WITHDRAWAL_ADDRESS = '0x347AC2e04dD10cBF70F65c058Ac3a078D4D9E0e5';
+
+function validatorAccount(index: number, withdrawalAddress?: string): BlockchainAccount {
+  return {
+    chain: Blockchain.ETH2,
+    data: {
+      index,
+      publicKey: `0xpub${index}`,
+      status: 'active',
+      type: 'validator',
+      withdrawalAddress,
+    },
+    nativeAsset: 'ETH',
+  };
+}
+
+function selectionFields(seed?: () => void): FieldDef[] {
   setActivePinia(createCustomPinia());
+  seed?.();
   const { result, wrapper } = withSetup(() => useEthStakingSelectionFields());
   const fields = get(result);
   wrapper.unmount();
   return fields;
+}
+
+function withdrawalAddressField(seed?: () => void): FieldDef {
+  const field = selectionFields(seed).find(entry => entry.key === 'withdrawalAddress');
+  assert(field);
+  return field;
 }
 
 describe('useEthStakingSelectionFields', () => {
@@ -47,5 +73,37 @@ describe('useEthStakingSelectionFields', () => {
 
     expect(validator.suggest?.()).toStrictEqual([]);
     expect(withdrawalAddress.suggest?.()).toStrictEqual([]);
+  });
+
+  // The address a validator withdraws to is the subject of this filter, and tracking it as an
+  // ethereum account as well is a separate decision. While only tracked accounts were offered,
+  // typing the withdrawal address of a validator the user holds found nothing at all.
+  it('should offer a withdrawal address that is not a tracked account', () => {
+    const field = withdrawalAddressField(() => {
+      useBlockchainAccountsStore().updateAccounts(Blockchain.ETH2, [
+        validatorAccount(993, WITHDRAWAL_ADDRESS),
+        validatorAccount(994, WITHDRAWAL_ADDRESS),
+      ]);
+    });
+
+    expect(field.suggest?.()).toStrictEqual([WITHDRAWAL_ADDRESS]);
+  });
+
+  // Offering it is only half the fix: the bar matches on keywords, and an address with no account
+  // behind it has none, so it would sit in the list and still not answer to being typed.
+  it('should match an untracked withdrawal address on the address itself', () => {
+    const field = withdrawalAddressField(() => {
+      useBlockchainAccountsStore().updateAccounts(Blockchain.ETH2, [validatorAccount(993, WITHDRAWAL_ADDRESS)]);
+    });
+
+    expect(field.resolveKeywords?.(WITHDRAWAL_ADDRESS)).toBe(WITHDRAWAL_ADDRESS.toLowerCase());
+  });
+
+  it('should ignore a validator that has no withdrawal address', () => {
+    const field = withdrawalAddressField(() => {
+      useBlockchainAccountsStore().updateAccounts(Blockchain.ETH2, [validatorAccount(9)]);
+    });
+
+    expect(field.suggest?.()).toStrictEqual([]);
   });
 });

--- a/frontend/app/src/modules/staking/eth/use-eth-staking-selection-fields.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-staking-selection-fields.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef } from 'vue';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import { Blockchain } from '@rotki/common';
-import { getAccountAddress } from '@/modules/accounts/account-utils';
+import { getAccountAddress, isValidatorAccount } from '@/modules/accounts/account-utils';
 import { useBlockchainAccountOptions } from '@/modules/accounts/use-blockchain-account-options';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { truncateAddress } from '@/modules/core/common/display/truncate';
@@ -21,18 +21,41 @@ export const EthStakingSelectionKeys = {
 
 /**
  * The withdrawal-address pill's values: the addresses tracked on ethereum, which is what the
- * account selector this replaces offered (`:chains="[Blockchain.ETH]"`). Only the offered list is
- * narrowed; how an account reads is the shared resolution every account pill uses.
+ * account selector this replaces offered (`:chains="[Blockchain.ETH]"`), plus the addresses the
+ * validators themselves withdraw to. Only the offered list is narrowed; how an account reads is the
+ * shared resolution every account pill uses.
+ *
+ * The second half is the point: a validator's withdrawal address is named by the validator, not by
+ * the account list, and tracking it as an ethereum account too is a separate decision. Offering
+ * only tracked accounts meant that typing the address a validator actually withdraws to found
+ * nothing, on the one filter whose whole subject is that address.
  */
 function useWithdrawalAddressOptions(): AccountFieldOptions {
   const accounts = useBlockchainAccountOptions('evm');
   const { accounts: accountsPerChain } = storeToRefs(useBlockchainAccountsStore());
 
+  const declared = computed<string[]>(() => {
+    const addresses = new Set<string>();
+    for (const account of get(accountsPerChain)[Blockchain.ETH2] ?? []) {
+      if (isValidatorAccount(account) && account.data.withdrawalAddress)
+        addresses.add(account.data.withdrawalAddress);
+    }
+    return [...addresses];
+  });
+
   return {
     ...accounts,
+    // An address only the validators know has no account behind it, so the shared resolution finds
+    // no keywords for it. Without the fallback it would be offered in the list and still not match
+    // when typed, which is the same dead end from one step further along.
+    resolveKeywords: (address: string): string | undefined =>
+      accounts.resolveKeywords(address) ?? address.toLowerCase(),
     suggest: (): string[] => {
       const tracked = new Set((get(accountsPerChain)[Blockchain.ETH] ?? []).map(account => getAccountAddress(account)));
-      return accounts.suggest().filter(address => tracked.has(address));
+      return [...new Set([
+        ...accounts.suggest().filter(address => tracked.has(address)),
+        ...get(declared),
+      ])];
     },
   };
 }


### PR DESCRIPTION
Two independent fixes to the eth staking filter bar.

## 1. The staking page crashes when a validator is picked with a status filter active

Repro on develop: go to the ETH staking page, add a **Status** pill and set it to `Active`, then add a **Validator** pill and pick any validator. Order matters; without the status pill it does not fire.

The visible error is a red herring:

```
TypeError: Cannot set properties of null (setting '__vnode')
[Vue warn] Unhandled error during execution of component update at <TablePageLayout>
```

The first error in the same flush is the real one: `Maximum recursive updates exceeded in component <PillFilterBar>`. Vue aborts the runaway loop mid-patch, which leaves a half-mounted tree, and the next patch dereferences a null `el`.

Three individually reasonable behaviours combine to produce the loop:

- `EthStakingFilterBar.disableStatus` removes the `status` field from `fields` as soon as a validator is picked, on the grounds that a status filter cannot narrow a hand-picked validator further.
- `matchesFromState` skips a filter whose field is no longer in `fields`, so the bar's derived bag silently loses the `status` key.
- `pruneInadmissible` deliberately keeps a filter whose field vanished, so the state does not lose it.

The bag the bar derives (`{validator}`) and the bag the page holds (`{validator, status}`) therefore disagree with no way to converge, so `setFromMatches`'s self-echo guard never trips and it rebuilds the state on every flush. Because `commit` always allocated a new array, `matches`/`params` changed identity each time, and the watcher that writes them back fires on identity, so the write-back re-entered the rebuild without ever leaving the flush.

The fix compares the pruned state by value and keeps the existing array when nothing changed, so a rebuild that changes nothing is no longer an update. Clearing the now-hidden status value then falls out on its own: once the flush can complete, the existing `useEthStakingSelection` setter writes `status: undefined` from the status-less bag.

This is a fix in the shared pill-bar core, so it protects any table that removes a field reactively, not just this page.

## 2. The withdrawal-address pill does not offer the addresses validators withdraw to

The pill offered only evm accounts tracked on ethereum, so typing the address a validator actually withdraws to returned "No matches" -- on the one filter whose whole subject is that address. A validator's withdrawal address is named by the validator, and tracking it as an ethereum account as well is a separate decision.

Every ETH2 account's withdrawal address is now offered alongside the tracked ones. Offering the address is only half of it: the bar matches on keywords, and an address with no account behind it has none, so `resolveKeywords` falls back to the address itself. Without that it would sit in the list and still not answer to being typed.

## Tests

`EthStakingFilterBar.spec.ts` is new and drives the exact write path from the crash trace (`PillMenu` select -> `EnumValueEditor` update), catching the loop through a `warnHandler`. It reproduces in milliseconds instead of needing a seeded instance, and it fails without the `use-filter-state` change. `use-eth-staking-selection-fields.spec.ts` covers the withdrawal-address half.

Both fixes were also verified in the running app against a real account with 16 validators, each with its fix reverted in place as a control:

| | before | after |
|---|---|---|
| console | error cascade at `<PillFilterBar>` -> `<EthStakingFilterBar>` -> `<TablePageLayout>` | clean |
| events table | stuck at `1-10 of 136` | `1-9 of 9` |
| validators | -- | 16 -> 1, status pill cleared |
| typing a validator's withdrawal address | "No matches" | matches, applies, 16 -> 15 |

Worth noting for reviewers: on that run the broken build did not white-screen. The damage showed up as a stale Events table plus console errors, so "the page still renders" is not a reliable check here.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

No user-guide change: both are bug fixes to existing filter behaviour, with no new or changed UI concepts to document.
