### PR TITLE
feat(wallet): derive send chains from the backend

### DIFF
--- a/frontend/app/src/modules/wallet/bridge/use-injected-wallet.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-injected-wallet.spec.ts
@@ -213,5 +213,23 @@ describe('modules/wallet/bridge/use-injected-wallet', () => {
 
       expect(request).toHaveBeenCalledWith(expect.objectContaining({ method: 'wallet_addEthereumChain' }));
     });
+
+    it('should surface the 4902 when it has no definition for the chain', async () => {
+      const request = vi.fn()
+        .mockImplementationOnce(async () => ['0xabc']) // eth_requestAccounts
+        .mockImplementationOnce(async () => '0x1') // eth_chainId
+        .mockImplementationOnce(async () => { throw Object.assign(new Error('unknown chain'), { code: 4902 }); })
+        .mockImplementation(async () => undefined);
+      const provider = makeProvider({ request });
+      selectProvider(provider);
+      // The chain list is dynamic, so it can name a chain the viem table lacks.
+      getWalletNetwork.mockReturnValue(undefined);
+      const wallet = useInjectedWallet();
+      await wallet.connectToSelectedProvider();
+
+      // Swallowing it leaves the user with a click that silently does nothing.
+      await expect(wallet.switchNetwork(143n)).rejects.toThrow('unknown chain');
+      expect(request).not.toHaveBeenCalledWith(expect.objectContaining({ method: 'wallet_addEthereumChain' }));
+    });
   });
 });

--- a/frontend/app/src/modules/wallet/bridge/use-injected-wallet.spec.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-injected-wallet.spec.ts
@@ -214,6 +214,30 @@ describe('modules/wallet/bridge/use-injected-wallet', () => {
       expect(request).toHaveBeenCalledWith(expect.objectContaining({ method: 'wallet_addEthereumChain' }));
     });
 
