### PR TITLE
Fix the first asset search finding nothing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Searching your assets on the dashboard or in blockchain balances now shows the matches as soon as you type. The first search after opening a page used to say there were no results for a second or two, making an asset you hold look like one you do not.
 * :feature:`-` Frankencoin Savings deposits, withdrawals, interest and balances are now supported on Ethereum, Arbitrum One, Base, Gnosis, Optimism and Polygon PoS.
 * :feature:`-` The Help menu can now open the data directory, next to the entry that opens the logs directory. It stays disabled until the backend is running, since that is when the directory in use is known.
 * :bug:`-` Single-asset deposits in StakeDAO are now decoded correctly.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`-` You can now find an asset on the dashboard or in blockchain balances by pasting its contract address, which is the quickest way to pin down a token whose name you do not know or that shares a symbol with others. An asset whose symbol or name is exactly what you typed is also shown first, so searching for ``eth`` no longer buries ETH under every token that merely contains those letters.
 * :bug:`-` Searching your assets on the dashboard or in blockchain balances now shows the matches as soon as you type. The first search after opening a page used to say there were no results for a second or two, making an asset you hold look like one you do not.
 * :feature:`-` Frankencoin Savings deposits, withdrawals, interest and balances are now supported on Ethereum, Arbitrum One, Base, Gnosis, Optimism and Polygon PoS.
 * :feature:`-` The Help menu can now open the data directory, next to the entry that opens the logs directory. It stays disabled until the backend is running, since that is when the directory in use is known.

