### PR TITLE
fix(frontend): keep pinned matching pager in view

### DIFF
--- a/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
@@ -78,7 +78,7 @@ onBeforeMount(async () => {
 <template>
   <RuiTabs
     v-model="activeTab"
-    class="border-b border-default"
+    class="border-b border-default shrink-0"
     color="primary"
   >
     <RuiTab>
@@ -105,10 +105,44 @@ onBeforeMount(async () => {
     </RuiTab>
   </RuiTabs>
 
+  <!-- Pinned bypasses RuiTabItems: it sizes itself from its content and hides the overflow, so
+       in a bounded column the bottom of the panel - the pager - is silently cut off. Rendering
+       the active list straight into a flex column lets it size to the space it actually has. -->
+  <div
+    v-if="isPinned"
+    class="flex-1 min-h-0 flex flex-col px-3 my-4"
+  >
+    <UnmatchedMovementsList
+      v-if="activeTab === 0"
+      v-model:selected="modelSelectedUnmatched"
+      :movements="unmatchedMovements"
+      :highlighted-group-identifier="highlightedGroupIdentifier"
+      :ignore-loading="ignoreLoading"
+      is-pinned
+      :loading="loading"
+      :match-disabled="!isAutoMatchAllowed"
+      :match-minimum-tier="autoMatchMinimumTier"
+      @action="handleAction($event)"
+      @pin="emit('pin')"
+    />
+    <UnmatchedMovementsList
+      v-else
+      v-model:selected="modelSelectedIgnored"
+      :movements="ignoredMovements"
+      :highlighted-group-identifier="highlightedGroupIdentifier"
+      :loading="ignoredLoading"
+      :ignore-loading="ignoreLoading"
+      is-pinned
+      show-restore
+      @action="handleAction($event)"
+      @pin="emit('pin')"
+    />
+  </div>
+
   <RuiTabItems
+    v-else
     v-model="activeTab"
     class="my-4"
-    :class="{ 'px-3': isPinned }"
   >
     <RuiTabItem>
       <UnmatchedMovementsList
@@ -116,7 +150,6 @@ onBeforeMount(async () => {
         :movements="unmatchedMovements"
         :highlighted-group-identifier="highlightedGroupIdentifier"
         :ignore-loading="ignoreLoading"
-        :is-pinned="isPinned"
         :loading="loading"
         :match-disabled="!isAutoMatchAllowed"
         :match-minimum-tier="autoMatchMinimumTier"
@@ -131,7 +164,6 @@ onBeforeMount(async () => {
         :highlighted-group-identifier="highlightedGroupIdentifier"
         :loading="ignoredLoading"
         :ignore-loading="ignoreLoading"
-        :is-pinned="isPinned"
         show-restore
         @action="handleAction($event)"
         @pin="emit('pin')"

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
@@ -80,7 +80,7 @@ onBeforeMount(async () => {
 <template>
   <RuiTabs
     v-model="activeTab"
-    class="border-b border-default"
+    class="border-b border-default shrink-0"
     color="primary"
   >
     <RuiTab>
@@ -107,10 +107,44 @@ onBeforeMount(async () => {
     </RuiTab>
   </RuiTabs>
 
+  <!-- Pinned bypasses RuiTabItems: it sizes itself from its content and hides the overflow, so
+       in a bounded column the bottom of the panel - the pager - is silently cut off. Rendering
+       the active list straight into a flex column lets it size to the space it actually has. -->
+  <div
+    v-if="isPinned"
+    class="flex-1 min-h-0 flex flex-col px-3 my-4"
+  >
+    <UnmatchedBridgesList
+      v-if="activeTab === 0"
+      v-model:selected="modelSelectedUnmatched"
+      :transactions="unmatchedTransactions"
+      :highlighted-group-identifier="highlightedGroupIdentifier"
+      :ignore-loading="ignoreLoading"
+      is-pinned
+      :loading="loading"
+      :match-disabled="!isAutoMatchAllowed"
+      :match-minimum-tier="autoMatchMinimumTier"
+      @action="handleAction($event)"
+      @pin="emit('pin')"
+    />
+    <UnmatchedBridgesList
+      v-else
+      v-model:selected="modelSelectedIgnored"
+      :transactions="ignoredTransactions"
+      :highlighted-group-identifier="highlightedGroupIdentifier"
+      :loading="ignoredLoading"
+      :ignore-loading="ignoreLoading"
+      is-pinned
+      show-restore
+      @action="handleAction($event)"
+      @pin="emit('pin')"
+    />
+  </div>
+
   <RuiTabItems
+    v-else
     v-model="activeTab"
     class="my-4"
-    :class="{ 'px-3': isPinned }"
   >
     <RuiTabItem>
       <UnmatchedBridgesList
@@ -118,7 +152,6 @@ onBeforeMount(async () => {
         :transactions="unmatchedTransactions"
         :highlighted-group-identifier="highlightedGroupIdentifier"
         :ignore-loading="ignoreLoading"
-        :is-pinned="isPinned"
         :loading="loading"
         :match-disabled="!isAutoMatchAllowed"
         :match-minimum-tier="autoMatchMinimumTier"
@@ -133,7 +166,6 @@ onBeforeMount(async () => {
         :highlighted-group-identifier="highlightedGroupIdentifier"
         :loading="ignoredLoading"
         :ignore-loading="ignoreLoading"
-        :is-pinned="isPinned"
         show-restore
         @action="handleAction($event)"
         @pin="emit('pin')"

--- a/frontend/app/src/modules/history/events/UnmatchedBridgesCards.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedBridgesCards.vue
@@ -18,7 +18,6 @@ const { rows, highlightedGroupIdentifier } = defineProps<{
   rows: UnmatchedBridgeRow[];
   specFor: (row: UnmatchedBridgeRow) => UnmatchedRowActionSpec;
   emptyDescription: string;
-  maxHeight: string;
   highlightedGroupIdentifier?: string;
   ignoreLoading?: boolean;
   loading?: boolean;
@@ -42,7 +41,6 @@ defineSlots<{
     :accented="(row: UnmatchedBridgeRow) => row.untrackedCounterpart"
     :empty-description="emptyDescription"
     :loading="loading"
-    :max-height="maxHeight"
   >
     <template
       v-if="$slots.alert"

--- a/frontend/app/src/modules/history/events/UnmatchedBridgesList.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedBridgesList.vue
@@ -48,25 +48,16 @@ const { description, emptyDescription, rows, specFor } = useUnmatchedBridgeRows(
   transactions: () => transactions,
 });
 
-const descriptionEl = useTemplateRef<HTMLElement>('description');
-const { height: descriptionHeight } = useElementSize(descriptionEl);
-
-const maxHeight = computed<string>(() =>
-  isPinned
-    // the card list keeps its select-all bar and pager outside the scroll area,
-    // so it gets less room than the table did at the same width
-    ? `calc(100vh - 20rem - ${get(descriptionHeight)}px)`
-    : 'calc(100vh - 23rem)',
-);
+// Pinned, the host is a bounded flex column, so the card list is sized by what is left over
+// and the pager stays in view. The dialog cannot propagate a height down to the table, so it
+// keeps its viewport cap.
+const maxHeight = 'calc(100vh - 23rem)';
 </script>
 
 <template>
-  <div>
-    <div class="flex items-center justify-between gap-2 mb-4">
-      <p
-        ref="description"
-        class="text-body-2 text-rui-text-secondary"
-      >
+  <div :class="isPinned ? 'flex-1 min-h-0 flex flex-col' : ''">
+    <div class="shrink-0 flex items-center justify-between gap-2 mb-4">
+      <p class="text-body-2 text-rui-text-secondary">
         {{ description }}
       </p>
       <RuiButton
@@ -92,7 +83,7 @@ const maxHeight = computed<string>(() =>
       :rows="rows"
       :spec-for="specFor"
       :empty-description="emptyDescription"
-      :max-height="maxHeight"
+      :max-height="isPinned ? undefined : maxHeight"
       :highlighted-group-identifier="highlightedGroupIdentifier"
       :ignore-loading="ignoreLoading"
       :loading="loading"

--- a/frontend/app/src/modules/history/events/UnmatchedCardList.spec.ts
+++ b/frontend/app/src/modules/history/events/UnmatchedCardList.spec.ts
@@ -39,7 +39,6 @@ function mountList(items: TestItem[], highlightedId?: string): VueWrapper {
         :row-key="rowKey"
         :highlighted="highlighted"
         empty-description="Nothing here"
-        max-height="20rem"
       >
         <template #header="{ item }">
           <span>{{ item.label }}</span>

--- a/frontend/app/src/modules/history/events/UnmatchedCardList.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedCardList.vue
@@ -4,7 +4,11 @@ import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogConten
 
 const selected = defineModel<string[]>('selected', { required: true });
 
-const { items, rowKey, emptyDescription, highlighted, accented, loading, maxHeight } = defineProps<{
+// The list fills the height its host gives it rather than capping itself against the
+// viewport: the select-all bar and the pager sit outside the scroll area, so a cap that
+// guesses the surrounding chrome loses the pager off the bottom of a short window. The
+// host must be a bounded flex column (the pinned rail is).
+const { items, rowKey, emptyDescription, highlighted, accented, loading } = defineProps<{
   items: T[];
   /** Stable identity of a card, and what the selection model stores. */
   rowKey: (item: T) => string;
@@ -14,7 +18,6 @@ const { items, rowKey, emptyDescription, highlighted, accented, loading, maxHeig
   /** Card whose row cannot be matched, marked with a warning edge. */
   accented?: (item: T) => boolean;
   loading?: boolean;
-  maxHeight: string;
 }>();
 
 defineSlots<{
@@ -97,12 +100,17 @@ watch(() => items.length, (length) => {
 </script>
 
 <template>
-  <div data-testid="unmatched-card-list">
-    <slot name="alert" />
+  <div
+    class="flex-1 min-h-0 flex flex-col"
+    data-testid="unmatched-card-list"
+  >
+    <div class="shrink-0">
+      <slot name="alert" />
+    </div>
 
     <div
       v-if="items.length > 0"
-      class="flex items-center gap-2 px-2 py-1 border border-default rounded-t"
+      class="shrink-0 flex items-center gap-2 px-2 py-1 border border-default rounded-t"
     >
       <RuiCheckbox
         :model-value="allSelected"
@@ -123,7 +131,7 @@ watch(() => items.length, (length) => {
       </span>
     </div>
 
-    <ScrollableDialogContent :max-height="maxHeight">
+    <ScrollableDialogContent fill>
       <div
         v-if="items.length === 0"
         class="flex flex-col items-center gap-2 py-8 border border-default rounded text-body-2 text-rui-text-secondary"
@@ -205,7 +213,7 @@ watch(() => items.length, (length) => {
       v-if="items.length > itemsPerPage"
       v-model="pagination"
       dense
-      class="mt-2"
+      class="shrink-0 mt-2"
       data-testid="unmatched-card-pagination"
     />
   </div>

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsCards.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsCards.vue
@@ -16,7 +16,6 @@ const { rows, highlightedGroupIdentifier } = defineProps<{
   rows: UnmatchedMovementRow[];
   specFor: (row: UnmatchedMovementRow) => UnmatchedRowActionSpec;
   emptyDescription: string;
-  maxHeight: string;
   highlightedGroupIdentifier?: string;
   ignoreLoading?: boolean;
   loading?: boolean;
@@ -41,7 +40,6 @@ const { t } = useI18n({ useScope: 'global' });
     :highlighted="(row: UnmatchedMovementRow) => row.groupIdentifier === highlightedGroupIdentifier"
     :empty-description="emptyDescription"
     :loading="loading"
-    :max-height="maxHeight"
   >
     <template
       v-if="$slots.alert"

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsList.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsList.vue
@@ -46,25 +46,16 @@ const { description, emptyDescription, rows, specFor } = useUnmatchedMovementRow
   showRestore: () => showRestore,
 });
 
-const descriptionEl = useTemplateRef<HTMLElement>('description');
-const { height: descriptionHeight } = useElementSize(descriptionEl);
-
-const maxHeight = computed<string>(() =>
-  isPinned
-    // the card list keeps its select-all bar and pager outside the scroll area,
-    // so it gets less room than the table did at the same width
-    ? `calc(100vh - 20rem - ${get(descriptionHeight)}px)`
-    : 'calc(100vh - 23rem)',
-);
+// Pinned, the host is a bounded flex column, so the card list is sized by what is left over
+// and the pager stays in view. The dialog cannot propagate a height down to the table, so it
+// keeps its viewport cap.
+const maxHeight = 'calc(100vh - 23rem)';
 </script>
 
 <template>
-  <div>
-    <div class="flex items-center justify-between gap-2 mb-4">
-      <p
-        ref="description"
-        class="text-body-2 text-rui-text-secondary"
-      >
+  <div :class="isPinned ? 'flex-1 min-h-0 flex flex-col' : ''">
+    <div class="shrink-0 flex items-center justify-between gap-2 mb-4">
+      <p class="text-body-2 text-rui-text-secondary">
         {{ description }}
       </p>
       <RuiButton
@@ -90,7 +81,7 @@ const maxHeight = computed<string>(() =>
       :rows="rows"
       :spec-for="specFor"
       :empty-description="emptyDescription"
-      :max-height="maxHeight"
+      :max-height="isPinned ? undefined : maxHeight"
       :highlighted-group-identifier="highlightedGroupIdentifier"
       :ignore-loading="ignoreLoading"
       :loading="loading"


### PR DESCRIPTION
The pinned **Match Bridge Transactions** and **Match Asset Movements** panels lost their
pagination row at 100% zoom. It only reappeared around 67%.

## Cause

Both panels capped their card list at `calc(100vh - 20rem - <description height>)` and
rendered it inside `RuiTabItems`. `RuiTabItems` sizes its root from its own content and
sets `overflow-hidden`, so in a bounded column flex shrinks it below that content and the
bottom is silently cut. The pager sits outside the card list's scroll area, so it is the
first thing lost. At a 900px viewport it landed 77px past the clip line.

Only these 2 of the 6 pinned panels were affected. The other paginated ones keep their
pager inside the scroll area, so it is merely scrolled to, never lost.

## Fix

Size the list by the space it actually has instead of guessing the surrounding chrome:

- the card list is a bounded flex column (`ScrollableDialogContent fill`), which is what
  that prop already documents itself as being for
- the pinned branch renders the active list into a plain flex column rather than through
  `RuiTabItems`
- the viewport cap is left to the dialog, which cannot propagate a height down to its table

## Verification

Driven in the running app against real data (237 unmatched bridge rows), with no test-only
edits in the tree:

| viewport | pager box | inside clip line by |
|---|---|---|
| 900px | 792-836 | 64px |
| 640px | 532-576 | 64px |

The headroom staying at exactly 64px across viewport heights is the point: the pager is
anchored to the bottom of a bounded flex container rather than to a guessed viewport
calculation.

The measurement was negative-controlled. Forcing the pre-fix shape (content refusing to
shrink inside a bounded clipper) drives the pager 482px past the clip line and is correctly
detected, so a passing reading is meaningful.

The Asset Movements panel was checked separately: the fixed code path is live (its ancestor
chain carries the new wrapper and no `RuiTabItems`), and with content forced to 3619px the
column held its bounds and absorbed the overflow by scrolling.

## Not covered by tests

This is a layout regression and the unit lane runs in happy-dom, which has no layout engine
and reports zero heights, so no vitest test can catch it. The existing
`UnmatchedCardList.spec.ts` covers pager behaviour (paging, hiding when everything fits,
selection across pages) and is touched here only to drop the removed `max-height` prop.
Nothing in the suite would fail if this regressed.

Guarding it properly needs a Playwright test that seeds more than one page of unmatched
bridge legs, pins the panel and asserts the pager's box against its clipping ancestor.
Happy to follow up with that separately.

One known gap in the manual pass: the test account has only 3 unmatched asset movements, so
that panel's pager never rendered and was not measured directly. It is covered by structural
equivalence with the bridge panel and by the bounded-column check above.
