### PR TITLE
Consolidate the frontend testing strategy and sync the two agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -516,21 +516,74 @@ free of side effects.
 - Avoid dynamic keys for translations, as they can break the linter.
 
 #### Testing
-- Run all tests with `pnpm run test:unit` from `frontend/` directory
-- Run a single test file: `pnpm run test:unit src/modules/path/to/file.spec.ts` (no `-- --run` needed)
-- Use Vitest for unit tests with Vue Test Utils
-- **Unit test file naming**: `.spec.ts` files should follow the naming of the tested file and be located in the same folder
+
+Vitest with Vue Test Utils for units and components, Playwright for e2e. This section is the single
+home for how to write a frontend test; `## Testing Strategy` below covers only running e2e.
+
+##### Where specs live
+
+- **Co-located** next to the source file they test, never in a separate `tests/` directory. The
+  `.spec.ts` takes the name of the file it tests:
   ```
-  // Example structure:
   src/modules/balances/use-balances-store.ts
   src/modules/balances/use-balances-store.spec.ts
-
-  src/modules/accounts/use-account-import-export.ts
-  src/modules/accounts/use-account-import-export.spec.ts
   ```
-- **All unit tests are co-located** next to the source file they test (not in a separate `tests/` directory)
-- Test descriptions must follow the `it('should ...'` pattern
-- Component tests should follow existing patterns in co-located `*.spec.ts` files
+- Shared fixtures, mocks and setup stay in `frontend/app/tests/unit/`, imported through `@test/*`.
+- Test descriptions follow the `it('should ...')` pattern.
+
+##### Testing components that are not pure display
+
+**Component tests are not optional here, and this is the single most important thing in this
+section.** Measured 2026-08-17 against the coverage push in rotki/rotki#11252: `.ts` files sit at
+~86% line coverage, `.vue` files at ~34%. Covering every remaining line of every `.ts` file would
+still leave the project short of its 70% target, so the uncovered lines that matter are logic living
+inside SFCs. Roughly 256 of ~875 specs already mount a component; follow them. Re-measure with
+`pnpm run test:unit` rather than trusting these figures indefinitely.
+
+**Extract before you test.** A component holding a hundred lines of script is the hardest thing to
+test and the thing the SFC size guidance above already says to split. Move the logic into a
+`use-*.ts` beside it, test that directly with no mounting or stubs, and let the component spec cover
+the wiring that remains. Testing a fat component first *pins its current shape*: the spec becomes an
+obstacle to the extraction that should have happened first. `accounts/management/AccountForm.vue`
+is the standing example of the cost, with 317 script lines now held in place by a spec.
+
+**Name the seam, then test only that.** Before writing assertions, decide what this component
+promises its parent, and put it in a comment at the top of the spec. In practice the seam is some
+combination of:
+- what it **renders** for a given set of props (`data-testid` queries, not classes or child
+  internals),
+- what it **emits**, and with what payload (`wrapper.emitted('update:modelValue')`),
+- what it **calls** on an injected composable or store, and
+- what it **disables or enables**, which for a form is usually the real validity contract.
+
+`modules/auth/login/LoginForm.spec.ts` is a good model: it states the seam in a header comment,
+types its mocks off the real composables (`ReturnType<typeof useSavedProfiles>`) so a drift in a
+dependency fails the typecheck instead of silently passing a test, and explains which binding the
+tests exist to catch.
+
+**Do not assert implementation detail.** No reaching into `wrapper.vm` for internal refs, no
+asserting the class list of a child component. Those tests break on every refactor and catch nothing.
+
+**A mount-only test is worse than no test.** `mount()` alone lights up most of a component's lines,
+because v8 counts template lines, so it moves the coverage number while proving nothing. If the only
+assertion is that the component rendered, either write a real assertion or skip the file. Pure
+presentational wrappers with no logic are legitimately not worth testing.
+
+**Unmount what you mount.** A spec that leaves wrappers alive leaks reactive instances. Where the
+module under test holds a shared module-level `ref`, leaked components keep reacting to it and their
+effects run during *later* tests, surfacing as calls on a mock the failing test never touched. Track
+the wrappers and unmount them in `afterEach`; ~148 specs already do.
+
+**Mocking notes.**
+- A component rendered inside `RuiDialog` (or any teleporting overlay) is not inside the wrapper.
+  Stub the dialog with a pass-through (`template: '<div v-if="modelValue"><slot /></div>'`) so its
+  contents can be queried.
+- `happy-dom` reports every element as zero-height, so anything driven by measured layout
+  (`useVirtualList`, `useElementSize`, `useFocusWithin`) does not behave as it does in a browser.
+  Stub it and assert the configuration you pass it, then check the real behaviour in the app.
+
+##### Writing any spec
+
 - **Re-run the full `pnpm run typecheck` after editing any `.spec.ts`**, even if you typechecked
   earlier in the change. The "Frontend lint" CI job runs `pnpm run build`, and `vue-tsc --build`
   type-checks specs too, so a green `test:unit` plus a green `lint:file:check` does not prove the
