### PR TITLE
fix: hide empty nft section on dashboard

### DIFF
--- a/frontend/app/src/modules/balances/non-fungible/use-nft-data.ts
+++ b/frontend/app/src/modules/balances/non-fungible/use-nft-data.ts
@@ -32,6 +32,8 @@ interface UseNftDataReturn {
   data: ComputedRef<NonFungibleBalance[]>;
   dataLoading: Ref<boolean>;
   fetchData: () => Promise<void>;
+  /** Entries matching the current filter, across all pages. Zero means there is nothing to show. */
+  found: ComputedRef<number>;
   modelIgnoredAssetsHandling: Ref<IgnoredAssetsHandlingType>;
   pagination: ComputedRef<TablePaginationData>;
   percentageOfCurrentGroup: (value: BigNumber) => string;
@@ -78,7 +80,7 @@ export function useNftData(options: UseNftDataOptions = {}): UseNftDataReturn {
     urlState: routeWhen(() => !dashboard),
   });
 
-  const { data, totalValue } = getCollectionData(balances);
+  const { data, found, totalValue } = getCollectionData(balances);
 
   // Watch ignoredAssetsHandling changes and reset to page 1 (only for non-dashboard)
   if (!dashboard) {
@@ -197,6 +199,7 @@ export function useNftData(options: UseNftDataOptions = {}): UseNftDataReturn {
     data,
     dataLoading,
     fetchData,
+    found,
     modelIgnoredAssetsHandling,
     pagination,
     percentageOfCurrentGroup,

--- a/frontend/app/src/modules/dashboard/NftBalanceTable.vue
+++ b/frontend/app/src/modules/dashboard/NftBalanceTable.vue
@@ -10,6 +10,10 @@ import PercentageDisplay from '@/modules/shell/components/display/PercentageDisp
 import RefreshButton from '@/modules/shell/components/RefreshButton.vue';
 import RowAppend from '@/modules/shell/components/RowAppend.vue';
 
+// The section renders nothing when there are no nfts, so attributes cannot be inherited automatically. They are
+// forwarded explicitly below instead, which also keeps vue from warning about the comment root.
+defineOptions({ inheritAttrs: false });
+
 const nonFungibleRoute: RouteLocationRaw = { name: '/balances/non-fungible/' };
 const group = DashboardTableType.NFT;
 
@@ -21,6 +25,7 @@ const {
   data,
   dataLoading,
   fetchData,
+  found,
   percentageOfCurrentGroup,
   percentageOfTotalNetValue,
   refreshNonFungibleBalances,
@@ -35,6 +40,12 @@ onMounted(async () => {
   await refreshNonFungibleBalances();
 });
 
+/**
+ * The section is only worth showing once we know there is at least one nft. `found` starts at zero and the fetch
+ * happens on mount, so this also keeps an empty table from flashing before the first response arrives.
+ */
+const hasBalances = computed<boolean>(() => get(found) > 0);
+
 watch(sectionLoading, async (isLoading, wasLoading) => {
   if (!isLoading && wasLoading)
     await fetchData();
@@ -42,7 +53,10 @@ watch(sectionLoading, async (isLoading, wasLoading) => {
 </script>
 
 <template>
-  <DashboardExpandableTable>
+  <DashboardExpandableTable
+    v-if="hasBalances"
+    v-bind="$attrs"
+  >
     <template #title>
       <RefreshButton
         :loading="sectionLoading"


### PR DESCRIPTION
The dashboard NFT section rendered whenever the NFTS module was active, regardless of whether the account owned any NFTs. Accounts with none got the section header plus an empty table reading "No data available".

The gate was module-only:

```
<NftBalanceTable v-if="nftEnabled" ... />
```

while the liabilities table right beside it already gates on its row count (`v-if="aggregatedLiabilities.length > 0"`).

## Change

`useNftData` now also returns the collection's `found` count, and `NftBalanceTable` renders only when that count is above zero.

The gate lives inside the component rather than in `Dashboard.vue` because `NftBalanceTable` fetches its own data in `onMounted`. Gating from the parent would prevent the fetch that produces the count, so the section would never appear even for accounts that do own NFTs.

Two consequences worth noting:

- `found` starts at zero and the fetch is not immediate, so the section stays hidden until the first response lands. That also removes the brief empty table that flashed during dashboard load.
- When hidden, the component root is a comment node, so the `id`, `data-testid` and `class` that `Dashboard.vue` passes down cannot be inherited automatically and Vue warns in dev. They are now forwarded explicitly via `inheritAttrs: false` plus `v-bind="$attrs"`.

`found` reflects the dashboard's fixed `ignoredAssetsHandling: 'exclude'` filter, so an account whose NFTs are all ignored also hides the section. The table would render no rows either way.

## Verification

Checked in a running app against a real backend.

Empty account:

- `GET /nfts/balances` returned `entries_found: 0`, confirming the module was active and the component had mounted and fetched, which is exactly the condition that previously produced the empty table.
- `#nft-balance-table-section` and `[data-testid=nft-balance-table]` both absent from the DOM.
- Negative control: relaxing the gate to `found >= 0` brought the empty "NFT Balances / No data available / Items # 0 of 0" section back, confirming the gate is what hides it rather than the module setting.
- No Vue attribute-inheritance warning in the console.

Account with NFTs: the section still renders, with its rows, total, and the `mt-8` spacing class intact.

`pnpm run lint:file:check`, `pnpm run typecheck` and `pnpm run knip` all pass.

The e2e helper in `tests/e2e/pages/dashboard-page.ts` already handles the table being absent and returns `Zero`, so it needed no change.
