### PR TITLE
Address history event rows by id in e2e, not index

### DIFF
--- a/frontend/app/tests/e2e/pages/history-event-rows.ts
+++ b/frontend/app/tests/e2e/pages/history-event-rows.ts
@@ -1,0 +1,82 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+import { TIMEOUT_MEDIUM } from '../helpers/constants';
+
+/**
+ * Addressing, reading and acting on the rows of the history events table.
+ *
+ * Split out of `HistoryEventsPage` because it is one concern with one rule behind it: **a row is
+ * named by the event it stands for, never by its position**. The table sorts timestamp DESC and
+ * re-renders on every write, so an index resolved before a mutation names a different event after
+ * it. That is not a stylistic preference — it is how the edit action ends up clicking the wrong
+ * row, and how an assertion ends up reading one.
+ */
+export class HistoryEventRows {
+  constructor(private readonly page: Page) {}
+
+  async countEvents(): Promise<number> {
+    return this.page.locator('[data-testid=history-event-row]').count();
+  }
+
+  async countSwaps(): Promise<number> {
+    return this.page.locator('[data-testid=history-event-swap]').count();
+  }
+
+  async countMovements(): Promise<number> {
+    return this.page.locator('[data-testid=history-event-movement]').count();
+  }
+
+  /** A row pinned to one event id — the only handle a re-sort cannot invalidate. */
+  byId(eventId: string): Locator {
+    return this.page.locator(`[data-event-id="${eventId}"]`);
+  }
+
+  /** The event id of the first row matching `rowSelector`. */
+  async idOfFirst(rowSelector: string): Promise<string> {
+    const id = await this.page.locator(rowSelector).first().getAttribute('data-event-id');
+    expect(id, `${rowSelector} carries no data-event-id`).toBeTruthy();
+    return id ?? '';
+  }
+
+  /**
+   * The first row matching `rowSelector`, pinned to the event it stands for right now.
+   *
+   * Resolve this once, before anything that mutates the list, and address the row through the
+   * result from then on.
+   */
+  async first(rowSelector: string): Promise<Locator> {
+    return this.byId(await this.idOfFirst(rowSelector));
+  }
+
+  async expectTypeLabel(row: Locator, expected: string): Promise<void> {
+    await expect(row.locator('[data-testid=event-type]')).toContainText(expected, { timeout: TIMEOUT_MEDIUM });
+  }
+
+  async expectNotes(row: Locator, expected: string): Promise<void> {
+    await expect(row.locator('[data-testid=event-notes]')).toContainText(expected, { timeout: TIMEOUT_MEDIUM });
+  }
+
+  async expectAmount(row: Locator, expected: string): Promise<void> {
+    await expect(row.locator('[data-testid=event-amount]').first()).toContainText(expected, { timeout: TIMEOUT_MEDIUM });
+  }
+
+  /**
+   * Opens the edit dialog for an already-resolved row.
+   *
+   * The edit button is only rendered for rows that may be edited (`hideEditAction` hides it for a
+   * swap sub-event and for a movement fee), so waiting on it against a position blocks for the
+   * whole timeout once the list has moved such an event into that slot.
+   */
+  async edit(row: Locator): Promise<void> {
+    await row.hover();
+    await row.locator('[data-testid=row-edit]').click();
+    await this.page.locator('[data-testid=bottom-dialog]').waitFor({ state: 'visible' });
+  }
+
+  async delete(row: Locator): Promise<void> {
+    await row.hover();
+    await row.locator('[data-testid=row-delete]').click();
+    const dialog = this.page.locator('[data-testid=confirm-dialog]');
+    await dialog.locator('[data-testid=button-confirm]').click();
+    await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
+  }
+}