+    it('should send an empty explorer list when the chain has no explorer', async () => {
+      const request = vi.fn()
+        .mockImplementationOnce(async () => ['0xabc']) // eth_requestAccounts
+        .mockImplementationOnce(async () => '0x1') // eth_chainId
+        .mockImplementationOnce(async () => { throw Object.assign(new Error('unknown chain'), { code: 4902 }); })
+        .mockImplementation(async () => undefined);
+      const provider = makeProvider({ request });
+      selectProvider(provider);
+      getWalletNetwork.mockReturnValue({
+        name: 'Monad',
+        nativeCurrency: { decimals: 18, name: 'Monad', symbol: 'MON' },
+        rpcUrls: { default: { http: ['https://rpc.monad'] } },
+      });
+      const wallet = useInjectedWallet();
+      await wallet.connectToSelectedProvider();
+
+      await wallet.switchNetwork(143n);
+
+      expect(request).toHaveBeenCalledWith(expect.objectContaining({
+        method: 'wallet_addEthereumChain',
+        params: [expect.objectContaining({ blockExplorerUrls: [] })],
+      }));
+    });
+
     it('should surface the 4902 when it has no definition for the chain', async () => {
       const request = vi.fn()
         .mockImplementationOnce(async () => ['0xabc']) // eth_requestAccounts

--- a/frontend/app/src/modules/wallet/bridge/use-injected-wallet.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-injected-wallet.ts
@@ -256,18 +256,22 @@ function _useInjectedWallet(): UseInjectedWalletReturn {
         if (error instanceof Object && 'code' in error && error.code === 4902) {
           const { getWalletNetwork } = await import('../chains-viem');
           const network = getWalletNetwork(chainId);
-          if (network) {
-            await injectedProvider.request({
-              method: 'wallet_addEthereumChain',
-              params: [{
-                blockExplorerUrls: network.blockExplorers?.default ? [network.blockExplorers.default.url] : [],
-                chainId: `0x${chainId.toString(16)}`,
-                chainName: network.name,
-                nativeCurrency: network.nativeCurrency,
-                rpcUrls: network.rpcUrls.default.http,
-              }],
-            });
-          }
+          // The chain list comes from the backend and can outrun the viem table,
+          // so a chain with no definition is normal. Nothing can be added for it:
+          // rethrow rather than return as if the switch had worked.
+          if (!network)
+            throw error;
+
+          await injectedProvider.request({
+            method: 'wallet_addEthereumChain',
+            params: [{
+              blockExplorerUrls: network.blockExplorers?.default ? [network.blockExplorers.default.url] : [],
+              chainId: `0x${chainId.toString(16)}`,
+              chainName: network.name,
+              nativeCurrency: network.nativeCurrency,
+              rpcUrls: network.rpcUrls.default.http,
+            }],
+          });
         }
         else {
           throw error;

--- a/frontend/app/src/modules/wallet/chains-viem.spec.ts
+++ b/frontend/app/src/modules/wallet/chains-viem.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { getWalletNetwork, SUPPORTED_WALLET_NETWORKS } from '@/modules/wallet/chains-viem';
+
+// The seam: this table only enriches a chain with an rpc url and the payload for
+// `wallet_addEthereumChain`. It does not decide which chains the wallet offers,
+// so a missing entry must return undefined rather than a wrong chain.
+
+describe('chains-viem', () => {
+  it('should carry the chains whose add-network fallback we rely on', () => {
+    // Deliberately not an equality assertion against the backend's chain list.
+    // Entries here are optional enrichment, so a chain rotki gains does not have
+    // to appear, and adding a new entry must not fail a test.
+    expect(SUPPORTED_WALLET_NETWORKS.map(network => network.id)).toEqual(
+      expect.arrayContaining([1, 143, 999]),
+    );
+  });
+
+  it('should resolve a network by its chain id', () => {
+    expect(getWalletNetwork(143n)?.id).toBe(143);
+    expect(getWalletNetwork(999n)?.id).toBe(999);
+  });
+
+  it('should return undefined for a chain it has no definition for', () => {
+    expect(getWalletNetwork(250n)).toBeUndefined();
+  });
+
+  it('should expose the fields wallet_addEthereumChain needs', () => {
+    const network = getWalletNetwork(143n);
+
+    expect(network?.name).toBeTruthy();
+    expect(network?.nativeCurrency.decimals).toBe(18);
+    expect(network?.rpcUrls.default.http[0]).toMatch(/^https:\/\//);
+  });
+});

--- a/frontend/app/src/modules/wallet/chains-viem.ts
+++ b/frontend/app/src/modules/wallet/chains-viem.ts
@@ -1,5 +1,5 @@
 import type { Chain } from '@/modules/wallet/viem-client';
-import { arbitrum, base, bsc, gnosis, mainnet, optimism, polygon, scroll } from 'viem/chains';
+import { arbitrum, base, bsc, gnosis, hyperEvm, mainnet, monad, optimism, polygon, scroll } from 'viem/chains';
 
 /**
  * The viem {@link Chain} objects for the chains rotki's wallet stack supports.
@@ -12,7 +12,12 @@ import { arbitrum, base, bsc, gnosis, mainnet, optimism, polygon, scroll } from 
  * `import('./chains-viem')`, so viem's chain data stays out of the initial
  * bundle and loads only when a wallet connection actually needs it.
  *
- * Keep the ids in sync with `SUPPORTED_WALLET_CHAIN_IDS` in `constants.ts`.
+ * This is an *enrichment* table, not the list of chains the wallet offers: that
+ * comes from the backend through `useWalletChains`. Only the RPC url and the
+ * `wallet_addEthereumChain` payload need a definition from here, and both call
+ * sites already handle a chain that has none. A chain the backend gains still
+ * works without an entry; adding one only buys the "add this network to your
+ * wallet" fallback.
  */
 export const SUPPORTED_WALLET_NETWORKS: readonly Chain[] = [
   mainnet,
@@ -23,6 +28,8 @@ export const SUPPORTED_WALLET_NETWORKS: readonly Chain[] = [
   gnosis,
   polygon,
   scroll,
+  monad,
+  hyperEvm,
 ] as const;
 
 export function getWalletNetwork(chainId: bigint): Chain | undefined {

--- a/frontend/app/src/modules/wallet/constants.ts
+++ b/frontend/app/src/modules/wallet/constants.ts
@@ -13,8 +13,6 @@ export type WalletMode = typeof WALLET_MODES[keyof typeof WALLET_MODES];
 
 export const EIP155 = 'eip155';
 
-export const SUPPORTED_WALLET_CHAIN_IDS = [1, 8453, 42161, 10, 56, 100, 137, 534352] as const;
-
 /**
  * EIP-155 methods requested in the WalletConnect session namespace.
  */
@@ -47,6 +45,7 @@ export const WALLET_ERRORS = {
   CONNECTION_FAILED: 'Failed to initiate wallet connection',
   GAS_ESTIMATION_FAILED: 'Error getting gas fee',
   NO_PROVIDERS: 'No wallet providers detected',
+  NO_SUPPORTED_CHAINS: 'No supported chains are available yet',
 } as const;
 
 /**

--- a/frontend/app/src/modules/wallet/send/TradeSendCard.spec.ts
+++ b/frontend/app/src/modules/wallet/send/TradeSendCard.spec.ts
@@ -10,8 +10,15 @@ import TradeSendCard from '@/modules/wallet/send/TradeSendCard.vue';
 const RECIPIENT = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65';
 const CONNECTED = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
 const ETHEREUM_CHAIN_ID = 1;
+const OPTIMISM_CHAIN_ID = 10;
+// A chain id the wallet can report that rotki does not support, e.g. fantom.
+const UNSUPPORTED_CHAIN_ID = 250;
 // A chain the backend reports but that resolves to no numeric id.
 const UNRESOLVABLE_CHAIN = 'newchain';
+const CHAIN_NAMES: Record<number, string | undefined> = {
+  [ETHEREUM_CHAIN_ID]: 'ethereum',
+  [OPTIMISM_CHAIN_ID]: 'optimism',
+};
 
 const connected = ref<boolean>(true);
 const connectedAddress = ref<string | undefined>(CONNECTED);
@@ -22,7 +29,7 @@ const preparing = ref<boolean>(false);
 const supportedChainsForConnectedAccount = ref<string[]>(['ethereum']);
 const waitingForWalletConfirmation = ref<boolean>(false);
 const walletMode = ref<string>('local-bridge');
-const switchNetwork = vi.fn();
+const switchNetwork = vi.fn<(chainId: bigint) => Promise<void>>(async () => {});
 
 const useQueryingBalances = ref<boolean>(false);
 const warnUntrackedAddress = ref<boolean>(false);
@@ -53,7 +60,7 @@ vi.mock('@/modules/wallet/use-wallet-store', () => ({
 
 vi.mock('@/modules/wallet/use-wallet-helper', () => ({
   useWalletHelper: vi.fn(() => ({
-    getChainFromChainId: (chainId: number): string => (chainId === ETHEREUM_CHAIN_ID ? 'ethereum' : 'optimism'),
+    getChainFromChainId: (chainId: number): string | undefined => CHAIN_NAMES[chainId],
     getChainIdFromChain: (chain: string): number | undefined =>
       (chain === UNRESOLVABLE_CHAIN ? undefined : ETHEREUM_CHAIN_ID),
   })),
@@ -373,6 +380,31 @@ describe('tradeSendCard', () => {
 
       // BigInt(undefined) throws, which would break the click handler entirely.
       expect(switchNetwork).not.toHaveBeenCalled();
+    });
+
+    it('should warn when the wallet is on a chain rotki does not support', async () => {
+      // Resolving an unknown chain to ethereum made this read as the right
+      // network, so the user could send believing they were on mainnet.
+      set(connectedChainId, UNSUPPORTED_CHAIN_ID);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=switch-network-action]').exists()).toBe(true);
+    });
+
+    it('should keep the selected chain when the wallet moves to an unsupported one', async () => {
+      // Must start away from ethereum: the fallback resolved to ethereum too, so
+      // starting there would pass whether or not the selection was overwritten.
+      set(supportedChainsForConnectedAccount, ['ethereum', 'optimism']);
+      set(connectedChainId, OPTIMISM_CHAIN_ID);
+      await nextTick();
+      expect(wrapper.findComponent({ name: 'TradeAssetSelector' }).props('chain')).toBe('optimism');
+
+      set(connectedChainId, UNSUPPORTED_CHAIN_ID);
+      await nextTick();
+
+      // Following the wallet would need a chain name there is none of; the
+      // selection stays put and the wrong-network warning carries the mismatch.
+      expect(wrapper.findComponent({ name: 'TradeAssetSelector' }).props('chain')).toBe('optimism');
     });
 
     it('should refresh the balance when the asset selector asks', async () => {

--- a/frontend/app/src/modules/wallet/send/TradeSendCard.spec.ts
+++ b/frontend/app/src/modules/wallet/send/TradeSendCard.spec.ts
@@ -10,6 +10,8 @@ import TradeSendCard from '@/modules/wallet/send/TradeSendCard.vue';
 const RECIPIENT = '0xc37b40ABdB939635068d3c5f13E7faF686F03B65';
 const CONNECTED = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
 const ETHEREUM_CHAIN_ID = 1;
+// A chain the backend reports but that resolves to no numeric id.
+const UNRESOLVABLE_CHAIN = 'newchain';
 
 const connected = ref<boolean>(true);
 const connectedAddress = ref<string | undefined>(CONNECTED);
@@ -52,7 +54,8 @@ vi.mock('@/modules/wallet/use-wallet-store', () => ({
 vi.mock('@/modules/wallet/use-wallet-helper', () => ({
   useWalletHelper: vi.fn(() => ({
     getChainFromChainId: (chainId: number): string => (chainId === ETHEREUM_CHAIN_ID ? 'ethereum' : 'optimism'),
-    getChainIdFromChain: (): number => ETHEREUM_CHAIN_ID,
+    getChainIdFromChain: (chain: string): number | undefined =>
+      (chain === UNRESOLVABLE_CHAIN ? undefined : ETHEREUM_CHAIN_ID),
   })),
 }));
 
@@ -359,6 +362,17 @@ describe('tradeSendCard', () => {
       await wrapper.find('[data-testid=switch-network-action]').trigger('click');
 
       expect(switchNetwork).toHaveBeenCalledWith(BigInt(ETHEREUM_CHAIN_ID));
+    });
+
+    it('should not ask the wallet to switch to a chain with no numeric id', async () => {
+      set(supportedChainsForConnectedAccount, [UNRESOLVABLE_CHAIN]);
+      set(connectedChainId, 10);
+      await nextTick();
+
+      await wrapper.find('[data-testid=switch-network-action]').trigger('click');
+
+      // BigInt(undefined) throws, which would break the click handler entirely.
+      expect(switchNetwork).not.toHaveBeenCalled();
     });
 
     it('should refresh the balance when the asset selector asks', async () => {

--- a/frontend/app/src/modules/wallet/send/TradeSendCard.vue
+++ b/frontend/app/src/modules/wallet/send/TradeSendCard.vue
@@ -120,7 +120,9 @@ function resetInput(): void {
 }
 
 function switchToDesireNetwork(): void {
-  switchNetwork(BigInt(getChainIdFromChain(get(assetChain))));
+  const chainId = getChainIdFromChain(get(assetChain));
+  if (chainId !== undefined)
+    switchNetwork(BigInt(chainId));
 }
 
 async function trackAddress(): Promise<void> {

--- a/frontend/app/src/modules/wallet/send/TradeSendCard.vue
+++ b/frontend/app/src/modules/wallet/send/TradeSendCard.vue
@@ -13,10 +13,10 @@ import TradeRecipientAddress from '@/modules/wallet/send/TradeRecipientAddress.v
 import { useBalanceQueries } from '@/modules/wallet/send/use-balance-queries';
 import { useTradeAssetBalance } from '@/modules/wallet/send/use-trade-asset-balance';
 import { useTradeGasEstimation } from '@/modules/wallet/send/use-trade-gas-estimation';
+import { useTradeNetworkMatch } from '@/modules/wallet/send/use-trade-network-match';
 import { useTradeRecipientWarning } from '@/modules/wallet/send/use-trade-recipient-warning';
 import { useTradeWalletActions } from '@/modules/wallet/send/use-trade-wallet-actions';
 import { TradableAssetKey, useTradableAsset } from '@/modules/wallet/use-tradable-asset';
-import { useWalletHelper } from '@/modules/wallet/use-wallet-helper';
 import { useWalletStore } from '@/modules/wallet/use-wallet-store';
 import WalletConnectionButton from '@/modules/wallet/WalletConnectionButton.vue';
 
@@ -30,14 +30,12 @@ const toAddress = ref<string>('');
 
 const tradeAmountInputRef = useTemplateRef<InstanceType<typeof TradeAmountInput>>('tradeAmountInputRef');
 
-const { getChainFromChainId, getChainIdFromChain } = useWalletHelper();
 const { getNativeAsset } = useSupportedChains();
 
 const walletStore = useWalletStore();
 const {
   connected,
   connectedAddress,
-  connectedChainId,
   isDisconnecting,
   isWalletConnect,
   preparing,
@@ -45,8 +43,9 @@ const {
   waitingForWalletConfirmation,
   walletMode,
 } = storeToRefs(walletStore);
-const { switchNetwork } = walletStore;
 const { useQueryingBalances, warnUntrackedAddress } = useBalanceQueries(connected, connectedAddress);
+
+const { switchToSelectedChain, wrongNetwork } = useTradeNetworkMatch(assetChain);
 
 const tradableAsset = useTradableAsset(connectedAddress);
 provide(TradableAssetKey, tradableAsset);
@@ -101,14 +100,6 @@ const { assetBalance, max, refreshAssetBalance, resetMax } = useTradeAssetBalanc
 
 const isWalletConnected = computed<boolean>(() => get(connected) && !!get(connectedAddress));
 
-const wrongNetwork = computed<boolean>(() => {
-  const chainId = get(connectedChainId);
-  if (!get(connected) || !chainId)
-    return false;
-
-  return get(assetChain) !== getChainFromChainId(chainId);
-});
-
 const amountExceeded = computed<boolean>(() => isAmountExceeded(get(amount), get(max)));
 
 const valid = computed<boolean>(() => isTradeValid(get(amount), get(toAddress), get(max)));
@@ -117,12 +108,6 @@ function resetInput(): void {
   set(toAddress, '');
   set(amount, '');
   resetMax();
-}
-
-function switchToDesireNetwork(): void {
-  const chainId = getChainIdFromChain(get(assetChain));
-  if (chainId !== undefined)
-    switchNetwork(BigInt(chainId));
 }
 
 async function trackAddress(): Promise<void> {
@@ -155,13 +140,6 @@ async function send(): Promise<void> {
 watch([assetChain, supportedChainsForConnectedAccount], ([currentChain, chainOptions]) => {
   if (!chainOptions.includes(currentChain))
     set(assetChain, chainOptions[0]);
-});
-
-watchImmediate(connectedChainId, (curr, prev) => {
-  if (!isDefined(curr) || curr === prev)
-    return;
-
-  set(assetChain, getChainFromChainId(curr));
 });
 </script>
 
@@ -278,7 +256,7 @@ watchImmediate(connectedChainId, (curr, prev) => {
         size="lg"
         class="!w-full"
         data-testid="switch-network-action"
-        @click="switchToDesireNetwork()"
+        @click="switchToSelectedChain()"
       >
         {{ t('trade.actions.change_network') }}
       </RuiButton>

--- a/frontend/app/src/modules/wallet/send/use-trade-gas-estimation.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-gas-estimation.spec.ts
@@ -6,6 +6,10 @@ import { useTradeGasEstimation } from '@/modules/wallet/send/use-trade-gas-estim
 
 const ETHEREUM_CHAIN_ID = 1;
 const OPTIMISM_CHAIN_ID = 10;
+const CHAIN_IDS: Record<string, number | undefined> = {
+  eth: ETHEREUM_CHAIN_ID,
+  optimism: OPTIMISM_CHAIN_ID,
+};
 
 const connected = ref<boolean>(true);
 const connectedChainId = ref<number>();
@@ -15,9 +19,11 @@ vi.mock('@/modules/wallet/use-wallet-store', () => ({
   useWalletStore: vi.fn(() => ({ connected, connectedChainId, getGasFeeForChain })),
 }));
 
+// The chain refs carry rotki blockchain ids (`eth`), which is what the send form
+// binds; an unknown chain resolves to no numeric id, as the real helper does.
 vi.mock('@/modules/wallet/use-wallet-helper', () => ({
   useWalletHelper: vi.fn(() => ({
-    getChainIdFromChain: (chain: string): number => (chain === 'ethereum' ? ETHEREUM_CHAIN_ID : OPTIMISM_CHAIN_ID),
+    getChainIdFromChain: (chain: string): number | undefined => CHAIN_IDS[chain],
   })),
 }));
 
@@ -53,7 +59,7 @@ describe('useTradeGasEstimation', () => {
     set(connected, true);
     set(connectedChainId, ETHEREUM_CHAIN_ID);
     asset = ref<string>('ETH');
-    chain = ref<string>('ethereum');
+    chain = ref<string>('eth');
     isNativeAsset = ref<boolean>(true);
     isAssetResolved = ref<boolean>(true);
     getGasFeeForChain.mockResolvedValue({ gasFee: '0.01', maxAmount: '0' });
@@ -101,6 +107,18 @@ describe('useTradeGasEstimation', () => {
 
   it('should charge no gas while the wallet is on another chain', async () => {
     set(connectedChainId, OPTIMISM_CHAIN_ID);
+    const { estimatedGasFee } = create();
+    await flushPromises();
+
+    expect(getGasFeeForChain).not.toHaveBeenCalled();
+    expect(get(estimatedGasFee)).toBe('0');
+  });
+
+  it('should charge no gas when the selected chain has no numeric id', async () => {
+    // Both sides of the chain comparison are undefined here: the chain cannot be
+    // resolved and the wallet has reported no chain. That is not a match.
+    set(chain, 'newchain');
+    set(connectedChainId, undefined);
     const { estimatedGasFee } = create();
     await flushPromises();
 

--- a/frontend/app/src/modules/wallet/send/use-trade-gas-estimation.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-gas-estimation.ts
@@ -91,7 +91,11 @@ export function useTradeGasEstimation(options: UseTradeGasEstimationOptions): Us
     }
 
     try {
-      if (getChainIdFromChain(currentChain) === currentChainId) {
+      // Both sides can be undefined (an unresolvable chain, a wallet that has not
+      // reported its chain yet). That is not a match: estimating then would price
+      // the transaction on a chain nothing has confirmed.
+      const selectedChainId = getChainIdFromChain(currentChain);
+      if (selectedChainId !== undefined && selectedChainId === currentChainId) {
         const estimation = await estimate(currentAsset);
         if (estimation) {
           set(estimatedGasFee, estimation.gasFee);

--- a/frontend/app/src/modules/wallet/send/use-trade-network-match.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-network-match.spec.ts
@@ -104,6 +104,27 @@ describe('useTradeNetworkMatch', () => {
       expect(get(selectedChain)).toBe('optimism');
     });
 
+    it('should leave the selection alone when the wallet reports no chain', async () => {
+      create();
+      set(selectedChain, 'optimism');
+      // What a disconnect looks like: there is no chain to follow.
+      set(connectedChainId, undefined);
+      await nextTick();
+
+      expect(get(selectedChain)).toBe('optimism');
+    });
+
+    it('should not pull the selection back while the wallet stays put', async () => {
+      create();
+      // The user picks a different chain to send on. Writing connectedChainId
+      // with the value it already holds must not drag the selection back.
+      set(selectedChain, 'optimism');
+      set(connectedChainId, ETHEREUM_CHAIN_ID);
+      await nextTick();
+
+      expect(get(selectedChain)).toBe('optimism');
+    });
+
     it('should keep the selection when the wallet moves to an unsupported chain', async () => {
       // Starting away from ethereum: the old fallback resolved there too, so a
       // test starting on ethereum would pass either way.

--- a/frontend/app/src/modules/wallet/send/use-trade-network-match.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-network-match.spec.ts
@@ -1,0 +1,144 @@
+import type { EffectScope, Ref } from 'vue';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTradeNetworkMatch } from '@/modules/wallet/send/use-trade-network-match';
+
+// The seam: reconcile the chain the form is sending on with the chain the wallet
+// is on. The wallet is free to report a chain rotki does not support, and every
+// path here has to say so rather than resolve it to something plausible.
+
+const ETHEREUM_CHAIN_ID = 1;
+const OPTIMISM_CHAIN_ID = 10;
+// A chain a wallet can be on that rotki does not support, e.g. fantom.
+const UNSUPPORTED_CHAIN_ID = 250;
+
+const CHAIN_NAMES: Record<number, string | undefined> = {
+  [ETHEREUM_CHAIN_ID]: 'eth',
+  [OPTIMISM_CHAIN_ID]: 'optimism',
+};
+const CHAIN_IDS: Record<string, number | undefined> = {
+  eth: ETHEREUM_CHAIN_ID,
+  optimism: OPTIMISM_CHAIN_ID,
+};
+
+const connected = ref<boolean>(true);
+const connectedChainId = ref<number>();
+// Async, as the store's is: the caller hands the promise to `startPromise`.
+const switchNetwork = vi.fn<(chainId: bigint) => Promise<void>>(async () => {});
+const error = vi.fn();
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  logger: { debug: vi.fn(), error: (...args: unknown[]): void => error(...args), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@/modules/wallet/use-wallet-store', () => ({
+  useWalletStore: vi.fn(() => ({ connected, connectedChainId, switchNetwork })),
+}));
+
+vi.mock('@/modules/wallet/use-wallet-helper', () => ({
+  useWalletHelper: vi.fn(() => ({
+    getChainFromChainId: (chainId: number): string | undefined => CHAIN_NAMES[chainId],
+    getChainIdFromChain: (chain: string): number | undefined => CHAIN_IDS[chain],
+  })),
+}));
+
+describe('useTradeNetworkMatch', () => {
+  let scope: EffectScope;
+  let selectedChain: Ref<string>;
+
+  function create(): ReturnType<typeof useTradeNetworkMatch> {
+    scope = effectScope();
+    const result = scope.run(() => useTradeNetworkMatch(selectedChain));
+    assert(result);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(connected, true);
+    set(connectedChainId, ETHEREUM_CHAIN_ID);
+    selectedChain = ref<string>('eth');
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('wrongNetwork', () => {
+    it('should be false while the wallet is on the selected chain', () => {
+      const { wrongNetwork } = create();
+
+      expect(get(wrongNetwork)).toBe(false);
+    });
+
+    it('should be false while no wallet is connected', () => {
+      set(connected, false);
+      set(connectedChainId, OPTIMISM_CHAIN_ID);
+      const { wrongNetwork } = create();
+
+      expect(get(wrongNetwork)).toBe(false);
+    });
+
+    it('should be true while the wallet is on another supported chain', () => {
+      const { wrongNetwork } = create();
+      set(connectedChainId, OPTIMISM_CHAIN_ID);
+
+      expect(get(wrongNetwork)).toBe(true);
+    });
+
+    it('should be true while the wallet is on a chain rotki does not support', () => {
+      const { wrongNetwork } = create();
+      // Resolving this to ethereum reported the right network, so no warning was
+      // shown and the user could send believing they were on mainnet.
+      set(connectedChainId, UNSUPPORTED_CHAIN_ID);
+
+      expect(get(wrongNetwork)).toBe(true);
+    });
+  });
+
+  describe('following the wallet', () => {
+    it('should adopt a supported chain the wallet moves to', async () => {
+      create();
+      set(connectedChainId, OPTIMISM_CHAIN_ID);
+      await nextTick();
+
+      expect(get(selectedChain)).toBe('optimism');
+    });
+
+    it('should keep the selection when the wallet moves to an unsupported chain', async () => {
+      // Starting away from ethereum: the old fallback resolved there too, so a
+      // test starting on ethereum would pass either way.
+      set(connectedChainId, OPTIMISM_CHAIN_ID);
+      create();
+      await nextTick();
+      expect(get(selectedChain)).toBe('optimism');
+
+      set(connectedChainId, UNSUPPORTED_CHAIN_ID);
+      await nextTick();
+
+      expect(get(selectedChain)).toBe('optimism');
+    });
+  });
+
+  describe('switchToSelectedChain', () => {
+    it('should ask the wallet for the selected chain', () => {
+      const { switchToSelectedChain } = create();
+      set(selectedChain, 'optimism');
+
+      switchToSelectedChain();
+
+      expect(switchNetwork).toHaveBeenCalledWith(BigInt(OPTIMISM_CHAIN_ID));
+    });
+
+    it('should log rather than switch when the selection has no chain id', () => {
+      const { switchToSelectedChain } = create();
+      set(selectedChain, 'newchain');
+
+      switchToSelectedChain();
+
+      // BigInt(undefined) would throw; a silent return would hide a broken
+      // invariant behind a button that does nothing.
+      expect(switchNetwork).not.toHaveBeenCalled();
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('newchain'));
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/send/use-trade-network-match.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-network-match.ts
@@ -1,0 +1,71 @@
+import type { ComputedRef, Ref } from 'vue';
+import { startPromise } from '@shared/utils';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useWalletHelper } from '@/modules/wallet/use-wallet-helper';
+import { useWalletStore } from '@/modules/wallet/use-wallet-store';
+
+interface UseTradeNetworkMatchReturn {
+  wrongNetwork: ComputedRef<boolean>;
+  switchToSelectedChain: () => void;
+}
+
+/**
+ * Keeps the selected chain and the chain the wallet is on in agreement.
+ *
+ * The wallet reports whatever chain it happens to sit on, which is not limited
+ * to the chains rotki supports, so every path here has to cope with a chain id
+ * that resolves to nothing. Resolving it to ethereum instead, as this used to,
+ * made an unsupported chain look like mainnet: no warning appeared and the
+ * selection silently followed the wallet onto the wrong chain.
+ *
+ * @param selectedChain the chain the send form is targeting, updated in place
+ * when the wallet moves to a chain rotki does support.
+ */
+export function useTradeNetworkMatch(selectedChain: Ref<string>): UseTradeNetworkMatchReturn {
+  const { getChainFromChainId, getChainIdFromChain } = useWalletHelper();
+
+  const walletStore = useWalletStore();
+  const { connected, connectedChainId } = storeToRefs(walletStore);
+  const { switchNetwork } = walletStore;
+
+  const wrongNetwork = computed<boolean>(() => {
+    const chainId = get(connectedChainId);
+    if (!get(connected) || !chainId)
+      return false;
+
+    // An unresolvable chain compares unequal, which is the answer we want: the
+    // wallet is on something the form cannot send from.
+    return get(selectedChain) !== getChainFromChainId(chainId);
+  });
+
+  function switchToSelectedChain(): void {
+    const chainId = getChainIdFromChain(get(selectedChain));
+    // Unreachable by construction: the selection only ever holds a chain from
+    // `supportedChainsForConnectedAccount`, and every entry there was built by
+    // pairing a chain *with* its numeric id. Log rather than return quietly, so
+    // a broken invariant surfaces instead of becoming a button that does nothing.
+    if (chainId === undefined) {
+      logger.error(`no chain id for ${get(selectedChain)}, cannot switch network`);
+      return;
+    }
+
+    startPromise(switchNetwork(BigInt(chainId)));
+  }
+
+  watchImmediate(connectedChainId, (curr, prev) => {
+    if (!isDefined(curr) || curr === prev)
+      return;
+
+    // Keep the selection where it is when the wallet moves somewhere rotki does
+    // not support: `wrongNetwork` then reports the mismatch, where adopting a
+    // fallback chain would have hidden it.
+    const chain = getChainFromChainId(curr);
+    if (chain)
+      set(selectedChain, chain);
+  });
+
+  return {
+    switchToSelectedChain,
+    wrongNetwork,
+  };
+}

--- a/frontend/app/src/modules/wallet/send/use-trade-network-match.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-network-match.ts
@@ -52,8 +52,10 @@ export function useTradeNetworkMatch(selectedChain: Ref<string>): UseTradeNetwor
     startPromise(switchNetwork(BigInt(chainId)));
   }
 
-  watchImmediate(connectedChainId, (curr, prev) => {
-    if (!isDefined(curr) || curr === prev)
+  // No `curr === prev` guard: `connectedChainId` is a plain ref, so Vue does not
+  // fire this when it is written with the value it already holds.
+  watchImmediate(connectedChainId, (curr) => {
+    if (!isDefined(curr))
       return;
 
     // Keep the selection where it is when the wallet moves somewhere rotki does

--- a/frontend/app/src/modules/wallet/use-transaction-manager.spec.ts
+++ b/frontend/app/src/modules/wallet/use-transaction-manager.spec.ts
@@ -1,0 +1,102 @@
+import type { TransactionParams } from '@/modules/wallet/types';
+import type { Hash, ViemWalletClient } from '@/modules/wallet/viem-client';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTransactionManager } from '@/modules/wallet/use-transaction-manager';
+
+// The seam: what ends up on the recent-transaction record, and that a completed
+// transfer both flips to `completed` and triggers the post-transaction refresh.
+
+type Receipt = Awaited<ReturnType<ViemWalletClient['waitForTransactionReceipt']>>;
+
+const HASH: Hash = '0xhash';
+
+const getAssetMappingHandler = vi.fn(async () => ({ assets: { 'eip155:1/erc20:0xtoken': { symbol: 'TOKEN' } } }));
+const updateStatePostTransaction = vi.fn(async () => {});
+
+vi.mock('@/modules/assets/use-asset-info-cache', () => ({
+  useAssetInfoCache: vi.fn(() => ({ getAssetMappingHandler })),
+}));
+
+vi.mock('@/modules/wallet/use-wallet-helper', () => ({
+  useWalletHelper: vi.fn(() => ({ updateStatePostTransaction })),
+}));
+
+function txParams(overrides: Partial<TransactionParams> = {}): TransactionParams {
+  return { amount: '1', chain: 'monad', native: true, to: '0xto', ...overrides };
+}
+
+function walletClient(): ViemWalletClient {
+  return createMock<ViemWalletClient>({
+    waitForTransactionReceipt: vi.fn(async () => createMock<Receipt>()),
+  });
+}
+
+describe('useTransactionManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('handleTransactionSuccess', () => {
+    it('should record the chain the transfer was prepared for', async () => {
+      const { handleTransactionSuccess, recentTransactions } = useTransactionManager();
+
+      await handleTransactionSuccess(walletClient(), HASH, txParams(), '0xfrom');
+      await vi.waitFor(() => expect(get(recentTransactions)).toHaveLength(1));
+
+      // Not the chain the wallet reports: nothing checks that the two agree, and
+      // only this one is known to be a chain rotki supports.
+      expect(get(recentTransactions)[0].chain).toBe('monad');
+    });
+
+    it('should mark the transaction completed once the receipt lands', async () => {
+      const { handleTransactionSuccess, recentTransactions } = useTransactionManager();
+
+      await handleTransactionSuccess(walletClient(), HASH, txParams(), '0xfrom');
+      await vi.waitFor(() => expect(get(recentTransactions)[0]?.status).toBe('completed'));
+
+      expect(updateStatePostTransaction).toHaveBeenCalledWith(
+        expect.objectContaining({ chain: 'monad', hash: HASH }),
+      );
+    });
+
+    it('should wait for the receipt of the hash it was given', async () => {
+      const client = walletClient();
+      const { handleTransactionSuccess } = useTransactionManager();
+
+      await handleTransactionSuccess(client, HASH, txParams(), '0xfrom');
+
+      expect(client.waitForTransactionReceipt).toHaveBeenCalledWith({ hash: HASH });
+    });
+  });
+
+  describe('addRecentTransaction', () => {
+    it('should resolve a token symbol for a non-native transfer', async () => {
+      const { addRecentTransaction, recentTransactions } = useTransactionManager();
+
+      await addRecentTransaction(HASH, 'eth', txParams({ assetIdentifier: 'eip155:1/erc20:0xtoken', native: false }), '0xfrom');
+
+      expect(get(recentTransactions)[0].context).toContain('TOKEN');
+    });
+
+    it('should put the newest transaction first', async () => {
+      const { addRecentTransaction, recentTransactions } = useTransactionManager();
+
+      await addRecentTransaction('0xolder', 'eth', txParams(), '0xfrom');
+      await addRecentTransaction('0xnewer', 'eth', txParams(), '0xfrom');
+
+      expect(get(recentTransactions).map(tx => tx.hash)).toEqual(['0xnewer', '0xolder']);
+    });
+  });
+
+  describe('reset', () => {
+    it('should drop every recorded transaction', async () => {
+      const { addRecentTransaction, recentTransactions, reset } = useTransactionManager();
+      await addRecentTransaction(HASH, 'eth', txParams(), '0xfrom');
+
+      reset();
+
+      expect(get(recentTransactions)).toEqual([]);
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/use-transaction-manager.ts
+++ b/frontend/app/src/modules/wallet/use-transaction-manager.ts
@@ -12,7 +12,7 @@ import { useWalletHelper } from '@/modules/wallet/use-wallet-helper';
 export function useTransactionManager(): {
   addRecentTransaction: (hash: string, chain: string, params: TransactionParams, initiatorAddress: string | undefined) => Promise<void>;
   getRecentTransactionByTxHash: (hash: string) => RecentTransaction | undefined;
-  handleTransactionSuccess: (client: ViemWalletClient, hash: Hash, chainId: number, params: TransactionParams, initiatorAddress: string | undefined, getChainFromChainId: (chainId: number) => string) => Promise<void>;
+  handleTransactionSuccess: (client: ViemWalletClient, hash: Hash, params: TransactionParams, initiatorAddress: string | undefined) => Promise<void>;
   recentTransactions: Readonly<Ref<RecentTransaction[]>>;
   reset: () => void;
   updateTransactionStatus: (hash: string, status: 'completed' | 'failed') => void;
@@ -83,12 +83,13 @@ export function useTransactionManager(): {
   const handleTransactionSuccess = async (
     client: ViemWalletClient,
     hash: Hash,
-    chainId: number,
     params: TransactionParams,
     initiatorAddress: string | undefined,
-    getChainFromChainId: (chainId: number) => string,
   ): Promise<void> => {
-    startPromise(addRecentTransaction(hash, getChainFromChainId(chainId), params, initiatorAddress));
+    // The chain the transfer was prepared for, not the one the wallet reports.
+    // Nothing checks that those agree, and only this one is known to be a chain
+    // rotki supports, which the balance refresh and hash import both require.
+    startPromise(addRecentTransaction(hash, params.chain, params, initiatorAddress));
     await client.waitForTransactionReceipt({ hash });
     updateTransactionStatus(hash, 'completed');
     startPromise(updateStatePostTransaction(getRecentTransactionByTxHash(hash)));

--- a/frontend/app/src/modules/wallet/use-wallet-chains.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-chains.spec.ts
@@ -1,0 +1,130 @@
+import type { EvmChainInfo } from '@/modules/core/api/types/chains';
+import { Blockchain } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWalletChains } from '@/modules/wallet/use-wallet-chains';
+
+// The seam: the wallet's chain list is whatever the backend reports, joined to
+// the numeric EIP-155 ids, and never a hardcoded list. A chain the backend gains
+// must show up with no frontend change; a chain that cannot be resolved to a
+// numeric id must be dropped, not silently turned into ethereum.
+
+function evmChain(id: string, evmChainName: string): EvmChainInfo {
+  return { evmChainName, id, image: `${id}.svg`, name: id, type: 'evm' };
+}
+
+const txEvmChains = ref<EvmChainInfo[]>([]);
+const allEvmChains = ref<{ id: number; label: string; name: string }[]>([]);
+
+// `evmChainsData` is the wider list that still holds AVAX. It is here so that
+// sourcing the wallet chains from it instead of `txEvmChains` fails a test
+// rather than passing unnoticed.
+const evmChainsData = computed<EvmChainInfo[]>(() => [
+  ...get(txEvmChains),
+  evmChain(Blockchain.AVAX, 'avalanche'),
+]);
+
+const getEvmChainId = vi.fn((name: string): number | undefined =>
+  get(allEvmChains).find(item => item.name === name)?.id);
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn().mockImplementation(() => ({ evmChainsData, getEvmChainId, txEvmChains })),
+}));
+
+describe('useWalletChains', () => {
+  beforeEach(() => {
+    // Ordered as the backend serializes SupportedBlockchain, ethereum first.
+    set(txEvmChains, [
+      evmChain(Blockchain.ETH, 'ethereum'),
+      evmChain(Blockchain.OPTIMISM, 'optimism'),
+      evmChain(Blockchain.BASE, 'base'),
+      evmChain(Blockchain.HYPERLIQUID, 'hyperliquid'),
+      evmChain(Blockchain.MONAD, 'monad'),
+    ]);
+    set(allEvmChains, [
+      { id: 1, label: 'Ethereum', name: 'ethereum' },
+      { id: 10, label: 'Optimism', name: 'optimism' },
+      { id: 8453, label: 'Base', name: 'base' },
+      { id: 999, label: 'Hyperliquid', name: 'hyperliquid' },
+      { id: 143, label: 'Monad', name: 'monad' },
+      { id: 43114, label: 'Avalanche', name: 'avalanche' },
+    ]);
+  });
+
+  it('should pair every chain the backend reports with its numeric id', () => {
+    const { walletChains } = useWalletChains();
+
+    expect(get(walletChains)).toEqual([
+      { chain: Blockchain.ETH, chainId: 1 },
+      { chain: Blockchain.OPTIMISM, chainId: 10 },
+      { chain: Blockchain.BASE, chainId: 8453 },
+      { chain: Blockchain.HYPERLIQUID, chainId: 999 },
+      { chain: Blockchain.MONAD, chainId: 143 },
+    ]);
+  });
+
+  it('should include a chain the backend has newly gained', () => {
+    const { walletChainIds, walletChains } = useWalletChains();
+
+    // The two chains the previously hardcoded list was missing.
+    expect(get(walletChains).map(item => item.chain)).toContain(Blockchain.MONAD);
+    expect(get(walletChainIds)).toContain(999);
+  });
+
+  it('should not offer a chain with no transaction support', () => {
+    const { walletChains } = useWalletChains();
+
+    // avalanche is an evm chain with a numeric id, so only the choice of
+    // `txEvmChains` over `evmChainsData` keeps it out. A send finishes by
+    // recording its hash, which avalanche cannot do.
+    expect(get(evmChainsData).map(item => item.id)).toContain(Blockchain.AVAX);
+    expect(get(walletChains).map(item => item.chain)).not.toContain(Blockchain.AVAX);
+  });
+
+  it('should drop a chain with no numeric id instead of defaulting it', () => {
+    set(txEvmChains, [...get(txEvmChains), evmChain('newchain', 'newchain')]);
+    const { walletChains } = useWalletChains();
+
+    expect(get(walletChains).map(item => item.chain)).not.toContain('newchain');
+    // The trap this guards: resolving it to 1 would label its balances ethereum.
+    expect(get(walletChains).filter(item => item.chainId === 1)).toHaveLength(1);
+  });
+
+  it('should react to the chain list arriving after login', () => {
+    const { walletChains } = useWalletChains();
+    set(txEvmChains, []);
+    expect(get(walletChains)).toEqual([]);
+
+    set(txEvmChains, [evmChain(Blockchain.MONAD, 'monad')]);
+    expect(get(walletChains)).toEqual([{ chain: Blockchain.MONAD, chainId: 143 }]);
+  });
+
+  describe('getSessionChains', () => {
+    it('should offer every chain when the connection reports none', () => {
+      const { getSessionChains, walletChains } = useWalletChains();
+
+      expect(getSessionChains()).toHaveLength(get(walletChains).length);
+      expect(getSessionChains([])).toHaveLength(get(walletChains).length);
+    });
+
+    it('should narrow to the chains the session reports', () => {
+      const { getSessionChains } = useWalletChains();
+
+      expect(getSessionChains([1, 143])).toEqual([Blockchain.ETH, Blockchain.MONAD]);
+    });
+
+    it('should drop a session chain rotki does not support', () => {
+      const { getSessionChains } = useWalletChains();
+
+      // 250 and 1284 are chains the backend never reported. Mapping each id to a
+      // chain instead of intersecting resolved both to ethereum, which put
+      // duplicate entries in the send form's chain picker.
+      expect(getSessionChains([1, 250, 1284])).toEqual([Blockchain.ETH]);
+    });
+
+    it('should keep rotki ordering, not the order the session sent', () => {
+      const { getSessionChains } = useWalletChains();
+
+      expect(getSessionChains([143, 1])).toEqual([Blockchain.ETH, Blockchain.MONAD]);
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/use-wallet-chains.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-chains.ts
@@ -1,0 +1,75 @@
+import type { ComputedRef } from 'vue';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+
+/**
+ * An EVM chain the wallet stack can operate on, paired with its EIP-155 id.
+ */
+interface WalletChain {
+  /** the rotki blockchain id, e.g. `eth`, `monad` */
+  chain: string;
+  /** the numeric EIP-155 chain id, e.g. `1`, `143` */
+  chainId: number;
+}
+
+interface UseWalletChainsReturn {
+  walletChains: ComputedRef<WalletChain[]>;
+  walletChainIds: ComputedRef<number[]>;
+  getSessionChains: (chainIds?: number[]) => string[];
+}
+
+/**
+ * The chains the wallet can send on, derived from what the backend reports
+ * rather than from a hardcoded list, so a chain the backend gains needs no
+ * frontend release.
+ *
+ * Two endpoints are joined because neither carries both halves:
+ * `/blockchains/supported` names the chains but serializes no numeric id, and
+ * `/blockchains/evm/all` carries the numeric id but iterates the whole `ChainID`
+ * enum, which is far broader than the chains rotki actually supports. The join
+ * key is `evmChainName`.
+ *
+ * The source is `txEvmChains`, not `evmChainsData`: that drops AVAX, which has
+ * no transaction support, and a send finishes by recording the hash through
+ * `addTransactionHash`.
+ *
+ * A chain with no matching numeric id is dropped. It must not fall back to
+ * ethereum — that would label another chain's balance as an ethereum one.
+ */
+export function useWalletChains(): UseWalletChainsReturn {
+  const { getEvmChainId, txEvmChains } = useSupportedChains();
+
+  const walletChains = computed<WalletChain[]>(() => {
+    const chains: WalletChain[] = [];
+    for (const info of get(txEvmChains)) {
+      const chainId = getEvmChainId(info.evmChainName);
+      if (chainId !== undefined)
+        chains.push({ chain: info.id, chainId });
+    }
+    return chains;
+  });
+
+  const walletChainIds = computed<number[]>(() => get(walletChains).map(item => item.chainId));
+
+  /**
+   * The chains usable by a connection that reports `chainIds`, or every chain
+   * when it reports none (an injected wallet, or a session with no namespaces).
+   *
+   * This is an intersection rather than a mapping, so a chain the wallet offers
+   * but rotki does not support is dropped instead of resolving to a wrong chain,
+   * and the order stays rotki's (ethereum first).
+   */
+  const getSessionChains = (chainIds?: number[]): string[] => {
+    const chains = get(walletChains);
+    if (!chainIds?.length)
+      return chains.map(item => item.chain);
+
+    const sessionChainIds = new Set(chainIds);
+    return chains.filter(item => sessionChainIds.has(item.chainId)).map(item => item.chain);
+  };
+
+  return {
+    getSessionChains,
+    walletChainIds,
+    walletChains,
+  };
+}

--- a/frontend/app/src/modules/wallet/use-wallet-connect.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-connect.spec.ts
@@ -12,6 +12,10 @@ vi.mock('./viem-client', () => ({
 const network1 = { id: 1, rpcUrls: { default: { http: ['https://rpc.one'] } } };
 const network8453 = { id: 8453, rpcUrls: { default: { http: ['https://rpc.base'] } } };
 
+// The caller supplies the chains; `chains-viem` only enriches them with an rpc
+// url. 143 is deliberately absent from the viem table.
+const CHAIN_IDS = [1, 8453];
+
 vi.mock('./chains-viem', () => ({
   SUPPORTED_WALLET_NETWORKS: [network1, network8453],
   getWalletNetwork: vi.fn((chainId: bigint) => (chainId === 1n ? network1 : undefined)),
@@ -72,7 +76,7 @@ describe('modules/wallet/use-wallet-connect', () => {
   describe('connect', () => {
     it('should initialize the provider and request the eip155 namespace', async () => {
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
 
       expect(mockProviderInstance.connect).toHaveBeenCalledTimes(1);
       const arg = mockProviderInstance.connect.mock.calls[0][0];
@@ -83,10 +87,36 @@ describe('modules/wallet/use-wallet-connect', () => {
       });
     });
 
+    it('should request a chain that has no viem definition, without an rpc url', async () => {
+      const wc = await loadComposable();
+      await wc.connect([1, 143]);
+
+      const arg = mockProviderInstance.connect.mock.calls[0][0];
+      expect(arg.optionalNamespaces.eip155.chains).toEqual(['eip155:1', 'eip155:143']);
+      expect(arg.optionalNamespaces.eip155.rpcMap).toEqual({ 'eip155:1': 'https://rpc.one' });
+    });
+
+    it('should refuse to pair when no chains are available', async () => {
+      const wc = await loadComposable();
+
+      // An empty list means the supported-chains fetch has not landed or failed.
+      // Pairing anyway opens a session that negotiates nothing.
+      await expect(wc.connect([])).rejects.toThrow('No supported chains');
+      expect(mockProviderInstance.connect).not.toHaveBeenCalled();
+    });
+
+    it('should not request a chain the caller left out', async () => {
+      const wc = await loadComposable();
+      await wc.connect([1]);
+
+      const arg = mockProviderInstance.connect.mock.calls[0][0];
+      expect(arg.optionalNamespaces.eip155.chains).toEqual(['eip155:1']);
+    });
+
     it('should sync an already-restored session and skip a new pairing', async () => {
       mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
 
       expect(mockProviderInstance.connect).not.toHaveBeenCalled();
       expect(get(wc.connected)).toBe(true);
@@ -99,7 +129,7 @@ describe('modules/wallet/use-wallet-connect', () => {
         mockProviderInstance.session = makeSession(['eip155:8453:0xdef'], ['eip155:8453', 'eip155:1']);
       });
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
 
       expect(get(wc.connected)).toBe(true);
       expect(get(wc.connectedAddress)).toBe('0xdef');
@@ -113,7 +143,7 @@ describe('modules/wallet/use-wallet-connect', () => {
         mockProviderInstance.emit('display_uri', 'wc:pair-uri');
       });
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
 
       expect(get(wc.connectUri)).toBeUndefined(); // closed in finally
       expect(get(wc.showConnectModal)).toBe(false);
@@ -125,7 +155,7 @@ describe('modules/wallet/use-wallet-connect', () => {
       });
       const wc = await loadComposable();
 
-      await expect(wc.connect()).rejects.toThrow('pairing blew up');
+      await expect(wc.connect(CHAIN_IDS)).rejects.toThrow('pairing blew up');
       expect(get(wc.preparing)).toBe(false);
     });
 
@@ -137,7 +167,7 @@ describe('modules/wallet/use-wallet-connect', () => {
         throw new Error('pairing aborted');
       });
 
-      await expect(wc.connect()).resolves.toBeUndefined();
+      await expect(wc.connect(CHAIN_IDS)).resolves.toBeUndefined();
     });
   });
 
@@ -150,7 +180,7 @@ describe('modules/wallet/use-wallet-connect', () => {
         throw new Error('aborted');
       });
 
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
 
       expect(mockProviderInstance.abortPairingAttempt).toHaveBeenCalledTimes(1);
       expect(get(wc.showConnectModal)).toBe(false);
@@ -162,7 +192,7 @@ describe('modules/wallet/use-wallet-connect', () => {
     it('should call provider.disconnect and reset state when a session exists', async () => {
       mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
       expect(get(wc.connected)).toBe(true);
 
       await wc.disconnect();
@@ -189,7 +219,7 @@ describe('modules/wallet/use-wallet-connect', () => {
 
     it('should build a viem client once the provider exists', async () => {
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
       expect(wc.getWalletClient()).toEqual({ __client: true });
     });
   });
@@ -197,7 +227,7 @@ describe('modules/wallet/use-wallet-connect', () => {
   describe('switchNetwork', () => {
     it('should request the chain switch and update the default chain', async () => {
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
       await wc.switchNetwork(1n);
 
       expect(mockProviderInstance.request).toHaveBeenCalledWith({
@@ -217,7 +247,7 @@ describe('modules/wallet/use-wallet-connect', () => {
   describe('checkWalletConnection', () => {
     it('should return early when there is no active WalletConnect session', async () => {
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
       await wc.checkWalletConnection();
       expect(mockProviderInstance.client.ping).not.toHaveBeenCalled();
     });
@@ -225,7 +255,7 @@ describe('modules/wallet/use-wallet-connect', () => {
     it('should ping the session and resolve when the wallet responds', async () => {
       mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
 
       await wc.checkWalletConnection();
 
@@ -239,7 +269,7 @@ describe('modules/wallet/use-wallet-connect', () => {
         throw new Error('ping failed');
       });
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
 
       await expect(wc.checkWalletConnection()).rejects.toThrow(/wallet is inactive/);
       expect(get(wc.preparing)).toBe(false);
@@ -250,7 +280,7 @@ describe('modules/wallet/use-wallet-connect', () => {
     it('should update the address on accountsChanged and reset on empty', async () => {
       mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
 
       mockProviderInstance.emit('accountsChanged', ['eip155:1:0xdeadbeef']);
       expect(get(wc.connectedAddress)).toBe('0xdeadbeef');
@@ -263,7 +293,7 @@ describe('modules/wallet/use-wallet-connect', () => {
 
     it('should parse a hex chainChanged value', async () => {
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
 
       mockProviderInstance.emit('chainChanged', '0xa');
       expect(get(wc.connectedChainId)).toBe(10);
@@ -272,7 +302,7 @@ describe('modules/wallet/use-wallet-connect', () => {
     it('should reset state on disconnect and session_delete events', async () => {
       mockProviderInstance.session = makeSession(['eip155:1:0xabc']);
       const wc = await loadComposable();
-      await wc.connect();
+      await wc.connect(CHAIN_IDS);
       expect(get(wc.connected)).toBe(true);
 
       mockProviderInstance.emit('disconnect');

--- a/frontend/app/src/modules/wallet/use-wallet-connect.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-connect.ts
@@ -2,7 +2,7 @@ import type UniversalProvider from '@walletconnect/universal-provider';
 import type { Ref } from 'vue';
 import { withTimeout } from '@/modules/core/common/async/async-utilities';
 import { logger } from '@/modules/core/common/logging/logging';
-import { EIP155, EIP155_EVENTS, EIP155_METHODS } from './constants';
+import { EIP155, EIP155_EVENTS, EIP155_METHODS, WALLET_ERRORS } from './constants';
 import { type Chain, createViemWalletClient, getAddress, type ViemWalletClient } from './viem-client';
 
 type WcSession = NonNullable<UniversalProvider['session']>;
@@ -23,6 +23,22 @@ async function loadWalletNetworks(): Promise<readonly Chain[]> {
   walletNetworksPromise ??= import('./chains-viem').then(mod => mod.SUPPORTED_WALLET_NETWORKS);
 
   return walletNetworksPromise;
+}
+
+/**
+ * The `rpcMap` a session is opened with. It is a hint the wallet may ignore, and
+ * `chains-viem` only knows the chains viem ships a definition for, so a chain
+ * with no entry is simply requested without a URL rather than withheld.
+ */
+async function getRpcMap(chainIds: number[]): Promise<Record<string, string>> {
+  const networks = await loadWalletNetworks();
+  const rpcMap: Record<string, string> = {};
+  for (const chainId of chainIds) {
+    const url = networks.find(network => network.id === chainId)?.rpcUrls.default.http[0];
+    if (url)
+      rpcMap[`${EIP155}:${chainId}`] = url;
+  }
+  return rpcMap;
 }
 
 const PING_TIMEOUT = 5000;
@@ -55,7 +71,7 @@ interface UseWalletConnectReturn {
   preparing: Ref<boolean>;
   connectUri: Ref<string | undefined>;
   showConnectModal: Ref<boolean>;
-  connect: () => Promise<void>;
+  connect: (chainIds: number[]) => Promise<void>;
   cancelConnect: () => void;
   disconnect: () => Promise<void>;
   getWalletClient: () => ViemWalletClient;
@@ -168,7 +184,18 @@ function closeModal(): void {
 }
 
 export function useWalletConnect(): UseWalletConnectReturn {
-  const connect = async (): Promise<void> => {
+  /**
+   * @param chainIds the EIP-155 chain ids to request in the session namespace.
+   * They come from the caller rather than from `chains-viem` so the session
+   * covers every chain rotki supports, not only the ones viem is imported for.
+   */
+  const connect = async (chainIds: number[]): Promise<void> => {
+    // A session that negotiates no chains is useless and the failure is silent
+    // later, so refuse it here. Empty means the supported-chains fetch has not
+    // landed or failed; the previous hardcoded list could never be empty.
+    if (chainIds.length === 0)
+      throw new Error(WALLET_ERRORS.NO_SUPPORTED_CHAINS);
+
     const provider = await getProvider();
 
     if (provider.session) {
@@ -181,19 +208,12 @@ export function useWalletConnect(): UseWalletConnectReturn {
     provider.on('display_uri', onDisplayUri);
 
     try {
-      const networks = await loadWalletNetworks();
-      const chains = networks.map(network => `${EIP155}:${network.id}`);
-      const rpcMap: Record<string, string> = {};
-      for (const network of networks) {
-        const url = network.rpcUrls.default.http[0];
-        if (url)
-          rpcMap[`${EIP155}:${network.id}`] = url;
-      }
+      const rpcMap = await getRpcMap(chainIds);
 
       await provider.connect({
         optionalNamespaces: {
           [EIP155]: {
-            chains,
+            chains: chainIds.map(chainId => `${EIP155}:${chainId}`),
             events: [...EIP155_EVENTS],
             methods: [...EIP155_METHODS],
             rpcMap,

--- a/frontend/app/src/modules/wallet/use-wallet-helper.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-helper.spec.ts
@@ -75,9 +75,12 @@ describe('useWalletHelper', () => {
       expect(getEvmChainNameFromChainId(42161n)).toBe('arbitrum_one');
     });
 
-    it('should fall back to ethereum for unknown chainId', () => {
+    it('should return undefined for a chain rotki does not support', () => {
       const { getEvmChainNameFromChainId } = useWalletHelper();
-      expect(getEvmChainNameFromChainId(99999)).toBe('ethereum');
+      // A connected wallet reports whatever chain it sits on, which is not
+      // constrained to rotki's list. Answering `ethereum` for it made the send
+      // form believe it was on mainnet.
+      expect(getEvmChainNameFromChainId(99999)).toBeUndefined();
     });
   });
 
@@ -87,6 +90,14 @@ describe('useWalletHelper', () => {
       const result = getChainFromChainId(10);
       expect(getChain).toHaveBeenCalledWith('optimism');
       expect(result).toBe(Blockchain.OPTIMISM);
+    });
+
+    it('should not resolve a chain rotki does not support', () => {
+      const { getChainFromChainId } = useWalletHelper();
+
+      // `getChain` itself defaults to ethereum, so it must not even be reached.
+      expect(getChainFromChainId(250)).toBeUndefined();
+      expect(getChain).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/app/src/modules/wallet/use-wallet-helper.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-helper.spec.ts
@@ -30,8 +30,20 @@ const getChain = vi.fn((name: string): Blockchain => {
   return Blockchain.ETH;
 });
 
+// `eth` is the only blockchain id that differs from its evm chain name, which is
+// what `getChainIdFromChain` has to bridge.
+const getEvmChainName = vi.fn((chain: string): string | undefined => {
+  if (chain === Blockchain.ETH)
+    return 'ethereum';
+  if (chain === Blockchain.OPTIMISM)
+    return 'optimism';
+  if (chain === Blockchain.ARBITRUM_ONE)
+    return 'arbitrum_one';
+  return undefined;
+});
+
 vi.mock('@/modules/core/common/use-supported-chains', () => ({
-  useSupportedChains: vi.fn().mockImplementation(() => ({ allEvmChains, getChain })),
+  useSupportedChains: vi.fn().mockImplementation(() => ({ allEvmChains, getChain, getEvmChainName })),
 }));
 
 const refreshBlockchainBalances = vi.fn();
@@ -81,12 +93,18 @@ describe('useWalletHelper', () => {
   describe('getChainIdFromChain', () => {
     it('should return numeric id for known chain', () => {
       const { getChainIdFromChain } = useWalletHelper();
-      expect(getChainIdFromChain('arbitrum_one')).toBe(42161);
+      expect(getChainIdFromChain(Blockchain.ARBITRUM_ONE)).toBe(42161);
     });
 
-    it('should default to 1 for unknown chain', () => {
+    it('should resolve a blockchain id that differs from its evm chain name', () => {
       const { getChainIdFromChain } = useWalletHelper();
-      expect(getChainIdFromChain('nope')).toBe(1);
+      // `eth` appears in allEvmChains as `ethereum`, so a direct id match misses.
+      expect(getChainIdFromChain(Blockchain.ETH)).toBe(1);
+    });
+
+    it('should return undefined for an unknown chain rather than ethereum', () => {
+      const { getChainIdFromChain } = useWalletHelper();
+      expect(getChainIdFromChain('nope')).toBeUndefined();
     });
   });
 

--- a/frontend/app/src/modules/wallet/use-wallet-helper.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-helper.ts
@@ -8,14 +8,14 @@ import { EIP155 } from './constants';
 interface UseWalletHelperReturn {
   getEvmChainNameFromChainId: (chainId: number | bigint) => string;
   getChainFromChainId: (chainId: number | bigint) => Blockchain;
-  getChainIdFromChain: (chain: string) => number;
+  getChainIdFromChain: (chain: string) => number | undefined;
   getChainIdFromNamespace: (namespace: string) => number;
   updateStatePostTransaction: (tx?: RecentTransaction) => Promise<void>;
   getEip155ChainId: (chainId: string | number) => string;
 }
 
 export function useWalletHelper(): UseWalletHelperReturn {
-  const { allEvmChains, getChain } = useSupportedChains();
+  const { allEvmChains, getChain, getEvmChainName } = useSupportedChains();
   const { refreshBlockchainBalances } = useBlockchainBalances();
   const { addTransactionHash } = useHistoryTransactions();
 
@@ -29,7 +29,16 @@ export function useWalletHelper(): UseWalletHelperReturn {
     return getChain(name);
   }
 
-  const getChainIdFromChain = (chain: string): number => get(allEvmChains).find(item => item.name === chain)?.id ?? 1;
+  /**
+   * `chain` is a rotki blockchain id (`eth`), while `allEvmChains` is keyed by the
+   * evm chain name (`ethereum`), so the two have to be bridged. They happen to be
+   * identical for every chain but ethereum, which is why matching the id directly
+   * used to work: it missed and fell through to a hardcoded `1`.
+   */
+  const getChainIdFromChain = (chain: string): number | undefined => {
+    const name = getEvmChainName(chain) ?? chain;
+    return get(allEvmChains).find(item => item.name === name)?.id;
+  };
 
   const getEip155ChainId = (chainId: string | number): string => `${EIP155}:${chainId}`;
 

--- a/frontend/app/src/modules/wallet/use-wallet-helper.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-helper.ts
@@ -6,8 +6,8 @@ import { useHistoryTransactions } from '@/modules/history/events/tx/use-history-
 import { EIP155 } from './constants';
 
 interface UseWalletHelperReturn {
-  getEvmChainNameFromChainId: (chainId: number | bigint) => string;
-  getChainFromChainId: (chainId: number | bigint) => Blockchain;
+  getEvmChainNameFromChainId: (chainId: number | bigint) => string | undefined;
+  getChainFromChainId: (chainId: number | bigint) => Blockchain | undefined;
   getChainIdFromChain: (chain: string) => number | undefined;
   getChainIdFromNamespace: (namespace: string) => number;
   updateStatePostTransaction: (tx?: RecentTransaction) => Promise<void>;
@@ -19,14 +19,20 @@ export function useWalletHelper(): UseWalletHelperReturn {
   const { refreshBlockchainBalances } = useBlockchainBalances();
   const { addTransactionHash } = useHistoryTransactions();
 
-  function getEvmChainNameFromChainId(chainId: number | bigint): string {
+  /**
+   * The chain id is whatever the connected wallet reports, which is not
+   * constrained to the chains rotki supports. An unknown id resolves to nothing:
+   * defaulting it to ethereum made a wallet sitting on an unsupported chain look
+   * like it was on mainnet, so the "wrong network" warning never appeared.
+   */
+  function getEvmChainNameFromChainId(chainId: number | bigint): string | undefined {
     const id = typeof chainId === 'bigint' ? Number(chainId) : chainId;
-    return get(allEvmChains).find(item => item.id === id)?.name ?? 'ethereum';
+    return get(allEvmChains).find(item => item.id === id)?.name;
   }
 
-  function getChainFromChainId(chainId: number | bigint): Blockchain {
+  function getChainFromChainId(chainId: number | bigint): Blockchain | undefined {
     const name = getEvmChainNameFromChainId(chainId);
-    return getChain(name);
+    return name === undefined ? undefined : getChain(name);
   }
 
   /**

--- a/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.spec.ts
@@ -49,6 +49,7 @@ vi.mock('./bridge/use-injected-wallet', () => ({ useInjectedWallet: (): Fake => 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({ useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({ isPackaged: mocks.state.isPackaged }) }));
 vi.mock('@/modules/wallet/use-wallet-helper', () => ({ useWalletHelper: (): Fake => mocks.state.walletHelper }));
 vi.mock('@/modules/core/common/use-supported-chains', () => ({ useSupportedChains: (): Fake => mocks.state.supportedChains }));
+vi.mock('./use-wallet-chains', () => ({ useWalletChains: (): Fake => mocks.state.walletChains }));
 
 function makeInjectedWallet(): Record<string, any> {
   return {
@@ -64,6 +65,22 @@ function makeInjectedWallet(): Record<string, any> {
     })),
     isConnecting: ref(false),
     switchNetwork: vi.fn(async () => {}),
+  };
+}
+
+// The chain list itself belongs to `use-wallet-chains`, which has its own spec.
+// What the store owns is the wiring: which chain ids it hands to a WalletConnect
+// pairing, and which ones it narrows the account's chains by.
+function makeWalletChains(): Record<string, any> {
+  const walletChains = ref([
+    { chain: 'eth', chainId: 1 },
+    { chain: 'monad', chainId: 143 },
+  ]);
+
+  return {
+    getSessionChains: vi.fn((chainIds?: number[]) => chainIds?.map(id => `session-${id}`) ?? ['all-chains']),
+    walletChainIds: computed(() => get(walletChains).map(item => item.chainId)),
+    walletChains,
   };
 }
 
@@ -113,6 +130,7 @@ describe('modules/wallet/use-wallet-store', () => {
         selectProvider: vi.fn(async () => {}),
         showProviderSelection: ref<boolean>(false),
       },
+      walletChains: makeWalletChains(),
       walletConnect: makeWalletConnect(),
       walletHelper: {
         getChainFromChainId: vi.fn((chainId: number) => `chain-${chainId}`),
@@ -219,6 +237,16 @@ describe('modules/wallet/use-wallet-store', () => {
       await store.connect();
       expect(walletConnect().connect).toHaveBeenCalledTimes(1);
     });
+
+    it('should request every chain rotki supports in the session', async () => {
+      const store = await getStore();
+      store.walletMode = WALLET_MODES.WALLET_CONNECT;
+      await nextTick();
+
+      await store.connect();
+      // Not a hardcoded list: these are the ids the backend reported.
+      expect(walletConnect().connect).toHaveBeenCalledWith([1, 143]);
+    });
   });
 
   describe('disconnect', () => {
@@ -313,18 +341,33 @@ describe('modules/wallet/use-wallet-store', () => {
   });
 
   describe('supportedChainsForConnectedAccount', () => {
-    it('should list all supported chains in local bridge mode', async () => {
+    // The session namespaces only reach the store through the sync watcher that
+    // `getWalletConnect()` installs, so the store has to actually connect first.
+    async function connectWithNamespaces(namespaces: string[]): Promise<Awaited<ReturnType<typeof getStore>>> {
       const store = await getStore();
-      expect(get(store.supportedChainsForConnectedAccount)).toEqual([
-        'chain-1',
-        'chain-8453',
-        'chain-42161',
-        'chain-10',
-        'chain-56',
-        'chain-100',
-        'chain-137',
-        'chain-534352',
-      ]);
+      store.walletMode = WALLET_MODES.WALLET_CONNECT;
+      await nextTick();
+      await store.connect();
+      set(walletConnect().supportedChainIds, namespaces);
+      await nextTick();
+      return store;
+    }
+
+    const walletChains = (): Record<string, any> => mocks.state.walletChains;
+
+    it('should not narrow the chains in local bridge mode', async () => {
+      const store = await getStore();
+
+      expect(get(store.supportedChainsForConnectedAccount)).toEqual(['all-chains']);
+      expect(walletChains().getSessionChains).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should narrow by the chain ids the walletconnect session reports', async () => {
+      const store = await connectWithNamespaces(['eip155:1', 'eip155:143']);
+
+      // Read first: the computed is lazy, so nothing is called until it is.
+      expect(get(store.supportedChainsForConnectedAccount)).toEqual(['session-1', 'session-143']);
+      expect(walletChains().getSessionChains).toHaveBeenCalledWith([1, 143]);
     });
   });
 

--- a/frontend/app/src/modules/wallet/use-wallet-store.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.ts
@@ -12,7 +12,7 @@ import { useInterop } from '@/modules/shell/app/use-electron-interop';
 import { useWalletHelper } from '@/modules/wallet/use-wallet-helper';
 import { getAddress, type Hash, isHex, type ViemWalletClient } from '@/modules/wallet/viem-client';
 import { useWalletProxy } from './bridge/use-wallet-proxy';
-import { calculateGasFee, SUPPORTED_WALLET_CHAIN_IDS, WALLET_ERRORS, WALLET_MODES, type WalletMode } from './constants';
+import { calculateGasFee, WALLET_ERRORS, WALLET_MODES, type WalletMode } from './constants';
 import { useUnifiedProviders } from './providers/use-unified-providers';
 import { useTradeApi } from './send/use-trade-api';
 import {
@@ -21,6 +21,7 @@ import {
   validateTransactionRequirements,
 } from './transaction-helpers';
 import { useTransactionManager } from './use-transaction-manager';
+import { useWalletChains } from './use-wallet-chains';
 
 export { type WalletMode } from './constants';
 
@@ -65,6 +66,7 @@ export const useWalletStore = defineStore(STORE_ID, () => {
   const { recentTransactions, reset: resetTransactions, updateTransactionStatus } = transactionManager;
 
   const { getChainFromChainId, getChainIdFromNamespace } = useWalletHelper();
+  const { getSessionChains, walletChainIds } = useWalletChains();
   const { prepareERC20Transfer, prepareNativeTransfer } = useTradeApi();
   const { getEvmChainName } = useSupportedChains();
 
@@ -140,15 +142,12 @@ export const useWalletStore = defineStore(STORE_ID, () => {
     return injectedWalletInstance;
   }
 
-  const supportedChainsIdForConnectedAccount = computed<number[]>(() => {
-    const chainIds = get(supportedChainIds);
-    if (chainIds.length === 0 || get(walletMode) === WALLET_MODES.LOCAL_BRIDGE) {
-      return [...SUPPORTED_WALLET_CHAIN_IDS];
-    }
-    return chainIds.map(item => getChainIdFromNamespace(item));
-  });
-
-  const supportedChainsForConnectedAccount = computed<string[]>(() => get(supportedChainsIdForConnectedAccount).map(item => getChainFromChainId(item)));
+  // An injected wallet reports no namespaces, so it gets every chain rotki supports.
+  const supportedChainsForConnectedAccount = computed<string[]>(() => getSessionChains(
+    get(walletMode) === WALLET_MODES.LOCAL_BRIDGE
+      ? undefined
+      : get(supportedChainIds).map(item => getChainIdFromNamespace(item)),
+  ));
 
   const getWalletClient = (): ViemWalletClient => {
     if (get(walletMode) === WALLET_MODES.LOCAL_BRIDGE) {
@@ -197,7 +196,7 @@ export const useWalletStore = defineStore(STORE_ID, () => {
     }
     else {
       const wc = await getWalletConnect();
-      await wc.connect();
+      await wc.connect(get(walletChainIds));
     }
   };
 

--- a/frontend/app/src/modules/wallet/use-wallet-store.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.ts
@@ -65,7 +65,7 @@ export const useWalletStore = defineStore(STORE_ID, () => {
   const transactionManager = useTransactionManager();
   const { recentTransactions, reset: resetTransactions, updateTransactionStatus } = transactionManager;
 
-  const { getChainFromChainId, getChainIdFromNamespace } = useWalletHelper();
+  const { getChainIdFromNamespace } = useWalletHelper();
   const { getSessionChains, walletChainIds } = useWalletChains();
   const { prepareERC20Transfer, prepareNativeTransfer } = useTradeApi();
   const { getEvmChainName } = useSupportedChains();
@@ -302,7 +302,7 @@ export const useWalletStore = defineStore(STORE_ID, () => {
     }
 
     try {
-      const { chainId, evmChain, fromAddress } = validateTransactionRequirements({
+      const { evmChain, fromAddress } = validateTransactionRequirements({
         connectedAddress: get(connectedAddress),
         connectedChainId: get(connectedChainId),
         getEvmChainName,
@@ -326,10 +326,8 @@ export const useWalletStore = defineStore(STORE_ID, () => {
       await transactionManager.handleTransactionSuccess(
         client,
         hash,
-        chainId,
         params,
         get(connectedAddress),
-        getChainFromChainId,
       );
 
       return hash;


### PR DESCRIPTION
Reported: the onchain send form is missing chains, specifically Monad and HyperEVM.

## Why they were missing

The wallet's chain list was a hardcoded `SUPPORTED_WALLET_CHAIN_IDS` of eight ids in `modules/wallet/constants.ts`. The backend has supported both chains for a while (`ChainID.MONAD = 143`, `ChainID.HYPERLIQUID = 999`), but nothing in the frontend consulted it, so `use-tradable-asset` filtered their balances out before they could be offered.

## Deriving the list instead

Neither endpoint carries the whole answer:

- `/blockchains/supported` names the chains rotki supports but serializes no numeric id.
- `/blockchains/evm/all` carries the ids for the entire `ChainID` enum, which is much wider (it includes Fantom, Celo, Cronos and others rotki has no blockchain support for).

`useWalletChains` joins the two on `evmChainName`, taking the *set* from the first and the *number* from the second. A chain the backend gains now reaches the send form with no frontend release. The source is `txEvmChains`, so AVAX stays out: it has no transaction support, and a send finishes by recording its hash.

Two behaviours follow from having the real list:

- A chain that resolves to no numeric id is **dropped**, not defaulted to ethereum, which would have labelled its balances as ethereum ones.
- The WalletConnect narrowing is now an **intersection**. Previously each session namespace was mapped to a chain, so two chains rotki does not support both resolved to ethereum and put duplicate entries in the picker.

`chains-viem.ts` stays, but only as enrichment for the `wallet_addEthereumChain` fallback. It no longer gates which chains are offered, so a missing entry costs that one prompt rather than the chain itself. It cannot be made dynamic: viem exports only `./chains` and `./chains/utils`, with no per-chain subpath, so a keyed lookup would retain all 1399 definitions (5.7 MB) instead of tree-shaking to the ones named.

## Second commit: the ethereum fallback

While tracing the above, `getEvmChainNameFromChainId` answered `"ethereum"` for any chain id it did not recognise. A connected wallet reports whatever chain it sits on, which is not limited to rotki's list, and the cost was silent:

- On an unsupported chain the send form adopted ethereum as the selection and then compared it against ethereum, so `wrongNetwork` stayed false. **No warning appeared and the user could send believing they were on mainnet.**
- The connected-address badge and wallet indicator painted an Ethereum icon for the same reason.
- A completed transfer was recorded against `eth`.

It now resolves to `undefined`. Nothing depended on the old default: both display sites already typed the chain optional and hide the icon behind `v-if`, and `wrongNetwork` reads an unresolvable chain as a mismatch. The transaction record takes the chain the transfer was *prepared* for, which is the only one known to be supported — nothing checked that it agreed with the wallet's.

The reconciliation moved into `useTradeNetworkMatch` so it can be tested without mounting, and because the SFC was at its 20-dependency cap.

## Verification

Checked in the running app against a live backend, not only in tests. The store returned `["eth","optimism","polygon_pos","arbitrum_one","base","hyperliquid","gnosis","scroll","binance_sc","monad"]` and the picker renders all of them.

The control that matters: mutating the backend payload in the running app **removed** monad from the list, and injecting a `fantom` entry **added** it. Fantom has a numeric id but was never in the hardcoded list, so its appearance is evidence the list is genuinely derived rather than newly hardcoded.

Every changed line is covered, measured against the diff rather than per file — that turned up `use-transaction-manager.ts`, which had no spec at all, leaving the line that decides a transfer's recorded chain at 0%. Each new test was checked with a negative control.

`pnpm run test:unit` (9287 tests), `typecheck`, `lint` and `knip` all pass.

## Follow-up, not in this PR

Adding the numeric `chain_id` to the `/blockchains/supported` EVM entries would remove the two-endpoint join entirely — it is one line next to the `evm_chain_name` the endpoint already computes. Happy to do it separately if wanted.
