### PR TITLE
feat(pill-filter): accept a date bound with no time

### DIFF
--- a/frontend/app/src/modules/core/table/pill/DateValueEditor.spec.ts
+++ b/frontend/app/src/modules/core/table/pill/DateValueEditor.spec.ts
@@ -24,6 +24,8 @@ const DateTimePickerStub = defineComponent({
     menuOpen: { default: false, type: Boolean },
     minDate: { default: undefined, type: Number },
     modelValue: { default: undefined, type: Number },
+    // which end of the day the picker completes an entry that omits the time with
+    partialTime: { default: undefined, type: String },
   },
   emits: ['update:modelValue', 'update:menuOpen'],
   mounted(): void {
@@ -67,7 +69,7 @@ function createWrapper(
 function boundProp(
   wrapper: VueWrapper<InstanceType<typeof DateValueEditor>>,
   testId: string,
-  prop: 'maxDate' | 'minDate',
+  prop: 'maxDate' | 'minDate' | 'partialTime',
 ): unknown {
   const found = wrapper.findAllComponents(DateTimePickerStub)
     .find(component => component.attributes('data-testid') === testId);
@@ -110,6 +112,16 @@ describe('dateValueEditor', () => {
     const before = createWrapper({ fieldKey: 'period', op: 'before', values: [] });
     expect(before.find('[data-testid=date-from]').exists()).toBe(false);
     expect(before.find('[data-testid=date-to]').exists()).toBe(true);
+  });
+
+  // A range is usually thought of in whole days, so a bound may be given as a bare date. The two
+  // ends take opposite sides of the day the entry omits the time of, or a To of today would cut
+  // the day off at midnight and hide everything that happened during it.
+  it('should complete a date-only bound from its own end of the day', () => {
+    const wrapper = createWrapper({ fieldKey: 'period', op: 'between', values: [] });
+
+    expect(boundProp(wrapper, 'date-from', 'partialTime')).toBe('start');
+    expect(boundProp(wrapper, 'date-to', 'partialTime')).toBe('end');
   });
 
   // Inclusive second bounds, so the same second on both ends is a filter for that second.

--- a/frontend/app/src/modules/core/table/pill/DateValueEditor.vue
+++ b/frontend/app/src/modules/core/table/pill/DateValueEditor.vue
@@ -140,7 +140,12 @@ function setBound(bound: 'from' | 'to', value: number | Date | undefined): void 
     </RuiButtonGroup>
 
     <!-- No `Now` action: the picker offers one by default, but as a filter bound this instant is
-         either empty (From: nothing happened after now) or the same as no bound at all (To). -->
+         either empty (From: nothing happened after now) or the same as no bound at all (To).
+
+         `partial-time` lets a bound be given as a bare date, which is how a date range is usually
+         thought of: the picker then fills the time the entry left out, and the two ends take
+         opposite sides of the day so that From/To spans whole days rather than cutting the last
+         one off at midnight. -->
     <RuiDateTimePicker
       v-if="showFrom"
       v-model:menu-open="fromMenuOpen"
@@ -150,6 +155,7 @@ function setBound(bound: 'from' | 'to', value: number | Date | undefined): void 
       :actions="[]"
       type="epoch"
       accuracy="second"
+      partial-time="start"
       allow-empty
       dense
       variant="outlined"
@@ -169,6 +175,7 @@ function setBound(bound: 'from' | 'to', value: number | Date | undefined): void 
       :actions="[]"
       type="epoch"
       accuracy="second"
+      partial-time="end"
       allow-empty
       dense
       variant="outlined"

--- a/frontend/app/tests/e2e/fixtures/pill-filter.ts
+++ b/frontend/app/tests/e2e/fixtures/pill-filter.ts
@@ -148,6 +148,17 @@ export const EVENTS_AFTER_CUTOFF = 3;
 export const DATE_CUTOFF_TYPED = '15/01/2024 12:02:30';
 
 /**
+ * `DD MM YYYY` alone: the day every seeded event sits on, typed without a time. A bound may be
+ * given as a bare date, and the picker completes it from the end of the day that bound stands
+ * for — the first second for a From and the last for a To.
+ */
+export const DATE_DAY_DIGITS = '15012024';
+
+/** 15/01/2024 00:00:00 and 23:59:59 UTC, the two ends the day above is completed to. */
+export const DAY_START_TS = 1705276800;
+export const DAY_END_TS = 1705363199;
+
+/**
  * A bulk set for the pagination tests, seeded into its own user so it cannot disturb the row
  * counts above. Plain history events need no transaction, so they are cheap to generate.
  *

--- a/frontend/app/tests/e2e/pages/pill-filter-bar.ts
+++ b/frontend/app/tests/e2e/pages/pill-filter-bar.ts
@@ -154,6 +154,11 @@ export class PillFilterBar {
    *
    * The picker auto-advances between segments as digits arrive, and it opens a calendar popover
    * on focus, so the popover is dismissed afterwards or it covers whatever is clicked next.
+   *
+   * That escape only closes the calendar: it never reaches the field itself, so a bound left
+   * incomplete is not committed here. A full entry is already a value the moment its last digit
+   * lands, but a bare date is written when the field is done with - setting the other bound blurs
+   * this one, and `closeEditor` sends the press that finishes the last one.
    */
   async setDateBound(bound: 'from' | 'to', digits: string): Promise<void> {
     const input = this.page.locator(`[data-testid=date-${bound}] input`);
@@ -194,14 +199,18 @@ export class PillFilterBar {
     // wait on. Leaving one open matters beyond the editor itself, since its popover covers part of
     // the bar and swallows the next click.
     //
-    // The date editor is deliberately absent: `RuiDateTimePicker` opens a calendar popover that
-    // eats Escape, so its editor cannot be closed this way. `setDateBound` dismisses the calendar
-    // itself, and the picker's keyboard handling is being fixed upstream in rotki/ui-library.
+    // The date editor takes two presses, and `setDateBound` has already spent the first: escape
+    // closes the picker's calendar before it means anything to the editor, so the press sent here
+    // is the one that reaches `DateValueEditor`'s own handler and closes it. That same press is
+    // what commits a bound typed as a bare date, which is why the date editor has to be waited on
+    // here rather than left to the caller.
     const editor = this.page
       .locator([
         '[data-testid=value-select-search]',
         '[data-testid=text-input]',
         '[data-testid=range-min]',
+        '[data-testid=date-from] input',
+        '[data-testid=date-to] input',
       ].join(', '))
       .first();
 

--- a/frontend/app/tests/e2e/specs/history/pill-filter.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/pill-filter.spec.ts
@@ -7,6 +7,9 @@ import {
   ADDRESS_BETA,
   DATE_CUTOFF_DIGITS,
   DATE_CUTOFF_TYPED,
+  DATE_DAY_DIGITS,
+  DAY_END_TS,
+  DAY_START_TS,
   EVENTS_AFTER_CUTOFF,
   multiChainChainIds,
   multiChainEvents,
@@ -431,6 +434,24 @@ test.describe.serial('history events pill filter', () => {
     await expect.poll(() => url(), { timeout: 10000 }).toContain('fromTimestamp=');
     // "after" carries no upper bound, so none may reach the wire.
     expect(url()).not.toContain('toTimestamp=');
+
+    await bar.clearAll();
+    await expectRows(TOTAL_SEEDED_EVENTS);
+  });
+
+  // A range is usually thought of in whole days, and a bound typed as a bare date used to be
+  // dropped without a word: no value reached the filter and the pill stayed empty. The two ends
+  // complete it from opposite sides of the day, so a From/To on the same date covers all of it
+  // rather than collapsing onto its first instant.
+  test('a bound given as a bare date covers the whole day', async () => {
+    await bar.addField('period');
+    await bar.setDateBound('from', DATE_DAY_DIGITS);
+    await bar.setDateBound('to', DATE_DAY_DIGITS);
+    await bar.closeEditor();
+
+    await expectRows(TOTAL_SEEDED_EVENTS);
+    await expect.poll(() => url(), { timeout: 10000 }).toContain(`fromTimestamp=${DAY_START_TS}`);
+    expect(url()).toContain(`toTimestamp=${DAY_END_TS}`);
 
     await bar.clearAll();
     await expectRows(TOTAL_SEEDED_EVENTS);

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.5.1
       version: 1.5.1
     '@rotki/ui-library':
-      specifier: 2.23.5
-      version: 2.23.5
+      specifier: 2.24.0
+      version: 2.24.0
     '@tsconfig/node24':
       specifier: 24.0.4
       version: 24.0.4
@@ -345,7 +345,7 @@ importers:
         version: link:../common
       '@rotki/ui-library':
         specifier: 'catalog:'
-        version: 2.23.5(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+        version: 2.24.0(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
       '@types/ws':
         specifier: 'catalog:'
         version: 8.18.1
@@ -2183,8 +2183,8 @@ packages:
     peerDependencies:
       eslint: ^9.20.0 || ^10.0.0
 
-  '@rotki/ui-library@2.23.5':
-    resolution: {integrity: sha512-a4Rji4O9lSE1GZbWOCNI5Icf2mvawfqvCy9Yz11C2Xu9er1lnS1A58uoL8BYrOhCqs0y8G9p5CyJs1jTSf5F+w==}
+  '@rotki/ui-library@2.24.0':
+    resolution: {integrity: sha512-NWFjV3PzG543EKvcTKAFEFENaQ+P+7nh4T9N0zYV8CLniUxefqRN1148i87cnV6HH++Mld52eg4x6E6slfo0bg==}
     engines: {node: '>=24 <25', pnpm: '>=11 <12'}
     peerDependencies:
       dayjs: '>=1.11.13 <12'
@@ -7905,7 +7905,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@rotki/ui-library@2.23.5(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
+  '@rotki/ui-library@2.24.0(dayjs@1.11.21)(tailwindcss@3.4.19(tsx@4.23.5)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.1)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.2.2)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.5)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
   '@playwright/test': 1.62.1
   '@rotki/eslint-config': 7.0.0
   '@rotki/eslint-plugin': 1.5.1
-  '@rotki/ui-library': 2.23.5
+  '@rotki/ui-library': 2.24.0
   '@tsconfig/node24': 24.0.4
   '@types/node': 24.13.3
   '@types/qrcode': 1.5.6


### PR DESCRIPTION
A period bound typed as a bare date was dropped without a word. The picker only emitted once every segment down to the minute was set, so the filter never saw the value, the pill stayed empty, and nothing said why.

The two bounds now declare which end of the day an incomplete entry stands for, From taking the start and To the end. A range given as two bare dates therefore covers those days whole, rather than collapsing the last one onto its first instant and hiding everything that happened during it.

This needs `@rotki/ui-library` 2.24.0, released for it, so the catalog pin is bumped in the first commit. The new prop is `partial-time`, see rotki/ui-library#578.

### The e2e page object was reading the wrong thing

`closeEditor` deliberately skipped date editors, and `setDateBound` ended with a single escape. That escape is entirely consumed closing the picker's calendar: `RuiDateTimePicker` returns early on it while the calendar is open, and `DateValueEditor.onEscape` stops it propagating for the same reason. So it never reached the field.

That left the two bounds asymmetric in a way no assertion caught, because only one of them was ever asserted. From was committed by accident, since setting To clicks into it and the blur commits. To had nothing following it, so it was never committed at all. Closing the editor now sends the press that finishes the last bound.

### Testing

- `DateValueEditor.spec.ts` gains a test pinning that the bounds get opposite ends (14 green).
- `pill-filter.spec.ts` gains "a bound given as a bare date covers the whole day", asserting the whole span rather than just that a filter applied: the failure worth catching is one end silently missing. Full spec green at 44/44, which includes the bar's keyboard block.
- Verified by hand in the app against the released 2.24.0: a From/To given as two bare dates produces `fromTimestamp` at local midnight and `toTimestamp` at 23:59:59, an 86399 second span.
- `pnpm run knip` clean, typecheck clean, lint clean.

### Note

2.24.0 also takes the picker's calendar toggle out of the tab sequence, so tabbing crosses a date field in one stop instead of two (a from/to pair cost four). That affects every date field in the app, not only this filter. I checked the report period selector as an untouched consumer: tab moves Start Date to End Date directly, and alt+arrowdown still opens the calendar, which is what makes skipping the toggle safe.
