### PR TITLE
Stop hover hijacking the pill filter's option list

### DIFF
--- a/frontend/app/src/modules/core/table/pill/ValueSelectList.spec.ts
+++ b/frontend/app/src/modules/core/table/pill/ValueSelectList.spec.ts
@@ -91,6 +91,45 @@ describe('valueSelectList', () => {
     expect(wrapper.emitted('update:modelValue')?.[0]).toStrictEqual([['uniswap']]);
   });
 
+  it('should move the highlight to a hovered option', async () => {
+    const wrapper = createWrapper([]);
+    const rows = wrapper.findAll('[data-testid="value-select-option"]');
+    await rows[2].trigger('mousemove', { clientX: 10, clientY: 10 });
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' });
+    expect(wrapper.emitted('update:modelValue')?.[0]).toStrictEqual([['curve']]);
+  });
+
+  // The list is virtualized and the arrows scroll it, so a row the user never pointed at arrives
+  // under a cursor that has not moved. The browser reports that as a mousemove at the same
+  // coordinates; obeying it hands the highlight straight back and the arrows cannot advance.
+  it('should ignore a row that slid under a still cursor', async () => {
+    const wrapper = createWrapper([]);
+    const rows = wrapper.findAll('[data-testid="value-select-option"]');
+    const input = wrapper.find('input');
+
+    await rows[0].trigger('mousemove', { clientX: 10, clientY: 10 });
+    await input.trigger('keydown', { key: 'ArrowDown' }); // 0 -> 1 (Uniswap)
+    // Hovering a row the keyboard did NOT move to: hovering row 1 here would agree with the buggy
+    // behaviour and the test could not fail.
+    await rows[2].trigger('mousemove', { clientX: 10, clientY: 10 });
+    await input.trigger('keydown', { key: 'Enter' });
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toStrictEqual([['uniswap']]);
+  });
+
+  it('should hand the highlight back once the pointer genuinely moves', async () => {
+    const wrapper = createWrapper([]);
+    const rows = wrapper.findAll('[data-testid="value-select-option"]');
+    const input = wrapper.find('input');
+
+    await rows[0].trigger('mousemove', { clientX: 10, clientY: 10 });
+    await input.trigger('keydown', { key: 'ArrowDown' });
+    await rows[2].trigger('mousemove', { clientX: 10, clientY: 40 });
+    await input.trigger('keydown', { key: 'Enter' });
+
+    expect(wrapper.emitted('update:modelValue')?.[0]).toStrictEqual([['curve']]);
+  });
+
   // Searching 'a' keeps Aave and Uniswap. With no pinned rows the highlight lands on the first of
   // them, which is the baseline the pinned cases below are contrasted against.
   it('should highlight the first result after a search', async () => {

--- a/frontend/app/src/modules/core/table/pill/ValueSelectList.vue
+++ b/frontend/app/src/modules/core/table/pill/ValueSelectList.vue
@@ -110,6 +110,24 @@ function toggle(value: string): void {
   }
 }
 
+// Last position the pointer was actually at.
+//
+// Any scroll slides rows under a cursor that never moved, and the browser reports that as a
+// mousemove at unchanged coordinates. Taking it at face value breaks both ways of moving through
+// this list: the arrow keys cannot advance past one row, because the row arriving under the pointer
+// hands the highlight straight back, and a wheel scroll drags the highlight along with it.
+let lastX = Number.NaN;
+let lastY = Number.NaN;
+
+function onPointerMove(event: MouseEvent, index: number): void {
+  if (event.clientX === lastX && event.clientY === lastY)
+    return;
+
+  lastX = event.clientX;
+  lastY = event.clientY;
+  set(highlighted, index);
+}
+
 function onKeydown(event: KeyboardEvent): void {
   // Escape comes first, and is handled here rather than left to the surrounding menu: dismissal by
   // the menu only works while its own content holds focus, and this list is what holds it. An
@@ -216,7 +234,7 @@ function onKeydown(event: KeyboardEvent): void {
           :aria-checked="selectedSet.has(item.data.value)"
           data-testid="value-select-option"
           :data-key="item.data.value"
-          @mousemove="highlighted = item.index"
+          @mousemove="onPointerMove($event, item.index)"
           @click="toggle(item.data.value)"
         >
           <!-- aria-checked on the row already states selection, so the indicator is decorative to


### PR DESCRIPTION
`ValueSelectList` set its highlight straight from a `mousemove`:

```vue
@mousemove="highlighted = item.index"
```

The list is virtualized and the arrow keys call `scrollTo`, so a row the user
never pointed at arrives under a cursor that has not moved. The browser reports
that as a mousemove at **unchanged coordinates**, and obeying it hands the
highlight straight back to whatever is under the pointer. Two consequences:

- **The arrow keys cannot advance past one row.** Each press scrolls, the next
  row lands under the stationary cursor, and the highlight snaps back.
- **A wheel scroll drags the highlight with it**, for the same reason.

Pointer moves are now taken only when `clientX`/`clientY` actually changed.

## Why this file

Same defect and same fix as the send form's token picker in #12961, where it was
found. This is the other virtualized picker in the app, so it had inherited the
same pattern. Kept as its own change rather than folded into that PR, since it
is a separate component with its own users.

## Tests

Three cases added to the existing spec, asserting through the emitted value
after `Enter` rather than any internal state, matching the file's style:

- hovering an option moves the highlight,
- a row that slid under a still cursor is ignored,
- a genuine pointer move takes the highlight back.

Negative-controlled: with the coordinate guard removed, exactly one test fails,
"should ignore a row that slid under a still cursor". The other two describe
behaviour that does not depend on the guard and correctly still pass.

⚠️ The middle test hovers a row the keyboard did **not** move to. Hovering the
row it had just moved to would agree with both the correct and the broken
behaviour, and the test could never fail.

## Not in this PR

`onKeydown` acts on `Enter` and the arrows without checking `event.isComposing`,
so an IME confirming a candidate commits a row and closes the list mid-word. The
token picker got that guard in #12961; this list still needs it. Left out to
keep this change to one thing.