@@ -552,6 +605,10 @@ free of side effects.
     branded, class, or large types where the test only reads a few fields, instead of a
     `as unknown as T` double cast. It returns a `Proxy`, so proxies do not deep-equal: build a real
     object when you need `toEqual`.
+    ⚠️ The proxy answers **every** property, so anything you did not set reads back as an
+    auto-stub, which is **truthy**. A boolean you omit therefore behaves as `true`: leaving
+    `isComposing` off a mocked `KeyboardEvent` makes every key look like it arrived mid-IME
+    composition. Set the booleans your code under test reads, explicitly.
   - `mockT` from `@test/i18n` is the echo translator. `useI18n` is globally mocked in
     `tests/unit/setup-files/setup.ts` to use it, so composables calling `useI18n()` get `t` for free.
   - Other fixtures: `@test/mocks/file`, `@test/utils/create-pinia`, `@test/utils/events`.
@@ -560,7 +617,32 @@ free of side effects.
   so a `data-testid` on a `Rui*` component falls through `$attrs` onto its root element.
 - **e2e: never locate a row by index.** Anchoring a history-events assertion on row position makes
   the test pass for the wrong reason as soon as ordering or fixture data shifts. Anchor on fixture
-  content, and pair the assertion with a negative control that proves the test can fail.
+  content. Counting rendered rows in a virtualized list asserts the overscan, not the data.
+
+##### Proving the test works
+
+**A passing test is not evidence that the code works; it is evidence that the test passed.** Before
+citing a suite as proof, break the thing it covers and watch it go red. Revert the fix, invert the
+condition, or delete the guard, run the spec, then restore. This costs one extra run and is the only
+thing that separates a test from a decoration.
+
+- **Break the specific line, not the feature.** Deleting a whole function fails everything and tells
+  you nothing about which test was doing the work.
+- **Check the right tests failed, and only those.** If fewer fail than you expected, the surplus
+  tests are not testing what their names claim.
+- **A negative control that passes is a finding.** It means the test cannot fail, so it is not
+  pinning the behaviour. Re-aim it rather than shrugging. The usual cause is an assertion that agrees
+  with both the correct and the broken behaviour: asserting a value the buggy path also produces,
+  or hovering the row the keyboard had already moved to.
+- **One control proves one test.** It says nothing about its neighbours.
+- Assertions of the form "was not called" and "emitted nothing" are the likeliest to pass for the
+  wrong reason, because an exception thrown mid-handler produces exactly that. Control them first.
+
+##### Gates before pushing
+
+`pnpm run test:unit`, `pnpm run lint:file:check`, `pnpm run lint:style` and `pnpm run typecheck`
+are not the whole set. **`pnpm run knip` runs in CI and no local lint script invokes it**, so an
+export used only inside its own file passes every local gate and fails the PR. Run it before pushing.
 
 #### Fast checks via pnpm scripts
 
@@ -913,11 +995,16 @@ Key files:
 - For Etherscan use the api key from ETHERSCAN_API_KEY env variable and use etherscan v2. It's as v1 but using https://api.etherscan.io/v2/api?chainid=${chainid} . As described here: https://docs.etherscan.io/etherscan-v2. If there is no API key in the env variable then prompt the user for it when you need to query etherscan.
 
 ### Frontend Testing
-- Vitest for unit tests with Vue Test Utils
-- **Unit tests are co-located**: `.spec.ts` files live next to the source file they test in `frontend/app/src/`
-- Test utilities (fixtures, mocks, setup) remain in `frontend/app/tests/unit/`
-- Playwright for E2E testing (specs in `frontend/app/tests/e2e/specs/`, page objects in `frontend/app/tests/e2e/pages/`, helpers in `frontend/app/tests/e2e/helpers/`)
-- Test descriptions must follow the `it('should ...'` pattern
+
+**How to write a frontend test is documented once, under "Testing" in the Frontend Development
+Guidelines above.** That covers unit specs, component specs (including why they are mandatory and
+how to test a component that is not pure display), negative controls and the gates. Do not restate
+it here; a second copy drifts from the first.
+
+Layout only:
+- Unit and component specs are co-located in `frontend/app/src/`; fixtures, mocks and setup are in
+  `frontend/app/tests/unit/`.
+- Playwright e2e lives in `frontend/app/tests/e2e/`: `specs/`, `pages/` for page objects, `helpers/`.
 
 #### Running e2e locally, sharded
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -518,7 +518,8 @@ free of side effects.
 #### Testing
 
 Vitest with Vue Test Utils for units and components, Playwright for e2e. This section is the single
