### PR TITLE
Make the send form's token picker searchable and navigable

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -6254,10 +6254,12 @@
       "tracked_addresses": "Tracked Addresses"
     },
     "select_asset": {
+      "asset_count": "{count} asset | {count} assets",
       "balance": "Balance",
       "max": "Max",
       "no_assets_found": "No assets found",
       "no_search_results": "No assets match \"{query}\"",
+      "result_count": "{count} of {total}",
       "search": "Search by symbol or name",
       "select_token": "Select a token",
       "title": "Select Asset"

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -6257,6 +6257,8 @@
       "balance": "Balance",
       "max": "Max",
       "no_assets_found": "No assets found",
+      "no_search_results": "No assets match \"{query}\"",
+      "search": "Search by symbol or name",
       "select_token": "Select a token",
       "title": "Select Asset"
     },

--- a/frontend/app/src/modules/wallet/send/TradeAssetDisplay.spec.ts
+++ b/frontend/app/src/modules/wallet/send/TradeAssetDisplay.spec.ts
@@ -1,0 +1,84 @@
+import type { ComputedRef } from 'vue';
+import type { TradableAsset } from '@/modules/wallet/types';
+import { bigNumberify } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import TradeAssetDisplay from '@/modules/wallet/send/TradeAssetDisplay.vue';
+
+const useAssetField = vi.fn<(identifier: unknown, field: string) => ComputedRef<string>>();
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn(() => ({ useAssetField })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({ getEvmChainName: (chain: string): string => chain })),
+}));
+
+const ASSET: TradableAsset = {
+  amount: bigNumberify(1),
+  asset: 'eip155:1/erc20:0xaaa',
+  chain: 'eth',
+};
+
+describe('tradeAssetDisplay', () => {
+  function createWrapper(props: Record<string, unknown> = {}): VueWrapper {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    return mount(TradeAssetDisplay, {
+      global: {
+        plugins: [pinia],
+        provide: libraryDefaults,
+        stubs: { AssetDetails: true },
+      },
+      props: { data: ASSET, list: true, ...props },
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAssetField.mockImplementation((_identifier: unknown, field: string) =>
+      computed(() => (field === 'symbol' ? 'RESOLVED_SYM' : 'RESOLVED_NAME')));
+  });
+
+  it('should resolve the symbol and name itself when none are provided', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.text()).toContain('RESOLVED_SYM');
+    expect(wrapper.text()).toContain('RESOLVED_NAME');
+  });
+
+  it('should prefer a provided symbol and name over resolving', () => {
+    const wrapper = createWrapper({ name: 'Zeus Finance', symbol: 'ZEU' });
+
+    expect(wrapper.text()).toContain('ZEU');
+    expect(wrapper.text()).toContain('Zeus Finance');
+    expect(wrapper.text()).not.toContain('RESOLVED_SYM');
+    expect(wrapper.text()).not.toContain('RESOLVED_NAME');
+  });
+
+  it('should not evaluate the resolution when both are provided', () => {
+    const resolver = vi.fn(() => 'RESOLVED');
+    useAssetField.mockImplementation(() => computed(resolver));
+
+    createWrapper({ name: 'Zeus Finance', symbol: 'ZEU' });
+
+    // The computeds are created but never read, so the lazy body must not run: this is what makes
+    // the pre-resolved props an actual saving rather than a cosmetic one.
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('should still resolve the half that was not provided', () => {
+    const wrapper = createWrapper({ symbol: 'ZEU' });
+
+    expect(wrapper.text()).toContain('ZEU');
+    expect(wrapper.text()).toContain('RESOLVED_NAME');
+  });
+
+  it('should treat an empty provided symbol as a value rather than falling back', () => {
+    const wrapper = createWrapper({ symbol: '' });
+
+    expect(wrapper.text()).not.toContain('RESOLVED_SYM');
+  });
+});

--- a/frontend/app/src/modules/wallet/send/TradeAssetDisplay.spec.ts
+++ b/frontend/app/src/modules/wallet/send/TradeAssetDisplay.spec.ts
@@ -76,6 +76,42 @@ describe('tradeAssetDisplay', () => {
     expect(wrapper.text()).toContain('RESOLVED_NAME');
   });
 
+  it('should show the balance on a list row when there is an amount', () => {
+    const wrapper = createWrapper({
+      data: { ...ASSET, amount: bigNumberify(42), fiatValue: bigNumberify(100) },
+    });
+
+    expect(wrapper.find('[data-testid="trade-asset-balance"]').exists()).toBe(true);
+  });
+
+  it('should hide the balance when the amount is zero', () => {
+    // Every row is zero until a wallet is connected, and a column of zeroes is worse than none.
+    const wrapper = createWrapper({ data: { ...ASSET, amount: bigNumberify(0) } });
+
+    expect(wrapper.find('[data-testid="trade-asset-balance"]').exists()).toBe(false);
+  });
+
+  it('should not show a balance outside a list row', () => {
+    const wrapper = createWrapper({
+      data: { ...ASSET, amount: bigNumberify(42) },
+      list: false,
+    });
+
+    expect(wrapper.find('[data-testid="trade-asset-balance"]').exists()).toBe(false);
+  });
+
+  it('should show the address only when one is provided', () => {
+    expect(createWrapper().find('[data-testid="trade-asset-address"]').exists()).toBe(false);
+
+    const wrapper = createWrapper({ address: '0x1f98…F984' });
+    expect(wrapper.find('[data-testid="trade-asset-address"]').text()).toBe('0x1f98…F984');
+  });
+
+  it('should mark the selected row', () => {
+    expect(createWrapper().find('[data-testid="trade-asset-selected"]').exists()).toBe(false);
+    expect(createWrapper({ selected: true }).find('[data-testid="trade-asset-selected"]').exists()).toBe(true);
+  });
+
   it('should treat an empty provided symbol as a value rather than falling back', () => {
     const wrapper = createWrapper({ symbol: '' });
 

--- a/frontend/app/src/modules/wallet/send/TradeAssetDisplay.vue
+++ b/frontend/app/src/modules/wallet/send/TradeAssetDisplay.vue
@@ -6,10 +6,14 @@ import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 
-const { data } = defineProps<{
+const { data, symbol: providedSymbol, name: providedName } = defineProps<{
   data: TradableAsset;
   list?: boolean;
   amount?: BigNumber;
+  /** Pre-resolved symbol. The option list resolves once per asset, so rows need not resolve again. */
+  symbol?: string;
+  /** Pre-resolved name, as above. */
+  name?: string;
 }>();
 
 const emit = defineEmits<{
@@ -21,8 +25,13 @@ const { t } = useI18n({ useScope: 'global' });
 const { useAssetField } = useAssetInfoRetrieval();
 const { getEvmChainName } = useSupportedChains();
 
-const symbol = useAssetField(data.asset, 'symbol', { collectionParent: false });
-const name = useAssetField(data.asset, 'name', { collectionParent: false });
+const resolvedSymbol = useAssetField(() => data.asset, 'symbol', { collectionParent: false });
+const resolvedName = useAssetField(() => data.asset, 'name', { collectionParent: false });
+
+// Short-circuits, so a provided value leaves the resolution computed unevaluated rather than
+// merely unused: `computed` is lazy, and nothing else reads these.
+const symbol = computed<string>(() => providedSymbol ?? get(resolvedSymbol));
+const name = computed<string>(() => providedName ?? get(resolvedName));
 </script>
 
 <template>

--- a/frontend/app/src/modules/wallet/send/TradeAssetDisplay.vue
+++ b/frontend/app/src/modules/wallet/send/TradeAssetDisplay.vue
@@ -6,7 +6,7 @@ import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 
-const { data, symbol: providedSymbol, name: providedName } = defineProps<{
+const { data, symbol: providedSymbol, name: providedName, address = '' } = defineProps<{
   data: TradableAsset;
   list?: boolean;
   amount?: BigNumber;
@@ -14,6 +14,10 @@ const { data, symbol: providedSymbol, name: providedName } = defineProps<{
   symbol?: string;
   /** Pre-resolved name, as above. */
   name?: string;
+  /** Shortened contract address, shown only when another row carries the same symbol. */
+  address?: string;
+  /** Marks the row the form currently has selected. */
+  selected?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -52,8 +56,17 @@ const name = computed<string>(() => providedName ?? get(resolvedName));
       }"
     >
       <div class="font-medium text-sm -mb-0.5 overflow-hidden truncate">
-        <div class="truncate">
-          {{ symbol }}
+        <div class="truncate flex items-center gap-1.5">
+          <span class="truncate">{{ symbol }}</span>
+          <!-- Only rendered for a symbol that appears twice in the list; otherwise the address is
+               noise on every row. -->
+          <span
+            v-if="address"
+            class="shrink-0 font-mono text-xs font-normal text-rui-text-secondary"
+            data-testid="trade-asset-address"
+          >
+            {{ address }}
+          </span>
         </div>
         <div
           v-if="list || !(data.price && data.fiatValue)"
@@ -61,6 +74,41 @@ const name = computed<string>(() => providedName ?? get(resolvedName));
         >
           {{ name }}
         </div>
+      </div>
+      <!-- The right-hand side of a list row: what you hold, and the tick for the active asset.
+           Hidden when the amount is zero, which is every row until a wallet is connected. -->
+      <div
+        v-if="list"
+        class="flex items-center gap-2 shrink-0 pl-2"
+      >
+        <div
+          v-if="data.amount && data.amount.gt(0)"
+          class="text-right"
+          data-testid="trade-asset-balance"
+        >
+          <div class="text-sm text-rui-text-primary">
+            <ValueDisplay
+              :value="data.amount"
+              no-scramble
+            />
+          </div>
+          <div
+            v-if="data.fiatValue"
+            class="text-xs font-normal text-rui-text-secondary"
+          >
+            <FiatDisplay
+              no-scramble
+              :value="data.fiatValue"
+            />
+          </div>
+        </div>
+        <RuiIcon
+          v-if="selected"
+          class="text-rui-primary"
+          name="lu-check"
+          size="16"
+          data-testid="trade-asset-selected"
+        />
       </div>
       <div
         v-if="!list && data.price"

--- a/frontend/app/src/modules/wallet/send/TradeAssetSelector.spec.ts
+++ b/frontend/app/src/modules/wallet/send/TradeAssetSelector.spec.ts
@@ -4,7 +4,7 @@ import { bigNumberify } from '@rotki/common';
 import { libraryDefaults } from '@test/utils/provide-defaults';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
-import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import TradeAssetSelector from '@/modules/wallet/send/TradeAssetSelector.vue';
 
 const NAMES: Record<string, { symbol: string; name: string }> = {
@@ -45,14 +45,11 @@ vi.mock('@/modules/wallet/use-tradable-asset', () => ({
   })),
 }));
 
+const getAssetField = vi.fn<(identifier: string, field: string) => string>();
+
 vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
   useAssetInfoRetrieval: vi.fn(() => ({
-    getAssetField: (identifier: string, field: string): string => {
-      const entry = NAMES[identifier];
-      if (!entry)
-        return '';
-      return field === 'symbol' ? entry.symbol : entry.name;
-    },
+    getAssetField,
     useAssetField: (): ComputedRef<string> => computed(() => ''),
   })),
 }));
@@ -98,10 +95,20 @@ vi.mock('@vueuse/core', async () => {
 });
 
 describe('tradeAssetSelector', () => {
+  // Wrappers are unmounted between tests. `allOwnedAssets` is a module-level ref shared by every
+  // instance, so a leaked component keeps reacting to it and its effects run during later tests,
+  // which is invisible except as call counts on a mock that this test never touched.
+  const mounted: VueWrapper[] = [];
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
   function createWrapper(props: Record<string, unknown> = {}): VueWrapper {
     const pinia = createPinia();
     setActivePinia(pinia);
-    return mount(TradeAssetSelector, {
+    const wrapper = mount(TradeAssetSelector, {
       global: {
         plugins: [pinia],
         provide: libraryDefaults,
@@ -129,6 +136,8 @@ describe('tradeAssetSelector', () => {
         ...props,
       },
     });
+    mounted.push(wrapper);
+    return wrapper;
   }
 
   async function openDialog(wrapper: VueWrapper): Promise<void> {
@@ -142,6 +151,12 @@ describe('tradeAssetSelector', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    getAssetField.mockImplementation((identifier: string, field: string) => {
+      const entry = NAMES[identifier];
+      if (!entry)
+        return '';
+      return field === 'symbol' ? entry.symbol : entry.name;
+    });
     set(supportedChainsForConnectedAccount, ['eth', 'optimism']);
     set(allOwnedAssets, [
       tradable('ETH', 'eth'),
@@ -233,6 +248,149 @@ describe('tradeAssetSelector', () => {
     await flushPromises();
 
     expect(wrapper.findAll('[data-testid="trade-asset-option"]')).toHaveLength(0);
+  });
+
+  it('should pick the highlighted row with the keyboard', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    const field = wrapper.find('[data-testid="trade-asset-search"]');
+    await field.trigger('keydown', { key: 'ArrowDown' });
+    await field.trigger('keydown', { key: 'Enter' });
+    await flushPromises();
+
+    // Second row of ETH, AGE, TUSD, ZEU.
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['eip155:1/erc20:0xbbb']);
+  });
+
+  it('should let a search be committed with enter alone', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    const field = wrapper.find('[data-testid="trade-asset-search"]');
+    await field.setValue('true');
+    await flushPromises();
+    await field.trigger('keydown', { key: 'Enter' });
+    await flushPromises();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['eip155:1/erc20:0xccc']);
+  });
+
+  it('should close on escape from the search field', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    await wrapper.find('[data-testid="trade-asset-search"]').trigger('keydown', { key: 'Escape' });
+    await flushPromises();
+
+    expect(wrapper.findAll('[data-testid="trade-asset-option"]')).toHaveLength(0);
+  });
+
+  it('should open highlighted on the current selection', async () => {
+    const wrapper = createWrapper({ modelValue: 'eip155:1/erc20:0xaaa' });
+    await openDialog(wrapper);
+
+    // Fourth of ETH, AGE, TUSD, ZEU: opening at the top would strand the active asset off screen
+    // and make enter commit a different one.
+    expect(virtualScrollTo).toHaveBeenCalledWith(3);
+  });
+
+  it('should mark the selected row', async () => {
+    const wrapper = createWrapper({ modelValue: 'eip155:1/erc20:0xaaa' });
+    await openDialog(wrapper);
+
+    const selected = wrapper.findAll('[data-testid="trade-asset-option"]')
+      .filter(node => node.attributes('aria-selected') === 'true');
+    expect(selected).toHaveLength(1);
+    expect(selected[0].attributes('data-key')).toBe('eip155:1/erc20:0xaaa');
+  });
+
+  it('should tick only the selected chain when an identifier spans chains', async () => {
+    // ETH is the native asset of ethereum, optimism and base alike, so comparing the identifier
+    // alone ticks every one of them and the user cannot tell which network is selected.
+    set(allOwnedAssets, [tradable('ETH', 'eth'), tradable('ETH', 'optimism')]);
+    set(supportedChainsForConnectedAccount, ['eth', 'optimism']);
+    const wrapper = createWrapper({ chain: 'optimism', modelValue: 'ETH' });
+    await openDialog(wrapper);
+    await wrapper.find('[data-testid="chain-select"]').trigger('click');
+    await flushPromises();
+
+    const ticked = wrapper.findAll('[data-testid="trade-asset-option"]')
+      .filter(node => node.attributes('aria-selected') === 'true');
+    expect(ticked).toHaveLength(1);
+    expect(ticked[0].attributes('data-chain')).toBe('optimism');
+  });
+
+  it('should not resolve any asset name before the dialog is opened', () => {
+    createWrapper();
+
+    // Resolution queues a backend mapping fetch per unknown asset, so touching it on mount costs a
+    // request for the entire holding even when the dialog is never opened.
+    expect(getAssetField).not.toHaveBeenCalled();
+  });
+
+  it('should resolve names once the dialog opens', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    expect(getAssetField).toHaveBeenCalled();
+  });
+
+  it('should point the search field at the highlighted row for assistive tech', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    const field = wrapper.find('[data-testid="trade-asset-search"]');
+    await field.trigger('keydown', { key: 'ArrowDown' });
+    await flushPromises();
+
+    const active = field.attributes('aria-activedescendant');
+    expect(active).toBe('trade-asset-option-1');
+    expect(wrapper.find(`#${active}`).exists()).toBe(true);
+  });
+
+  it('should report how many assets the chain holds', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    expect(wrapper.find('[data-testid="trade-asset-count"]').text()).toContain('4');
+  });
+
+  it('should report the narrowed count against the total while searching', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    await wrapper.find('[data-testid="trade-asset-search"]').setValue('agent');
+    await flushPromises();
+
+    const text = wrapper.find('[data-testid="trade-asset-count"]').text();
+    expect(text).toContain('1');
+    expect(text).toContain('4');
+  });
+
+  it('should default to the head of the display order rather than the raw owned list', async () => {
+    // Raw order puts TUSD first; display order puts native ETH first. The form must open on what
+    // the dialog shows at the top, or the selection sits nowhere near it.
+    set(allOwnedAssets, [
+      tradable('eip155:1/erc20:0xccc', 'eth'),
+      tradable('ETH', 'eth'),
+      tradable('eip155:1/erc20:0xaaa', 'eth'),
+    ]);
+    const wrapper = createWrapper({ modelValue: '' });
+    await flushPromises();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['ETH']);
+  });
+
+  it('should never default to a collectible', async () => {
+    set(allOwnedAssets, [
+      tradable('eip155:1/erc721:0xC0a302e6Ad8EcCC4d7A6c1514F8671D6B79269c7/104', 'eth'),
+      tradable('eip155:1/erc20:0xccc', 'eth'),
+    ]);
+    const wrapper = createWrapper({ modelValue: '' });
+    await flushPromises();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['eip155:1/erc20:0xccc']);
   });
 
   it('should window the list rather than rendering every row', async () => {

--- a/frontend/app/src/modules/wallet/send/TradeAssetSelector.spec.ts
+++ b/frontend/app/src/modules/wallet/send/TradeAssetSelector.spec.ts
@@ -1,0 +1,350 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { TradableAsset } from '@/modules/wallet/types';
+import { bigNumberify } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import TradeAssetSelector from '@/modules/wallet/send/TradeAssetSelector.vue';
+
+const NAMES: Record<string, { symbol: string; name: string }> = {
+  'ETH': { name: 'Ethereum', symbol: 'ETH' },
+  'eip155:1/erc20:0xaaa': { name: 'Zeus Finance', symbol: 'ZEU' },
+  'eip155:1/erc20:0xbbb': { name: 'AgentX', symbol: 'AGE' },
+  'eip155:1/erc20:0xccc': { name: 'TrueUSD', symbol: 'TUSD' },
+  'OP': { name: 'Optimism', symbol: 'OP' },
+};
+
+function tradable(identifier: string, chain: string): TradableAsset {
+  return { amount: bigNumberify(1), asset: identifier, chain };
+}
+
+interface VirtualListStub {
+  containerProps: { ref: Ref<HTMLElement | undefined>; style: Record<string, string> };
+  list: ComputedRef<{ data: unknown; index: number }[]>;
+  scrollTo: (index: number) => void;
+  wrapperProps: ComputedRef<{ style: Record<string, string> }>;
+}
+
+const allOwnedAssets = ref<TradableAsset[]>([]);
+const supportedChainsForConnectedAccount = ref<string[]>(['eth', 'optimism']);
+const connected = ref<boolean>(true);
+const connectedAddress = ref<string | undefined>('0xabc');
+const virtualListArgs = vi.fn();
+const virtualScrollTo = vi.fn();
+const orchestratorDetect = vi.fn();
+
+vi.mock('@/modules/wallet/use-wallet-store', () => ({
+  useWalletStore: vi.fn(() => ({ connected, connectedAddress, supportedChainsForConnectedAccount })),
+}));
+
+vi.mock('@/modules/wallet/use-tradable-asset', () => ({
+  useInjectedTradableAsset: vi.fn(() => ({
+    allOwnedAssets,
+    getAssetDetail: (): ComputedRef<undefined> => computed(() => undefined),
+  })),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn(() => ({
+    getAssetField: (identifier: string, field: string): string => {
+      const entry = NAMES[identifier];
+      if (!entry)
+        return '';
+      return field === 'symbol' ? entry.symbol : entry.name;
+    },
+    useAssetField: (): ComputedRef<string> => computed(() => ''),
+  })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({
+    getEvmChainName: (chain: string): string => chain,
+    getNativeAsset: (chain: string): string => (chain === 'eth' ? 'ETH' : 'OP'),
+  })),
+}));
+
+vi.mock('@/modules/wallet/send/use-balance-queries', () => ({
+  useBalanceQueries: vi.fn(() => ({ useQueryingBalances: ref(false), warnUntrackedAddress: ref(false) })),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', () => ({
+  useTaskCenter: vi.fn(() => ({ useIsActive: (): Ref<boolean> => ref(false) })),
+}));
+
+vi.mock('@/modules/balances/blockchain/use-token-detection-orchestrator', () => ({
+  useTokenDetectionOrchestrator: vi.fn(() => ({ detectTokens: orchestratorDetect })),
+}));
+
+// happy-dom reports every element as zero-height, so the real useVirtualList would render an empty
+// window and no assertion about rows could distinguish "filtered out" from "scrolled out of view".
+// The stub renders everything and records the windowing config, which is what this component owns.
+vi.mock('@vueuse/core', async () => {
+  const mod = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+  const { computed: vueComputed, shallowRef, toValue: vueToValue } = await import('vue');
+  return {
+    ...mod,
+    useVirtualList: (source: MaybeRefOrGetter<unknown[]>, options: unknown): VirtualListStub => {
+      virtualListArgs(options);
+      return {
+        // A real ref, not a computed: Vue writes the element into it and a computed is readonly.
+        containerProps: { ref: shallowRef(), style: {} },
+        list: vueComputed(() => vueToValue(source).map((data, index) => ({ data, index }))),
+        scrollTo: virtualScrollTo,
+        wrapperProps: vueComputed(() => ({ style: {} })),
+      };
+    },
+  };
+});
+
+describe('tradeAssetSelector', () => {
+  function createWrapper(props: Record<string, unknown> = {}): VueWrapper {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    return mount(TradeAssetSelector, {
+      global: {
+        plugins: [pinia],
+        provide: libraryDefaults,
+        stubs: {
+          AssetDetails: true,
+          // Drivable, so a test can widen the dialog to every chain and pick across one.
+          ChainSelect: {
+            emits: ['update:modelValue'],
+            props: { modelValue: String },
+            template: '<button data-testid="chain-select" @click="$emit(\'update:modelValue\', \'all\')" />',
+          },
+          // RuiDialog teleports to body, which puts its content outside the wrapper. This renders
+          // the same slot inline so the dialog's contents can be queried.
+          RuiDialog: {
+            props: { modelValue: Boolean },
+            template: '<div v-if="modelValue"><slot /></div>',
+          },
+        },
+      },
+      props: {
+        address: '0xabc',
+        amount: bigNumberify(1),
+        chain: 'eth',
+        modelValue: 'ETH',
+        ...props,
+      },
+    });
+  }
+
+  async function openDialog(wrapper: VueWrapper): Promise<void> {
+    await wrapper.find('[class*="rounded-b-lg"]').trigger('click');
+    await flushPromises();
+  }
+
+  function optionKeys(wrapper: VueWrapper): string[] {
+    return wrapper.findAll('[data-testid="trade-asset-option"]').map(node => node.attributes('data-key') ?? '');
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(supportedChainsForConnectedAccount, ['eth', 'optimism']);
+    set(allOwnedAssets, [
+      tradable('ETH', 'eth'),
+      tradable('eip155:1/erc20:0xccc', 'eth'),
+      tradable('eip155:1/erc20:0xbbb', 'eth'),
+      tradable('eip155:1/erc20:0xaaa', 'eth'),
+      tradable('OP', 'optimism'),
+    ]);
+  });
+
+  it('should list the selected chain ordered native first then by symbol', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    expect(optionKeys(wrapper)).toEqual([
+      'ETH',
+      'eip155:1/erc20:0xbbb',
+      'eip155:1/erc20:0xccc',
+      'eip155:1/erc20:0xaaa',
+    ]);
+  });
+
+  it('should render each option as a button so it is keyboard reachable', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    const options = wrapper.findAll('[data-testid="trade-asset-option"]');
+    expect(options.length).toBeGreaterThan(0);
+    options.forEach((option) => {
+      expect(option.element.tagName).toBe('BUTTON');
+      expect(option.attributes('type')).toBe('button');
+    });
+  });
+
+  it('should scroll back to the top when the search narrows the list', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+    virtualScrollTo.mockClear();
+
+    await wrapper.find('[data-testid="trade-asset-search"]').setValue('agent');
+    await flushPromises();
+
+    expect(virtualScrollTo).toHaveBeenCalledWith(0);
+  });
+
+  it('should not scroll back to the top when the balances tick', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+    virtualScrollTo.mockClear();
+
+    // A balances refresh rebuilds the owned list into a new array with the same contents. Resetting
+    // the scroll on that would yank the list from under a user who was scrolling it.
+    set(allOwnedAssets, [...get(allOwnedAssets)]);
+    await flushPromises();
+
+    expect(virtualScrollTo).not.toHaveBeenCalled();
+  });
+
+  it('should hold one height whether the list is populated or empty', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    const populated = wrapper.find('[data-testid="trade-asset-option"]').element.parentElement?.parentElement;
+    assert(populated);
+    const populatedHeight = [...populated.classList].find(name => name.startsWith('h-['));
+
+    await wrapper.find('[data-testid="trade-asset-search"]').setValue('zzzznomatch');
+    await flushPromises();
+    const emptyHeight = [...wrapper.find('[data-testid="trade-asset-empty"]').element.classList]
+      .find(name => name.startsWith('h-['));
+
+    // A `max-h` would size the dialog to the result count, so it would grow and collapse on every
+    // keystroke. Both states must pin the same fixed height instead.
+    expect(populatedHeight).toBeDefined();
+    expect(emptyHeight).toBe(populatedHeight);
+    expect(populated.className).not.toContain('max-h-');
+  });
+
+  it('should close from the header button without painting it white on white', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    const close = wrapper.find('[data-testid="trade-asset-close"]');
+    // happy-dom computes no colours, so the guard is on the override that caused it: the icon sat
+    // on the card's white header with `text-white`, which made it invisible in light mode.
+    expect(close.html()).not.toContain('text-white');
+
+    await close.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.findAll('[data-testid="trade-asset-option"]')).toHaveLength(0);
+  });
+
+  it('should window the list rather than rendering every row', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    expect(virtualListArgs).toHaveBeenCalledWith(expect.objectContaining({ itemHeight: 56, overscan: 6 }));
+  });
+
+  it('should filter the options by the search box', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    await wrapper.find('[data-testid="trade-asset-search"]').setValue('agent');
+    await flushPromises();
+
+    expect(optionKeys(wrapper)).toEqual(['eip155:1/erc20:0xbbb']);
+  });
+
+  it('should show a search-specific empty message when nothing matches', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    await wrapper.find('[data-testid="trade-asset-search"]').setValue('zzzznomatch');
+    await flushPromises();
+
+    expect(optionKeys(wrapper)).toEqual([]);
+    expect(wrapper.find('[data-testid="trade-asset-empty"]').text()).toContain('no_search_results');
+  });
+
+  it('should show the no-assets message when the chain owns nothing', async () => {
+    set(allOwnedAssets, []);
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    expect(wrapper.find('[data-testid="trade-asset-empty"]').text()).toContain('no_assets_found');
+  });
+
+  it('should clear the search when the dialog closes', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+    await wrapper.find('[data-testid="trade-asset-search"]').setValue('agent');
+    await flushPromises();
+    expect(optionKeys(wrapper)).toHaveLength(1);
+
+    await wrapper.findAll('[data-testid="trade-asset-option"]')[0].trigger('click');
+    await flushPromises();
+    await openDialog(wrapper);
+
+    expect(optionKeys(wrapper)).toHaveLength(4);
+  });
+
+  it('should emit the picked asset and close the dialog', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    await wrapper.findAll('[data-testid="trade-asset-option"]')[1].trigger('click');
+    await flushPromises();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['eip155:1/erc20:0xbbb']);
+    expect(wrapper.findAll('[data-testid="trade-asset-option"]')).toHaveLength(0);
+  });
+
+  it('should list every supported chain and carry the chain across when "all" is picked', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+
+    await wrapper.find('[data-testid="chain-select"]').trigger('click');
+    await flushPromises();
+    expect(optionKeys(wrapper)).toHaveLength(5);
+
+    const optimism = wrapper.findAll('[data-testid="trade-asset-option"]')
+      .find(option => option.attributes('data-key') === 'OP');
+    assert(optimism);
+    await optimism.trigger('click');
+    await flushPromises();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['OP']);
+    expect(wrapper.emitted('update:chain')?.at(-1)).toEqual(['optimism']);
+  });
+
+  it('should clear the search box with the clear button', async () => {
+    const wrapper = createWrapper();
+    await openDialog(wrapper);
+    await wrapper.find('[data-testid="trade-asset-search"]').setValue('agent');
+    await flushPromises();
+
+    await wrapper.find('[data-testid="trade-asset-search-clear"]').trigger('click');
+    await flushPromises();
+
+    expect(optionKeys(wrapper)).toHaveLength(4);
+  });
+
+  it('should replace a selection that the chain does not own', async () => {
+    const wrapper = createWrapper({ chain: 'optimism', modelValue: 'ETH' });
+    await flushPromises();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['OP']);
+  });
+
+  it('should keep a selection the chain does own', async () => {
+    const wrapper = createWrapper({ chain: 'eth', modelValue: 'eip155:1/erc20:0xaaa' });
+    await flushPromises();
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  it('should not clear the selection when the chain owns nothing', async () => {
+    set(allOwnedAssets, [tradable('ETH', 'eth')]);
+    const wrapper = createWrapper({ chain: 'optimism', modelValue: 'ETH' });
+    await flushPromises();
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
+++ b/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
@@ -8,6 +8,7 @@ import { ActivityKind } from '@/modules/task-center/core/types';
 import { useTaskCenter } from '@/modules/task-center/use-task-center';
 import TradeAssetDisplay from '@/modules/wallet/send/TradeAssetDisplay.vue';
 import { useBalanceQueries } from '@/modules/wallet/send/use-balance-queries';
+import { ALL_CHAINS, useTradeAssetOptions } from '@/modules/wallet/send/use-trade-asset-options';
 import { useInjectedTradableAsset } from '@/modules/wallet/use-tradable-asset';
 import { useWalletStore } from '@/modules/wallet/use-wallet-store';
 
@@ -24,8 +25,13 @@ const emit = defineEmits<{
   'refresh': [];
 }>();
 
-const openDialog = ref(false);
+/** Row height in px, matching the padded two-line row below. The virtual list needs it up front. */
+const ITEM_HEIGHT = 56;
+
+const openDialog = ref<boolean>(false);
 const internalChain = ref<string>(Blockchain.ETH);
+const search = ref<string>('');
+const searchField = useTemplateRef<HTMLInputElement>('searchField');
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -40,25 +46,24 @@ const { useQueryingBalances } = useBalanceQueries(connected, connectedAddress);
 
 const assetDetail = getAssetDetail(asset, chain);
 
-const chainOptions = computed(() => [
-  'all',
+const chainOptions = computed<string[]>(() => [
+  ALL_CHAINS,
   ...get(supportedChainsForConnectedAccount),
 ]);
 
-const assetOptions = computed(() => {
-  const chain = get(internalChain);
-  const options = get(allOwnedAssets);
-  if (chain === 'all') {
-    return options.filter(item => get(supportedChainsForConnectedAccount).includes(item.chain));
-  }
-  return options.filter(item => item.chain === chain);
+const { options: assetOptions } = useTradeAssetOptions(
+  allOwnedAssets,
+  internalChain,
+  search,
+  supportedChainsForConnectedAccount,
+);
+
+const { containerProps, list, scrollTo, wrapperProps } = useVirtualList(assetOptions, {
+  itemHeight: ITEM_HEIGHT,
+  overscan: 6,
 });
 
-function getOwnedAssetsByChain(chain: string) {
-  return get(allOwnedAssets).filter(item => item.chain === chain);
-}
-
-async function selectAsset(item: TradableAsset) {
+function selectAsset(item: TradableAsset): void {
   set(chain, item.chain);
   set(asset, item.asset);
   set(openDialog, false);
@@ -68,36 +73,58 @@ function setMax() {
   emit('set-max');
 }
 
-watchImmediate([asset, chain, allOwnedAssets], ([currentAsset, chain]) => {
-  const ownedByChain = getOwnedAssetsByChain(chain);
-
-  if (ownedByChain.length > 0 && !ownedByChain.map(item => item.asset).includes(currentAsset)) {
-    set(asset, ownedByChain[0].asset || '');
-  }
-});
-
-watchImmediate([() => address, chain], ([_, currentChain]) => {
+/**
+ * Keeps the selection valid for the chain in play.
+ *
+ * This was two overlapping `watchImmediate` blocks that both assigned `asset`, one of which also
+ * assigned `chain` and so re-triggered the other. One watcher covers both cases: with a chain, hold
+ * the selection if it is still owned there and otherwise take the head of that chain's list; with
+ * no chain, take the head of the whole list, which is already ordered native-first.
+ */
+watchImmediate([() => address, chain, allOwnedAssets], ([, currentChain]) => {
   const owned = get(allOwnedAssets);
-  if (currentChain) {
-    const filteredByChain = owned.filter(item => item.chain === currentChain);
-    if (filteredByChain.length > 0) {
-      const currentAsset = get(asset);
-      if (!currentAsset || !filteredByChain.map(item => item.asset).includes(currentAsset)) {
-        set(asset, filteredByChain[0].asset);
-      }
+
+  if (!currentChain) {
+    const first = owned[0];
+    if (first) {
+      set(asset, first.asset);
+      set(chain, first.chain);
     }
     return;
   }
 
-  const mostBalance = owned[0];
-  if (mostBalance) {
-    set(asset, mostBalance.asset);
-    set(chain, mostBalance.chain);
+  const ownedOnChain = owned.filter(item => item.chain === currentChain);
+  if (ownedOnChain.length === 0)
+    return;
+
+  const currentAsset = get(asset);
+  if (!currentAsset || !ownedOnChain.some(item => item.asset === currentAsset)) {
+    set(asset, ownedOnChain[0].asset);
   }
 });
 
 watchImmediate(chain, (chainVal: string) => {
   set(internalChain, chainVal);
+});
+
+// A stale query would otherwise hide the list the next time the dialog opens.
+watch(openDialog, async (open) => {
+  if (!open) {
+    set(search, '');
+    return;
+  }
+  await nextTick();
+  get(searchField)?.focus();
+});
+
+// Narrowing the list should show its results from the top, since the virtual list keeps whatever
+// offset it was scrolled to.
+//
+// Watched on the inputs rather than on `assetOptions`: that computed rebuilds into a new array on
+// every balances tick, so watching it would yank the list back to the top while the user was
+// scrolling it.
+watch([search, internalChain], () => {
+  scrollTo(0);
 });
 
 const { detectTokens: orchestratorDetect } = useTokenDetectionOrchestrator();
@@ -159,16 +186,18 @@ function redetectTokens(): void {
       <template #header>
         {{ t('trade.select_asset.select_token') }}
       </template>
+      <!-- No colour override: `text-white` painted the icon white on the card's white header, so
+           the close button was invisible in light mode. The button's own colour handles both
+           themes. -->
       <RuiButton
         variant="text"
         class="absolute top-2 right-2"
         icon
+        :aria-label="t('common.actions.close')"
+        data-testid="trade-asset-close"
         @click="openDialog = false"
       >
-        <RuiIcon
-          class="text-white"
-          name="lu-x"
-        />
+        <RuiIcon name="lu-x" />
       </RuiButton>
       <div class="p-4 pb-4">
         <RuiAlert
@@ -206,25 +235,81 @@ function redetectTokens(): void {
             {{ t('account_balances.detect_tokens.tooltip.redetect') }}
           </RuiTooltip>
         </div>
+        <div class="flex items-center gap-2 mt-2 px-3 border rounded-md transition-colors border-default focus-within:border-rui-primary">
+          <RuiIcon
+            name="lu-search"
+            size="16"
+            class="text-rui-text-secondary shrink-0"
+            aria-hidden="true"
+          />
+          <input
+            ref="searchField"
+            v-model="search"
+            type="text"
+            class="flex-1 min-w-0 bg-transparent py-2 text-sm text-rui-text-primary outline-none placeholder:text-rui-text-secondary"
+            :placeholder="t('trade.select_asset.search')"
+            :aria-label="t('trade.select_asset.search')"
+            autocomplete="off"
+            spellcheck="false"
+            data-testid="trade-asset-search"
+          />
+          <RuiButton
+            v-if="search"
+            variant="text"
+            icon
+            size="sm"
+            class="!p-1 shrink-0"
+            :aria-label="t('common.actions.clear')"
+            data-testid="trade-asset-search-clear"
+            @click="search = ''"
+          >
+            <RuiIcon
+              name="lu-x"
+              size="14"
+            />
+          </RuiButton>
+        </div>
       </div>
+      <!-- Virtualized: a single chain can carry well over a hundred owned assets, and every row
+           mounts an icon plus its asset resolution. -->
+      <!-- A fixed height, not a max: the list is searched, and sizing to the result count makes the
+           dialog grow and collapse on every keystroke. Viewport-relative so it still fits a short
+           window, but never content-relative. -->
       <div
         v-if="assetOptions.length > 0"
-        class="flex flex-col max-h-[calc(100vh-400px)] overflow-auto pb-2"
+        v-bind="containerProps"
+        class="h-[min(24rem,50vh)] pb-2"
       >
-        <TradeAssetDisplay
-          v-for="item in assetOptions"
-          :key="item.asset + item.chain"
-          list
-          class="hover:bg-rui-grey-100 dark:hover:bg-rui-grey-800 cursor-pointer py-2 px-4"
-          :data="item"
-          @click="selectAsset(item)"
-        />
+        <div v-bind="wrapperProps">
+          <button
+            v-for="{ data: option } in list"
+            :key="option.asset.asset + option.asset.chain"
+            type="button"
+            class="w-full text-left hover:bg-rui-grey-100 dark:hover:bg-rui-grey-800 cursor-pointer py-2 px-4 focus-visible:outline-none focus-visible:bg-rui-grey-100 dark:focus-visible:bg-rui-grey-800"
+            :style="{ height: `${ITEM_HEIGHT}px` }"
+            data-testid="trade-asset-option"
+            :data-key="option.asset.asset"
+            @click="selectAsset(option.asset)"
+          >
+            <TradeAssetDisplay
+              list
+              :data="option.asset"
+              :symbol="option.symbol"
+              :name="option.name"
+            />
+          </button>
+        </div>
       </div>
+      <!-- Same height as the populated list, so searching down to nothing does not collapse the
+           dialog around the search box the user is still typing in. -->
       <div
         v-else
-        class="pb-4 px-4 text-rui-text-secondary"
+        class="h-[min(24rem,50vh)] px-4 flex items-center justify-center text-center text-rui-text-secondary"
+        role="status"
+        aria-live="polite"
+        data-testid="trade-asset-empty"
       >
-        {{ t('trade.select_asset.no_assets_found') }}
+        {{ search ? t('trade.select_asset.no_search_results', { query: search }) : t('trade.select_asset.no_assets_found') }}
       </div>
     </RuiCard>
   </RuiDialog>

--- a/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
+++ b/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
@@ -8,7 +8,8 @@ import { ActivityKind } from '@/modules/task-center/core/types';
 import { useTaskCenter } from '@/modules/task-center/use-task-center';
 import TradeAssetDisplay from '@/modules/wallet/send/TradeAssetDisplay.vue';
 import { useBalanceQueries } from '@/modules/wallet/send/use-balance-queries';
-import { ALL_CHAINS, useTradeAssetOptions } from '@/modules/wallet/send/use-trade-asset-options';
+import { useTradeAssetNavigation } from '@/modules/wallet/send/use-trade-asset-navigation';
+import { ALL_CHAINS, type TradeAssetOption, useTradeAssetOptions } from '@/modules/wallet/send/use-trade-asset-options';
 import { useInjectedTradableAsset } from '@/modules/wallet/use-tradable-asset';
 import { useWalletStore } from '@/modules/wallet/use-wallet-store';
 
@@ -51,11 +52,16 @@ const chainOptions = computed<string[]>(() => [
   ...get(supportedChainsForConnectedAccount),
 ]);
 
-const { options: assetOptions } = useTradeAssetOptions(
+// Latched rather than tracking `openDialog`: once the names are resolved they are cached, and
+// dropping back to identifier ordering on close would reshuffle the list between openings.
+const namesNeeded = ref<boolean>(false);
+
+const { options: assetOptions, orderedAssets } = useTradeAssetOptions(
   allOwnedAssets,
   internalChain,
   search,
   supportedChainsForConnectedAccount,
+  namesNeeded,
 );
 
 const { containerProps, list, scrollTo, wrapperProps } = useVirtualList(assetOptions, {
@@ -69,8 +75,30 @@ function selectAsset(item: TradableAsset): void {
   set(openDialog, false);
 }
 
+// How many the chain holds before the search box narrows it, so the count can read "12 of 836".
+const totalForChain = computed<number>(() => {
+  const selected = get(internalChain);
+  if (selected === ALL_CHAINS) {
+    const allowed = new Set(get(supportedChainsForConnectedAccount));
+    return get(orderedAssets).filter(option => allowed.has(option.asset.chain)).length;
+  }
+  return get(orderedAssets).filter(option => option.asset.chain === selected).length;
+});
+
+const { highlight, highlighted, onKeydown, onPointerMove } = useTradeAssetNavigation(assetOptions, {
+  onClose: () => set(openDialog, false),
+  onSelect: (option: TradeAssetOption) => selectAsset(option.asset),
+  scrollTo,
+});
+
 function setMax() {
   emit('set-max');
+}
+
+// Both halves, not just the identifier: a native token id is shared across chains, so comparing on
+// the identifier alone ticks the ETH row of every chain at once.
+function isSelected(option: TradeAssetOption): boolean {
+  return option.asset.asset === get(asset) && option.asset.chain === get(chain);
 }
 
 /**
@@ -81,25 +109,28 @@ function setMax() {
  * the selection if it is still owned there and otherwise take the head of that chain's list; with
  * no chain, take the head of the whole list, which is already ordered native-first.
  */
-watchImmediate([() => address, chain, allOwnedAssets], ([, currentChain]) => {
-  const owned = get(allOwnedAssets);
+watchImmediate([() => address, chain, orderedAssets], ([, currentChain]) => {
+  // Drawn from the display order, not from the raw owned list: picking the default off a different
+  // ordering than the dialog shows meant the form opened on an asset nowhere near the top of the
+  // list the user then saw.
+  const owned = get(orderedAssets);
 
   if (!currentChain) {
     const first = owned[0];
     if (first) {
-      set(asset, first.asset);
-      set(chain, first.chain);
+      set(asset, first.asset.asset);
+      set(chain, first.asset.chain);
     }
     return;
   }
 
-  const ownedOnChain = owned.filter(item => item.chain === currentChain);
+  const ownedOnChain = owned.filter(option => option.asset.chain === currentChain);
   if (ownedOnChain.length === 0)
     return;
 
   const currentAsset = get(asset);
-  if (!currentAsset || !ownedOnChain.some(item => item.asset === currentAsset)) {
-    set(asset, ownedOnChain[0].asset);
+  if (!currentAsset || !ownedOnChain.some(option => option.asset.asset === currentAsset)) {
+    set(asset, ownedOnChain[0].asset.asset);
   }
 });
 
@@ -113,18 +144,12 @@ watch(openDialog, async (open) => {
     set(search, '');
     return;
   }
+  set(namesNeeded, true);
   await nextTick();
   get(searchField)?.focus();
-});
-
-// Narrowing the list should show its results from the top, since the virtual list keeps whatever
-// offset it was scrolled to.
-//
-// Watched on the inputs rather than on `assetOptions`: that computed rebuilds into a new array on
-// every balances tick, so watching it would yank the list back to the top while the user was
-// scrolling it.
-watch([search, internalChain], () => {
-  scrollTo(0);
+  // Opens on what is currently selected rather than at the top, so the active asset is both visible
+  // and the row Enter would commit.
+  highlight(get(asset), get(chain));
 });
 
 const { detectTokens: orchestratorDetect } = useTokenDetectionOrchestrator();
@@ -251,7 +276,12 @@ function redetectTokens(): void {
             :aria-label="t('trade.select_asset.search')"
             autocomplete="off"
             spellcheck="false"
+            role="combobox"
+            aria-controls="trade-asset-listbox"
+            :aria-expanded="assetOptions.length > 0"
+            :aria-activedescendant="assetOptions.length > 0 ? `trade-asset-option-${highlighted}` : undefined"
             data-testid="trade-asset-search"
+            @keydown="onKeydown($event)"
           />
           <RuiButton
             v-if="search"
@@ -269,6 +299,16 @@ function redetectTokens(): void {
             />
           </RuiButton>
         </div>
+        <!-- The list is a fixed height, so how much sits below the fold is not otherwise visible. -->
+        <div
+          class="mt-2 text-xs text-rui-text-secondary"
+          aria-live="polite"
+          data-testid="trade-asset-count"
+        >
+          {{ search
+            ? t('trade.select_asset.result_count', { count: assetOptions.length, total: totalForChain })
+            : t('trade.select_asset.asset_count', { count: assetOptions.length }, assetOptions.length) }}
+        </div>
       </div>
       <!-- Virtualized: a single chain can carry well over a hundred owned assets, and every row
            mounts an icon plus its asset resolution. -->
@@ -278,17 +318,27 @@ function redetectTokens(): void {
       <div
         v-if="assetOptions.length > 0"
         v-bind="containerProps"
+        id="trade-asset-listbox"
+        role="listbox"
         class="h-[min(24rem,50vh)] pb-2"
       >
         <div v-bind="wrapperProps">
           <button
-            v-for="{ data: option } in list"
+            v-for="{ data: option, index } in list"
+            :id="`trade-asset-option-${index}`"
             :key="option.asset.asset + option.asset.chain"
             type="button"
-            class="w-full text-left hover:bg-rui-grey-100 dark:hover:bg-rui-grey-800 cursor-pointer py-2 px-4 focus-visible:outline-none focus-visible:bg-rui-grey-100 dark:focus-visible:bg-rui-grey-800"
+            role="option"
+            class="w-full text-left cursor-pointer py-2 px-4 focus-visible:outline-none"
+            :class="index === highlighted
+              ? 'bg-rui-primary/10'
+              : 'hover:bg-rui-grey-100 dark:hover:bg-rui-grey-800'"
             :style="{ height: `${ITEM_HEIGHT}px` }"
+            :aria-selected="isSelected(option)"
             data-testid="trade-asset-option"
             :data-key="option.asset.asset"
+            :data-chain="option.asset.chain"
+            @mousemove="onPointerMove($event, index)"
             @click="selectAsset(option.asset)"
           >
             <TradeAssetDisplay
@@ -296,14 +346,19 @@ function redetectTokens(): void {
               :data="option.asset"
               :symbol="option.symbol"
               :name="option.name"
+              :address="option.ambiguous ? option.address : ''"
+              :selected="isSelected(option)"
             />
           </button>
         </div>
       </div>
       <!-- Same height as the populated list, so searching down to nothing does not collapse the
            dialog around the search box the user is still typing in. -->
+      <!-- Keeps the id the search field's aria-controls names, so it does not dangle when the list
+           is empty. -->
       <div
         v-else
+        id="trade-asset-listbox"
         class="h-[min(24rem,50vh)] px-4 flex items-center justify-center text-center text-rui-text-secondary"
         role="status"
         aria-live="polite"

--- a/frontend/app/src/modules/wallet/send/use-trade-asset-navigation.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-asset-navigation.spec.ts
@@ -1,0 +1,260 @@
+import type { TradeAssetOption } from '@/modules/wallet/send/use-trade-asset-options';
+import { bigNumberify } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTradeAssetNavigation } from './use-trade-asset-navigation';
+
+function option(identifier: string, chain = 'eth'): TradeAssetOption {
+  return {
+    address: '',
+    ambiguous: false,
+    asset: { amount: bigNumberify(1), asset: identifier, chain },
+    name: identifier,
+    symbol: identifier,
+  };
+}
+
+// `isComposing` is set explicitly: createMock proxies unknown properties to auto-stubs, which are
+// truthy, so leaving it out makes every key look like it arrived mid-IME-composition.
+function key(name: string): KeyboardEvent {
+  return createMock<KeyboardEvent>({ isComposing: false, key: name, preventDefault: vi.fn() });
+}
+
+function move(clientX: number, clientY: number): MouseEvent {
+  return createMock<MouseEvent>({ clientX, clientY });
+}
+
+describe('useTradeAssetNavigation', () => {
+  const onSelect = vi.fn();
+  const onClose = vi.fn();
+  const scrollTo = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should start on the first row', () => {
+    const { highlighted } = useTradeAssetNavigation([option('A'), option('B')], { onClose, onSelect, scrollTo });
+
+    expect(get(highlighted)).toBe(0);
+  });
+
+  it('should move down and scroll the highlighted row into view', () => {
+    const { highlighted, onKeydown } = useTradeAssetNavigation(
+      [option('A'), option('B'), option('C')],
+      { onClose, onSelect, scrollTo },
+    );
+
+    onKeydown(key('ArrowDown'));
+
+    expect(get(highlighted)).toBe(1);
+    // Virtualized, so moving the highlight without scrolling would point at an off-screen row.
+    expect(scrollTo).toHaveBeenCalledWith(1);
+  });
+
+  it('should wrap from the last row to the first', () => {
+    const { highlighted, onKeydown } = useTradeAssetNavigation(
+      [option('A'), option('B')],
+      { onClose, onSelect, scrollTo },
+    );
+
+    onKeydown(key('ArrowDown'));
+    onKeydown(key('ArrowDown'));
+
+    expect(get(highlighted)).toBe(0);
+  });
+
+  it('should wrap backwards from the first row to the last', () => {
+    const { highlighted, onKeydown } = useTradeAssetNavigation(
+      [option('A'), option('B'), option('C')],
+      { onClose, onSelect, scrollTo },
+    );
+
+    onKeydown(key('ArrowUp'));
+
+    expect(get(highlighted)).toBe(2);
+  });
+
+  it('should commit the highlighted row on enter', () => {
+    const items = [option('A'), option('B')];
+    const { onKeydown } = useTradeAssetNavigation(items, { onClose, onSelect, scrollTo });
+
+    onKeydown(key('ArrowDown'));
+    onKeydown(key('Enter'));
+
+    expect(onSelect).toHaveBeenCalledWith(items[1]);
+  });
+
+  it('should close on escape', () => {
+    const { onKeydown } = useTradeAssetNavigation([option('A')], { onClose, onSelect, scrollTo });
+
+    onKeydown(key('Escape'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should close on escape even with nothing to pick', () => {
+    const { onKeydown } = useTradeAssetNavigation([], { onClose, onSelect, scrollTo });
+
+    onKeydown(key('Escape'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('should do nothing on enter when the list is empty', () => {
+    const { onKeydown } = useTradeAssetNavigation([], { onClose, onSelect, scrollTo });
+
+    onKeydown(key('Enter'));
+    onKeydown(key('ArrowDown'));
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('should highlight a given identifier and scroll to it', () => {
+    const { highlight, highlighted } = useTradeAssetNavigation(
+      [option('A'), option('B'), option('C')],
+      { onClose, onSelect, scrollTo },
+    );
+
+    highlight('C', 'eth');
+
+    expect(get(highlighted)).toBe(2);
+    expect(scrollTo).toHaveBeenCalledWith(2);
+  });
+
+  it('should match the highlighted row on chain as well as identifier', () => {
+    // A native token id is shared across chains: ETH is native to ethereum, optimism and base
+    // alike, so matching on the identifier alone lands on the wrong row and enter would commit a
+    // different network than the one shown.
+    const { highlight, highlighted } = useTradeAssetNavigation(
+      [option('ETH', 'eth'), option('USDC', 'eth'), option('ETH', 'base')],
+      { onClose, onSelect, scrollTo },
+    );
+
+    highlight('ETH', 'base');
+
+    expect(get(highlighted)).toBe(2);
+  });
+
+  it('should fall back to the first row for an identifier not in the list', () => {
+    const { highlight, highlighted } = useTradeAssetNavigation(
+      [option('A'), option('B')],
+      { onClose, onSelect, scrollTo },
+    );
+
+    highlight('NOT_THERE', 'eth');
+
+    expect(get(highlighted)).toBe(0);
+  });
+
+  it('should follow the pointer to a hovered row without scrolling', () => {
+    const { highlighted, onPointerMove } = useTradeAssetNavigation(
+      [option('A'), option('B'), option('C')],
+      { onClose, onSelect, scrollTo },
+    );
+
+    onPointerMove(move(10, 10), 2);
+
+    expect(get(highlighted)).toBe(2);
+    // The row is already under the cursor; scrolling to it would shift the list out from under it.
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('should ignore a pointer move on a row index outside the list', () => {
+    const { highlighted, onPointerMove } = useTradeAssetNavigation(
+      [option('A'), option('B')],
+      { onClose, onSelect, scrollTo },
+    );
+
+    onPointerMove(move(10, 10), 7);
+
+    expect(get(highlighted)).toBe(0);
+  });
+
+  it('should ignore a row that slid under a still cursor', () => {
+    const { highlighted, onKeydown, onPointerMove } = useTradeAssetNavigation(
+      [option('A'), option('B'), option('C')],
+      { onClose, onSelect, scrollTo },
+    );
+
+    onPointerMove(move(10, 10), 0);
+    onKeydown(key('ArrowDown'));
+    expect(get(highlighted)).toBe(1);
+
+    // Arrow keys scrolled the list, so a different row arrived under a cursor that never moved.
+    // The browser reports that as a mousemove at the same coordinates.
+    onPointerMove(move(10, 10), 2);
+
+    expect(get(highlighted)).toBe(1);
+  });
+
+  it('should let the keyboard walk the list without the pointer stealing it back', () => {
+    const { highlighted, onKeydown, onPointerMove } = useTradeAssetNavigation(
+      [option('A'), option('B'), option('C'), option('D'), option('E')],
+      { onClose, onSelect, scrollTo },
+    );
+    onPointerMove(move(10, 10), 0);
+
+    // The cursor never moves, so each keyboard step scrolls a row that is NOT the one being
+    // highlighted under it. Hovering the same row the key just moved to would agree with the
+    // buggy behaviour and the test could not fail.
+    for (const slidUnderCursor of [2, 3, 4]) {
+      onKeydown(key('ArrowDown'));
+      onPointerMove(move(10, 10), slidUnderCursor);
+    }
+
+    expect(get(highlighted)).toBe(3);
+  });
+
+  it('should hand control back once the pointer genuinely moves', () => {
+    const { highlighted, onKeydown, onPointerMove } = useTradeAssetNavigation(
+      [option('A'), option('B'), option('C')],
+      { onClose, onSelect, scrollTo },
+    );
+    onPointerMove(move(10, 10), 0);
+    onKeydown(key('ArrowDown'));
+
+    onPointerMove(move(10, 40), 2);
+
+    expect(get(highlighted)).toBe(2);
+  });
+
+  it('should ignore keys while an IME is composing', () => {
+    const items = [option('A'), option('B')];
+    const { highlighted, onKeydown } = useTradeAssetNavigation(items, { onClose, onSelect, scrollTo });
+
+    // Confirming a candidate sends Enter, and the candidate list is walked with the arrows. Acting
+    // on either would commit a row and close the dialog mid-word.
+    onKeydown(createMock<KeyboardEvent>({ isComposing: true, key: 'ArrowDown', preventDefault: vi.fn() }));
+    onKeydown(createMock<KeyboardEvent>({ isComposing: true, key: 'Enter', preventDefault: vi.fn() }));
+
+    expect(get(highlighted)).toBe(0);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('should reset to the first result when the list contents change', async () => {
+    const items = ref<TradeAssetOption[]>([option('A'), option('B'), option('C')]);
+    const { highlighted, onKeydown } = useTradeAssetNavigation(items, { onClose, onSelect, scrollTo });
+    onKeydown(key('ArrowDown'));
+    expect(get(highlighted)).toBe(1);
+
+    set(items, [option('B')]);
+    await nextTick();
+
+    expect(get(highlighted)).toBe(0);
+  });
+
+  it('should hold the highlight when the list is reordered but holds the same options', async () => {
+    const items = ref<TradeAssetOption[]>([option('A'), option('B'), option('C')]);
+    const { highlighted, onKeydown } = useTradeAssetNavigation(items, { onClose, onSelect, scrollTo });
+    onKeydown(key('ArrowDown'));
+    scrollTo.mockClear();
+
+    // A balances tick rebuilds the array. Same contents, so the highlight must not jump.
+    set(items, [option('C'), option('A'), option('B')]);
+    await nextTick();
+
+    expect(get(highlighted)).toBe(1);
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/wallet/send/use-trade-asset-navigation.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-asset-navigation.ts
@@ -1,0 +1,122 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { TradeAssetOption } from '@/modules/wallet/send/use-trade-asset-options';
+
+interface UseTradeAssetNavigationOptions {
+  /** Called when the highlighted option is committed with Enter. */
+  onSelect: (option: TradeAssetOption) => void;
+  /** Called on Escape, so the dialog can close from the search field. */
+  onClose: () => void;
+  /** Brings an index into view; the list is virtualized, so moving the highlight is not enough. */
+  scrollTo: (index: number) => void;
+}
+
+interface UseTradeAssetNavigationReturn {
+  highlighted: Readonly<Ref<number>>;
+  onKeydown: (event: KeyboardEvent) => void;
+  /** Puts the highlight on a given row, or on the first one when it is not in the list. */
+  highlight: (identifier: string, chain: string) => void;
+  /** Moves the highlight to the hovered row, ignoring rows that slid under a still cursor. */
+  onPointerMove: (event: MouseEvent, index: number) => void;
+}
+
+/**
+ * Arrow-key and Enter handling for the token dialog's search field.
+ *
+ * The list is virtualized, so every highlight move has to scroll as well: leaving the offset where
+ * it was would highlight a row that is nowhere on screen.
+ */
+export function useTradeAssetNavigation(
+  options: MaybeRefOrGetter<TradeAssetOption[]>,
+  { onClose, onSelect, scrollTo }: UseTradeAssetNavigationOptions,
+): UseTradeAssetNavigationReturn {
+  const highlighted = shallowRef<number>(0);
+
+  // Matched on asset AND chain. A native token id is shared across chains (ETH is the native asset
+  // of ethereum, optimism, base and more), so with the chain filter on "all" the identifier alone
+  // matches the wrong row and Enter would commit a different network than the one shown.
+  function highlight(identifier: string, chain: string): void {
+    const index = toValue(options)
+      .findIndex(option => option.asset.asset === identifier && option.asset.chain === chain);
+    const target = index >= 0 ? index : 0;
+    set(highlighted, target);
+    scrollTo(target);
+  }
+
+  // Last position the pointer was actually at.
+  //
+  // Any scroll slides rows under a cursor that never moved, and the browser reports that as a
+  // mousemove at unchanged coordinates. Taking it at face value breaks both ways of scrolling:
+  // arrow keys cannot move more than one row, because the row arriving under the pointer hands the
+  // highlight straight back, and a wheel scroll drags the highlight along with it.
+  let lastX = Number.NaN;
+  let lastY = Number.NaN;
+
+  // Takes the row's index rather than its identifier: the template already knows which row it is,
+  // and a native token id is not unique across chains.
+  function onPointerMove(event: MouseEvent, index: number): void {
+    if (event.clientX === lastX && event.clientY === lastY)
+      return;
+
+    lastX = event.clientX;
+    lastY = event.clientY;
+
+    // No scrolling: the row is already under the cursor, and scrolling to it would shift the list
+    // out from under the pointer.
+    if (index >= 0 && index < toValue(options).length)
+      set(highlighted, index);
+  }
+
+  // Which options the list holds, order-independent: picking a value can reorder the list without
+  // changing its contents, and that must not count as a new list or the highlight jumps off the row
+  // the user was on.
+  const identifiers = computed<string>(() =>
+    [...toValue(options).map(option => option.asset.asset)].sort().join(','));
+
+  // A search that returns something different should highlight its first result, not keep an index
+  // pointing into the previous list.
+  watch(identifiers, () => {
+    set(highlighted, 0);
+    scrollTo(0);
+  });
+
+  function move(delta: number): void {
+    const items = toValue(options);
+    if (items.length === 0)
+      return;
+    const next = (get(highlighted) + delta + items.length) % items.length;
+    set(highlighted, next);
+    scrollTo(next);
+  }
+
+  function onKeydown(event: KeyboardEvent): void {
+    // Escape is handled here rather than left to the dialog: the search field holds focus, and an
+    // empty list has to be dismissable too, so this cannot sit behind the row check.
+    if (event.key === 'Escape') {
+      onClose();
+      return;
+    }
+
+    // While an IME is composing, Enter confirms the candidate and the arrows walk the candidate
+    // list. Acting on them would commit a row and close the dialog mid-word.
+    if (event.isComposing)
+      return;
+
+    const items = toValue(options);
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      move(1);
+    }
+    else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      move(-1);
+    }
+    else if (event.key === 'Enter') {
+      event.preventDefault();
+      const option = items[get(highlighted)];
+      if (option)
+        onSelect(option);
+    }
+  }
+
+  return { highlight, highlighted: readonly(highlighted), onKeydown, onPointerMove };
+}

--- a/frontend/app/src/modules/wallet/send/use-trade-asset-options.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-asset-options.spec.ts
@@ -1,0 +1,156 @@
+import type { TradableAsset } from '@/modules/wallet/types';
+import { bigNumberify } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ALL_CHAINS, useTradeAssetOptions } from './use-trade-asset-options';
+
+const getAssetField = vi.fn<(identifier: string, field: string) => string>();
+const getNativeAsset = vi.fn<(chain: string) => string>();
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: vi.fn(() => ({ getAssetField })),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn(() => ({ getNativeAsset })),
+}));
+
+const NAMES: Record<string, { symbol: string; name: string }> = {
+  'ETH': { name: 'Ethereum', symbol: 'ETH' },
+  'eip155:1/erc20:0xaaa': { name: 'Zeus Finance', symbol: 'ZEU' },
+  'eip155:1/erc20:0xbbb': { name: 'AgentX', symbol: 'AGE' },
+  'eip155:1/erc20:0xccc': { name: 'TrueUSD', symbol: 'TUSD' },
+  'eip155:10/erc20:0xddd': { name: 'Optimism Token', symbol: 'OPT' },
+};
+
+function asset(identifier: string, chain: string, fiatValue?: string): TradableAsset {
+  return {
+    amount: bigNumberify(1),
+    asset: identifier,
+    chain,
+    fiatValue: fiatValue ? bigNumberify(fiatValue) : undefined,
+  };
+}
+
+describe('useTradeAssetOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getNativeAsset.mockImplementation((chain: string) => (chain === 'eth' ? 'ETH' : 'OP'));
+    getAssetField.mockImplementation((identifier: string, field: string) => {
+      const entry = NAMES[identifier];
+      if (!entry)
+        return '';
+      return field === 'symbol' ? entry.symbol : entry.name;
+    });
+  });
+
+  it('should order an unpriced list alphabetically by symbol, native first', () => {
+    const assets = [
+      asset('eip155:1/erc20:0xaaa', 'eth'),
+      asset('eip155:1/erc20:0xbbb', 'eth'),
+      asset('ETH', 'eth'),
+      asset('eip155:1/erc20:0xccc', 'eth'),
+    ];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth']);
+
+    expect(get(options).map(option => option.symbol)).toEqual(['ETH', 'AGE', 'TUSD', 'ZEU']);
+  });
+
+  it('should keep fiat value ahead of the symbol ordering', () => {
+    const assets = [
+      asset('eip155:1/erc20:0xbbb', 'eth', '5'),
+      asset('eip155:1/erc20:0xccc', 'eth', '100'),
+      asset('eip155:1/erc20:0xaaa', 'eth', '50'),
+    ];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth']);
+
+    expect(get(options).map(option => option.symbol)).toEqual(['TUSD', 'ZEU', 'AGE']);
+  });
+
+  it('should fall back to the identifier when a symbol has not resolved yet', () => {
+    getAssetField.mockReturnValue('');
+    const assets = [asset('eip155:1/erc20:0xbbb', 'eth'), asset('eip155:1/erc20:0xaaa', 'eth')];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth']);
+
+    expect(get(options).map(option => option.asset.asset)).toEqual([
+      'eip155:1/erc20:0xaaa',
+      'eip155:1/erc20:0xbbb',
+    ]);
+  });
+
+  it('should narrow to the selected chain', () => {
+    const assets = [asset('ETH', 'eth'), asset('eip155:10/erc20:0xddd', 'optimism')];
+
+    const { options } = useTradeAssetOptions(assets, 'optimism', '', ['eth', 'optimism']);
+
+    expect(get(options).map(option => option.symbol)).toEqual(['OPT']);
+  });
+
+  it('should keep every supported chain when the chain is "all"', () => {
+    const assets = [
+      asset('ETH', 'eth'),
+      asset('eip155:10/erc20:0xddd', 'optimism'),
+      asset('eip155:1/erc20:0xaaa', 'gnosis'),
+    ];
+
+    const { options } = useTradeAssetOptions(assets, ALL_CHAINS, '', ['eth', 'optimism']);
+
+    expect(get(options).map(option => option.symbol)).toEqual(['ETH', 'OPT']);
+  });
+
+  it('should match the search against the symbol', () => {
+    const assets = [asset('eip155:1/erc20:0xccc', 'eth'), asset('eip155:1/erc20:0xbbb', 'eth')];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', 'tus', ['eth']);
+
+    expect(get(options).map(option => option.symbol)).toEqual(['TUSD']);
+  });
+
+  it('should match the search against the name, case insensitively', () => {
+    const assets = [asset('eip155:1/erc20:0xaaa', 'eth'), asset('eip155:1/erc20:0xbbb', 'eth')];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', 'ZEUS fin', ['eth']);
+
+    expect(get(options).map(option => option.symbol)).toEqual(['ZEU']);
+  });
+
+  it('should match the search against the identifier so an address finds its token', () => {
+    const assets = [asset('eip155:1/erc20:0xaaa', 'eth'), asset('eip155:1/erc20:0xbbb', 'eth')];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '0xBBB', ['eth']);
+
+    expect(get(options).map(option => option.symbol)).toEqual(['AGE']);
+  });
+
+  it('should return an empty list when nothing matches the search', () => {
+    const assets = [asset('eip155:1/erc20:0xaaa', 'eth')];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', 'nothingmatchesthis', ['eth']);
+
+    expect(get(options)).toEqual([]);
+  });
+
+  it('should resolve each asset once rather than once per field read', () => {
+    const assets = [asset('ETH', 'eth'), asset('eip155:1/erc20:0xaaa', 'eth')];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth']);
+    get(options);
+    get(options);
+
+    // two assets, symbol + name each, and the computed is cached across reads
+    expect(getAssetField).toHaveBeenCalledTimes(4);
+  });
+
+  it('should react to the search changing', () => {
+    const search = ref<string>('');
+    const assets = [asset('eip155:1/erc20:0xccc', 'eth'), asset('eip155:1/erc20:0xbbb', 'eth')];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', search, ['eth']);
+    expect(get(options)).toHaveLength(2);
+
+    set(search, 'age');
+    expect(get(options).map(option => option.symbol)).toEqual(['AGE']);
+  });
+});

--- a/frontend/app/src/modules/wallet/send/use-trade-asset-options.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-asset-options.spec.ts
@@ -143,6 +143,111 @@ describe('useTradeAssetOptions', () => {
     expect(getAssetField).toHaveBeenCalledTimes(4);
   });
 
+  it('should drop collectibles, which this form cannot send', () => {
+    const assets = [
+      asset('ETH', 'eth'),
+      asset('eip155:1/erc721:0xC0a302e6Ad8EcCC4d7A6c1514F8671D6B79269c7/104', 'eth'),
+      asset('eip155:1/erc1155:0xC0a302e6Ad8EcCC4d7A6c1514F8671D6B79269c7/7', 'eth'),
+      asset('_nft_0xC0a302e6Ad8EcCC4d7A6c1514F8671D6B79269c7_104', 'eth'),
+    ];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth']);
+
+    expect(get(options).map(option => option.asset.asset)).toEqual(['ETH']);
+  });
+
+  it('should flag a symbol that another row on the chain also uses', () => {
+    getAssetField.mockImplementation((_identifier: string, field: string) =>
+      field === 'symbol' ? 'ASK' : 'GoAsk');
+    const assets = [
+      asset('eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', 'eth'),
+      asset('eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F', 'eth'),
+    ];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth']);
+
+    const flagged = get(options);
+    expect(flagged.every(option => option.ambiguous)).toBe(true);
+    expect(flagged.map(option => option.address)).toEqual(['0x1f98…F984', '0x6B17…1d0F']);
+  });
+
+  it('should not flag a symbol that is unique on the chain', () => {
+    const assets = [asset('eip155:1/erc20:0xaaa', 'eth'), asset('eip155:1/erc20:0xbbb', 'eth')];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth']);
+
+    expect(get(options).every(option => !option.ambiguous)).toBe(true);
+  });
+
+  it('should judge ambiguity per chain rather than across the whole holding', () => {
+    getAssetField.mockImplementation((_identifier: string, field: string) =>
+      field === 'symbol' ? 'USDC' : 'USD Coin');
+    const assets = [
+      asset('eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', 'eth'),
+      asset('eip155:10/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F', 'optimism'),
+    ];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth', 'optimism']);
+
+    // One USDC on this chain: the other lives on optimism and is not on screen beside it.
+    expect(get(options).every(option => !option.ambiguous)).toBe(true);
+  });
+
+  it('should not flag unresolved assets as sharing a symbol', () => {
+    // Everything is unresolved on first open, so every symbol is ''. Counting those together would
+    // mark the whole list ambiguous and print an address beside a blank symbol on every row.
+    getAssetField.mockReturnValue('');
+    const assets = [
+      asset('eip155:1/erc20:0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984', 'eth'),
+      asset('eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F', 'eth'),
+    ];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth']);
+
+    expect(get(options).every(option => !option.ambiguous)).toBe(true);
+  });
+
+  it('should resolve nothing until the caller opens the gate', () => {
+    const assets = [asset('ETH', 'eth'), asset('eip155:1/erc20:0xaaa', 'eth')];
+    const resolveNames = ref<boolean>(false);
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth'], resolveNames);
+    expect(get(options)).toHaveLength(2);
+    // getAssetField resolves through a cache that queues a backend fetch for anything it lacks, so
+    // touching it before the dialog opens costs a mapping request for the whole holding.
+    expect(getAssetField).not.toHaveBeenCalled();
+    expect(get(options).every(option => option.symbol === '')).toBe(true);
+
+    set(resolveNames, true);
+
+    // Read first: the computed is lazy, so asserting before touching it would only prove that
+    // nothing had re-evaluated yet.
+    expect(get(options)[0].symbol).toBe('ETH');
+    expect(getAssetField).toHaveBeenCalled();
+  });
+
+  it('should still order without symbols while the gate is closed', () => {
+    const assets = [asset('eip155:1/erc20:0xbbb', 'eth'), asset('ETH', 'eth')];
+
+    const { options } = useTradeAssetOptions(assets, 'eth', '', ['eth'], false);
+
+    // Native first still holds; the rest falls back to the identifier, which needs no resolution.
+    expect(get(options).map(option => option.asset.asset)).toEqual(['ETH', 'eip155:1/erc20:0xbbb']);
+  });
+
+  it('should expose the full ordered list unnarrowed by chain or search', () => {
+    const assets = [
+      asset('eip155:10/erc20:0xddd', 'optimism'),
+      asset('ETH', 'eth'),
+      asset('eip155:1/erc20:0xaaa', 'eth'),
+    ];
+
+    const { orderedAssets } = useTradeAssetOptions(assets, 'eth', 'tus', ['eth']);
+
+    expect(get(orderedAssets)).toHaveLength(3);
+    expect(get(orderedAssets)[0].asset.asset).toBe('ETH');
+  });
+
   it('should react to the search changing', () => {
     const search = ref<string>('');
     const assets = [asset('eip155:1/erc20:0xccc', 'eth'), asset('eip155:1/erc20:0xbbb', 'eth')];

--- a/frontend/app/src/modules/wallet/send/use-trade-asset-options.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-asset-options.ts
@@ -1,6 +1,7 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { TradableAsset } from '@/modules/wallet/types';
-import { Zero } from '@rotki/common';
+import { getAddressFromEvmIdentifier, isEvmIdentifier, Zero } from '@rotki/common';
+import { isNft } from '@/modules/assets/nft-utils';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { sortDesc } from '@/modules/core/common/data/bignumbers';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -9,17 +10,39 @@ import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
  * A tradable asset with its symbol and name resolved once, so the row that renders it does not
  * have to resolve them itself.
  */
-interface TradeAssetOption {
+export interface TradeAssetOption {
   asset: TradableAsset;
   symbol: string;
   name: string;
+  /** True when another option on the same chain shows the same symbol. */
+  ambiguous: boolean;
+  /** Shortened contract address, used to tell ambiguous rows apart. */
+  address: string;
 }
 
 interface UseTradeAssetOptionsReturn {
+  /** Every tradable option, display-ordered. Drives the default selection. */
+  orderedAssets: ComputedRef<TradeAssetOption[]>;
+  /** `orderedAssets` narrowed to the chain and the search box. Drives the list. */
   options: ComputedRef<TradeAssetOption[]>;
 }
 
 export const ALL_CHAINS = 'all';
+
+/**
+ * Collectibles cannot be sent through this form, which moves a fungible amount. The legacy `_nft_`
+ * identifiers and the CAIP `eip155:1/erc721:0x…/123` form are both in circulation.
+ */
+function isCollectible(identifier: string): boolean {
+  return isNft(identifier) || identifier.includes('/erc721:') || identifier.includes('/erc1155:');
+}
+
+function shortenAddress(identifier: string): string {
+  if (!isEvmIdentifier(identifier))
+    return '';
+  const address = getAddressFromEvmIdentifier(identifier);
+  return address ? `${address.slice(0, 6)}…${address.slice(-4)}` : '';
+}
 
 /**
  * Builds the option list the send form's token dialog shows: the owned assets narrowed to a chain,
@@ -34,24 +57,17 @@ export function useTradeAssetOptions(
   chain: MaybeRefOrGetter<string>,
   search: MaybeRefOrGetter<string>,
   supportedChains: MaybeRefOrGetter<string[]>,
+  /**
+   * Gate on resolving symbols and names. `getAssetField` resolves through the asset info cache,
+   * which **queues a backend fetch for anything it does not hold**, so reading this list eagerly
+   * would fire a mapping request for the user's entire holding as soon as the send form mounts,
+   * whether or not the token dialog is ever opened. The caller opens the gate when the dialog
+   * first opens; until then the list orders by identifier, which needs no resolution.
+   */
+  resolveNames: MaybeRefOrGetter<boolean> = true,
 ): UseTradeAssetOptionsReturn {
   const { getAssetField } = useAssetInfoRetrieval();
   const { getNativeAsset } = useSupportedChains();
-
-  const resolved = computed<TradeAssetOption[]>(() => toValue(assets).map(asset => ({
-    asset,
-    name: getAssetField(asset.asset, 'name', { collectionParent: false }),
-    symbol: getAssetField(asset.asset, 'symbol', { collectionParent: false }),
-  })));
-
-  const byChain = computed<TradeAssetOption[]>(() => {
-    const selected = toValue(chain);
-    if (selected === ALL_CHAINS) {
-      const allowed = new Set(toValue(supportedChains));
-      return get(resolved).filter(option => allowed.has(option.asset.chain));
-    }
-    return get(resolved).filter(option => option.asset.chain === selected);
-  });
 
   /**
    * The chain's native asset first, then by fiat value, then alphabetically by symbol.
@@ -76,19 +92,57 @@ export function useTradeAssetOptions(
     return (a.symbol || a.asset.asset).localeCompare(b.symbol || b.asset.asset);
   }
 
-  const options = computed<TradeAssetOption[]>(() => {
-    const query = toValue(search).trim().toLowerCase();
-    const matching = query
-      ? get(byChain).filter(option =>
-          option.symbol.toLowerCase().includes(query)
-          || option.name.toLowerCase().includes(query)
-          // Matched too, so pasting a contract address finds its token.
-          || option.asset.asset.toLowerCase().includes(query),
-        )
-      : get(byChain);
-
-    return [...matching].sort(compareForDisplay);
+  const orderedAssets = computed<TradeAssetOption[]>(() => {
+    const resolve = toValue(resolveNames);
+    return toValue(assets)
+      .filter(asset => !isCollectible(asset.asset))
+      .map(asset => ({
+        address: shortenAddress(asset.asset),
+        ambiguous: false,
+        asset,
+        name: resolve ? getAssetField(asset.asset, 'name', { collectionParent: false }) : '',
+        symbol: resolve ? getAssetField(asset.asset, 'symbol', { collectionParent: false }) : '',
+      }))
+      .sort(compareForDisplay);
   });
 
-  return { options };
+  const byChain = computed<TradeAssetOption[]>(() => {
+    const selected = toValue(chain);
+    // Built once, not inside the predicate: a Set per option is a Set per asset on every recompute.
+    const allowed = new Set(toValue(supportedChains));
+    const narrowed = selected === ALL_CHAINS
+      ? get(orderedAssets).filter(option => allowed.has(option.asset.chain))
+      : get(orderedAssets).filter(option => option.asset.chain === selected);
+
+    // Flagged against what the list shows rather than the whole holding: two rows reading "ASK /
+    // GoAsk" are indistinguishable, and only rows visible together need telling apart.
+    const counts = new Map<string, number>();
+    for (const option of narrowed) {
+      // Unresolved assets all carry an empty symbol. Counting those together would flag every one
+      // of them as a collision on first open, printing an address beside a blank symbol on every
+      // row until the names arrive and they all disappear again.
+      if (option.symbol)
+        counts.set(option.symbol, (counts.get(option.symbol) ?? 0) + 1);
+    }
+
+    return narrowed.map(option => ({
+      ...option,
+      ambiguous: (counts.get(option.symbol) ?? 0) > 1,
+    }));
+  });
+
+  const options = computed<TradeAssetOption[]>(() => {
+    const query = toValue(search).trim().toLowerCase();
+    if (!query)
+      return get(byChain);
+
+    return get(byChain).filter(option =>
+      option.symbol.toLowerCase().includes(query)
+      || option.name.toLowerCase().includes(query)
+      // Matched too, so pasting a contract address finds its token.
+      || option.asset.asset.toLowerCase().includes(query),
+    );
+  });
+
+  return { options, orderedAssets };
 }

--- a/frontend/app/src/modules/wallet/send/use-trade-asset-options.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-asset-options.ts
@@ -1,0 +1,94 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { TradableAsset } from '@/modules/wallet/types';
+import { Zero } from '@rotki/common';
+import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
+import { sortDesc } from '@/modules/core/common/data/bignumbers';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+
+/**
+ * A tradable asset with its symbol and name resolved once, so the row that renders it does not
+ * have to resolve them itself.
+ */
+interface TradeAssetOption {
+  asset: TradableAsset;
+  symbol: string;
+  name: string;
+}
+
+interface UseTradeAssetOptionsReturn {
+  options: ComputedRef<TradeAssetOption[]>;
+}
+
+export const ALL_CHAINS = 'all';
+
+/**
+ * Builds the option list the send form's token dialog shows: the owned assets narrowed to a chain,
+ * matched against the search box, and ordered for reading.
+ *
+ * Symbol and name are resolved here, once per asset, rather than in each row. The dialog used to
+ * mount two `useAssetField` computeds per row on top of the resolution `AssetDetails` does its own,
+ * which is a cost paid for every option whether or not it is on screen.
+ */
+export function useTradeAssetOptions(
+  assets: MaybeRefOrGetter<TradableAsset[]>,
+  chain: MaybeRefOrGetter<string>,
+  search: MaybeRefOrGetter<string>,
+  supportedChains: MaybeRefOrGetter<string[]>,
+): UseTradeAssetOptionsReturn {
+  const { getAssetField } = useAssetInfoRetrieval();
+  const { getNativeAsset } = useSupportedChains();
+
+  const resolved = computed<TradeAssetOption[]>(() => toValue(assets).map(asset => ({
+    asset,
+    name: getAssetField(asset.asset, 'name', { collectionParent: false }),
+    symbol: getAssetField(asset.asset, 'symbol', { collectionParent: false }),
+  })));
+
+  const byChain = computed<TradeAssetOption[]>(() => {
+    const selected = toValue(chain);
+    if (selected === ALL_CHAINS) {
+      const allowed = new Set(toValue(supportedChains));
+      return get(resolved).filter(option => allowed.has(option.asset.chain));
+    }
+    return get(resolved).filter(option => option.asset.chain === selected);
+  });
+
+  /**
+   * The chain's native asset first, then by fiat value, then alphabetically by symbol.
+   *
+   * The identifier is deliberately not the tiebreak: with no connected address nothing is priced,
+   * so the tiebreak becomes the only live comparison, and ordering by `eip155:1/erc20:0x…` puts the
+   * list in what reads as a random order. The symbol is what the row actually shows.
+   */
+  function compareForDisplay(a: TradeAssetOption, b: TradeAssetOption): number {
+    const aNative = getNativeAsset(a.asset.chain) === a.asset.asset;
+    const bNative = getNativeAsset(b.asset.chain) === b.asset.asset;
+
+    if (aNative !== bNative)
+      return aNative ? -1 : 1;
+
+    const byValue = sortDesc(a.asset.fiatValue ?? Zero, b.asset.fiatValue ?? Zero);
+    if (byValue !== 0)
+      return byValue;
+
+    // Fall back to the identifier when an asset has no resolved symbol yet, so the order stays
+    // stable while the asset info is still loading instead of shuffling as names arrive.
+    return (a.symbol || a.asset.asset).localeCompare(b.symbol || b.asset.asset);
+  }
+
+  const options = computed<TradeAssetOption[]>(() => {
+    const query = toValue(search).trim().toLowerCase();
+    const matching = query
+      ? get(byChain).filter(option =>
+          option.symbol.toLowerCase().includes(query)
+          || option.name.toLowerCase().includes(query)
+          // Matched too, so pasting a contract address finds its token.
+          || option.asset.asset.toLowerCase().includes(query),
+        )
+      : get(byChain);
+
+    return [...matching].sort(compareForDisplay);
+  });
+
+  return { options };
+}


### PR DESCRIPTION
Follow-up to #12955, which fixed the spam token but left the picker itself
untouched.

## Problem

The token dialog listed every owned asset at once with no way to search it. On
a test account a single chain carried 83 options, each mounting an icon
component plus its own symbol and name resolution, and the only way to find a
token was to scroll. Collectibles were listed too, though the form moves a
fungible amount. Two rows reading "ASK / GoAsk" were indistinguishable. The
dialog was mouse-only.

Ordering was the other half. With no connected address nothing is priced, so
the identifier tiebreak #12955 added was the only live comparison and the list
came out ordered by `eip155:1/erc20:0x…`, which reads as random.

## Change

**Finding a token.** A search box matches symbol, name and identifier, so
pasting a contract address finds its token. The list is virtualized with
`useVirtualList`, following `ValueSelectList`, so only the visible window
mounts. Symbol and name resolve once per asset rather than once per row.

**Reading it.** The display falls back to the symbol rather than the
identifier, which is what the row actually shows; native-first and
fiat-value-descending still come first. Rows carry the amount held and its
value when there is one. A symbol another row on the same chain also uses is
qualified by a shortened contract address. A count says how much is there and
how much a search matched. The list holds one height rather than sizing to its
contents, which made the dialog grow and collapse on every keystroke.

**Navigating it.** Arrows move a highlight, enter commits, escape closes.
Opening highlights and scrolls to the current selection, which carries a tick.
Options are buttons, and the search field carries `aria-activedescendant`.

**Correctness.** Collectibles are dropped (legacy `_nft_` and CAIP erc721 and
erc1155). Options are matched on asset **and** chain: a native token id is not
unique, so `ETH` alone would highlight the wrong network's row with the chain
filter on "all" and tick every chain's ETH at once. The two overlapping
`watchImmediate` blocks that both assigned the default asset are one watcher.
The header's close button dropped a `text-white` override that painted it white
on the card's white header, invisible in light mode.

Symbol resolution is gated on the dialog having been opened. `getAssetField`
goes through the asset info cache, whose `resolve()` queues a backend mapping
fetch for anything it does not hold, so reading the ordered list on mount would
cost a request for the entire holding even when the dialog is never opened.

## Tests

157 in the send module, including three new specs. Each behaviour was checked
with a negative control: the fix reverted, and only the tests that should fail
failing.

## Verified in the app

Row height measured at exactly the value the virtual list is given; 28 rows
rendered rather than the full list; the list height constant across empty,
broad, one-result and no-match; 83 options down to 72 with collectibles gone;
arrows advancing through seven distinct rows while a same-coordinate mousemove
fires after each; the highlight holding steady across a 952px wheel scroll.

## Not in this PR

- With no wallet connected nothing is priced, so the display order is
  alphabetical and whatever sorts first becomes the default. On the test
  account that is an ERC20 whose symbol is an emoji. Whether to auto-select
  from an unpriced list at all is a product decision, unchanged here.
- `ValueSelectList.vue` sets its highlight from a bare `@mousemove` and is
  virtualized, so it likely has the same hover-versus-scroll defect fixed here.