--- a/frontend/app/tests/e2e/pages/history-events-page.ts
+++ b/frontend/app/tests/e2e/pages/history-events-page.ts
@@ -1,4 +1,4 @@
-import { expect, type Locator, type Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import { getValidSelectorFromEvmAddress } from '@rotki/common';
 import {
   type AssetMovementEventFixture,
@@ -16,13 +16,19 @@ import {
 } from '../fixtures/history-events';
 import { TIMEOUT_LONG, TIMEOUT_MEDIUM } from '../helpers/constants';
 import { selectAsset } from '../helpers/utils';
+import { HistoryEventRows } from './history-event-rows';
 import { PillFilterBar } from './pill-filter-bar';
 import { RotkiApp } from './rotki-app';
 
 export class HistoryEventsPage {
   private dateSequence = 0;
 
-  constructor(private readonly page: Page) {}
+  /** Addressing, reading and acting on the table's rows. See `HistoryEventRows`. */
+  readonly rows: HistoryEventRows;
+
+  constructor(private readonly page: Page) {
+    this.rows = new HistoryEventRows(page);
+  }
 
   async visit(): Promise<void> {
     await RotkiApp.navigateTo(this.page, 'history');
@@ -170,75 +176,6 @@ export class HistoryEventsPage {
     await bar.selectValueOnce(value);
     await bar.closeEditor();
     await bar.expectPillVisible(fieldKey);
-  }
-
-  async getEventRows(): Promise<number> {
-    const rows = this.page.locator('[data-testid=history-event-row]');
-    return rows.count();
-  }
-
-  async getSwapRows(): Promise<number> {
-    const rows = this.page.locator('[data-testid=history-event-swap]');
-    return rows.count();
-  }
-
-  /**
-   * A row addressed by the id of the event it stands for — the only stable handle. The table sorts
-   * timestamp DESC and re-renders, so `nth(i)` names a different row from one query to the next.
-   */
-  rowById(eventId: string): Locator {
-    return this.page.locator(`[data-event-id="${eventId}"]`);
-  }
-
-  /** The event id of the first row matching `rowSelector`. */
-  async eventIdOf(rowSelector: string): Promise<string> {
-    const id = await this.page.locator(rowSelector).first().getAttribute('data-event-id');
-    expect(id, `${rowSelector} carries no data-event-id`).toBeTruthy();
-    return id ?? '';
-  }
-
-  async getMovementRows(): Promise<number> {
-    const rows = this.page.locator('[data-testid=history-event-movement]');
-    return rows.count();
-  }
-
-  async verifyEventTypeLabel(rowSelector: string, index: number, expectedText: string): Promise<void> {
-    const row = this.page.locator(rowSelector).nth(index);
-    const eventType = row.locator('[data-testid=event-type]');
-    await expect(eventType).toContainText(expectedText, { timeout: TIMEOUT_MEDIUM });
-  }
-
-  async verifyEventNotes(rowSelector: string, index: number, expectedNotes: string): Promise<void> {
-    const row = this.page.locator(rowSelector).nth(index);
-    const notes = row.locator('[data-testid=event-notes]');
-    await expect(notes).toContainText(expectedNotes, { timeout: TIMEOUT_MEDIUM });
-  }
-
-  async verifyEventAmount(rowSelector: string, index: number, expectedAmount: string): Promise<void> {
-    const row = this.page.locator(rowSelector).nth(index);
-    const amount = row.locator('[data-testid=event-amount]').first();
-    await expect(amount).toContainText(expectedAmount, { timeout: TIMEOUT_MEDIUM });
-  }
-
-  async editEvent(rowSelector: string, index: number): Promise<void> {
-    const row = this.page.locator(rowSelector).nth(index);
-    await row.hover();
-    await row.locator('[data-testid=row-edit]').click();
-    await this.page.locator('[data-testid=bottom-dialog]').waitFor({ state: 'visible' });
-  }
-
-  async deleteEvent(rowSelector: string, index: number): Promise<void> {
-    return this.deleteEventRow(this.page.locator(rowSelector).nth(index));
-  }
-
-  /** Deletes an already-resolved row — `deleteEvent` re-queries by index and the list re-sorts. */
-  async deleteEventRow(row: Locator): Promise<void> {
-    await row.hover();
-    await row.locator('[data-testid=row-delete]').click();
-    // Confirm the delete dialog
-    const dialog = this.page.locator('[data-testid=confirm-dialog]');
-    await dialog.locator('[data-testid=button-confirm]').click();
-    await dialog.waitFor({ state: 'detached', timeout: TIMEOUT_MEDIUM });
   }
 
   private async fillAddressAutocomplete(dataTestid: string, address: string): Promise<void> {

--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -55,20 +55,22 @@ test.describe.serial('history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getEventRows();
+      const count = await page.rows.countEvents();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
 
-    await page.verifyEventTypeLabel('[data-testid=history-event-row]', 0, 'Airdrop');
-    await page.verifyEventAmount('[data-testid=history-event-row]', 0, onlineEventFixture.amount);
-    await page.verifyEventNotes('[data-testid=history-event-row]', 0, onlineEventFixture.notes);
+    const added = await page.rows.first('[data-testid=history-event-row]');
+    await page.rows.expectTypeLabel(added, 'Airdrop');
+    await page.rows.expectAmount(added, onlineEventFixture.amount);
+    await page.rows.expectNotes(added, onlineEventFixture.notes);
   });
 
   test('edit online history event', async () => {
     const updatedAmount = '2.5';
     const updatedNotes = 'Updated online event notes';
 
-    await page.editEvent('[data-testid=history-event-row]', 0);
+    const row = await page.rows.first('[data-testid=history-event-row]');
+    await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
     await ctx.sharedPage.locator('[data-testid=amount] input').fill(updatedAmount);
@@ -77,8 +79,8 @@ test.describe.serial('history events', () => {
 
     await page.saveForm();
 
-    await page.verifyEventAmount('[data-testid=history-event-row]', 0, updatedAmount);
-    await page.verifyEventNotes('[data-testid=history-event-row]', 0, updatedNotes);
+    await page.rows.expectAmount(row, updatedAmount);
+    await page.rows.expectNotes(row, updatedNotes);
   });
 
   test('add swap event', async () => {
@@ -88,7 +90,7 @@ test.describe.serial('history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getSwapRows();
+      const count = await page.rows.countSwaps();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
 
@@ -101,7 +103,7 @@ test.describe.serial('history events', () => {
   test('edit swap event', async () => {
     const updatedReceiveAmount = '3500';
 
-    await page.editEvent('[data-testid=history-event-swap]', 0);
+    await page.rows.edit(await page.rows.first('[data-testid=history-event-swap]'));
 
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').clear();
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').fill(updatedReceiveAmount);
@@ -110,7 +112,7 @@ test.describe.serial('history events', () => {
 
     // Verify the swap still exists after edit
     await expect(async () => {
-      const count = await page.getSwapRows();
+      const count = await page.rows.countSwaps();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
   });
@@ -138,7 +140,7 @@ test.describe.serial('history events', () => {
 
     // The swap group should still exist (spend + receive remain)
     await expect(async () => {
-      const swaps = await page.getSwapRows();
+      const swaps = await page.rows.countSwaps();
       const expandedRows = await page.getExpandedEventRows();
       expect(swaps + expandedRows).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
@@ -176,19 +178,19 @@ test.describe.serial('history events', () => {
   });
 
   test('delete history event', async () => {
-    const eventsBefore = await page.getEventRows();
-    const swapsBefore = await page.getSwapRows();
-    const movementsBefore = await page.getMovementRows();
+    const eventsBefore = await page.rows.countEvents();
+    const swapsBefore = await page.rows.countSwaps();
+    const movementsBefore = await page.rows.countMovements();
     const totalBefore = eventsBefore + swapsBefore + movementsBefore;
 
     // Delete the first regular event row (the online event)
     if (eventsBefore > 0) {
-      await page.deleteEvent('[data-testid=history-event-row]', 0);
+      await page.rows.delete(await page.rows.first('[data-testid=history-event-row]'));
 
       await expect(async () => {
-        const eventsAfter = await page.getEventRows();
-        const swapsAfter = await page.getSwapRows();
-        const movementsAfter = await page.getMovementRows();
+        const eventsAfter = await page.rows.countEvents();
+        const swapsAfter = await page.rows.countSwaps();
+        const movementsAfter = await page.rows.countMovements();
         const totalAfter = eventsAfter + swapsAfter + movementsAfter;
         expect(totalAfter).toBeLessThan(totalBefore);
       }).toPass({ timeout: 10000 });
@@ -202,20 +204,22 @@ test.describe.serial('history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getEventRows();
+      const count = await page.rows.countEvents();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
 
-    await page.verifyEventTypeLabel('[data-testid=history-event-row]', 0, 'Airdrop');
-    await page.verifyEventAmount('[data-testid=history-event-row]', 0, solanaEventFixture.amount);
-    await page.verifyEventNotes('[data-testid=history-event-row]', 0, solanaEventFixture.notes);
+    const added = await page.rows.first('[data-testid=history-event-row]');
+    await page.rows.expectTypeLabel(added, 'Airdrop');
+    await page.rows.expectAmount(added, solanaEventFixture.amount);
+    await page.rows.expectNotes(added, solanaEventFixture.notes);
   });
 
   test('edit solana event', async () => {
     const updatedAmount = '5.0';
     const updatedNotes = 'Updated solana event notes';
 
-    await page.editEvent('[data-testid=history-event-row]', 0);
+    const row = await page.rows.first('[data-testid=history-event-row]');
+    await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
     await ctx.sharedPage.locator('[data-testid=amount] input').fill(updatedAmount);
@@ -224,8 +228,8 @@ test.describe.serial('history events', () => {
 
     await page.saveForm();
 
-    await page.verifyEventAmount('[data-testid=history-event-row]', 0, updatedAmount);
-    await page.verifyEventNotes('[data-testid=history-event-row]', 0, updatedNotes);
+    await page.rows.expectAmount(row, updatedAmount);
+    await page.rows.expectNotes(row, updatedNotes);
   });
 
   test('add solana swap event', async () => {
@@ -236,7 +240,7 @@ test.describe.serial('history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getSwapRows();
+      const count = await page.rows.countSwaps();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
 
@@ -248,7 +252,7 @@ test.describe.serial('history events', () => {
   test('edit solana swap event', async () => {
     const updatedReceiveAmount = '75';
 
-    await page.editEvent('[data-testid=history-event-swap]', 0);
+    await page.rows.edit(await page.rows.first('[data-testid=history-event-swap]'));
 
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').clear();
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').fill(updatedReceiveAmount);
@@ -256,7 +260,7 @@ test.describe.serial('history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getSwapRows();
+      const count = await page.rows.countSwaps();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
   });
@@ -268,7 +272,7 @@ test.describe.serial('history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getEventRows();
+      const count = await page.rows.countEvents();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
   });
@@ -276,7 +280,8 @@ test.describe.serial('history events', () => {
   test('edit eth block event', async () => {
     const updatedAmount = '0.1';
 
-    await page.editEvent('[data-testid=history-event-row]', 0);
+    const row = await page.rows.first('[data-testid=history-event-row]');
+    await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
     await ctx.sharedPage.locator('[data-testid=amount] input').fill(updatedAmount);
@@ -284,7 +289,7 @@ test.describe.serial('history events', () => {
     await page.saveForm();
 
     // Eth block events render the amount in the notes, not via event-amount
-    await page.verifyEventNotes('[data-testid=history-event-row]', 0, updatedAmount);
+    await page.rows.expectNotes(row, updatedAmount);
   });
 
   test('add eth withdrawal event', async () => {
@@ -294,7 +299,7 @@ test.describe.serial('history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getEventRows();
+      const count = await page.rows.countEvents();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
   });
@@ -302,7 +307,8 @@ test.describe.serial('history events', () => {
   test('edit eth withdrawal event', async () => {
     const updatedAmount = '16';
 
-    await page.editEvent('[data-testid=history-event-row]', 0);
+    const row = await page.rows.first('[data-testid=history-event-row]');
+    await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
     await ctx.sharedPage.locator('[data-testid=amount] input').fill(updatedAmount);
@@ -310,7 +316,7 @@ test.describe.serial('history events', () => {
     await page.saveForm();
 
     // Eth withdrawal events render the amount in the notes, not via event-amount
-    await page.verifyEventNotes('[data-testid=history-event-row]', 0, updatedAmount);
+    await page.rows.expectNotes(row, updatedAmount);
   });
 
   test('delete solana event', async () => {
@@ -318,7 +324,7 @@ test.describe.serial('history events', () => {
     const firstRow = ctx.sharedPage.locator('[data-testid=history-event-row]').first();
     const notesBefore = await firstRow.locator('[data-testid=event-notes]').textContent();
 
-    await page.deleteEvent('[data-testid=history-event-row]', 0);
+    await page.rows.delete(await page.rows.first('[data-testid=history-event-row]'));
 
     // Wait until the deleted event's notes are no longer the first row's notes
     await expect(async () => {
@@ -341,9 +347,9 @@ test.describe.serial('history events', () => {
     // deleted a *different* swap: the list is timestamp DESC and re-renders under the test, so the
     // index no longer names the row that was read. The id is on both the collapsed row and the
     // collapse header, so a swap that merely expands still matches and only a deletion clears it.
-    const target = page.rowById(await page.eventIdOf('[data-testid=history-event-swap]'));
+    const target = await page.rows.first('[data-testid=history-event-swap]');
 
-    await page.deleteEventRow(target);
+    await page.rows.delete(target);
 
     await expect(target).toHaveCount(0, { timeout: 10000 });
   });
@@ -384,20 +390,22 @@ test.describe.serial('evm history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getEventRows();
+      const count = await page.rows.countEvents();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
 
-    await page.verifyEventTypeLabel('[data-testid=history-event-row]', 0, 'Airdrop');
-    await page.verifyEventAmount('[data-testid=history-event-row]', 0, evmEventFixture.amount);
-    await page.verifyEventNotes('[data-testid=history-event-row]', 0, evmEventFixture.notes);
+    const added = await page.rows.first('[data-testid=history-event-row]');
+    await page.rows.expectTypeLabel(added, 'Airdrop');
+    await page.rows.expectAmount(added, evmEventFixture.amount);
+    await page.rows.expectNotes(added, evmEventFixture.notes);
   });
 
   test('edit evm event', async () => {
     const updatedAmount = '2.5';
     const updatedNotes = 'Updated evm event notes';
 
-    await page.editEvent('[data-testid=history-event-row]', 0);
+    const row = await page.rows.first('[data-testid=history-event-row]');
+    await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
     await ctx.sharedPage.locator('[data-testid=amount] input').fill(updatedAmount);
@@ -406,8 +414,8 @@ test.describe.serial('evm history events', () => {
 
     await page.saveForm();
 
-    await page.verifyEventAmount('[data-testid=history-event-row]', 0, updatedAmount);
-    await page.verifyEventNotes('[data-testid=history-event-row]', 0, updatedNotes);
+    await page.rows.expectAmount(row, updatedAmount);
+    await page.rows.expectNotes(row, updatedNotes);
   });
 
   test('add evm swap event', async () => {
@@ -417,7 +425,7 @@ test.describe.serial('evm history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getSwapRows();
+      const count = await page.rows.countSwaps();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
 
@@ -429,7 +437,7 @@ test.describe.serial('evm history events', () => {
   test('edit evm swap event', async () => {
     const updatedReceiveAmount = '3500';
 
-    await page.editEvent('[data-testid=history-event-swap]', 0);
+    await page.rows.edit(await page.rows.first('[data-testid=history-event-swap]'));
 
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').clear();
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').fill(updatedReceiveAmount);
@@ -437,14 +445,14 @@ test.describe.serial('evm history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getSwapRows();
+      const count = await page.rows.countSwaps();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
   });
 
   test('add evm multi-asset swap with fees', async () => {
     await waitForNoRunningTasks(ctx.sharedPage);
-    const swapsBefore = await page.getSwapRows();
+    const swapsBefore = await page.rows.countSwaps();
 
     await page.openAddDialog();
     await page.selectEntryType('evm swap event');
@@ -452,7 +460,7 @@ test.describe.serial('evm history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getSwapRows();
+      const count = await page.rows.countSwaps();
       expect(count).toBeGreaterThan(swapsBefore);
     }).toPass({ timeout: 10000 });
   });
@@ -483,7 +491,7 @@ test.describe.serial('evm history events', () => {
 
     // The swap group should still exist
     await expect(async () => {
-      const swaps = await page.getSwapRows();
+      const swaps = await page.rows.countSwaps();
       // Swap rows are hidden when expanded, so check sub-events remain
       const expandedRows = await page.getExpandedEventRows();
       expect(swaps + expandedRows).toBeGreaterThanOrEqual(1);
@@ -497,7 +505,7 @@ test.describe.serial('evm history events', () => {
     await page.saveForm();
 
     await expect(async () => {
-      const count = await page.getEventRows();
+      const count = await page.rows.countEvents();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: 10000 });
   });
@@ -505,7 +513,8 @@ test.describe.serial('evm history events', () => {
   test('edit eth deposit event', async () => {
     const updatedAmount = '16';
 
-    await page.editEvent('[data-testid=history-event-row]', 0);
+    const row = await page.rows.first('[data-testid=history-event-row]');
+    await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
     await ctx.sharedPage.locator('[data-testid=amount] input').fill(updatedAmount);
@@ -513,27 +522,27 @@ test.describe.serial('evm history events', () => {
     await page.saveForm();
 
     // Eth deposit events render the amount in the notes, not via event-amount
-    await page.verifyEventNotes('[data-testid=history-event-row]', 0, updatedAmount);
+    await page.rows.expectNotes(row, updatedAmount);
   });
 
   test('delete evm event', async () => {
-    const eventsBefore = await page.getEventRows();
+    const eventsBefore = await page.rows.countEvents();
 
-    await page.deleteEvent('[data-testid=history-event-row]', 0);
+    await page.rows.delete(await page.rows.first('[data-testid=history-event-row]'));
 
     await expect(async () => {
-      const eventsAfter = await page.getEventRows();
+      const eventsAfter = await page.rows.countEvents();
       expect(eventsAfter).toBeLessThan(eventsBefore);
     }).toPass({ timeout: 10000 });
   });
 
   test('delete evm swap event', async () => {
-    const swapsBefore = await page.getSwapRows();
+    const swapsBefore = await page.rows.countSwaps();
 
-    await page.deleteEvent('[data-testid=history-event-swap]', 0);
+    await page.rows.delete(await page.rows.first('[data-testid=history-event-swap]'));
 
     await expect(async () => {
-      const swapsAfter = await page.getSwapRows();
+      const swapsAfter = await page.rows.countSwaps();
       expect(swapsAfter).toBeLessThan(swapsBefore);
     }).toPass({ timeout: 10000 });
   });

--- a/frontend/app/tests/e2e/specs/import/csv-import.spec.ts
+++ b/frontend/app/tests/e2e/specs/import/csv-import.spec.ts
@@ -39,12 +39,12 @@ test.describe.serial('csv import', () => {
     await historyPage.applyTableFilter('location', 'coinbase');
 
     await expect(async () => {
-      const count = await historyPage.getEventRows();
+      const count = await historyPage.rows.countEvents();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: TIMEOUT_MEDIUM });
 
     // 0.091 BTC → rounded up to 0.10 with '<' prefix
-    await historyPage.verifyEventAmount('[data-testid=history-event-row]', 0, '0.10');
+    await historyPage.rows.expectAmount(await historyPage.rows.first('[data-testid=history-event-row]'), '0.10');
   });
 
   test('import rotki generic trades', async () => {
@@ -58,12 +58,12 @@ test.describe.serial('csv import', () => {
     await historyPage.applyTableFilter('location', 'kraken');
 
     await expect(async () => {
-      const count = await historyPage.getSwapRows();
+      const count = await historyPage.rows.countSwaps();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: TIMEOUT_MEDIUM });
 
     // 392.887 LTC → rounded up to 392.89 with '<' prefix
-    await historyPage.verifyEventAmount('[data-testid=history-event-swap]', 0, '392.89');
+    await historyPage.rows.expectAmount(await historyPage.rows.first('[data-testid=history-event-swap]'), '392.89');
   });
 
   test('import cointracking csv', async () => {
@@ -81,13 +81,14 @@ test.describe.serial('csv import', () => {
     await historyPage.applyTableFilter('location', 'poloniex');
 
     await expect(async () => {
-      const count = await historyPage.getEventRows();
+      const count = await historyPage.rows.countEvents();
       expect(count).toBeGreaterThanOrEqual(1);
     }).toPass({ timeout: TIMEOUT_MEDIUM });
 
     // 5.00 XMR — exact, no rounding needed
-    await historyPage.verifyEventAmount('[data-testid=history-event-row]', 0, '5.00');
-    await historyPage.verifyEventTypeLabel('[data-testid=history-event-row]', 0, 'Exchange deposit');
+    const deposit = await historyPage.rows.first('[data-testid=history-event-row]');
+    await historyPage.rows.expectAmount(deposit, '5.00');
+    await historyPage.rows.expectTypeLabel(deposit, 'Exchange deposit');
   });
 
   test('import nexo csv', async () => {
@@ -101,8 +102,8 @@ test.describe.serial('csv import', () => {
     await historyPage.applyTableFilter('location', 'nexo');
 
     await expect(async () => {
-      const count = await historyPage.getEventRows();
-      const swaps = await historyPage.getSwapRows();
+      const count = await historyPage.rows.countEvents();
+      const swaps = await historyPage.rows.countSwaps();
       expect(count + swaps).toBeGreaterThanOrEqual(5);
     }).toPass({ timeout: TIMEOUT_MEDIUM });
 
@@ -119,12 +120,12 @@ test.describe.serial('csv import', () => {
     await historyPage.applyTableFilter('location', 'binance');
 
     await expect(async () => {
-      const rows = await historyPage.getEventRows();
-      const swaps = await historyPage.getSwapRows();
+      const rows = await historyPage.rows.countEvents();
+      const swaps = await historyPage.rows.countSwaps();
       expect(rows + swaps).toBeGreaterThanOrEqual(2);
     }).toPass({ timeout: TIMEOUT_MEDIUM });
 
     // Verify the USDC→ETH swap exists: 1,875.64 USDC spend → rounded up to 1,875.64 (exact 2 decimals)
-    await historyPage.verifyEventAmount('[data-testid=history-event-swap]', 0, '1,875.64');
+    await historyPage.rows.expectAmount(await historyPage.rows.first('[data-testid=history-event-swap]'), '1,875.64');
   });
 });


### PR DESCRIPTION
`history events › edit eth block event` failed on CI (shard 2 of [this run](https://github.com/rotki/rotki/actions/runs/32253527423/job/96070295576)), on both the first attempt and the retry:

```
TimeoutError: locator.click: Timeout 60000ms exceeded.
  waiting for locator('[data-testid=history-event-row]').first().locator('[data-testid=row-edit]')
```

It is flaky rather than broken (a re-run went green), but the reason it can fail at all is worth removing.

## Why it hangs

`editEvent` resolved its row with `nth(index)` and then **re-queried that index** when clicking:

```ts
const row = this.page.locator(rowSelector).nth(index);
await row.hover();
await row.locator('[data-testid=row-edit]').click();
```

Two facts combine against it. The table sorts timestamp DESC and re-renders on every write, so the event at a given position changes underneath the test. And the edit button is not merely disabled but **absent** for rows that may not be edited:

```ts
export function hideEditAction(item: HistoryEventEntry, index: number): boolean {
  const isSwapSubEvent = isSwapTypeEvent(item.entryType) && index !== 0;
  const isAssetMovementFee = isAssetMovementEvent(item) && item.eventSubtype === 'fee';
  return isAssetMovementFee || isSwapSubEvent;
}
```

So when a re-sort moves a swap sub-event or a movement fee into the slot the test is holding, the locator has nothing to wait for and burns the whole 60s. The preceding tests add and edit a solana swap, then add the eth block event, which is exactly the churn that sets this up.

The assertions carried the same defect in a quieter form: they re-read `nth(0)` *after* saving, so they could report on a different row than the one just edited and still pass, because that row happened to contain the expected text. That is the failure mode where a green test tells you nothing.

## The change

Resolve the row once, before anything mutates the list, and use that id-pinned handle for both the edit and the checks:

```ts
const row = await page.rows.first('[data-testid=history-event-row]');
await page.rows.edit(row);
// …edit…
await page.rows.expectNotes(row, updatedAmount);
```

This is the convention the repo already states — `rowById`'s own docstring calls it "the only stable handle", CLAUDE.md says never locate a row by index, and several commits have been migrating this file that way. `editEvent` had just never been converted. The delete flows and the csv-import assertions follow too, so no index addressing is left in either spec.

## On the new file

The page object was already at 399 of its 400-line `max-lines` ceiling, and CLAUDE.md asks for a split rather than shaving lines at that point. The row concern moves to `HistoryEventRows` — addressing, assertions and actions in one place, with the reason a row is named by its event documented where the next person will look. `HistoryEventsPage` exposes it as `page.rows` and drops to 336 lines.

## Verification

Both affected specs run locally, sharded:

- `history-events.spec.ts` — **30 passed (2.9m)**, including all seven edit flows. `edit eth block event` now takes **596ms**, against the 60s timeout it was hitting.
- `csv-import.spec.ts` — **5 passed (54.6s)**

Typecheck, eslint and knip are clean.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

No user-guide change: test-only.