-home for how to write a frontend test; `## Testing Strategy` below covers only running e2e.
+home for how to write a frontend test. See "Fast checks via pnpm scripts" immediately below for how
+to run one, and `## Testing Strategy` for running e2e.
 
 ##### Where specs live
 
@@ -830,6 +831,42 @@ alphabetically sorted). A key referenced only from the registry/catalog must be 
 | Category visual grouping | `frontend/app/src/modules/settings/SettingCategory.vue` |
 | Settings pages | `frontend/app/src/pages/settings/*/index.vue` |
 
+### Navigation, search & tab metadata (`meta.nav`)
+
+Routing uses the typed, file-based router (`unplugin-vue-router`). Route **names are generated from the file path** (e.g. `pages/balances/blockchain/index.vue` -> `'/balances/blockchain/'`); do not add custom `name:` overrides. Navigate by typed name: `router.push({ name: '/balances/blockchain/' })` or `<RouterLink :to="{ name: '/balances/blockchain/' }">`. The drawer, the global search palette and sub-page tab bars are all **derived from route meta** - there is no route registry to maintain.
+
+Add navigation for a page by declaring `nav` in its `definePage`:
+
+```ts
+definePage({
+  meta: {
+    nav: {
+      labelKey: 'navigation_menu.balances_sub.blockchain_balances', // i18n key (required)
+      icon: 'lu-blockchain',                                        // RuiIcons (required)
+      parent: '/balances/',      // logical parent: drawer nesting + search breadcrumb
+      order: 10,                 // order among siblings
+      section: 1,                // drawer top-level section (dividers between sections); omit for sub-items
+      drawer: 'balances-blockchain', // present => shown in the drawer; value is the entry's data-key test selector
+      searchable: false,         // optional: exclude from the (default-on) search palette
+      keywords: ['some.i18n.alias'], // optional: extra i18n keys the search palette matches
+    },
+  },
+});
+```
+
+Rules of thumb:
+- **Drawer entry**: set `drawer` (the test id). Top-level items also set `section` + `order`; sub-items set `parent` + `order` (the parent route must also have a `nav`). `useNavigationMenu` builds the tree.
+- **Search palette**: every route with `nav` is searchable automatically (the superset of the drawer) unless `searchable: false`. The breadcrumb is the `nav.labelKey` of the route named by `parent`. `useRouteSearch` builds it; `GlobalSearch.vue` renders it.
+- **Sub-page tab bars**: use `useChildNavTabs('/parent/')` when the bar is every child of a parent (e.g. price-manager), or `useNavTabs(['/a/', '/b/'])` for a specific subset/order (e.g. asset-manager/more). Both live in `use-nav-tabs.ts`.
+- **Settings tabs**: each tab's route/label/icon comes from its page `nav`; the per-setting search rows are derived from the settings registry + `settings-search-catalog.ts` (no hand-maintained per-tab list).
+
+| Purpose | File |
+|---------|------|
+| `nav` meta type | `frontend/app/src/types/router.d.ts` |
+| Drawer derivation | `frontend/app/src/modules/shell/layout/use-navigation-menu.ts` |
+| Search derivation | `frontend/app/src/modules/shell/layout/use-route-search.ts` |
+| Tab bars from meta | `frontend/app/src/modules/shell/layout/use-nav-tabs.ts` |
+
 ### Adding EVM protocol decoders
 
 As an example decoder, we can look at [MakerDAO](https://github.com/rotki/rotki/blob/1039e04304cc034a57060757a1a8ae88b3c51806/rotkehlchen/chain/ethereum/modules/makerdao/decoder.py).
@@ -972,8 +1009,6 @@ When editing backend Python and tests, follow these preferences unless explicitl
  - Match nearby file style even if generic Python style differs.
  - For rotki tests, prefer concise expected-event construction with inline assignments where practical.
 
-## Testing Strategy
-
 ### Historical balance / accounting refactor context
 
 When a user mentions the "accounting refactor", "accounting buckets", "balance buckets", or issue/PR `#12204`, assume they are referring to the historical balance engine in `rotkehlchen/tasks/historical_balances.py` and its `event_metrics` bucket tracking, not the legacy accounting pot/cost-basis code unless they explicitly say cost basis or PnL accounting.
@@ -985,8 +1020,10 @@ Key files:
 - `rotkehlchen/db/history_events.py` — stale marker invalidation when events change.
 - `rotkehlchen/tests/unit/test_historical_balances.py` and `rotkehlchen/tests/api/test_historical_balances.py` — primary tests.
 
+## Testing Strategy
+
 ### Backend Testing
-- Uses pytest with gevent for async testing
+- Uses pytest, with concurrency via rotkehlchen.concurrency tasks (threads)
 - Extensive fixtures in `rotkehlchen/tests/fixtures/`
 - Mock external APIs for deterministic tests
 - Database fixtures for integration testing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,7 +518,8 @@ free of side effects.
 #### Testing
 
 Vitest with Vue Test Utils for units and components, Playwright for e2e. This section is the single
-home for how to write a frontend test; `## Testing Strategy` below covers only running e2e.
+home for how to write a frontend test. See "Fast checks via pnpm scripts" immediately below for how
+to run one, and `## Testing Strategy` for running e2e.
 
 ##### Where specs live
 
@@ -874,6 +875,47 @@ It needs to contain a class that inherits from the `DecoderInterface` and is nam
 
 Note: If your new decoder decodes an airdrop's claiming event and this airdrop is present in the [data repo airdrop index](https://github.com/rotki/data/blob/develop/airdrops/index_v2.json) with `has_decoder` as `false`, please update that also.
 
+When you need to check a contract ABI, use Sourcify's repository URL format:
+`https://repo.sourcify.dev/<chainID>/<contract_address>`.
+For example, for address `0x3337286E850cf01B8A8B6094574f0dd6a2108B16` on chain ID `1`, check `https://repo.sourcify.dev/1/0x3337286E850cf01B8A8B6094574f0dd6a2108B16`.
+For raw ABI data, read the verified metadata JSON at `https://repo.sourcify.dev/contracts/full_match/<chainID>/<contract_address>/metadata.json` and use `output.abi`.
+
+### Decoder scope policy (performance-critical)
+
+- Prefer `addresses_to_decoders()` over generic `decoding_rules()` whenever a protocol emits identifiable logs from known contract addresses.
+- Use `decoding_rules()` only as a last resort when no reliable address/topic/input selector scoping exists.
+
+Why:
+- `decoding_rules()` are evaluated for every log in every transaction on that chain, which increases per-log decoding overhead.
+- `addresses_to_decoders()` restricts execution to logs from relevant protocol contracts, reducing unnecessary rule invocations and improving decode throughput.
+- Narrow-scoped decoders also reduce false positives and make behavior easier to reason about.
+
+### ActionItem matching rule (avoid redundant log scans)
+
+- When creating an `ActionItem` from a log handler, prefer using data already available in the current `context.tx_log` for matching fields (`amount`, `asset`, `location_label`, `to_address`) whenever possible.
+- Do not iterate `context.all_logs` just to rediscover transfer data if the current log already provides the same amount/address relation.
+- Only scan `context.all_logs` when correlating multiple distinct logs is strictly required.
+
+Why:
+- Reduces per-transaction work and decoder complexity.
+- Avoids introducing fragile cross-log assumptions.
+- Keeps action-item transformations deterministic and easier to review.
+
+### Fallback when chain indexers are unavailable
+
+If a chain cannot be queried via explorer/indexer APIs (`etherscanscan` / `routescan` / `blockscout` etc ), do not stop. Use this fallback flow:
+
+1. Add a public RPC node for the chain in the test via `*_manager_connect_at_start` + `WeightedNode(NodeName(...))`.
+2. Query tx/receipt/logs from RPC directly (not from explorer APIs).
+3. If internal txs are not needed for the specific decoder path, patch:
+   `rotkehlchen.chain.evm.transactions.EvmTransactions._query_and_save_internal_transactions_for_range_or_parent_hash`
+   to return `[]`.
+4. Keep the test focused on decoded events from logs/transfers.
+5. Prefer deterministic assertions and exact tx-hash regression tests.
+6. Do not block on explorer availability; only ask the user if RPC data is insufficient.
+
+Example intent: Base currently may fail on explorer/indexer paths; use `https://mainnet.base.org` until indexers recover.
+
 #### Counterparties
 
 It needs to implement a method called `counterparties()` which returns a list of counterparties that can be associated with the transactions of this module. Most of the time these are protocol names like `uniswap-v1`, `makerdao_dsr`, etc.
@@ -912,9 +954,16 @@ Each combination of event type and subtype and counterparty creates a new unique
 
 The mapping of these HistoryEvents types, subtypes, and categories is done in [rotkehlchen/accounting/constants.py](https://github.com/rotki/rotki/blob/17b4368bc15043307fa6acf536b5237b3840c40e/rotkehlchen/accounting/constants.py).
 
-#### Things to keep in mind
+### Hex / bytes constants policy (strict)
 
-- All byte signatures should be a constant byte literal. Like ```DEPOSIT_TOPIC: Final = b'\xdc\xbc\x1c\x05$\x0f1\xff:\xd0g\xef\x1e\xe3\\\xe4\x99wbu.:\tR\x84uED\xf4\xc7\t\xd7'```
+- Source of truth: copy exact on-chain/API `0x...` hex.
+- Validation step (during implementation): convert with `bytes.fromhex(hex_str.removeprefix('0x'))` and verify round-trip:
+  - `hex_str = value.removeprefix('0x')`
+  - `const = bytes.fromhex(hex_str)`
+  - `assert const.hex() == hex_str.lower()`
+- Final committed form: all event topics, method selectors, hashes, and byte signatures must be byte literals (for example `TOPIC: Final = b'\xdc\xbc\x1c\x05...\xd7'`).
+- Do not keep `bytes.fromhex(...)` in final constant definitions.
+- If useful for readability, keep the canonical `0x...` value as a comment next to the byte literal.
 - Don't put assets as constants. If you need a constant just use the asset identifier as a string and compare against it.
 
 ### Database schema changes (user DB and global DB)
@@ -938,6 +987,38 @@ Per-DB locations:
 Always keep the fresh-create schema (`schema.py`) in sync with the upgrade so newly created DBs match the upgraded state.
 
 **Global DB only — extra hazard:** the global DB also ships as a packaged file (`rotkehlchen/data/global.db`) in the `rotki/data` submodule, which is only regenerated/bumped per release. Bumping `GLOBAL_DB_VERSION` ahead of that packaged DB makes its version (e.g. 17) mismatch the code (e.g. 18), which breaks `soft_reset_assets_list`/`hard_reset_assets_list` (version-equality guard) and the packaged-DB consistency tests — exactly the kind of "tests fail on develop" caused by an unmerged data-repo change. This is the strongest reason to fold into the unreleased upgrade rather than create a premature new version.
+
+## Rotki Backend Style Preferences (strict)
+
+When editing backend Python and tests, follow these preferences unless explicitly told otherwise:
+
+1. Prefer narrow exceptions.
+ - Do not use `except Exception`.
+ - Catch the concrete error type used by the surrounding code path (e.g. `RemoteError` for rpc/multicall).
+
+ 2. Prefer inline one-time assignment via walrus operator.
+ - If a variable is used only once in a small local scope, inline it with `:=` instead of introducing a standalone line.
+ - Apply this especially in tests for constants like `timestamp`, `amount_str`, `gas_str`, `user_address`.
+ - Example: `location_label=(user_address := ethereum_accounts[0])`.
+
+ 3. Avoid unnecessary temporary locals.
+ - If a value is only used once and readability is preserved, inline it.
+ - Keep code compact and avoid “setup variable blocks” in tests.
+
+ 4. Keep existing codebase idioms first.
+ - Match nearby file style even if generic Python style differs.
+ - For rotki tests, prefer concise expected-event construction with inline assignments where practical.
+
+### Historical balance / accounting refactor context
+
+When a user mentions the "accounting refactor", "accounting buckets", "balance buckets", or issue/PR `#12204`, assume they are referring to the historical balance engine in `rotkehlchen/tasks/historical_balances.py` and its `event_metrics` bucket tracking, not the legacy accounting pot/cost-basis code unless they explicitly say cost basis or PnL accounting.
+
+Key files:
+- `rotkehlchen/tasks/historical_balances.py` — bucket derivation and event metric generation.
+- `rotkehlchen/balances/historical.py` — historical balance query/read API.
+- `rotkehlchen/db/schema.py` — `event_metrics` schema.
+- `rotkehlchen/db/history_events.py` — stale marker invalidation when events change.
+- `rotkehlchen/tests/unit/test_historical_balances.py` and `rotkehlchen/tests/api/test_historical_balances.py` — primary tests.
 
 ## Testing Strategy
 
@@ -1007,7 +1088,7 @@ python package.py
 - `.github/workflows/` - CI/CD pipelines
 
 ## Development Tips
-1. Run backend tests with plain `uv run pytest`
+1. Run backend tests directly with `uv run pytest`
 2. Frontend uses strict TypeScript - ensure types are properly defined
 3. Follow existing code patterns - the codebase has established conventions
 4. Use the existing test infrastructure - comprehensive fixtures are available
@@ -1027,6 +1108,7 @@ python package.py
 
 ## Common Issues & Solutions
 - Frontend build fails: Run `pnpm run clean:modules` then `pnpm install --frozen-lockfile`
+- Backend test failures: Re-run the relevant test directly with `uv run pytest`
 - WebSocket connection issues: Check ports 4242 (API) and 4333 (WS) are free
 
 ## Code Review Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -516,21 +516,74 @@ free of side effects.
 - Avoid dynamic keys for translations, as they can break the linter.
 
 #### Testing
-- Run all tests with `pnpm run test:unit` from `frontend/` directory
-- Run a single test file: `pnpm run test:unit src/modules/path/to/file.spec.ts` (no `-- --run` needed)
-- Use Vitest for unit tests with Vue Test Utils
-- **Unit test file naming**: `.spec.ts` files should follow the naming of the tested file and be located in the same folder
+
+Vitest with Vue Test Utils for units and components, Playwright for e2e. This section is the single
+home for how to write a frontend test; `## Testing Strategy` below covers only running e2e.
+
+##### Where specs live
+
+- **Co-located** next to the source file they test, never in a separate `tests/` directory. The
+  `.spec.ts` takes the name of the file it tests:
   ```
-  // Example structure:
   src/modules/balances/use-balances-store.ts
   src/modules/balances/use-balances-store.spec.ts
-
-  src/modules/accounts/use-account-import-export.ts
-  src/modules/accounts/use-account-import-export.spec.ts
   ```
-- **All unit tests are co-located** next to the source file they test (not in a separate `tests/` directory)
-- Test descriptions must follow the `it('should ...'` pattern
-- Component tests should follow existing patterns in co-located `*.spec.ts` files
+- Shared fixtures, mocks and setup stay in `frontend/app/tests/unit/`, imported through `@test/*`.
+- Test descriptions follow the `it('should ...')` pattern.
+
+##### Testing components that are not pure display
+
+**Component tests are not optional here, and this is the single most important thing in this
+section.** Measured 2026-08-17 against the coverage push in rotki/rotki#11252: `.ts` files sit at
+~86% line coverage, `.vue` files at ~34%. Covering every remaining line of every `.ts` file would
+still leave the project short of its 70% target, so the uncovered lines that matter are logic living
+inside SFCs. Roughly 256 of ~875 specs already mount a component; follow them. Re-measure with
+`pnpm run test:unit` rather than trusting these figures indefinitely.
+
+**Extract before you test.** A component holding a hundred lines of script is the hardest thing to
+test and the thing the SFC size guidance above already says to split. Move the logic into a
+`use-*.ts` beside it, test that directly with no mounting or stubs, and let the component spec cover
+the wiring that remains. Testing a fat component first *pins its current shape*: the spec becomes an
+obstacle to the extraction that should have happened first. `accounts/management/AccountForm.vue`
+is the standing example of the cost, with 317 script lines now held in place by a spec.
+
+**Name the seam, then test only that.** Before writing assertions, decide what this component
+promises its parent, and put it in a comment at the top of the spec. In practice the seam is some
+combination of:
+- what it **renders** for a given set of props (`data-testid` queries, not classes or child
+  internals),
+- what it **emits**, and with what payload (`wrapper.emitted('update:modelValue')`),
+- what it **calls** on an injected composable or store, and
+- what it **disables or enables**, which for a form is usually the real validity contract.
+
+`modules/auth/login/LoginForm.spec.ts` is a good model: it states the seam in a header comment,
+types its mocks off the real composables (`ReturnType<typeof useSavedProfiles>`) so a drift in a
+dependency fails the typecheck instead of silently passing a test, and explains which binding the
+tests exist to catch.
+
+**Do not assert implementation detail.** No reaching into `wrapper.vm` for internal refs, no
+asserting the class list of a child component. Those tests break on every refactor and catch nothing.
+
+**A mount-only test is worse than no test.** `mount()` alone lights up most of a component's lines,
+because v8 counts template lines, so it moves the coverage number while proving nothing. If the only
+assertion is that the component rendered, either write a real assertion or skip the file. Pure
+presentational wrappers with no logic are legitimately not worth testing.
+
+**Unmount what you mount.** A spec that leaves wrappers alive leaks reactive instances. Where the
+module under test holds a shared module-level `ref`, leaked components keep reacting to it and their
+effects run during *later* tests, surfacing as calls on a mock the failing test never touched. Track
+the wrappers and unmount them in `afterEach`; ~148 specs already do.
+
+**Mocking notes.**
+- A component rendered inside `RuiDialog` (or any teleporting overlay) is not inside the wrapper.
+  Stub the dialog with a pass-through (`template: '<div v-if="modelValue"><slot /></div>'`) so its
+  contents can be queried.
+- `happy-dom` reports every element as zero-height, so anything driven by measured layout
+  (`useVirtualList`, `useElementSize`, `useFocusWithin`) does not behave as it does in a browser.
+  Stub it and assert the configuration you pass it, then check the real behaviour in the app.
+
+##### Writing any spec
+
 - **Re-run the full `pnpm run typecheck` after editing any `.spec.ts`**, even if you typechecked
   earlier in the change. The "Frontend lint" CI job runs `pnpm run build`, and `vue-tsc --build`
   type-checks specs too, so a green `test:unit` plus a green `lint:file:check` does not prove the
@@ -552,6 +605,10 @@ free of side effects.
     branded, class, or large types where the test only reads a few fields, instead of a
     `as unknown as T` double cast. It returns a `Proxy`, so proxies do not deep-equal: build a real
     object when you need `toEqual`.
+    ⚠️ The proxy answers **every** property, so anything you did not set reads back as an
+    auto-stub, which is **truthy**. A boolean you omit therefore behaves as `true`: leaving
+    `isComposing` off a mocked `KeyboardEvent` makes every key look like it arrived mid-IME
+    composition. Set the booleans your code under test reads, explicitly.
   - `mockT` from `@test/i18n` is the echo translator. `useI18n` is globally mocked in
     `tests/unit/setup-files/setup.ts` to use it, so composables calling `useI18n()` get `t` for free.
   - Other fixtures: `@test/mocks/file`, `@test/utils/create-pinia`, `@test/utils/events`.
@@ -560,7 +617,32 @@ free of side effects.
   so a `data-testid` on a `Rui*` component falls through `$attrs` onto its root element.
 - **e2e: never locate a row by index.** Anchoring a history-events assertion on row position makes
   the test pass for the wrong reason as soon as ordering or fixture data shifts. Anchor on fixture
-  content, and pair the assertion with a negative control that proves the test can fail.
+  content. Counting rendered rows in a virtualized list asserts the overscan, not the data.
+
+##### Proving the test works
+
+**A passing test is not evidence that the code works; it is evidence that the test passed.** Before
+citing a suite as proof, break the thing it covers and watch it go red. Revert the fix, invert the
+condition, or delete the guard, run the spec, then restore. This costs one extra run and is the only
+thing that separates a test from a decoration.
+
+- **Break the specific line, not the feature.** Deleting a whole function fails everything and tells
+  you nothing about which test was doing the work.
+- **Check the right tests failed, and only those.** If fewer fail than you expected, the surplus
+  tests are not testing what their names claim.
+- **A negative control that passes is a finding.** It means the test cannot fail, so it is not
+  pinning the behaviour. Re-aim it rather than shrugging. The usual cause is an assertion that agrees
+  with both the correct and the broken behaviour: asserting a value the buggy path also produces,
+  or hovering the row the keyboard had already moved to.
+- **One control proves one test.** It says nothing about its neighbours.
+- Assertions of the form "was not called" and "emitted nothing" are the likeliest to pass for the
+  wrong reason, because an exception thrown mid-handler produces exactly that. Control them first.
+
+##### Gates before pushing
+
+`pnpm run test:unit`, `pnpm run lint:file:check`, `pnpm run lint:style` and `pnpm run typecheck`
+are not the whole set. **`pnpm run knip` runs in CI and no local lint script invokes it**, so an
+export used only inside its own file passes every local gate and fails the PR. Run it before pushing.
 
 #### Fast checks via pnpm scripts
 
@@ -869,11 +951,16 @@ Always keep the fresh-create schema (`schema.py`) in sync with the upgrade so ne
 - For Etherscan use the api key from ETHERSCAN_API_KEY env variable and use etherscan v2. It's as v1 but using https://api.etherscan.io/v2/api?chainid=${chainid} . As described here: https://docs.etherscan.io/etherscan-v2. If there is no API key in the env variable then prompt the user for it when you need to query etherscan.
 
 ### Frontend Testing
-- Vitest for unit tests with Vue Test Utils
-- **Unit tests are co-located**: `.spec.ts` files live next to the source file they test in `frontend/app/src/`
-- Test utilities (fixtures, mocks, setup) remain in `frontend/app/tests/unit/`
-- Playwright for E2E testing (specs in `frontend/app/tests/e2e/specs/`, page objects in `frontend/app/tests/e2e/pages/`, helpers in `frontend/app/tests/e2e/helpers/`)
-- Test descriptions must follow the `it('should ...'` pattern
+
+**How to write a frontend test is documented once, under "Testing" in the Frontend Development
+Guidelines above.** That covers unit specs, component specs (including why they are mandatory and
+how to test a component that is not pure display), negative controls and the gates. Do not restate
+it here; a second copy drifts from the first.
+
+Layout only:
+- Unit and component specs are co-located in `frontend/app/src/`; fixtures, mocks and setup are in
+  `frontend/app/tests/unit/`.
+- Playwright e2e lives in `frontend/app/tests/e2e/`: `specs/`, `pages/` for page objects, `helpers/`.
 
 #### Running e2e locally, sharded
 


### PR DESCRIPTION
Documentation only. Two commits, readable in order.

## 1. Consolidate the frontend testing strategy

Frontend testing was documented in three overlapping places (`#### Testing`,
`#### Fast checks`, and `### Frontend Testing` under `## Testing Strategy`),
with four facts stated twice. An edit to one silently contradicted the other,
and a reader could not tell which was authoritative. It now lives once, under
Testing in the Frontend Development Guidelines; `## Testing Strategy` keeps only
the directory layout and how to run e2e.

Consolidating exposed the real gap: **component testing had one line of
guidance**, "follow existing patterns". The coverage split is ~86% for `.ts`
against ~34% for `.vue`, and covering every remaining `.ts` line still falls
short of the 70% target tracked in #11252, so the lines that matter are logic
living inside SFCs. The new section says component tests are mandatory and why,
then covers what was missing:

- **Extract before you test.** Testing a fat component pins the shape that
  should have been split. `AccountForm.vue` is the standing example, 317 script
  lines now held in place by a spec.
- **Name the seam, then test only that** — rendered output, emits, calls on an
  injected composable, and what it enables or disables. `LoginForm.spec.ts` is
  cited as the model.
- **A mount-only test is worse than no test.** v8 counts template lines, so
  `mount()` alone moves the coverage number and proves nothing.
- **Unmount what you mount.** A leaked wrapper keeps reacting to a shared
  module-level ref, and its effects surface during later tests as calls on a
  mock those tests never touched.
- Mocking notes for teleported dialogs and for happy-dom reporting every element
  as zero-height, which breaks anything driven by measured layout.

Negative controls are promoted from a single e2e bullet about row indices to a
general rule: how to break the right line, what it means when the control
passes, and which assertion shapes most often pass for the wrong reason.

Two traps that were nowhere and cost real time: `createMock` proxies any
property it was not given to a truthy auto-stub, so an omitted boolean reads as
`true`; and `knip` runs in CI while no local lint script invokes it, so an
export used only inside its own file passes every local gate and fails the PR.

Coverage figures are dated and point at #11252 so a later reader re-measures.

## 2. Sync CLAUDE.md and AGENTS.md

AGENTS.md states that it mirrors CLAUDE.md. It did not: 129 diverging lines, so
which file an assistant happened to read decided what it was told. Both now
carry the union of the two.

One difference was a **factual contradiction rather than drift**. AGENTS.md said
the backend "uses pytest with gevent for async testing"; CLAUDE.md said
concurrency runs through `rotkehlchen.concurrency` tasks on threads. The second
is correct: `concurrency/tasks.py` spawns `threading.Thread`, and its docstring
describes the module as the seam for the gevent removal, with gevent imports
banned via ruff TID251. AGENTS.md has been telling assistants something false.

AGENTS.md also had `### Historical balance / accounting refactor context` nested
under `## Testing Strategy`, where it does not belong.

The two files are now byte-identical apart from the title line and the sentence
that states the mirroring, so any future divergence is a two-line diff.

## Not included

A CI check to keep the two files in sync. It would be cheap now that they differ
by exactly two known lines, roughly
`diff <(tail -n +4 CLAUDE.md) <(tail -n +4 AGENTS.md)`, but I did not want to add
a gate to this PR without asking.
