### PR TITLE
ci(sqldiff): cap job and apt install runtime

### DIFF
--- a/.github/workflows/rotki_sqldiff.yml
+++ b/.github/workflows/rotki_sqldiff.yml
@@ -18,6 +18,7 @@ jobs:
   sql-diff:
     name: SQLDiff
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     permissions:
       contents: read
@@ -31,6 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Install required
+        timeout-minutes: 10
         run: sudo apt-get update && sudo apt-get install -y sqlcipher sqlite3-tools
 
       - name: SQLDiff action


### PR DESCRIPTION
The `SQLDiff` job declares no `timeout-minutes`, so it inherits GitHub's default of **360 minutes**. On #12965 a run sat `pending` for 55 minutes and only cleared as `CANCELLED`, while every other check on the PR settled inside ~15. Because the job holds `pull-requests: write` and the merge state reads `BLOCKED` while a required check is pending, a hung run is indistinguishable from a slow one for up to six hours.

## Where the time goes

Step timings across the last 40 runs of the workflow:

| Step | Median | Worst success | Hung run |
|------|--------|---------------|----------|
| `Install required` (`apt-get update` + `sqlcipher`, `sqlite3-tools`) | ~12s | 253s | **3302s (55m)** |
| `SQLDiff action` (`rotki/action-sqldiff@v3.0.1`) | 1s | 1s | n/a |

31 of the 39 successful runs finished the install in under 20s. The action itself is 0-1s every single time, so the risk is entirely in the apt step.

Worth noting explicitly: the `pending` then `CANCELLED` pattern was **not** `concurrency: cancel-in-progress` working as designed. The run really was stuck inside `apt-get`.

## The caps

- **`Install required`: 10 minutes**, about 2.4x the worst observed success. Nothing legitimate has come near it.
- **Job: 15 minutes** as an outer bound, so a hang anywhere else is caught too. The slowest complete run in the sample was ~4m45s, so there is plenty of headroom.

A hang now fails fast and legibly instead of blocking the PR for six hours.