### PR TITLE
Key the table page title breadcrumb correctly

### DIFF
--- a/frontend/app/src/modules/shell/layout/TablePageLayout.spec.ts
+++ b/frontend/app/src/modules/shell/layout/TablePageLayout.spec.ts
@@ -1,0 +1,67 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import TablePageLayout from './TablePageLayout.vue';
+
+function createWrapper(props: { title?: string[]; hideHeader?: boolean; child?: boolean } = {}, slots: Record<string, string> = {}): VueWrapper {
+  return mount(TablePageLayout, {
+    global: { stubs: { RuiIcon: true } },
+    props,
+    slots,
+  });
+}
+
+/** The breadcrumb entries, as the rendered spans read. */
+function crumbs(wrapper: VueWrapper): string[] {
+  return wrapper.findAll('.text-rui-text > span').map(span => span.text());
+}
+
+describe('tablePageLayout', () => {
+  // Every entry but the last is a step on the way; only the last one is the page you are on. The
+  // two read differently on purpose, and which branch an entry takes is decided per index.
+  it('should render every title entry', () => {
+    const wrapper = createWrapper({ title: ['Balances', 'Blockchain', 'Ethereum'] });
+
+    expect(crumbs(wrapper)).toEqual(['Balances', 'Blockchain', 'Ethereum']);
+  });
+
+  it('should follow all but the last entry with a separator', () => {
+    const wrapper = createWrapper({ title: ['Balances', 'Blockchain', 'Ethereum'] });
+    const spans = wrapper.findAll('.text-rui-text > span');
+
+    expect(spans[0].findComponent({ name: 'RuiIcon' }).exists()).toBe(true);
+    expect(spans[1].findComponent({ name: 'RuiIcon' }).exists()).toBe(true);
+    expect(spans[2].findComponent({ name: 'RuiIcon' }).exists()).toBe(false);
+  });
+
+  // The last entry is the current page, so it is the one carrying the filled pill.
+  it('should render only the last entry as the current page', () => {
+    const wrapper = createWrapper({ title: ['Balances', 'Blockchain'] });
+    const spans = wrapper.findAll('.text-rui-text > span');
+
+    expect(spans[0].classes()).not.toContain('rounded-md');
+    expect(spans[1].classes()).toContain('rounded-md');
+  });
+
+  // A one-entry title has no "way there", so it must not render a dangling separator.
+  it('should render a single entry as the current page with no separator', () => {
+    const wrapper = createWrapper({ title: ['Dashboard'] });
+    const spans = wrapper.findAll('.text-rui-text > span');
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].classes()).toContain('rounded-md');
+    expect(spans[0].findComponent({ name: 'RuiIcon' }).exists()).toBe(false);
+  });
+
+  it('should render no header at all when it is hidden', () => {
+    const wrapper = createWrapper({ hideHeader: true, title: ['Dashboard'] });
+
+    expect(crumbs(wrapper)).toEqual([]);
+  });
+
+  it('should let the title slot replace the derived breadcrumb', () => {
+    const wrapper = createWrapper({ title: ['Balances'] }, { title: '<span data-testid="own">Custom</span>' });
+
+    expect(wrapper.find('[data-testid=own]').exists()).toBe(true);
+    expect(crumbs(wrapper)).toEqual(['Custom']);
+  });
+});

--- a/frontend/app/src/modules/shell/layout/TablePageLayout.vue
+++ b/frontend/app/src/modules/shell/layout/TablePageLayout.vue
@@ -9,6 +9,8 @@ const slots = defineSlots<{
 }>();
 
 const hasTabs = computed<boolean>(() => Boolean(slots.tabs));
+
+const lastTitleIndex = computed<number>(() => (title?.length ?? 0) - 1);
 </script>
 
 <template>
@@ -23,10 +25,12 @@ const hasTabs = computed<boolean>(() => Boolean(slots.tabs));
           class="text-sm text-rui-text flex items-center font-medium"
         >
           <slot name="title">
-            <template v-for="(item, index) in title">
+            <template
+              v-for="(item, index) in title"
+              :key="index"
+            >
               <span
-                v-if="title && index < title.length - 1"
-                :key="index"
+                v-if="index < lastTitleIndex"
                 class="text-rui-text-secondary flex items-center"
               >
                 {{ item }}
@@ -36,14 +40,12 @@ const hasTabs = computed<boolean>(() => Boolean(slots.tabs));
                   class="mx-2"
                 />
               </span>
-              <template v-else>
-                <span
-                  :key="index"
-                  class="bg-rui-grey-200 dark:bg-rui-grey-900 text-rui-text-secondary rounded-md px-2 py-1"
-                >
-                  {{ item }}
-                </span>
-              </template>
+              <span
+                v-else
+                class="bg-rui-grey-200 dark:bg-rui-grey-900 text-rui-text-secondary rounded-md px-2 py-1"
+              >
+                {{ item }}
+              </span>
             </template>
           </slot>
         </div>


### PR DESCRIPTION
Found while investigating the eth staking crash (#12957). It turned out not to be that crash's cause, and, as the smoke test below shows, it has no user-visible symptom today either. It is a latent correctness issue in how the title breadcrumb is keyed, worth fixing on its own terms rather than for a bug it causes.

## The problem

In `TablePageLayout`, the title breadcrumb's `:key` sat on the `v-if` and `v-else` branches *inside* the `<template v-for>` rather than on the template itself, and both branches carried the same `index`.

Compiling the template shows what that costs:

| | before | after |
|---|---|---|
| list fragment | `256 /* UNKEYED_FRAGMENT */` | `128 /* KEYED_FRAGMENT */` |
| branch keys | both branches `key: index` | `key: 0` / `key: 1` |

Two consequences. The list is diffed by position rather than by key, and the two branches are indistinguishable to the diff because their keys are equal, so an entry moving between the "separator" form and the "current page" form is patched into the other rather than replaced.

## The change

Move `:key` onto the `<template v-for>`. The compiler then keys the list properly and gives each branch its own discriminating key.

Two small things while in there:

- Hoist the bound check into a `lastTitleIndex` computed. The branch was re-testing `title`, which its own enclosing `v-if="title"` already guarantees.
- Drop the `<template v-else>` wrapper that contained a single `<span>`.

## Tests

The component had no spec despite being used by 38 pages, so this adds one covering the branch the key distinguishes: every entry renders, all but the last get a separator, only the last gets the current-page pill, a single-entry title renders just the pill with no dangling separator, `hideHeader` renders nothing, and the `title` slot overrides the derived breadcrumb.

Negative control: inverting the branch condition to `index <= lastTitleIndex` fails 3 of the 6 tests, so they test the logic rather than pass incidentally.

## Smoke test, and an honest caveat

Ran in the app across the route transitions this keying governs, reading the rendered breadcrumb structure directly (text, separator presence, pill class):

- 1 entry -> 2 entries (Calendar -> Manage Prices > Latest Prices), which is the case where the entry at index 0 flips branch
- 2 -> 1 (back to Tag Manager)
- 2 -> 2 with the last entry changing (Manage Assets > Assets -> > Custom Assets)
- History > History Events

All correct after the change, no console errors. **Reverting the fix and repeating the same transitions produced identical rendering**, so this is not a user-visible bug being fixed: Vue patches the old markup into the right result anyway. The value here is the correct keying (position-independent list diffing, and branch replacement instead of element reuse) plus the test coverage, not a behaviour change.

Happy to drop this if you would rather not carry the churn for a latent issue.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

No user-guide change: internal rendering correctness, with no visible or behavioural change to document.
