### PR TITLE
test(e2e): wait for the saved event, not a row count

### DIFF
--- a/frontend/app/src/modules/history/IgnoredInAccountingIcon.vue
+++ b/frontend/app/src/modules/history/IgnoredInAccountingIcon.vue
@@ -9,7 +9,7 @@ const { t } = useI18n({ useScope: 'global' });
 </script>
 
 <template>
-  <div>
+  <div data-testid="ignored-in-accounting">
     <BadgeDisplay
       v-if="mobile"
       color="grey"

--- a/frontend/app/tests/e2e/pages/history-event-rows.ts
+++ b/frontend/app/tests/e2e/pages/history-event-rows.ts
@@ -1,6 +1,15 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 import { TIMEOUT_MEDIUM } from '../helpers/constants';
 
+/** A regular event row, and the sub-event rows of an expanded swap. */
+export const EVENT_ROW = '[data-testid=history-event-row]';
+
+/** A swap group, collapsed or expanded — the id is on the collapse header too. */
+export const SWAP_ROW = '[data-testid=history-event-swap]';
+
+/** A movement that paired with another one and renders as a single matched row. */
+export const MOVEMENT_ROW = '[data-testid=history-event-movement]';
+
 /**
  * Addressing, reading and acting on the rows of the history events table.
  *
@@ -9,20 +18,53 @@ import { TIMEOUT_MEDIUM } from '../helpers/constants';
  * re-renders on every write, so an index resolved before a mutation names a different event after
  * it. That is not a stylistic preference — it is how the edit action ends up clicking the wrong
  * row, and how an assertion ends up reading one.
+ *
+ * The rule has a second half, which `waitForNewRow` exists to enforce: **an id resolved too early
+ * names the wrong event, and pinning it does not save you.** A save is followed by a refetch, and
+ * for as long as that is in flight the table still holds the previous rows. Waiting for a row
+ * *count* does not close that window — the specs run serial against a shared page, so any
+ * `>= n` guard is already satisfied by the rows earlier tests left behind and passes on the first
+ * tick. Wait for the event itself.
  */
 export class HistoryEventRows {
   constructor(private readonly page: Page) {}
 
   async countEvents(): Promise<number> {
-    return this.page.locator('[data-testid=history-event-row]').count();
+    return this.page.locator(EVENT_ROW).count();
   }
 
   async countSwaps(): Promise<number> {
-    return this.page.locator('[data-testid=history-event-swap]').count();
+    return this.page.locator(SWAP_ROW).count();
   }
 
   async countMovements(): Promise<number> {
-    return this.page.locator('[data-testid=history-event-movement]').count();
+    return this.page.locator(MOVEMENT_ROW).count();
+  }
+
+  /** The event ids currently rendered for `rowSelector`, in DOM order. */
+  async idsOf(rowSelector: string): Promise<string[]> {
+    const ids = await this.page.locator(rowSelector).evaluateAll(rows =>
+      rows.map(row => row.getAttribute('data-event-id')));
+    return ids.filter((id): id is string => !!id);
+  }
+
+  /**
+   * Waits for a row that is not one of `idsBefore` and pins it by its id.
+   *
+   * This is the gate to use after saving a new event: it is false until that event renders, which
+   * is what a count guard is not. Capture `idsBefore` with `idsOf` before opening the dialog, so
+   * the comparison spans the whole save.
+   */
+  async waitForNewRow(idsBefore: string[], rowSelector: string): Promise<Locator> {
+    const seen = new Set(idsBefore);
+    let added: string | undefined;
+
+    await expect(async () => {
+      added = (await this.idsOf(rowSelector)).find(id => !seen.has(id));
+      expect(added, `no new ${rowSelector} appeared`).toBeTruthy();
+    }).toPass({ timeout: TIMEOUT_MEDIUM });
+
+    return this.byId(added ?? '');
   }
 
   /** A row pinned to one event id — the only handle a re-sort cannot invalidate. */
@@ -41,7 +83,9 @@ export class HistoryEventRows {
    * The first row matching `rowSelector`, pinned to the event it stands for right now.
    *
    * Resolve this once, before anything that mutates the list, and address the row through the
-   * result from then on.
+   * result from then on. ⚠️ Only valid where the top row is already the one you mean: after a save
+   * the refetch may still be in flight, and this then pins the *previous* top row. Use
+   * `waitForNewRow` there.
    */
   async first(rowSelector: string): Promise<Locator> {
     return this.byId(await this.idOfFirst(rowSelector));
@@ -70,6 +114,12 @@ export class HistoryEventRows {
     await row.hover();
     await row.locator('[data-testid=row-edit]').click();
     await this.page.locator('[data-testid=bottom-dialog]').waitFor({ state: 'visible' });
+  }
+
+  /** Expands an already-resolved swap row, so which group opens does not depend on its position. */
+  async expand(row: Locator): Promise<void> {
+    await row.hover();
+    await row.locator('[data-testid=swap-expand]').click();
   }
 
   async delete(row: Locator): Promise<void> {

--- a/frontend/app/tests/e2e/pages/history-events-page.ts
+++ b/frontend/app/tests/e2e/pages/history-events-page.ts
@@ -301,12 +301,6 @@ export class HistoryEventsPage {
     }
   }
 
-  async expandSwap(index: number): Promise<void> {
-    const swapRow = this.page.locator('[data-testid=history-event-swap]').nth(index);
-    await swapRow.hover();
-    await swapRow.locator('[data-testid=swap-expand]').click();
-  }
-
   async getExpandedEventRows(): Promise<number> {
     return this.page.locator('[data-testid=history-event-row]').count();
   }

--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -16,7 +16,9 @@ import {
 } from '../../fixtures/history-events';
 import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { waitForNoRunningTasks } from '../../helpers/api';
+import { TIMEOUT_MEDIUM } from '../../helpers/constants';
 import { seedEvmTransaction, seedHistoricPrices } from '../../helpers/seed-db';
+import { EVENT_ROW, MOVEMENT_ROW, SWAP_ROW } from '../../pages/history-event-rows';
 import { HistoryEventsPage } from '../../pages/history-events-page';
 import { PillFilterBar } from '../../pages/pill-filter-bar';
 import { RotkiApp } from '../../pages/rotki-app';
@@ -28,13 +30,29 @@ import { RotkiApp } from '../../pages/rotki-app';
  */
 function assetMovementRow(ctx: SharedTestContext): Locator {
   return ctx.sharedPage
-    .locator('[data-testid=history-event-row], [data-testid=history-event-movement]')
+    .locator(`${EVENT_ROW}, ${MOVEMENT_ROW}`)
     .filter({ hasText: assetMovementEventFixture.notes });
 }
 
 test.describe.serial('history events', () => {
   let ctx: SharedTestContext;
   let page: HistoryEventsPage;
+
+  /**
+   * The rows each `add` test created, pinned by event id and handed to the tests that edit and
+   * delete them.
+   *
+   * A later test cannot re-find them with "the first row": the table sorts timestamp DESC and every
+   * test adds to it, so which event sits on top changes under them, and the online event's own
+   * deletion is what moves it. Naming the row here is also what makes the edit tests assert against
+   * the event they mean rather than against whatever survived.
+   */
+  let onlineRow: Locator;
+  let swapRow: Locator;
+  let solanaRow: Locator;
+  let solanaSwapRow: Locator;
+  let blockRow: Locator;
+  let withdrawalRow: Locator;
 
   test.beforeAll(async ({ browser, request }) => {
     seedHistoricPrices(TEST_PRICE_ENTRIES, TEST_EVENT_TIMESTAMP);
@@ -49,27 +67,24 @@ test.describe.serial('history events', () => {
   test('add online history event', async () => {
     await page.visit();
     await waitForNoRunningTasks(ctx.sharedPage);
+    const before = await page.rows.idsOf(EVENT_ROW);
+
     await page.openAddDialog();
     await page.selectEntryType('history event');
     await page.fillOnlineEventForm(onlineEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countEvents();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
-
-    const added = await page.rows.first('[data-testid=history-event-row]');
-    await page.rows.expectTypeLabel(added, 'Airdrop');
-    await page.rows.expectAmount(added, onlineEventFixture.amount);
-    await page.rows.expectNotes(added, onlineEventFixture.notes);
+    onlineRow = await page.rows.waitForNewRow(before, EVENT_ROW);
+    await page.rows.expectTypeLabel(onlineRow, 'Airdrop');
+    await page.rows.expectAmount(onlineRow, onlineEventFixture.amount);
+    await page.rows.expectNotes(onlineRow, onlineEventFixture.notes);
   });
 
   test('edit online history event', async () => {
     const updatedAmount = '2.5';
     const updatedNotes = 'Updated online event notes';
 
-    const row = await page.rows.first('[data-testid=history-event-row]');
+    const row = onlineRow;
     await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
@@ -84,44 +99,43 @@ test.describe.serial('history events', () => {
   });
 
   test('add swap event', async () => {
+    const before = await page.rows.idsOf(SWAP_ROW);
+
     await page.openAddDialog();
     await page.selectEntryType('swap event');
     await page.fillSwapEventForm(swapEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countSwaps();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
+    swapRow = await page.rows.waitForNewRow(before, SWAP_ROW);
 
     // Verify the swap row shows the spend asset amount
-    const swapRow = ctx.sharedPage.locator('[data-testid=history-event-swap]').first();
-    const assets = swapRow.locator('[data-testid=event-asset]');
-    await expect(assets.first()).toBeVisible();
+    await expect(swapRow.locator('[data-testid=event-asset]').first()).toBeVisible();
   });
 
   test('edit swap event', async () => {
     const updatedReceiveAmount = '3500';
 
-    await page.rows.edit(await page.rows.first('[data-testid=history-event-swap]'));
+    // A swap row renders spend then receive, one `event-amount` each, so the second one is what
+    // this edit changes. Asserting that it *changed* holds whatever the amount display rounds it
+    // to, and unlike a swap count it is false until the edit lands.
+    const receiveAmount = swapRow.locator('[data-testid=event-amount]').nth(1);
+    const before = await receiveAmount.textContent();
+
+    await page.rows.edit(swapRow);
 
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').clear();
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').fill(updatedReceiveAmount);
 
     await page.saveForm();
 
-    // Verify the swap still exists after edit
-    await expect(async () => {
-      const count = await page.rows.countSwaps();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
+    await expect.poll(async () => receiveAmount.textContent(), { timeout: TIMEOUT_MEDIUM }).not.toBe(before);
   });
 
   test('delete fee sub-event from online swap', async () => {
     // The swap created earlier has 3 sub-events: spend, receive, fee.
     // Expand it, delete the fee, and verify the swap group survives.
     const rowsBeforeExpand = await page.getExpandedEventRows();
-    await page.expandSwap(0);
+    await page.rows.expand(swapRow);
 
     await expect(async () => {
       const rows = await page.getExpandedEventRows();
@@ -178,47 +192,32 @@ test.describe.serial('history events', () => {
   });
 
   test('delete history event', async () => {
-    const eventsBefore = await page.rows.countEvents();
-    const swapsBefore = await page.rows.countSwaps();
-    const movementsBefore = await page.rows.countMovements();
-    const totalBefore = eventsBefore + swapsBefore + movementsBefore;
+    // The online event, named. A total over the whole table cannot say *which* row went away, and
+    // the swap expanded by an earlier test leaves its sub-events under the same selector.
+    await page.rows.delete(onlineRow);
 
-    // Delete the first regular event row (the online event)
-    if (eventsBefore > 0) {
-      await page.rows.delete(await page.rows.first('[data-testid=history-event-row]'));
-
-      await expect(async () => {
-        const eventsAfter = await page.rows.countEvents();
-        const swapsAfter = await page.rows.countSwaps();
-        const movementsAfter = await page.rows.countMovements();
-        const totalAfter = eventsAfter + swapsAfter + movementsAfter;
-        expect(totalAfter).toBeLessThan(totalBefore);
-      }).toPass({ timeout: 10000 });
-    }
+    await expect(onlineRow).toHaveCount(0, { timeout: TIMEOUT_MEDIUM });
   });
 
   test('add solana event', async () => {
+    const before = await page.rows.idsOf(EVENT_ROW);
+
     await page.openAddDialog();
     await page.selectEntryType('solana event');
     await page.fillSolanaEventForm(solanaEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countEvents();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
-
-    const added = await page.rows.first('[data-testid=history-event-row]');
-    await page.rows.expectTypeLabel(added, 'Airdrop');
-    await page.rows.expectAmount(added, solanaEventFixture.amount);
-    await page.rows.expectNotes(added, solanaEventFixture.notes);
+    solanaRow = await page.rows.waitForNewRow(before, EVENT_ROW);
+    await page.rows.expectTypeLabel(solanaRow, 'Airdrop');
+    await page.rows.expectAmount(solanaRow, solanaEventFixture.amount);
+    await page.rows.expectNotes(solanaRow, solanaEventFixture.notes);
   });
 
   test('edit solana event', async () => {
     const updatedAmount = '5.0';
     const updatedNotes = 'Updated solana event notes';
 
-    const row = await page.rows.first('[data-testid=history-event-row]');
+    const row = solanaRow;
     await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
@@ -234,53 +233,48 @@ test.describe.serial('history events', () => {
 
   test('add solana swap event', async () => {
     await waitForNoRunningTasks(ctx.sharedPage);
+    const before = await page.rows.idsOf(SWAP_ROW);
+
     await page.openAddDialog();
     await page.selectEntryType('solana swap event');
     await page.fillSolanaSwapEventForm(solanaSwapEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countSwaps();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
-
-    const swapRow = ctx.sharedPage.locator('[data-testid=history-event-swap]').first();
-    const assets = swapRow.locator('[data-testid=event-asset]');
-    await expect(assets.first()).toBeVisible();
+    solanaSwapRow = await page.rows.waitForNewRow(before, SWAP_ROW);
+    await expect(solanaSwapRow.locator('[data-testid=event-asset]').first()).toBeVisible();
   });
 
   test('edit solana swap event', async () => {
     const updatedReceiveAmount = '75';
 
-    await page.rows.edit(await page.rows.first('[data-testid=history-event-swap]'));
+    const receiveAmount = solanaSwapRow.locator('[data-testid=event-amount]').nth(1);
+    const before = await receiveAmount.textContent();
+
+    await page.rows.edit(solanaSwapRow);
 
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').clear();
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').fill(updatedReceiveAmount);
 
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countSwaps();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
+    await expect.poll(async () => receiveAmount.textContent(), { timeout: TIMEOUT_MEDIUM }).not.toBe(before);
   });
 
   test('add eth block event', async () => {
+    const before = await page.rows.idsOf(EVENT_ROW);
+
     await page.openAddDialog();
     await page.selectEntryType('eth block event');
     await page.fillEthBlockEventForm(ethBlockEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countEvents();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
+    blockRow = await page.rows.waitForNewRow(before, EVENT_ROW);
   });
 
   test('edit eth block event', async () => {
     const updatedAmount = '0.1';
 
-    const row = await page.rows.first('[data-testid=history-event-row]');
+    const row = blockRow;
     await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
@@ -293,21 +287,20 @@ test.describe.serial('history events', () => {
   });
 
   test('add eth withdrawal event', async () => {
+    const before = await page.rows.idsOf(EVENT_ROW);
+
     await page.openAddDialog();
     await page.selectEntryType('eth withdrawal event');
     await page.fillEthWithdrawalEventForm(ethWithdrawalEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countEvents();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
+    withdrawalRow = await page.rows.waitForNewRow(before, EVENT_ROW);
   });
 
   test('edit eth withdrawal event', async () => {
     const updatedAmount = '16';
 
-    const row = await page.rows.first('[data-testid=history-event-row]');
+    const row = withdrawalRow;
     await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
@@ -320,21 +313,11 @@ test.describe.serial('history events', () => {
   });
 
   test('delete solana event', async () => {
-    // Read the notes of the first event row so we can verify it's gone after deletion
-    const firstRow = ctx.sharedPage.locator('[data-testid=history-event-row]').first();
-    const notesBefore = await firstRow.locator('[data-testid=event-notes]').textContent();
+    // The solana event, named. Reading the top row's notes and then deleting the top row asserts
+    // only that *something* changed there, which a re-sort or a refetch also produces.
+    await page.rows.delete(solanaRow);
 
-    await page.rows.delete(await page.rows.first('[data-testid=history-event-row]'));
-
-    // Wait until the deleted event's notes are no longer the first row's notes
-    await expect(async () => {
-      const rows = ctx.sharedPage.locator('[data-testid=history-event-row]');
-      const count = await rows.count();
-      if (count === 0)
-        return; // all event rows gone, deletion succeeded
-      const currentNotes = await rows.first().locator('[data-testid=event-notes]').textContent();
-      expect(currentNotes).not.toBe(notesBefore);
-    }).toPass({ timeout: 10000 });
+    await expect(solanaRow).toHaveCount(0, { timeout: TIMEOUT_MEDIUM });
   });
 
   test('delete swap event', async () => {
@@ -347,17 +330,23 @@ test.describe.serial('history events', () => {
     // deleted a *different* swap: the list is timestamp DESC and re-renders under the test, so the
     // index no longer names the row that was read. The id is on both the collapsed row and the
     // collapse header, so a swap that merely expands still matches and only a deletion clears it.
-    const target = await page.rows.first('[data-testid=history-event-swap]');
+    // The solana swap, because the online one is still expanded from `delete fee sub-event` and an
+    // expanded group renders its collapse header, which carries no row actions.
+    await page.rows.delete(solanaSwapRow);
 
-    await page.rows.delete(target);
-
-    await expect(target).toHaveCount(0, { timeout: 10000 });
+    await expect(solanaSwapRow).toHaveCount(0, { timeout: TIMEOUT_MEDIUM });
   });
 });
 
 test.describe.serial('evm history events', () => {
   let ctx: SharedTestContext;
   let page: HistoryEventsPage;
+
+  /** The rows this block's `add` tests created — see the note on the block above. */
+  let evmRow: Locator;
+  let evmSwapRow: Locator;
+  let multiSwapRow: Locator;
+  let depositRow: Locator;
 
   test.beforeAll(async ({ browser, request }) => {
     ctx = await createLoggedInContext(browser, request, {
@@ -384,27 +373,24 @@ test.describe.serial('evm history events', () => {
   test('add evm event', async () => {
     await page.visit();
     await waitForNoRunningTasks(ctx.sharedPage);
+    const before = await page.rows.idsOf(EVENT_ROW);
+
     await page.openAddDialog();
     await page.selectEntryType('evm event');
     await page.fillEvmEventForm(evmEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countEvents();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
-
-    const added = await page.rows.first('[data-testid=history-event-row]');
-    await page.rows.expectTypeLabel(added, 'Airdrop');
-    await page.rows.expectAmount(added, evmEventFixture.amount);
-    await page.rows.expectNotes(added, evmEventFixture.notes);
+    evmRow = await page.rows.waitForNewRow(before, EVENT_ROW);
+    await page.rows.expectTypeLabel(evmRow, 'Airdrop');
+    await page.rows.expectAmount(evmRow, evmEventFixture.amount);
+    await page.rows.expectNotes(evmRow, evmEventFixture.notes);
   });
 
   test('edit evm event', async () => {
     const updatedAmount = '2.5';
     const updatedNotes = 'Updated evm event notes';
 
-    const row = await page.rows.first('[data-testid=history-event-row]');
+    const row = evmRow;
     await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
@@ -419,58 +405,51 @@ test.describe.serial('evm history events', () => {
   });
 
   test('add evm swap event', async () => {
+    const before = await page.rows.idsOf(SWAP_ROW);
+
     await page.openAddDialog();
     await page.selectEntryType('evm swap event');
     await page.fillEvmSwapEventForm(evmSwapEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countSwaps();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
-
-    const swapRow = ctx.sharedPage.locator('[data-testid=history-event-swap]').first();
-    const assets = swapRow.locator('[data-testid=event-asset]');
-    await expect(assets.first()).toBeVisible();
+    evmSwapRow = await page.rows.waitForNewRow(before, SWAP_ROW);
+    await expect(evmSwapRow.locator('[data-testid=event-asset]').first()).toBeVisible();
   });
 
   test('edit evm swap event', async () => {
     const updatedReceiveAmount = '3500';
 
-    await page.rows.edit(await page.rows.first('[data-testid=history-event-swap]'));
+    const receiveAmount = evmSwapRow.locator('[data-testid=event-amount]').nth(1);
+    const before = await receiveAmount.textContent();
+
+    await page.rows.edit(evmSwapRow);
 
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').clear();
     await ctx.sharedPage.locator('[data-testid=sub-event-amount][data-key=receive] input').fill(updatedReceiveAmount);
 
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countSwaps();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
+    await expect.poll(async () => receiveAmount.textContent(), { timeout: TIMEOUT_MEDIUM }).not.toBe(before);
   });
 
   test('add evm multi-asset swap with fees', async () => {
     await waitForNoRunningTasks(ctx.sharedPage);
-    const swapsBefore = await page.rows.countSwaps();
+    const before = await page.rows.idsOf(SWAP_ROW);
 
     await page.openAddDialog();
     await page.selectEntryType('evm swap event');
     await page.fillEvmMultiSwapEventForm(evmMultiSwapEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countSwaps();
-      expect(count).toBeGreaterThan(swapsBefore);
-    }).toPass({ timeout: 10000 });
+    multiSwapRow = await page.rows.waitForNewRow(before, SWAP_ROW);
   });
 
   test('delete extra sub-event from multi-asset swap', async () => {
     // The multi-asset swap has 2 spend + 2 receive + 2 fee = 6 sub-events.
-    // It was added last so it has the most recent timestamp.
-    // With descending sort it appears first (index 0).
+    // It was added last so it has the most recent timestamp, which with the descending sort puts
+    // its sub-events first once expanded — that is what the `deleteSubEvent` index below relies on.
     const rowsBeforeExpand = await page.getExpandedEventRows();
-    await page.expandSwap(0);
+    await page.rows.expand(multiSwapRow);
 
     // Wait for the 6 sub-event rows to appear (on top of any existing event-rows)
     await expect(async () => {
@@ -499,21 +478,20 @@ test.describe.serial('evm history events', () => {
   });
 
   test('add eth deposit event', async () => {
+    const before = await page.rows.idsOf(EVENT_ROW);
+
     await page.openAddDialog();
     await page.selectEntryType('eth deposit event');
     await page.fillEthDepositEventForm(ethDepositEventFixture);
     await page.saveForm();
 
-    await expect(async () => {
-      const count = await page.rows.countEvents();
-      expect(count).toBeGreaterThanOrEqual(1);
-    }).toPass({ timeout: 10000 });
+    depositRow = await page.rows.waitForNewRow(before, EVENT_ROW);
   });
 
   test('edit eth deposit event', async () => {
     const updatedAmount = '16';
 
-    const row = await page.rows.first('[data-testid=history-event-row]');
+    const row = depositRow;
     await page.rows.edit(row);
 
     await ctx.sharedPage.locator('[data-testid=amount] input').clear();
@@ -525,26 +503,29 @@ test.describe.serial('evm history events', () => {
     await page.rows.expectNotes(row, updatedAmount);
   });
 
-  test('delete evm event', async () => {
-    const eventsBefore = await page.rows.countEvents();
+  test('the row action on a lone evm event excludes it from accounting', async () => {
+    // rotki does not delete the only event of a decoded EVM transaction — it would come back with
+    // the transaction — so `HistoryEventsListItemAction.deleteEvent` turns the row action into an
+    // ignore for that case. The row therefore stays and its group gains the ignored badge.
+    //
+    // The old test asserted a total row count that merely went down, and passed: `first()` handed
+    // it a sub-event of the multi-asset swap the previous test left expanded, so it deleted that
+    // instead and never touched the evm event.
+    const ignored = ctx.sharedPage.locator('[data-testid=ignored-in-accounting]');
+    await expect(ignored).toHaveCount(0);
 
-    await page.rows.delete(await page.rows.first('[data-testid=history-event-row]'));
+    await page.rows.delete(evmRow);
 
-    await expect(async () => {
-      const eventsAfter = await page.rows.countEvents();
-      expect(eventsAfter).toBeLessThan(eventsBefore);
-    }).toPass({ timeout: 10000 });
+    await expect(ignored).toHaveCount(1, { timeout: TIMEOUT_MEDIUM });
+    await expect(evmRow).toHaveCount(1);
   });
 
   test('delete evm swap event', async () => {
-    const swapsBefore = await page.rows.countSwaps();
+    // The single-asset swap: the multi-asset one is still expanded from the sub-event test, and an
+    // expanded group renders a collapse header, which carries no row actions.
+    await page.rows.delete(evmSwapRow);
 
-    await page.rows.delete(await page.rows.first('[data-testid=history-event-swap]'));
-
-    await expect(async () => {
-      const swapsAfter = await page.rows.countSwaps();
-      expect(swapsAfter).toBeLessThan(swapsBefore);
-    }).toPass({ timeout: 10000 });
+    await expect(evmSwapRow).toHaveCount(0, { timeout: TIMEOUT_MEDIUM });
   });
 });
 


### PR DESCRIPTION
`Frontend e2e tests / shard-2` has failed three times now on unrelated PRs (#12970 twice, #12972 once), always the same way:

```
history-events.spec.ts:200 › history events › add solana event
  at pages/history-event-rows.ts:51
  Locator: locator('[data-event-id="2"]').locator('[data-testid=event-type]')
  Expected substring: "Airdrop"
  Received string:    "Swap"
```

The resolved element carried `chain="eth"`: the assertion was reading a leftover ethereum swap row from an earlier test, not the solana event the test had just saved.

## The defect

Every add test gated its save on a row count and then resolved the row by position:

```ts
await expect(async () => {
  const count = await page.rows.countEvents();
  expect(count).toBeGreaterThanOrEqual(1);   // already true before the save
}).toPass({ timeout: 10000 });

const added = await page.rows.first('[data-testid=history-event-row]');
```

The specs run `describe.serial` against a shared page, so the table already holds rows from earlier tests. `count >= 1` passes on the first tick and the block waits for nothing; `rows.first()` then pins whatever is on top at that instant, which mid-refetch is still the previous top row. Every later assertion in the test addresses that wrong row. `HistoryEventRows` already carried the rule this trips over — *a row is named by the event it stands for, never by its position* — and `first()` obeys it, but resolving it too early hands it the wrong id, so the pinning does not save you.

The shape appeared about ten times in the file. The solana case just lost the race first.

## The fix

`HistoryEventRows` gains `idsOf(selector)` and `waitForNewRow(idsBefore, selector)`: capture the ids before the save, wait for one that was not there, pin it. That gate is false until the saved event renders. Each add test stores its pinned row and hands it to the tests that edit and delete it, so nothing re-resolves a row by position. `expandSwap(index)` is replaced by `rows.expand(row)`.

## Two tests that were passing for unrelated reasons

Naming the rows made this visible:

- **`delete evm event` never deleted the evm event.** `first()` handed it a sub-event of the multi-asset swap the previous test left expanded, and "the total went down" accepted that. Deleting the evm event is not possible by design: `HistoryEventsListItemAction.deleteEvent` turns the row action into an *ignore* when the row is the only event of a decoded EVM transaction. The backend log confirms it — the click issues `PUT /api/1/actions/ignored` and no delete at all. The test is renamed for that contract and asserts the ignored badge appears, which is why `IgnoredInAccountingIcon` gains a `data-testid`.
- **`delete solana event`** read the top row's notes before and after and asserted they differed, which a re-sort or a refetch also produces. It now deletes the named row and asserts it is gone.

The two `edit swap` tests also closed on a swap count that was already true. They now assert the receive amount actually changed, which holds whatever the amount display rounds it to.

## Verification

Three full runs of the spec file, 30/30 passing each (2.3-2.5m); the same three runs against the pre-fix assertions reproduced the `delete evm event` defect every time, which is how it was found.

Negative control: capturing the ids *after* the save (so the new row is already in the set) makes `add online history event` fail with `no new [data-testid=history-event-row] appeared` — the gate is genuinely waiting for the event rather than passing vacuously.

`typecheck`, `lint` and `knip` pass. A local run cannot prove a CI race is gone, so the evidence here is the mechanism plus the controls; CI is the rest of it.

## Not in this PR

`specs/import/csv-import.spec.ts` (lines 42, 61, 84, 105, 123) has the same shape: import, apply a location filter, gate on `count >= 1`, then read `rows.first()`. The table still holds the pre-filter rows while the filtered request is in flight, so that guard also passes on the first tick. It has not been seen failing; happy to convert it separately.
