### PR TITLE
Ignore keys while an IME is composing in the pill filter list

### DIFF
--- a/frontend/app/src/modules/core/table/pill/ValueSelectList.spec.ts
+++ b/frontend/app/src/modules/core/table/pill/ValueSelectList.spec.ts
@@ -194,4 +194,21 @@ describe('valueSelectList', () => {
 
     expect(wrapper.emitted('close')).toHaveLength(1);
   });
+
+  // An IME confirms its candidate with Enter and walks the candidate list with the arrows, so
+  // acting on either would commit a row and close the list mid-word.
+  it('should ignore keys while an IME is composing', async () => {
+    const wrapper = createWrapper([]);
+    const input = wrapper.find('input');
+
+    await input.trigger('keydown', { isComposing: true, key: 'ArrowDown' });
+    await input.trigger('keydown', { isComposing: true, key: 'Enter' });
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+
+    // And the highlight never moved: committing after composition picks the first row, not the
+    // second. Asserting only that nothing was emitted would also pass if the arrow had moved it.
+    await input.trigger('keydown', { key: 'Enter' });
+    expect(wrapper.emitted('update:modelValue')?.[0]).toStrictEqual([['aave']]);
+  });
 });

--- a/frontend/app/src/modules/core/table/pill/ValueSelectList.vue
+++ b/frontend/app/src/modules/core/table/pill/ValueSelectList.vue
@@ -137,6 +137,12 @@ function onKeydown(event: KeyboardEvent): void {
     return;
   }
 
+  // While an IME is composing, Enter confirms the candidate and the arrows walk the candidate
+  // list. Acting on them would commit a row and close the list mid-word. Same guard as the send
+  // form's token picker, the app's other virtualized picker.
+  if (event.isComposing)
+    return;
+
   const items = get(filtered);
   if (items.length === 0)
     return;


### PR DESCRIPTION
The pill filter list's option search acted on `Enter` and the arrow keys without checking whether
the key arrived mid-composition. An IME confirming a candidate therefore committed a row and closed
the list mid-word, and the arrows walked the option list instead of the candidate list.

`onKeydown` now returns early on `event.isComposing`. It sits after the Escape branch and before the
arrow and Enter branches, the same shape as the send form's token picker, which got this guard in
#12961. This list is the app's other virtualized picker.

A spec covers it. It asserts both halves: nothing is committed while composing, and the highlight
did not move either, so committing afterwards picks the first row rather than the second. Asserting
only that nothing was emitted would also pass if the arrow had moved the highlight.

The guard was negative-controlled (`if (false && event.isComposing)`): that failed the new test and
only the new test.