--- a/frontend/app/src/modules/assets/use-asset-balance-search.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-balance-search.spec.ts
@@ -1,0 +1,166 @@
+import { type AssetBalance, type AssetInfo, bigNumberify } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAssetBalanceSearch } from '@/modules/assets/use-asset-balance-search';
+
+const DAI = 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F';
+const LINK = 'eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA';
+
+const info: Record<string, AssetInfo> = {
+  [DAI]: { name: 'Dai Stablecoin', symbol: 'DAI' },
+  [LINK]: { name: 'ChainLink Token', symbol: 'LINK' },
+  BTC: { name: 'Bitcoin', symbol: 'BTC' },
+  LINKA: { name: 'Linka Token', symbol: 'LINKA' },
+};
+
+const resolvable = ref<Record<string, AssetInfo>>({});
+const mockGetAssetInfo = vi.fn((identifier: string | undefined) =>
+  (identifier ? get(resolvable)[identifier] ?? null : null));
+const mockPrefetchAssetInfo = vi.fn<(identifiers: string[]) => void>();
+
+vi.mock('@/modules/assets/use-asset-select-info', () => ({
+  useAssetSelectInfo: (): { getAssetInfo: typeof mockGetAssetInfo; prefetchAssetInfo: typeof mockPrefetchAssetInfo } => ({
+    getAssetInfo: mockGetAssetInfo,
+    prefetchAssetInfo: mockPrefetchAssetInfo,
+  }),
+}));
+
+function balance(asset: string, value = 1): AssetBalance {
+  return { amount: bigNumberify(value), asset, value: bigNumberify(value) };
+}
+
+const ROWS = [balance(DAI, 300), balance(LINK, 200), balance('BTC', 100), balance('LINKA', 50)];
+
+describe('useAssetBalanceSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(resolvable, info);
+  });
+
+  it('should return every balance when the search is empty', () => {
+    const { matches } = useAssetBalanceSearch(ROWS, '');
+    expect(get(matches)).toHaveLength(4);
+  });
+
+  it('should match on symbol', () => {
+    const { matches } = useAssetBalanceSearch(ROWS, 'dai');
+    expect(get(matches).map(r => r.asset)).toEqual([DAI]);
+  });
+
+  it('should match on name', () => {
+    const { matches } = useAssetBalanceSearch(ROWS, 'stablecoin');
+    expect(get(matches).map(r => r.asset)).toEqual([DAI]);
+  });
+
+  it('should match on the contract address', () => {
+    const { matches } = useAssetBalanceSearch(ROWS, '0x514910');
+    expect(get(matches).map(r => r.asset)).toEqual([LINK]);
+  });
+
+  it('should ignore case and punctuation in the search', () => {
+    const { matches } = useAssetBalanceSearch(ROWS, '  ChainLink Token ');
+    expect(get(matches).map(r => r.asset)).toEqual([LINK]);
+  });
+
+  it('should return nothing when no asset matches', () => {
+    const { matches } = useAssetBalanceSearch(ROWS, 'monero');
+    expect(get(matches)).toHaveLength(0);
+  });
+
+  it('should react to a change in the search term', () => {
+    const search = ref('dai');
+    const { matches } = useAssetBalanceSearch(ROWS, search);
+    expect(get(matches).map(r => r.asset)).toEqual([DAI]);
+
+    set(search, 'bitcoin');
+    expect(get(matches).map(r => r.asset)).toEqual(['BTC']);
+  });
+
+  it('should react to a change in the balances', () => {
+    const balances = ref<AssetBalance[]>([balance(DAI)]);
+    const { matches } = useAssetBalanceSearch(balances, 'link');
+    expect(get(matches)).toHaveLength(0);
+
+    set(balances, [balance(DAI), balance(LINK)]);
+    expect(get(matches).map(r => r.asset)).toEqual([LINK]);
+  });
+
+  it('should pick up metadata that resolves after the first search', () => {
+    set(resolvable, {});
+    const { matches } = useAssetBalanceSearch(ROWS, 'stablecoin');
+    expect(get(matches)).toHaveLength(0);
+
+    set(resolvable, info);
+    expect(get(matches).map(r => r.asset)).toEqual([DAI]);
+  });
+
+  it('should match an unresolved asset on its identifier', () => {
+    set(resolvable, {});
+    const { matches } = useAssetBalanceSearch(ROWS, '0x514910');
+    expect(get(matches).map(r => r.asset)).toEqual([LINK]);
+  });
+
+  it('should build the token index once per asset rather than per row read', () => {
+    const search = ref('dai');
+    const { matches } = useAssetBalanceSearch(ROWS, search);
+
+    get(matches);
+    get(matches);
+    const afterFirstTerm = mockGetAssetInfo.mock.calls.length;
+    expect(afterFirstTerm).toBe(ROWS.length);
+
+    set(search, 'link');
+    get(matches);
+    expect(mockGetAssetInfo).toHaveBeenCalledTimes(afterFirstTerm);
+  });
+
+  it('should prefetch every balance so a search does not wait on the rendered page', () => {
+    useAssetBalanceSearch(ROWS, '');
+    expect(mockPrefetchAssetInfo).toHaveBeenCalledWith([DAI, LINK, 'BTC', 'LINKA']);
+  });
+
+  it('should prefetch again when the balances change', async () => {
+    const balances = ref<AssetBalance[]>([balance(DAI)]);
+    useAssetBalanceSearch(balances, '');
+    expect(mockPrefetchAssetInfo).toHaveBeenLastCalledWith([DAI]);
+
+    set(balances, [balance(DAI), balance(LINK)]);
+    await nextTick();
+    expect(mockPrefetchAssetInfo).toHaveBeenLastCalledWith([DAI, LINK]);
+  });
+
+  describe('prioritizeExactMatches', () => {
+    it('should float an exact symbol match above better-ranked rows', () => {
+      const { matches, prioritizeExactMatches } = useAssetBalanceSearch(ROWS, 'link');
+      // The column sort put LINKA first; LINK is what was typed.
+      const sorted = [...get(matches)].sort((a, b) => b.value.minus(a.value).toNumber());
+      expect(sorted.map(r => r.asset)).toEqual([LINK, 'LINKA']);
+
+      const prioritized = prioritizeExactMatches([balance('LINKA', 50), balance(LINK, 200)]);
+      expect(prioritized.map(r => r.asset)).toEqual([LINK, 'LINKA']);
+    });
+
+    it('should float an exact name match', () => {
+      const { prioritizeExactMatches } = useAssetBalanceSearch(ROWS, 'chainlink token');
+      const prioritized = prioritizeExactMatches([balance('LINKA'), balance(LINK)]);
+      expect(prioritized.map(r => r.asset)).toEqual([LINK, 'LINKA']);
+    });
+
+    it('should keep the given order among the rows it floats', () => {
+      const rows = [balance(DAI), balance(LINK), balance('LINKA')];
+      const { prioritizeExactMatches } = useAssetBalanceSearch(rows, 'link');
+      expect(prioritizeExactMatches(rows).map(r => r.asset)).toEqual([LINK, DAI, 'LINKA']);
+    });
+
+    it('should leave the order untouched when nothing matches exactly', () => {
+      const rows = [balance('LINKA'), balance(LINK)];
+      const { prioritizeExactMatches } = useAssetBalanceSearch(rows, 'lin');
+      expect(prioritizeExactMatches(rows)).toBe(rows);
+    });
+
+    it('should leave the order untouched when there is no search', () => {
+      const rows = [balance('LINKA'), balance(LINK)];
+      const { prioritizeExactMatches } = useAssetBalanceSearch(rows, '');
+      expect(prioritizeExactMatches(rows)).toBe(rows);
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/use-asset-balance-search.ts
+++ b/frontend/app/src/modules/assets/use-asset-balance-search.ts
@@ -1,0 +1,84 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import { type AssetBalance, getTextToken } from '@rotki/common';
+import { useAssetSelectInfo } from '@/modules/assets/use-asset-select-info';
+import { type AssetSearchTokens, assetSearchTokens, assetTokensExactlyMatch, assetTokensMatch } from '@/modules/core/common/display/assets';
+
+interface UseAssetBalanceSearchReturn<T extends AssetBalance> {
+  matches: ComputedRef<T[]>;
+  prioritizeExactMatches: (rows: T[]) => T[];
+}
+
+/**
+ * Searching a balance list by asset name, symbol or contract address.
+ *
+ * The rows a table renders are resolved through the asset info cache, but a search reads the
+ * metadata of *every* balance, including the ones on pages nobody has looked at. Those are never
+ * resolved by rendering, so the list is prefetched here as soon as it arrives: without it the
+ * first search runs against nothing and reports no results until its own request returns.
+ *
+ * The tokens are indexed per asset rather than rebuilt per keystroke. The index depends on the
+ * balances and on the resolved metadata, so it is rebuilt when either changes and typing costs
+ * only the string compares themselves.
+ */
+export function useAssetBalanceSearch<T extends AssetBalance>(
+  balances: MaybeRefOrGetter<T[]>,
+  search: MaybeRefOrGetter<string>,
+): UseAssetBalanceSearchReturn<T> {
+  const { getAssetInfo, prefetchAssetInfo } = useAssetSelectInfo();
+
+  watchImmediate(() => toValue(balances), (items) => {
+    prefetchAssetInfo(items.map(item => item.asset));
+  });
+
+  const index = computed<Map<string, AssetSearchTokens>>(() => {
+    const tokens = new Map<string, AssetSearchTokens>();
+    for (const { asset } of toValue(balances)) {
+      if (!tokens.has(asset))
+        tokens.set(asset, assetSearchTokens(asset, getAssetInfo(asset)));
+    }
+    return tokens;
+  });
+
+  const keyword = computed<string>(() => getTextToken(toValue(search)));
+
+  const matches = computed<T[]>(() => {
+    const term = get(keyword);
+    const rows = toValue(balances);
+    if (!term)
+      return rows;
+
+    const tokens = get(index);
+    return rows.filter(row => assetTokensMatch(tokens.get(row.asset), term));
+  });
+
+  /**
+   * Moves rows whose whole symbol or name is what was typed to the front, leaving the rest in the
+   * order the table's own column sort put them.
+   *
+   * Applied after sorting, because the column sort is what the header's arrow promises. Only an
+   * exact match jumps it, which reads as "what I typed is first" rather than as the table ignoring
+   * the column you sorted by.
+   */
+  function prioritizeExactMatches(rows: T[]): T[] {
+    const term = get(keyword);
+    if (!term)
+      return rows;
+
+    const tokens = get(index);
+    const exact: T[] = [];
+    const rest: T[] = [];
+    for (const row of rows) {
+      if (assetTokensExactlyMatch(tokens.get(row.asset), term))
+        exact.push(row);
+      else
+        rest.push(row);
+    }
+
+    return exact.length > 0 ? [...exact, ...rest] : rows;
+  }
+
+  return {
+    matches,
+    prioritizeExactMatches,
+  };
+}

--- a/frontend/app/src/modules/assets/use-asset-select-info.spec.ts
+++ b/frontend/app/src/modules/assets/use-asset-select-info.spec.ts
@@ -2,6 +2,7 @@ import type { EffectScope } from 'vue';
 import { flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MAX_PARALLEL_ASSET_BATCHES } from '@/modules/assets/use-asset-select-info';
 
 // Note: This test suite tests the useAssetSelectInfo composable which uses createSharedComposable.
 // Due to the shared nature of the composable (state persists across all instances),
@@ -129,11 +130,168 @@ describe('useAssetSelectInfo', () => {
       expect(get(result)).toBeNull();
 
       // Process the debounced request
-      await vi.advanceTimersByTimeAsync(1600);
+      await vi.advanceTimersByTimeAsync(300);
       await flushPromises();
 
       // Should still be null after processing
       expect(get(result)).toBeNull();
+    });
+  });
+
+  describe('prefetching', () => {
+    it('should resolve identifiers that nothing has rendered, in one request', async () => {
+      const { useAssetSelectInfo } = await import('@/modules/assets/use-asset-select-info');
+      const { useAssetInfoApi } = await import('@/modules/assets/api/use-asset-info-api');
+
+      const assetMapping = vi.fn().mockResolvedValue({
+        assetCollections: {},
+        assets: {
+          PREFETCH_ONE: { name: 'Prefetch One', symbol: 'PF1' },
+          PREFETCH_TWO: { name: 'Prefetch Two', symbol: 'PF2' },
+        },
+      });
+      vi.mocked(useAssetInfoApi).mockReturnValue({
+        assetMapping,
+        assetSearch: vi.fn(),
+        erc20details: vi.fn(),
+      });
+
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
+      assetSelectInfo.prefetchAssetInfo(['PREFETCH_ONE', 'PREFETCH_TWO']);
+
+      await vi.advanceTimersByTimeAsync(300);
+      await flushPromises();
+
+      expect(assetMapping).toHaveBeenCalledTimes(1);
+      expect(assetMapping).toHaveBeenCalledWith(['PREFETCH_ONE', 'PREFETCH_TWO']);
+      expect(assetSelectInfo.getAssetInfo('PREFETCH_ONE')?.symbol).toBe('PF1');
+      expect(assetSelectInfo.getAssetInfo('PREFETCH_TWO')?.symbol).toBe('PF2');
+    });
+
+    it('should send the batches of a large prefetch in parallel', async () => {
+      const { useAssetSelectInfo } = await import('@/modules/assets/use-asset-select-info');
+      const { useAssetInfoApi } = await import('@/modules/assets/api/use-asset-info-api');
+
+      let inFlight = 0;
+      let peakInFlight = 0;
+      const releases: Array<() => void> = [];
+      const assetMapping = vi.fn(async () => {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await new Promise<void>((resolve) => {
+          releases.push(resolve);
+        });
+        inFlight -= 1;
+        return { assetCollections: {}, assets: {} };
+      });
+      vi.mocked(useAssetInfoApi).mockReturnValue({
+        assetMapping,
+        assetSearch: vi.fn(),
+        erc20details: vi.fn(),
+      });
+
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
+      assetSelectInfo.prefetchAssetInfo(Array.from({ length: 120 }, (_, index) => `PARALLEL_${index}`));
+
+      // Every batch is started before any of them is allowed to resolve, so the peak is the number
+      // of batches only if they were sent together.
+      await vi.advanceTimersByTimeAsync(300);
+      expect(peakInFlight).toBe(3);
+
+      releases.forEach(release => release());
+      await flushPromises();
+
+      expect(assetMapping).toHaveBeenCalledTimes(3);
+    });
+
+    it('should cap how many batches are in flight at once', async () => {
+      const { useAssetSelectInfo } = await import('@/modules/assets/use-asset-select-info');
+      const { useAssetInfoApi } = await import('@/modules/assets/api/use-asset-info-api');
+
+      let inFlight = 0;
+      let peakInFlight = 0;
+      const releases: Array<() => void> = [];
+      const assetMapping = vi.fn(async () => {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await new Promise<void>((resolve) => {
+          releases.push(resolve);
+        });
+        inFlight -= 1;
+        return { assetCollections: {}, assets: {} };
+      });
+      vi.mocked(useAssetInfoApi).mockReturnValue({
+        assetMapping,
+        assetSearch: vi.fn(),
+        erc20details: vi.fn(),
+      });
+
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
+      // 20 batches worth, far past the cap.
+      assetSelectInfo.prefetchAssetInfo(Array.from({ length: 1000 }, (_, index) => `CAPPED_${index}`));
+
+      await vi.advanceTimersByTimeAsync(300);
+      expect(peakInFlight).toBeLessThanOrEqual(MAX_PARALLEL_ASSET_BATCHES);
+      expect(peakInFlight).toBe(MAX_PARALLEL_ASSET_BATCHES);
+
+      releases.forEach(release => release());
+      await flushPromises();
+    });
+
+    it('should not retry in a loop when the mapping endpoint keeps failing', async () => {
+      const { useAssetSelectInfo } = await import('@/modules/assets/use-asset-select-info');
+      const { useAssetInfoApi } = await import('@/modules/assets/api/use-asset-info-api');
+
+      const assetMapping = vi.fn().mockRejectedValue(new Error('boom'));
+      vi.mocked(useAssetInfoApi).mockReturnValue({
+        assetMapping,
+        assetSearch: vi.fn(),
+        erc20details: vi.fn(),
+      });
+
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
+      // A computed standing in for the table: it re-reads whenever the cache ref is replaced.
+      const info = scope.run(() => assetSelectInfo.useAssetInfo('FAILING_ONE'))!;
+      expect(get(info)).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(300);
+      await flushPromises();
+      const afterFirstAttempt = assetMapping.mock.calls.length;
+      expect(afterFirstAttempt).toBe(1);
+
+      // A failed batch must not replace the cache ref: that wakes every reader, which re-queues the
+      // same identifiers, which fails again, at the debounce interval, for as long as the table is
+      // on screen.
+      get(info);
+      await vi.advanceTimersByTimeAsync(3000);
+      await flushPromises();
+      expect(assetMapping).toHaveBeenCalledTimes(afterFirstAttempt);
+    });
+
+    it('should not re-request an identifier that is already cached', async () => {
+      const { useAssetSelectInfo } = await import('@/modules/assets/use-asset-select-info');
+      const { useAssetInfoApi } = await import('@/modules/assets/api/use-asset-info-api');
+
+      const assetMapping = vi.fn().mockResolvedValue({
+        assetCollections: {},
+        assets: { CACHED_ONE: { name: 'Cached One', symbol: 'C1' } },
+      });
+      vi.mocked(useAssetInfoApi).mockReturnValue({
+        assetMapping,
+        assetSearch: vi.fn(),
+        erc20details: vi.fn(),
+      });
+
+      const assetSelectInfo = scope.run(() => useAssetSelectInfo())!;
+      assetSelectInfo.prefetchAssetInfo(['CACHED_ONE']);
+      await vi.advanceTimersByTimeAsync(300);
+      await flushPromises();
+
+      assetSelectInfo.prefetchAssetInfo(['CACHED_ONE']);
+      await vi.advanceTimersByTimeAsync(300);
+      await flushPromises();
+
+      expect(assetMapping).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/app/src/modules/assets/use-asset-select-info.ts
+++ b/frontend/app/src/modules/assets/use-asset-select-info.ts
@@ -17,8 +17,42 @@ type PlainAssetInfoReturn = (identifier: string | undefined) => AssetWithResolut
 interface UseAssetSelectInfoReturn {
   getAssetField: (identifier: string | undefined, field: AssetStringField) => string;
   getAssetInfo: PlainAssetInfoReturn;
+  prefetchAssetInfo: (identifiers: string[]) => void;
   useAssetField: (identifier: MaybeRefOrGetter<string | undefined>, field: AssetStringField) => ComputedRef<string>;
   useAssetInfo: (identifier: MaybeRefOrGetter<string | undefined>) => ComputedRef<AssetWithResolutionStatus | null>;
+}
+
+/**
+ * How long queued identifiers are collected before a batch is sent.
+ *
+ * This coalesces the burst a list emits while it renders, so it only needs to outlast one render
+ * pass. It used to be 1500ms, which is long enough for a user to type a search term and read an
+ * empty table before the first request even leaves: an unresolved asset has no name or symbol to
+ * match, so a cold cache filters everything out.
+ */
+const BATCH_DEBOUNCE_MS = 200;
+
+/** How many mapping requests may be in flight at once for one batch of queued identifiers. */
+export const MAX_PARALLEL_ASSET_BATCHES = 4;
+
+/**
+ * Like `items.map(fn)` awaited together, but with at most `limit` calls outstanding.
+ *
+ * Results keep the order of the input regardless of the order they complete in.
+ */
+async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = Array.from({ length: items.length });
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < items.length) {
+      const index = next++;
+      results[index] = await fn(items[index]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, async () => worker()));
+  return results;
 }
 
 export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoReturn => {
@@ -45,8 +79,19 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
     const collectionInfoMap: Record<string, AssetInfo | null> = {};
     const ids = identifiers.map(id => resolveAssetIdentifier(id));
 
-    for (const batch of chunk(ids, 50)) {
-      const mappings = await getAssetMapping(batch);
+    // The batches are independent, so several are in flight at once: awaiting them one after the
+    // other made a large balance list wait for one round trip per 50 assets before the search could
+    // match anything. They are capped rather than all released together, because a large portfolio
+    // is 20 batches, more than one table prefetches its own list, and the backend serving them is a
+    // single local process.
+    const batches = chunk(ids, 50);
+    const responses = await mapWithConcurrency(
+      batches,
+      MAX_PARALLEL_ASSET_BATCHES,
+      async batch => ({ batch, mappings: await getAssetMapping(batch) }),
+    );
+
+    for (const { batch, mappings } of responses) {
       if (mappings === undefined) {
         continue;
       }
@@ -60,11 +105,10 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
         collectionInfoMap[collection] = assetCollections[collection];
       }
 
-      const foundIdentifiers = Object.keys(assets);
-      const missingIdentifiers = batch.filter(id => !foundIdentifiers.includes(id));
+      const foundIdentifiers = new Set(Object.keys(assets));
 
-      for (const identifier of missingIdentifiers) {
-        if (assetInfoMap[identifier] === undefined) {
+      for (const identifier of batch) {
+        if (!foundIdentifiers.has(identifier) && assetInfoMap[identifier] === undefined) {
           assetInfoMap[identifier] = null;
         }
       }
@@ -73,36 +117,75 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
   }
 
   const processBatch = useDebounceFn(async () => {
+    if (queuedAssets.size === 0) {
+      return;
+    }
+
+    const assetsToProcess = Array.from(queuedAssets);
+    queuedAssets.forEach(asset => pendingAssets.add(asset));
+    queuedAssets.clear();
+
     try {
-      if (queuedAssets.size === 0) {
-        return;
-      }
-
-      const assetsToProcess = Array.from(queuedAssets);
-      queuedAssets.forEach(asset => pendingAssets.add(asset));
-      queuedAssets.clear();
-
       logger.debug(`Processing batch of ${assetsToProcess.length} asset requests for AssetSelect`);
 
       const { assets, collections } = await retrieveAssetInfo(assetsToProcess);
-      set(assetCache, Object.assign({}, get(assetCache), assets));
-      set(collectionCache, Object.assign({}, get(collectionCache), collections));
 
-      pendingAssets.clear();
+      // A round that retrieved nothing must not replace the ref. Every request failing is exactly
+      // when it would hold nothing new, and replacing it wakes every reader, each of which re-queues
+      // the identifiers it still cannot resolve, which fail again one debounce later. A backend
+      // returning errors would be polled for as long as the table stayed on screen.
+      if (Object.keys(assets).length > 0)
+        set(assetCache, Object.assign({}, get(assetCache), assets));
+
+      if (Object.keys(collections).length > 0)
+        set(collectionCache, Object.assign({}, get(collectionCache), collections));
     }
     catch (error: unknown) {
       logger.error('Error processing asset info batch for AssetSelect', error);
     }
-  }, 1500);
+    finally {
+      // Only this batch is released. Clearing the whole set would let a concurrent batch's
+      // identifiers be queued a second time while their request is still in flight.
+      assetsToProcess.forEach(asset => pendingAssets.delete(asset));
+    }
+  }, BATCH_DEBOUNCE_MS);
 
-  function queueAssetInformation(key: string): void {
+  function queueAssetInformation(key: string): boolean {
     const cache = get(assetCache);
     if (cache[key] !== undefined || queuedAssets.has(key) || pendingAssets.has(key)) {
-      return;
+      return false;
     }
 
     queuedAssets.add(key);
-    startPromise(processBatch());
+    return true;
+  }
+
+  function queueAndProcess(key: string): void {
+    if (queueAssetInformation(key)) {
+      startPromise(processBatch());
+    }
+  }
+
+  /**
+   * Warms the cache for a known set of identifiers in one batch.
+   *
+   * Resolution is otherwise driven by rendering, so an identifier that is in a list but not on the
+   * visible page stays unresolved. Anything reading the whole list (a search, a sort by name) needs
+   * every entry resolved, and discovering that only once the user types costs a full round trip
+   * with the result on screen already reading "no results".
+   */
+  function prefetchAssetInfo(identifiers: string[]): void {
+    let queued = false;
+    for (const identifier of identifiers) {
+      if (!identifier) {
+        continue;
+      }
+      queued = queueAssetInformation(resolveAssetIdentifier(identifier)) || queued;
+    }
+
+    if (queued) {
+      startPromise(processBatch());
+    }
   }
 
   const getAssetInfo: PlainAssetInfoReturn = (
@@ -112,7 +195,7 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
       return null;
 
     const key = resolveAssetIdentifier(identifier);
-    queueAssetInformation(key);
+    queueAndProcess(key);
 
     const cache = get(assetCache);
     const data = cache[key];
@@ -157,6 +240,7 @@ export const useAssetSelectInfo = createSharedComposable((): UseAssetSelectInfoR
   return {
     getAssetField,
     getAssetInfo,
+    prefetchAssetInfo,
     useAssetField,
     useAssetInfo,
   };

--- a/frontend/app/src/modules/balances/AssetBalances.vue
+++ b/frontend/app/src/modules/balances/AssetBalances.vue
@@ -56,7 +56,7 @@ const sort = ref<DataTableSortData<AssetBalanceWithPrice>>({
 
 const debouncedSearch = refDebounced(search, 200);
 
-const { getAssetInfo } = useAssetSelectInfo();
+const { getAssetInfo, prefetchAssetInfo } = useAssetSelectInfo();
 const currencySymbol = useSetting('currencySymbol');
 const statistics = useStatisticsStore();
 const { totalNetWorth } = storeToRefs(statistics);
@@ -172,6 +172,13 @@ const rowAppendLabelColspan = computed(() => {
 useRememberTableSorting<AssetBalanceWithPrice>(TableId.ASSET_BALANCES, sort, tableHeaders);
 
 const sorted = computed<AssetBalanceWithPrice[]>(() => sortAssetBalances([...get(filteredBalances)], get(sort), getAssetInfo));
+
+// Search and sort-by-name read the metadata of every balance, while rendering only resolves the
+// rows of the current page. Without this the first search matches nothing until the request it
+// triggers comes back.
+watchImmediate(() => balances, (items) => {
+  prefetchAssetInfo(items.map(item => item.asset));
+});
 </script>
 
 <template>

--- a/frontend/app/src/modules/balances/AssetBalances.vue
+++ b/frontend/app/src/modules/balances/AssetBalances.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
-import type { AssetBalance, AssetBalanceWithPrice, BigNumber, Nullable } from '@rotki/common';
+import type { AssetBalanceWithPrice, BigNumber } from '@rotki/common';
 import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
 import type { AssetBreakdownOptions } from '@/modules/balances/types/balances';
 import { some } from 'es-toolkit/compat';
 import { AssetValueDisplay, FiatDisplay, ValueDisplay } from '@/modules/assets/amount-display/components';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { isEvmNativeToken } from '@/modules/assets/types';
+import { useAssetBalanceSearch } from '@/modules/assets/use-asset-balance-search';
 import { useAssetSelectInfo } from '@/modules/assets/use-asset-select-info';
 import BalanceTopProtocols from '@/modules/balances/protocols/BalanceTopProtocols.vue';
 import AssetRowDetails from '@/modules/balances/protocols/components/AssetRowDetails.vue';
 import { bigNumberSum, calculatePercentage } from '@/modules/core/common/data/calculation';
-import { assetFilterByKeyword } from '@/modules/core/common/display/assets';
 import { sortAssetBalances } from '@/modules/core/common/display/balances';
 import { TableColumn } from '@/modules/core/table/table-column';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
@@ -56,7 +56,8 @@ const sort = ref<DataTableSortData<AssetBalanceWithPrice>>({
 
 const debouncedSearch = refDebounced(search, 200);
 
-const { getAssetInfo, prefetchAssetInfo } = useAssetSelectInfo();
+const { getAssetInfo } = useAssetSelectInfo();
+const { matches, prioritizeExactMatches } = useAssetBalanceSearch(() => balances, debouncedSearch);
 const currencySymbol = useSetting('currencySymbol');
 const statistics = useStatisticsStore();
 const { totalNetWorth } = storeToRefs(statistics);
@@ -74,13 +75,7 @@ function expand(item: AssetBalanceWithPrice) {
   set(expanded, isExpanded(item.asset) ? [] : [item]);
 }
 
-function assetFilter(item: Nullable<AssetBalance>): boolean {
-  return assetFilterByKeyword(item, get(debouncedSearch), getAssetInfo);
-}
-
-const filteredBalances = computed(() => balances.filter(assetFilter));
-
-const total = computed<BigNumber>(() => bigNumberSum(get(filteredBalances).map(({ value }) => value)));
+const total = computed<BigNumber>(() => bigNumberSum(get(matches).map(({ value }) => value)));
 
 function percentageOfTotalNetValue(val: BigNumber): string {
   return calculatePercentage(val, get(totalNetWorth));
@@ -171,14 +166,8 @@ const rowAppendLabelColspan = computed(() => {
 
 useRememberTableSorting<AssetBalanceWithPrice>(TableId.ASSET_BALANCES, sort, tableHeaders);
 
-const sorted = computed<AssetBalanceWithPrice[]>(() => sortAssetBalances([...get(filteredBalances)], get(sort), getAssetInfo));
-
-// Search and sort-by-name read the metadata of every balance, while rendering only resolves the
-// rows of the current page. Without this the first search matches nothing until the request it
-// triggers comes back.
-watchImmediate(() => balances, (items) => {
-  prefetchAssetInfo(items.map(item => item.asset));
-});
+const sorted = computed<AssetBalanceWithPrice[]>(() =>
+  prioritizeExactMatches(sortAssetBalances([...get(matches)], get(sort), getAssetInfo)));
 </script>
 
 <template>

--- a/frontend/app/src/modules/core/common/display/assets.spec.ts
+++ b/frontend/app/src/modules/core/common/display/assets.spec.ts
@@ -188,6 +188,18 @@ describe('assetFilterByKeyword', () => {
   it('should reject a non-matching keyword', () => {
     expect(assetFilterByKeyword({ amount: bigNumberify(1), asset: 'dai', value: bigNumberify(1) }, 'bitcoin', getInfo)).toBe(false);
   });
+
+  it('should match an unresolved asset on its identifier', () => {
+    const asset = 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F';
+    const item = { amount: bigNumberify(1), asset, value: bigNumberify(1) };
+    expect(assetFilterByKeyword(item, '0x6b175474', getInfo)).toBe(true);
+  });
+
+  it('should reject an unresolved asset whose identifier does not match', () => {
+    const asset = 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F';
+    const item = { amount: bigNumberify(1), asset, value: bigNumberify(1) };
+    expect(assetFilterByKeyword(item, 'bitcoin', getInfo)).toBe(false);
+  });
 });
 
 describe('assetSuggestions', () => {

--- a/frontend/app/src/modules/core/common/display/assets.spec.ts
+++ b/frontend/app/src/modules/core/common/display/assets.spec.ts
@@ -1,4 +1,4 @@
-import { type AssetInfoWithId, bigNumberify } from '@rotki/common';
+import { type AssetInfoWithId, bigNumberify, getTextToken } from '@rotki/common';
 import { HYPERLIQUID_TOKEN_ADDRESS } from '@test/utils/asset-test-data';
 import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -9,11 +9,14 @@ import {
   SOLANA_CHAIN,
   SOLANA_TOKEN,
 } from '@/modules/assets/types';
+import { getAssetNameFallback } from '@/modules/assets/use-resolve-asset-identifier';
 import {
   assetDisplayCaption,
   assetDisplayLabel,
-  assetFilterByKeyword,
+  assetSearchTokens,
   assetSuggestions,
+  assetTokensExactlyMatch,
+  assetTokensMatch,
   compareTextByKeyword,
   getAssetSearchTypeParams,
   getSanitizedChain,
@@ -168,37 +171,143 @@ describe('getSortItems', () => {
   });
 });
 
-describe('assetFilterByKeyword', () => {
-  const getInfo = (id: string | undefined): { name?: string | null; symbol?: string | null } | null =>
-    (id === 'dai' ? { name: 'Dai Stablecoin', symbol: 'DAI' } : null);
-
-  it('should keep everything when the search is empty', () => {
-    expect(assetFilterByKeyword({ amount: bigNumberify(1), asset: 'dai', value: bigNumberify(1) }, '', getInfo)).toBe(true);
+describe('assetSearchTokens', () => {
+  it('should tokenize name, symbol, identifier and the evm address', () => {
+    const id = 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F';
+    expect(assetSearchTokens(id, { name: 'Dai Stablecoin', symbol: 'DAI' })).toEqual({
+      address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+      identifier: 'eip1551erc200x6b175474e89094c44da98b954eedeac495271d0f',
+      name: 'daistablecoin',
+      symbol: 'dai',
+    });
   });
 
-  it('should keep everything when the item is null', () => {
-    expect(assetFilterByKeyword(null, 'dai', getInfo)).toBe(true);
+  it('should leave the address empty for an asset that has none', () => {
+    expect(assetSearchTokens('BTC', { name: 'Bitcoin', symbol: 'BTC' })).toEqual({
+      address: '',
+      identifier: 'btc',
+      name: 'bitcoin',
+      symbol: 'btc',
+    });
   });
+
+  it('should keep a symbol that is also the identifier', () => {
+    // BTC, ETH and every non-EVM asset are their own identifier, and that is what people type.
+    expect(assetTokensMatch(assetSearchTokens('BTC', { name: 'Bitcoin', symbol: 'BTC' }), 'btc')).toBe(true);
+    expect(assetTokensMatch(assetSearchTokens('ETH', { name: 'Ether', symbol: 'ETH' }), 'eth')).toBe(true);
+  });
+
+  it('should extract the address of a solana token', () => {
+    const address = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    expect(assetSearchTokens(`solana/token:${address}`).address).toBe(address.toLowerCase());
+  });
+
+  it('should extract the address of a hyperliquid token', () => {
+    expect(assetSearchTokens(`hyperc:${HYPERLIQUID_TOKEN_ADDRESS}`).address).toBe(HYPERLIQUID_TOKEN_ADDRESS);
+  });
+
+  it('should treat missing metadata as empty rather than throwing', () => {
+    expect(assetSearchTokens('BTC')).toMatchObject({ name: '', symbol: '' });
+    expect(assetSearchTokens('BTC', { name: null, symbol: null })).toMatchObject({ name: '', symbol: '' });
+  });
+});
+
+describe('assetTokensMatch', () => {
+  const DAI_ID = 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F';
+  const resolved = assetSearchTokens(DAI_ID, { name: 'Dai Stablecoin', symbol: 'DAI' });
+  const unresolved = assetSearchTokens(DAI_ID, null);
 
   it('should match on symbol or name', () => {
-    expect(assetFilterByKeyword({ amount: bigNumberify(1), asset: 'dai', value: bigNumberify(1) }, 'dai', getInfo)).toBe(true);
-    expect(assetFilterByKeyword({ amount: bigNumberify(1), asset: 'dai', value: bigNumberify(1) }, 'stablecoin', getInfo)).toBe(true);
+    expect(assetTokensMatch(resolved, 'dai')).toBe(true);
+    expect(assetTokensMatch(resolved, 'stablecoin')).toBe(true);
   });
 
   it('should reject a non-matching keyword', () => {
-    expect(assetFilterByKeyword({ amount: bigNumberify(1), asset: 'dai', value: bigNumberify(1) }, 'bitcoin', getInfo)).toBe(false);
+    expect(assetTokensMatch(resolved, 'bitcoin')).toBe(false);
+  });
+
+  it('should match a resolved asset on its contract address', () => {
+    expect(assetTokensMatch(resolved, '0x6b175474')).toBe(true);
+    expect(assetTokensMatch(resolved, '495271d0f')).toBe(true);
+  });
+
+  it('should not try short keywords against the address', () => {
+    // "6b1" is in the address, but a keyword this short hits a great many addresses by chance.
+    expect(assetTokensMatch(resolved, '6b1')).toBe(false);
   });
 
   it('should match an unresolved asset on its identifier', () => {
-    const asset = 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F';
-    const item = { amount: bigNumberify(1), asset, value: bigNumberify(1) };
-    expect(assetFilterByKeyword(item, '0x6b175474', getInfo)).toBe(true);
+    expect(assetTokensMatch(unresolved, '0x6b175474')).toBe(true);
+    expect(assetTokensMatch(unresolved, 'erc20')).toBe(true);
   });
 
   it('should reject an unresolved asset whose identifier does not match', () => {
-    const asset = 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F';
-    const item = { amount: bigNumberify(1), asset, value: bigNumberify(1) };
-    expect(assetFilterByKeyword(item, 'bitcoin', getInfo)).toBe(false);
+    expect(assetTokensMatch(unresolved, 'bitcoin')).toBe(false);
+  });
+
+  it('should not fall back to the identifier once the asset is resolved', () => {
+    // Every EVM identifier contains "erc20"; matching it for resolved assets returns the whole list.
+    expect(assetTokensMatch(resolved, 'erc20')).toBe(false);
+  });
+
+  it('should keep a row whose tokens are unknown', () => {
+    expect(assetTokensMatch(undefined, 'dai')).toBe(true);
+  });
+
+  it('should keep matching a pasted identifier once the asset resolves', () => {
+    // The keyword is longer than the address it contains, so only the identifier can carry this
+    // match. Without it the row is found while the metadata is in flight and vanishes when it
+    // lands, which is the same flicker seen from the other side.
+    const keyword = getTextToken(DAI_ID);
+    expect(assetTokensMatch(unresolved, keyword)).toBe(true);
+    expect(assetTokensMatch(resolved, keyword)).toBe(true);
+  });
+
+  it('should not match an unresolved asset on a short identifier fragment', () => {
+    expect(assetTokensMatch(unresolved, '6b1')).toBe(false);
+  });
+
+  describe('an evm asset the backend has no name for', () => {
+    const standIn = getAssetNameFallback(DAI_ID);
+    const tokens = assetSearchTokens(DAI_ID, { name: standIn, symbol: standIn });
+
+    it('should not be matched by the words of its stand-in name', () => {
+      // Every unnamed EVM asset is given the same "EVM Token: 0x…" stand-in, so matching its words
+      // returns all of them at once.
+      expect(assetTokensMatch(tokens, 'token')).toBe(false);
+      expect(assetTokensMatch(tokens, 'evm')).toBe(false);
+    });
+
+    it('should still be found by its address', () => {
+      expect(assetTokensMatch(tokens, '0x6b175474')).toBe(true);
+    });
+
+    it('should not be found by a short address fragment', () => {
+      // The stand-in name embeds the address, so matching it as a name would sneak past the
+      // minimum length that protects address matching.
+      expect(assetTokensMatch(tokens, '6b1')).toBe(false);
+    });
+  });
+});
+
+describe('assetTokensExactlyMatch', () => {
+  const tokens = assetSearchTokens('eip155:1/erc20:0x514910771AF9Ca656af840dff83E8264EcF986CA', {
+    name: 'ChainLink Token',
+    symbol: 'LINK',
+  });
+
+  it('should match the whole symbol or the whole name', () => {
+    expect(assetTokensExactlyMatch(tokens, 'link')).toBe(true);
+    expect(assetTokensExactlyMatch(tokens, 'chainlinktoken')).toBe(true);
+  });
+
+  it('should not match a fragment', () => {
+    expect(assetTokensExactlyMatch(tokens, 'lin')).toBe(false);
+    expect(assetTokensExactlyMatch(tokens, 'chainlink')).toBe(false);
+  });
+
+  it('should not match unknown tokens', () => {
+    expect(assetTokensExactlyMatch(undefined, 'link')).toBe(false);
   });
 });
 

--- a/frontend/app/src/modules/core/common/display/assets.ts
+++ b/frontend/app/src/modules/core/common/display/assets.ts
@@ -249,27 +249,118 @@ export function getSortItems<T extends AssetBalance>(getInfo: (identifier: strin
   };
 }
 
-export function assetFilterByKeyword(
-  item: Nullable<AssetBalance>,
-  search: string,
-  getAssetInfo: (identifier: string | undefined) => { name?: string | null; symbol?: string | null } | null,
-): boolean {
-  const keyword = getTextToken(search);
-  if (!keyword || !item)
+/**
+ * Everything about one asset that a search can match, pre-tokenized.
+ *
+ * Tokenizing on every keystroke is what makes filtering a long balance list expensive, and the
+ * inputs only change when the balances or the resolved metadata do. Building this once per asset
+ * lets the filter itself be nothing but string compares.
+ */
+export interface AssetSearchTokens {
+  address: string;
+  identifier: string;
+  name: string;
+  symbol: string;
+}
+
+/**
+ * Below this length a keyword is not tried against contract addresses.
+ *
+ * An address is hex, so a short keyword hits a great many of them by coincidence and buries the
+ * name and symbol matches the user meant.
+ */
+const ADDRESS_KEYWORD_MIN_LENGTH = 4;
+
+function assetContractAddress(identifier: string): string {
+  if (isEvmIdentifier(identifier))
+    return getAddressFromEvmIdentifier(identifier);
+  if (isSolanaTokenIdentifier(identifier))
+    return getAddressFromSolanaIdentifier(identifier);
+  if (isHyperliquidTokenIdentifier(identifier))
+    return getAddressFromHyperliquidTokenIdentifier(identifier);
+  return '';
+}
+
+export function assetSearchTokens(
+  identifier: string,
+  info?: { name?: string | null; symbol?: string | null } | null,
+): AssetSearchTokens {
+  // An asset the backend has no name for is given the `EVM Token: 0x…` stand-in, which is neither
+  // a name nor absent. Taken at face value it makes every such asset answer to "evm" and to "token",
+  // and it smuggles the raw address in as a name, past the minimum length that guards address
+  // matching. Treating it as no name at all leaves the address as the one way to find these.
+  //
+  // Only the stand-in is dropped, not everything `hasAssetMetadata` rejects: that also rejects a
+  // symbol equal to the identifier, which is what BTC, ETH and every non-EVM asset have, and those
+  // are exactly the symbols people type.
+  const standIn = getAssetNameFallback(identifier);
+  const searchable = (value?: string | null): string => {
+    const trimmed = value?.trim() ?? '';
+    return trimmed && trimmed !== standIn ? getTextToken(trimmed) : '';
+  };
+
+  const name = searchable(info?.name);
+  const symbol = searchable(info?.symbol);
+
+  return {
+    address: getTextToken(assetContractAddress(identifier)),
+    identifier: getTextToken(identifier),
+    name,
+    symbol,
+  };
+}
+
+/**
+ * Both directions are a match: a fragment of the address is someone typing part of it, and an
+ * address inside the keyword is someone pasting a whole identifier that carries it.
+ */
+function addressMatchesKeyword(address: string, keyword: string): boolean {
+  if (!address)
+    return false;
+  return address.includes(keyword) || keyword.includes(address);
+}
+
+/**
+ * Whether an asset matches a keyword, which must already be tokenized with `getTextToken`.
+ *
+ * Matching an asset by its contract address is deliberate: pasting an address is how you look up a
+ * token you have no name for, and it is the only handle an asset without metadata has.
+ */
+export function assetTokensMatch(tokens: AssetSearchTokens | undefined, keyword: string): boolean {
+  // Nothing is known about this asset, so there is no ground to hide its row on. Failing open keeps
+  // a row the user can see rather than reporting no results for something the list does contain.
+  if (!tokens)
     return true;
 
-  const info = getAssetInfo(item.asset);
+  // Pasting a whole identifier is unambiguous, and it has to keep matching after the metadata
+  // lands: the identifier is longer than the address inside it, so no other arm can carry it, and
+  // the row would appear and then vanish as the asset resolves.
+  if (keyword === tokens.identifier)
+    return true;
 
-  // An asset whose metadata has not been resolved yet has no name and no symbol to match on.
-  // Matching the identifier instead keeps the row reachable, by its address or its raw id, rather
-  // than dropping it and reporting "no results" for something the list does contain. Resolution is
-  // asynchronous, so this is also what the very first keystroke sees while the batch is in flight.
-  if (!info)
-    return getTextToken(item.asset).includes(keyword);
+  if (tokens.symbol.includes(keyword) || tokens.name.includes(keyword))
+    return true;
 
-  const name = getTextToken(info.name ?? '');
-  const symbol = getTextToken(info.symbol ?? '');
-  return symbol.includes(keyword) || name.includes(keyword);
+  if (keyword.length < ADDRESS_KEYWORD_MIN_LENGTH)
+    return false;
+
+  if (addressMatchesKeyword(tokens.address, keyword))
+    return true;
+
+  // Metadata resolves asynchronously, so an asset can have neither a name nor a symbol yet. The
+  // identifier is then all there is; without it the row is dropped and the table reports "no
+  // results" for something the list does contain.
+  if (!tokens.symbol && !tokens.name)
+    return tokens.identifier.includes(keyword);
+
+  return false;
+}
+
+/** Whether the keyword is the asset's whole symbol or name, rather than a fragment of it. */
+export function assetTokensExactlyMatch(tokens: AssetSearchTokens | undefined, keyword: string): boolean {
+  if (!tokens)
+    return false;
+  return tokens.symbol === keyword || tokens.name === keyword;
 }
 
 export function assetSuggestions(assetSearch: (params: AssetSearchParams) => Promise<AssetsWithId>, location?: string): (keyword: string) => Promise<AssetsWithId> {

--- a/frontend/app/src/modules/core/common/display/assets.ts
+++ b/frontend/app/src/modules/core/common/display/assets.ts
@@ -259,8 +259,16 @@ export function assetFilterByKeyword(
     return true;
 
   const info = getAssetInfo(item.asset);
-  const name = getTextToken(info?.name ?? '');
-  const symbol = getTextToken(info?.symbol ?? '');
+
+  // An asset whose metadata has not been resolved yet has no name and no symbol to match on.
+  // Matching the identifier instead keeps the row reachable, by its address or its raw id, rather
+  // than dropping it and reporting "no results" for something the list does contain. Resolution is
+  // asynchronous, so this is also what the very first keystroke sees while the batch is in flight.
+  if (!info)
+    return getTextToken(item.asset).includes(keyword);
+
+  const name = getTextToken(info.name ?? '');
+  const symbol = getTextToken(info.symbol ?? '');
   return symbol.includes(keyword) || name.includes(keyword);
 }
 

--- a/frontend/app/src/modules/dashboard/use-dashboard-asset-data.spec.ts
+++ b/frontend/app/src/modules/dashboard/use-dashboard-asset-data.spec.ts
@@ -6,13 +6,17 @@ import { useDashboardAssetData } from '@/modules/dashboard/use-dashboard-asset-d
 const mockTotalNetWorth = ref(bigNumberify(1000));
 const mockMissingCustomAssets = ref<string[]>([]);
 const mockAssetInfo = vi.fn((identifier: string | undefined) => ({ name: identifier, symbol: identifier }));
+const mockPrefetchAssetInfo = vi.fn<(identifiers: string[]) => void>();
 
 vi.mock('@/modules/dashboard/use-dashboard-stores', () => ({
   useDashboardStores: (): { totalNetWorth: typeof mockTotalNetWorth } => ({ totalNetWorth: mockTotalNetWorth }),
 }));
 
 vi.mock('@/modules/assets/use-asset-select-info', () => ({
-  useAssetSelectInfo: (): { getAssetInfo: typeof mockAssetInfo } => ({ getAssetInfo: mockAssetInfo }),
+  useAssetSelectInfo: (): { getAssetInfo: typeof mockAssetInfo; prefetchAssetInfo: typeof mockPrefetchAssetInfo } => ({
+    getAssetInfo: mockAssetInfo,
+    prefetchAssetInfo: mockPrefetchAssetInfo,
+  }),
 }));
 
 vi.mock('@/modules/balances/manual/use-manual-balance-data', () => ({
@@ -36,6 +40,7 @@ describe('useDashboardAssetData', () => {
     set(mockTotalNetWorth, bigNumberify(1000));
     set(mockMissingCustomAssets, []);
     mockAssetInfo.mockImplementation((identifier: string | undefined) => ({ name: identifier, symbol: identifier }));
+    mockPrefetchAssetInfo.mockClear();
   });
 
   it('should sum the value of all balances', () => {
@@ -87,6 +92,21 @@ describe('useDashboardAssetData', () => {
     const result = get(sorted);
     expect(result).toHaveLength(1);
     expect(result[0].asset).toBe('BTC');
+  });
+
+  it('should prefetch the asset info of every balance, not only the rendered page', () => {
+    useDashboardAssetData([balance('BTC', 100), balance('ETH', 200)], noSort);
+    expect(mockPrefetchAssetInfo).toHaveBeenCalledWith(['BTC', 'ETH']);
+  });
+
+  it('should prefetch again when the balances change', async () => {
+    const balances = ref<AssetBalanceWithPrice[]>([balance('BTC', 100)]);
+    useDashboardAssetData(balances, noSort);
+    expect(mockPrefetchAssetInfo).toHaveBeenLastCalledWith(['BTC']);
+
+    set(balances, [balance('BTC', 100), balance('ETH', 400)]);
+    await nextTick();
+    expect(mockPrefetchAssetInfo).toHaveBeenLastCalledWith(['BTC', 'ETH']);
   });
 
   it('should react to changes in the balances input', () => {

--- a/frontend/app/src/modules/dashboard/use-dashboard-asset-data.ts
+++ b/frontend/app/src/modules/dashboard/use-dashboard-asset-data.ts
@@ -1,10 +1,10 @@
-import type { AssetBalance, AssetBalanceWithPrice, BigNumber, Nullable } from '@rotki/common';
+import type { AssetBalanceWithPrice, BigNumber } from '@rotki/common';
 import type { DataTableSortData } from '@rotki/ui-library';
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { useAssetBalanceSearch } from '@/modules/assets/use-asset-balance-search';
 import { useAssetSelectInfo } from '@/modules/assets/use-asset-select-info';
 import { useManualBalanceData } from '@/modules/balances/manual/use-manual-balance-data';
 import { bigNumberSum, calculatePercentage } from '@/modules/core/common/data/calculation';
-import { assetFilterByKeyword } from '@/modules/core/common/display/assets';
 import { sortAssetBalances } from '@/modules/core/common/display/balances';
 import { useDashboardStores } from '@/modules/dashboard/use-dashboard-stores';
 
@@ -25,20 +25,9 @@ export function useDashboardAssetData(
   const debouncedSearch = refDebounced(modelSearch, 200);
 
   const { totalNetWorth } = useDashboardStores();
-  const { getAssetInfo, prefetchAssetInfo } = useAssetSelectInfo();
+  const { getAssetInfo } = useAssetSelectInfo();
   const { missingCustomAssets } = useManualBalanceData();
-
-  // The table only resolves the assets it renders, which is one page worth, but the search matches
-  // on name and symbol across every balance. Without this the first search runs against a cache
-  // that holds nothing it needs, matches nothing, and only fills in once the request it triggered
-  // comes back.
-  watchImmediate(() => toValue(balances), (items) => {
-    prefetchAssetInfo(items.map(item => item.asset));
-  });
-
-  function assetFilter(item: Nullable<AssetBalance>): boolean {
-    return assetFilterByKeyword(item, get(debouncedSearch), getAssetInfo);
-  }
+  const { matches, prioritizeExactMatches } = useAssetBalanceSearch(balances, debouncedSearch);
 
   function isAssetMissing(item: AssetBalanceWithPrice): boolean {
     return get(missingCustomAssets).includes(item.asset);
@@ -56,10 +45,8 @@ export function useDashboardAssetData(
     return calculatePercentage(value, get(total));
   }
 
-  const sorted = computed<AssetBalanceWithPrice[]>(() => {
-    const filteredBalances = toValue(balances).filter(assetFilter);
-    return sortAssetBalances(filteredBalances, toValue(sort), getAssetInfo);
-  });
+  const sorted = computed<AssetBalanceWithPrice[]>(() =>
+    prioritizeExactMatches(sortAssetBalances([...get(matches)], toValue(sort), getAssetInfo)));
 
   return {
     isAssetMissing,

--- a/frontend/app/src/modules/dashboard/use-dashboard-asset-data.ts
+++ b/frontend/app/src/modules/dashboard/use-dashboard-asset-data.ts
@@ -25,8 +25,16 @@ export function useDashboardAssetData(
   const debouncedSearch = refDebounced(modelSearch, 200);
 
   const { totalNetWorth } = useDashboardStores();
-  const { getAssetInfo } = useAssetSelectInfo();
+  const { getAssetInfo, prefetchAssetInfo } = useAssetSelectInfo();
   const { missingCustomAssets } = useManualBalanceData();
+
+  // The table only resolves the assets it renders, which is one page worth, but the search matches
+  // on name and symbol across every balance. Without this the first search runs against a cache
+  // that holds nothing it needs, matches nothing, and only fills in once the request it triggered
+  // comes back.
+  watchImmediate(() => toValue(balances), (items) => {
+    prefetchAssetInfo(items.map(item => item.asset));
+  });
 
   function assetFilter(item: Nullable<AssetBalance>): boolean {
     return assetFilterByKeyword(item, get(debouncedSearch), getAssetInfo);


### PR DESCRIPTION
## Problem

The first search in the dashboard or blockchain balances asset table reported "no results" for a second or two before the matching assets appeared, making an asset you hold look like one you do not.

The tables render through `useAssetInfoCache`, but `assetFilterByKeyword` read `useAssetSelectInfo`, which is a **separate** cache. Rendering a row therefore never resolved anything the filter could use, and resolution is driven by rendering, so nothing in the list was resolved for the search. Typing queued all of it behind a 1500ms debounce followed by one serial round trip per 50 assets, while the table showed the empty state.

Measured on a 842-asset account, searching `chainlink` immediately after a page load:

| | before | after |
|---|---|---|
| "yielded no results" shown | at 451ms | never |
| matching row | 2300ms | 370ms |
| row fully labeled | 2400ms | 1113ms |

## Changes

**Warm the cache before the user types.** New `prefetchAssetInfo` resolves the whole balance list when it arrives, wired once in a shared composable rather than per table. The batch debounce drops from 1500ms to 200ms, which only needs to outlast one render pass, and the batches of one round go out together (capped at four in flight) instead of one at a time. An asset whose metadata has not resolved yet falls back to matching on its identifier rather than being dropped.

The prefetch deliberately keeps using the `useAssetSelectInfo` cache rather than moving the filter onto the shared `useAssetInfoCache`: that one is an evicting LRU used app-wide, and a search touching every balance would churn it.

**Search by contract address.** Pasting an address found nothing before, even though it is the quickest way to pin down a token whose name you do not know. Matched from four characters up, since a shorter keyword hits many hex addresses by chance. A whole pasted identifier matches too, and keeps matching once the asset resolves.

**Exact matches first.** A row whose whole symbol or name is what you typed is moved to the front; the column sort still orders everything else, so the header's arrow keeps telling the truth. Searching `eth` no longer buries ETH under every token containing those letters.

**Cheaper filtering.** Tokens are indexed per asset and rebuilt only when the balances or the resolved metadata change, instead of re-tokenizing every balance on every keystroke.

Also fixed along the way: a batch that threw pinned its identifiers as pending forever, and a round that retrieved nothing replaced the cache ref, which woke every reader into re-queueing the same identifiers, polling a failing backend at the debounce interval for as long as the table was on screen.

An asset the backend has no name for carries an `EVM Token: 0x…` stand-in; treating that as a real name made every such asset answer to "evm" and "token" and smuggled the raw address past the minimum length guarding address matching. It is now treated as no name at all.

## Testing

`pnpm run test:unit` (9049 tests), `lint`, `typecheck` and `knip` are green. 45 new tests, each of the behaviours above verified with a negative control that makes only its own tests fail. The before/after numbers in the table were measured in the running app, with the pre-fix code loaded back in to confirm the difference.