### PR TITLE
Fix the ETH staking total when filtering

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3213,6 +3213,11 @@
       "title": "Alchemy"
     },
     "api_key": "API key",
+    "api_key_menu": {
+      "consensus_rpc_title": "Staking data source",
+      "dismiss": "Don't show again",
+      "optional": "Optional API key"
+    },
     "beaconchain": {
       "api_key_message": "If you have a Beaconcha.in API key, you can add it here to retrieve block production history and improved staking analytics. It is not required to add a validator.",
       "description": "rotki uses Beaconcha.in to retrieve block production history and improved staking analytics. An API key is needed if you want this data.",

--- a/frontend/app/src/modules/accounts/api/use-blockchain-accounts-api.ts
+++ b/frontend/app/src/modules/accounts/api/use-blockchain-accounts-api.ts
@@ -1,5 +1,5 @@
 import type { Eth2Validator } from '@/modules/balances/types/balances';
-import { assert, type Eth2ValidatorEntry, type EthValidatorFilter, type Nullable, onlyIfTruthy } from '@rotki/common';
+import { assert, type Eth2ValidatorEntry, Eth2Validators, type EthValidatorFilter, type Nullable, onlyIfTruthy } from '@rotki/common';
 import { omit } from 'es-toolkit';
 import {
   type AccountPayload,
@@ -48,6 +48,7 @@ interface UseBlockchainAccountsApiReturn {
   queryBtcAccounts: (blockchain: BtcChains) => Promise<BitcoinAccounts>;
   deleteXpub: ({ chain, derivationPath, xpub }: DeleteXpubParams) => Promise<PendingTask>;
   getEth2Validators: (payload?: EthValidatorFilter) => Promise<PendingTask>;
+  queryEth2Validators: (payload?: EthValidatorFilter) => Promise<Eth2Validators>;
   addEth2Validator: (payload: Eth2Validator) => Promise<PendingTask>;
   editEth2Validator: ({ ownershipPercentage, validatorIndex }: Eth2Validator) => Promise<boolean>;
   deleteEth2Validators: (validators: Eth2ValidatorEntry[]) => Promise<boolean>;
@@ -192,6 +193,24 @@ export function useBlockchainAccountsApi(): UseBlockchainAccountsApiReturn {
     return PendingTaskSchema.parse(response);
   };
 
+  /**
+   * The same query as {@link getEth2Validators}, answered in the response rather than through a
+   * task.
+   *
+   * This is a filtered read of `eth2_validators`, which measures in single-digit milliseconds for
+   * every filter shape the staking page can build. Routed through the async task machinery the
+   * answer instead arrives on the polling cadence, seconds after the request, which is far too slow
+   * for something recomputed on every keystroke-sized filter change.
+   */
+  const queryEth2Validators = async (payload: EthValidatorFilter = {}): Promise<Eth2Validators> => {
+    const response = await api.get<Eth2Validators>('/blockchains/eth2/validators', {
+      filterEmptyProperties: true,
+      query: { ...payload },
+      validStatuses: VALID_WITH_SESSION_STATUS,
+    });
+    return Eth2Validators.parse(response);
+  };
+
   const addEth2Validator = async (payload: Eth2Validator): Promise<PendingTask> => {
     const response = await api.put<PendingTask>(
       '/blockchains/eth2/validators',
@@ -257,6 +276,7 @@ export function useBlockchainAccountsApi(): UseBlockchainAccountsApiReturn {
     getEth2Validators,
     queryAccounts,
     queryBtcAccounts,
+    queryEth2Validators,
     removeAgnosticBlockchainAccount,
     removeBlockchainAccount,
   };

--- a/frontend/app/src/modules/accounts/management/AccountFormApiKeyMenu.spec.ts
+++ b/frontend/app/src/modules/accounts/management/AccountFormApiKeyMenu.spec.ts
@@ -1,0 +1,115 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AccountFormApiKeyMenu from '@/modules/accounts/management/AccountFormApiKeyMenu.vue';
+
+/**
+ * The seam: which service's guidance the popover carries, the disclosure semantics on the trigger,
+ * and dismissal. Dismissal is the part worth pinning, because a prompt that cannot be put away is
+ * permanent chrome and a dismissal that is not persisted comes back on the next login.
+ *
+ * `RuiMenu` is stubbed to a pass-through. Its open/close behaviour belongs to the library and does
+ * not work under happy-dom anyway, since floating-ui needs real layout.
+ */
+const RuiMenu = {
+  template: '<div><slot name="activator" :attrs="{}" /><slot /></div>',
+};
+
+const dismissedNotices = ref<string[]>([]);
+const updateFrontendSetting = vi.fn(async () => ({ success: true }));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: vi.fn(() => dismissedNotices),
+}));
+
+vi.mock('@/modules/settings/use-frontend-settings-writer', () => ({
+  useFrontendSettingsWriter: vi.fn(() => ({ updateFrontendSetting })),
+}));
+
+describe('accountFormApiKeyMenu', () => {
+  let wrapper: VueWrapper | undefined;
+
+  function create(service: 'beaconchain' | 'consensusRpc' | 'etherscan'): VueWrapper {
+    wrapper = mount(AccountFormApiKeyMenu, {
+      global: { stubs: { RuiMenu } },
+      props: { service },
+    });
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(dismissedNotices, []);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should head the guidance with the name of the service', () => {
+    const content = create('beaconchain').find('[data-testid=api-key-menu-content]');
+
+    expect(content.text()).toContain('external_services.beaconchain.title');
+  });
+
+  it('should head the consensus rpc case with its own title', () => {
+    // This one has no service name of its own to borrow, so it carries a dedicated heading rather
+    // than falling through to another service's.
+    const content = create('consensusRpc').find('[data-testid=api-key-menu-content]');
+
+    expect(content.text()).toContain('external_services.api_key_menu.consensus_rpc_title');
+  });
+
+  it('should show the guidance belonging to the given service', () => {
+    const content = create('etherscan').find('[data-testid=api-key-menu-content]');
+
+    expect(content.text()).toContain('external_services.etherscan.api_key_message');
+  });
+
+  it('should announce the trigger as a collapsed disclosure', () => {
+    // RuiMenu supplies neither attribute, so without these a screen reader is told nothing about
+    // there being anything to open.
+    const trigger = create('beaconchain').find('[data-testid=api-key-menu-activator]');
+
+    expect(trigger.attributes('aria-haspopup')).toBe('dialog');
+    expect(trigger.attributes('aria-expanded')).toBe('false');
+  });
+
+  it('should label the panel as a dialog naming the service', () => {
+    const panel = create('beaconchain').find('[data-testid=api-key-menu-content]');
+
+    expect(panel.attributes('role')).toBe('dialog');
+    expect(panel.attributes('aria-label')).toBe('external_services.beaconchain.title');
+  });
+
+  it('should persist the dismissal so it survives a reload', async () => {
+    const view = create('beaconchain');
+    await view.find('[data-testid=api-key-menu-dismiss]').trigger('click');
+    await flushPromises();
+
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ dismissedApiKeyNotices: ['beaconchain'] });
+  });
+
+  it('should keep the dismissals of other services when dismissing one', async () => {
+    set(dismissedNotices, ['etherscan']);
+
+    const view = create('beaconchain');
+    await view.find('[data-testid=api-key-menu-dismiss]').trigger('click');
+    await flushPromises();
+
+    expect(updateFrontendSetting).toHaveBeenCalledWith({ dismissedApiKeyNotices: ['etherscan', 'beaconchain'] });
+  });
+
+  it('should render nothing once the service has been dismissed', () => {
+    set(dismissedNotices, ['beaconchain']);
+
+    expect(create('beaconchain').find('[data-testid=api-key-menu-activator]').exists()).toBe(false);
+  });
+
+  it('should still render when a different service was dismissed', () => {
+    set(dismissedNotices, ['etherscan']);
+
+    expect(create('beaconchain').find('[data-testid=api-key-menu-activator]').exists()).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/accounts/management/AccountFormApiKeyMenu.vue
+++ b/frontend/app/src/modules/accounts/management/AccountFormApiKeyMenu.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import AccountFormApiKeyAlertContent from '@/modules/accounts/management/AccountFormApiKeyAlertContent.vue';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useFrontendSettingsWriter } from '@/modules/settings/use-frontend-settings-writer';
+import { useSetting } from '@/modules/settings/use-setting';
+
+/**
+ * An optional API key offer, behind a button instead of a banner.
+ *
+ * Reserved for keys the page works without. A page that is actually missing a data source stays on
+ * the banner, because prominence should follow severity; demoting a "there is no data" state to
+ * something you have to click would hide it.
+ *
+ * Since the prompt is an offer rather than a fault, it is dismissible and the dismissal is
+ * remembered, so it does not become permanent chrome for someone who has decided against the key.
+ */
+const { service } = defineProps<{
+  service: 'etherscan' | 'helius' | 'beaconchain' | 'consensusRpc' | 'blockscout';
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const open = ref<boolean>(false);
+const activator = useTemplateRef<HTMLElement>('activator');
+const panel = useTemplateRef<HTMLElement>('panel');
+
+const dismissed = useSetting('dismissedApiKeyNotices');
+const { updateFrontendSetting } = useFrontendSettingsWriter();
+
+const visible = computed<boolean>(() => !get(dismissed).includes(service));
+
+/** Names the subject, so the popover does not open as an unheaded paragraph. */
+const title = computed<string>(() => {
+  if (service === 'etherscan')
+    return t('external_services.etherscan.title');
+
+  if (service === 'consensusRpc')
+    return t('external_services.api_key_menu.consensus_rpc_title');
+
+  if (service === 'beaconchain')
+    return t('external_services.beaconchain.title');
+
+  if (service === 'helius')
+    return t('external_services.helius.title');
+
+  return t('external_services.blockscout.title');
+});
+
+async function dismiss(): Promise<void> {
+  set(open, false);
+  const current = get(dismissed);
+  if (current.includes(service))
+    return;
+
+  const status = await updateFrontendSetting({ dismissedApiKeyNotices: [...current, service] });
+  if (!status.success)
+    logger.error(`failed to dismiss the ${service} api key notice: ${status.message}`);
+}
+
+// `RuiMenu` supplies neither the disclosure semantics nor the focus move, so both are wired here.
+// Without the move, the popover is teleported to the end of the document and a keyboard user
+// reaches its link only after tabbing through the rest of the page.
+watch(open, async (isOpen) => {
+  await nextTick();
+  if (isOpen)
+    get(panel)?.focus();
+  else
+    get(activator)?.focus();
+});
+</script>
+
+<template>
+  <RuiMenu
+    v-if="visible"
+    v-model="open"
+    menu-class="w-[26rem] max-w-[90vw]"
+    :popper="{ placement: 'bottom-end' }"
+  >
+    <template #activator="{ attrs }">
+      <RuiButton
+        ref="activator"
+        variant="outlined"
+        color="info"
+        size="lg"
+        class="!rounded-full"
+        aria-haspopup="dialog"
+        :aria-expanded="open"
+        data-testid="api-key-menu-activator"
+        v-bind="attrs"
+      >
+        <template #prepend>
+          <RuiIcon name="lu-info" />
+        </template>
+        {{ t('external_services.api_key_menu.optional') }}
+      </RuiButton>
+    </template>
+
+    <div
+      ref="panel"
+      role="dialog"
+      tabindex="-1"
+      :aria-label="title"
+      class="p-4 flex flex-col gap-2 text-body-2 focus:outline-none"
+      data-testid="api-key-menu-content"
+    >
+      <div class="font-medium text-rui-text">
+        {{ title }}
+      </div>
+
+      <AccountFormApiKeyAlertContent :service="service" />
+
+      <div class="flex justify-end -mb-1 mt-1">
+        <RuiButton
+          variant="text"
+          color="secondary"
+          size="sm"
+          data-testid="api-key-menu-dismiss"
+          @click="dismiss()"
+        >
+          {{ t('external_services.api_key_menu.dismiss') }}
+        </RuiButton>
+      </div>
+    </div>
+  </RuiMenu>
+</template>

--- a/frontend/app/src/modules/settings/settings-registry-frontend.ts
+++ b/frontend/app/src/modules/settings/settings-registry-frontend.ts
@@ -56,6 +56,7 @@ export const frontendRegistry = {
   dateInputFormat: frontend('dateInputFormat'),
   decimalSeparator: frontend('decimalSeparator', { anchor: SettingsHighlightIds.AMOUNT_FORMAT, effects: [applyBigNumberFormat] }),
   defaultThemeVersion: frontend('defaultThemeVersion'),
+  dismissedApiKeyNotices: frontend('dismissedApiKeyNotices', { userFacing: false }),
   enableAliasNames: frontend('enableAliasNames'),
   enablePasswordConfirmation: frontend('enablePasswordConfirmation', {
     anchor: SettingsHighlightIds.PASSWORD_CONFIRMATION,

--- a/frontend/app/src/modules/settings/settings-repo.spec.ts
+++ b/frontend/app/src/modules/settings/settings-repo.spec.ts
@@ -53,6 +53,7 @@ describe('useSettingsRepo frontend channel', () => {
       schemaVersion: 2,
       clientId: '',
       defiSetupDone: true,
+      dismissedApiKeyNotices: [],
       language: SupportedLanguage.EN,
       lastAppliedSettingsVersion: '0.0.0',
       answeredSuggestions: [],

--- a/frontend/app/src/modules/settings/types/frontend-settings.ts
+++ b/frontend/app/src/modules/settings/types/frontend-settings.ts
@@ -230,6 +230,9 @@ export const FrontendSettings = z.object({
   decimalSeparator: z.string().default(Defaults.DEFAULT_DECIMAL_SEPARATOR),
   defaultThemeVersion: z.number().default(1),
   defiSetupDone: z.boolean().default(false),
+  // The external services whose optional-API-key prompt the user has dismissed. No `.catch`: an
+  // unreadable value here should surface rather than silently re-show every prompt.
+  dismissedApiKeyNotices: z.array(z.string()).default([]),
   enableAliasNames: z.boolean().default(true),
   enablePasswordConfirmation: EnablePasswordConfirmation.default(true),
   evmQueryIndicatorDismissalThreshold: EvmQueryIndicatorDismissalThreshold.default(

--- a/frontend/app/src/modules/settings/types/user-settings.spec.ts
+++ b/frontend/app/src/modules/settings/types/user-settings.spec.ts
@@ -62,6 +62,7 @@ describe('user-types', () => {
         graph: '#555555',
       },
       defaultThemeVersion: 1,
+      dismissedApiKeyNotices: [],
       graphZeroBased: true,
       ignoreSnapshotError: false,
       showGraphRangeSelector: true,

--- a/frontend/app/src/modules/staking/eth/EthStakingPage.vue
+++ b/frontend/app/src/modules/staking/eth/EthStakingPage.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import AccountFormApiKeyAlert from '@/modules/accounts/management/AccountFormApiKeyAlert.vue';
+import AccountFormApiKeyMenu from '@/modules/accounts/management/AccountFormApiKeyMenu.vue';
 import { EthStaking } from '@/modules/premium/premium';
 import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
 import ModuleNotActive from '@/modules/settings/modules/ModuleNotActive.vue';
@@ -37,6 +38,18 @@ const missingApiKeyService = computed<'beaconchain' | 'consensusRpc' | undefined
 
   return undefined;
 });
+
+/**
+ * Beaconcha.in only sharpens a page that already works, so it is an offer the user can put away.
+ * A missing consensus RPC means there is no staking data at all, which is a fault and stays inline.
+ */
+const optionalApiKeyService = computed<'beaconchain' | undefined>(() =>
+  get(missingApiKeyService) === 'beaconchain' ? 'beaconchain' : undefined,
+);
+
+const blockingApiKeyService = computed<'consensusRpc' | undefined>(() =>
+  get(missingApiKeyService) === 'consensusRpc' ? 'consensusRpc' : undefined,
+);
 
 // Validator management
 const {
@@ -85,6 +98,11 @@ onBeforeMount(async () => {
       child
     >
       <template #buttons>
+        <AccountFormApiKeyMenu
+          v-if="optionalApiKeyService"
+          :service="optionalApiKeyService"
+        />
+
         <EthStakingHeaderActions
           :refreshing="refreshing"
           @refresh="refresh(true)"
@@ -92,8 +110,8 @@ onBeforeMount(async () => {
       </template>
 
       <AccountFormApiKeyAlert
-        v-if="missingApiKeyService"
-        :service="missingApiKeyService"
+        v-if="blockingApiKeyService"
+        :service="blockingApiKeyService"
       />
 
       <EthStaking

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-management.spec.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-management.spec.ts
@@ -2,32 +2,16 @@ import type { EffectScope } from 'vue';
 import type { EthereumValidator } from '@/modules/accounts/blockchain-accounts';
 import { bigNumberify, Zero } from '@rotki/common';
 import { createMock } from '@test/utils/create-mock';
-import { runSpecWith } from '@test/utils/mocks/native-task';
 import flushPromises from 'flush-promises';
-import { err, ok } from 'plainfp/result';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { TaskFailed } from '@/modules/core/tasks/task-result';
 import { useEthValidatorManagement } from '@/modules/staking/eth/use-eth-validator-management';
 
-const mockGetEth2Validators = vi.fn();
+const mockQueryEth2Validators = vi.fn();
 const mockEthStakingValidators = ref<EthereumValidator[]>([]);
 
 vi.mock('@/modules/accounts/api/use-blockchain-accounts-api', () => ({
   useBlockchainAccountsApi: vi.fn(() => ({
-    getEth2Validators: mockGetEth2Validators,
-  })),
-}));
-
-const runTaskResult = vi.fn();
-/** Runs the submitted spec inline so assertions see the real `run` body. */
-const submitTask = vi.fn(runSpecWith(runTaskResult));
-
-vi.mock('@/modules/task-center/use-native-task', () => ({
-  useNativeTask: vi.fn(() => ({
-    cancelByType: vi.fn(() => vi.fn()),
-    runTaskResult,
-    statusOf: vi.fn(),
-    submitTask,
+    queryEth2Validators: mockQueryEth2Validators,
   })),
 }));
 
@@ -85,67 +69,92 @@ describe('useEthValidatorManagement', () => {
 
       expect(get(total)).toStrictEqual(Zero);
     });
+
+    it('should total zero when every selected validator has exited', () => {
+      // The balance response omits exited validators entirely, so they carry a stand-in zero.
+      set(mockEthStakingValidators, [validator('0xaaa', 32), validator('0xexited', 0)]);
+
+      const { setTotal, total } = create();
+      setTotal([{ index: 1000, publicKey: '0xexited', status: 'exited' }]);
+
+      expect(get(total)).toStrictEqual(Zero);
+    });
+
+    it('should sum only the backed part of a mixed selection', () => {
+      set(mockEthStakingValidators, [validator('0xactive', 32), validator('0xexited', 0)]);
+
+      const { setTotal, total } = create();
+      setTotal([
+        { index: 9, publicKey: '0xactive', status: 'active' },
+        { index: 1000, publicKey: '0xexited', status: 'exited' },
+      ]);
+
+      expect(get(total).toNumber()).toBe(32);
+    });
   });
 
   describe('fetchValidatorsWithFilter', () => {
-    it('should skip the task and total all validators when the filter is empty', async () => {
+    /** The shape `queryEth2Validators` resolves with, for the given entries. */
+    function answer(entries: Array<{ index: number; publicKey: string; status: string }>): unknown {
+      return { entries, entriesFound: entries.length, entriesLimit: 100 };
+    }
+
+    /**
+     * Holds every request open so a test can decide the order the answers arrive in.
+     * @returns the resolvers, in request order.
+     */
+    function deferAnswers(): Array<(value: unknown) => void> {
+      const pending: Array<(value: unknown) => void> = [];
+      mockQueryEth2Validators.mockImplementation(async () => new Promise((resolve) => {
+        pending.push(resolve);
+      }));
+      return pending;
+    }
+
+    it('should skip the request and total all validators when the filter is empty', async () => {
       set(mockEthStakingValidators, [validator('0xaaa', 2), validator('0xbbb', 3)]);
 
       const { fetchValidatorsWithFilter, total } = create();
       await fetchValidatorsWithFilter();
 
-      expect(submitTask).not.toHaveBeenCalled();
+      expect(mockQueryEth2Validators).not.toHaveBeenCalled();
       expect(get(total).toNumber()).toBe(5);
     });
 
     it('should query by validator indices when validators are selected', async () => {
-      runTaskResult.mockImplementation(async (fn: () => Promise<unknown>) => {
-        await fn();
-        return ok({ entries: [], entriesFound: 0, entriesLimit: 100 });
-      });
+      mockQueryEth2Validators.mockResolvedValue(answer([]));
 
       const { modelSelection } = create();
       set(modelSelection, { validators: [{ index: 42, publicKey: '0xaaa', status: 'active' }] });
       await flushPromises();
 
-      expect(submitTask).toHaveBeenCalledOnce();
-      expect(mockGetEth2Validators).toHaveBeenCalledWith({ validatorIndices: [42] });
+      expect(mockQueryEth2Validators).toHaveBeenCalledWith({ validatorIndices: [42] });
     });
 
     it('should query by addresses when accounts are selected', async () => {
-      runTaskResult.mockImplementation(async (fn: () => Promise<unknown>) => {
-        await fn();
-        return ok({ entries: [], entriesFound: 0, entriesLimit: 100 });
-      });
+      mockQueryEth2Validators.mockResolvedValue(answer([]));
 
       const { modelSelection } = create();
       set(modelSelection, { accounts: [{ address: '0xdead', chain: 'eth2' }] });
       await flushPromises();
 
-      expect(mockGetEth2Validators).toHaveBeenCalledWith({ addresses: ['0xdead'] });
+      expect(mockQueryEth2Validators).toHaveBeenCalledWith({ addresses: ['0xdead'] });
     });
 
     it('should merge the status filter with the account selection', async () => {
-      runTaskResult.mockImplementation(async (fn: () => Promise<unknown>) => {
-        await fn();
-        return ok({ entries: [], entriesFound: 0, entriesLimit: 100 });
-      });
+      mockQueryEth2Validators.mockResolvedValue(answer([]));
 
       const { modelFilter, modelSelection } = create();
       set(modelSelection, { validators: [{ index: 7, publicKey: '0xaaa', status: 'active' }] });
       set(modelFilter, { fromTimestamp: 100, status: 'active', toTimestamp: 200 });
       await flushPromises();
 
-      expect(mockGetEth2Validators).toHaveBeenLastCalledWith({ status: 'active', validatorIndices: [7] });
+      expect(mockQueryEth2Validators).toHaveBeenLastCalledWith({ status: 'active', validatorIndices: [7] });
     });
 
-    it('should update the total from the parsed result on success', async () => {
+    it('should update the total from the result on success', async () => {
       set(mockEthStakingValidators, [validator('0xaaa', 4), validator('0xbbb', 6)]);
-      runTaskResult.mockResolvedValue(ok({
-        entries: [{ index: 1, publicKey: '0xbbb', status: 'active' }],
-        entriesFound: 1,
-        entriesLimit: 100,
-      }));
+      mockQueryEth2Validators.mockResolvedValue(answer([{ index: 1, publicKey: '0xbbb', status: 'active' }]));
 
       const { modelSelection, total } = create();
       set(modelSelection, { validators: [{ index: 1, publicKey: '0xbbb', status: 'active' }] });
@@ -154,15 +163,90 @@ describe('useEthValidatorManagement', () => {
       expect(get(total).toNumber()).toBe(6);
     });
 
-    it('should leave the total unchanged when the task fails', async () => {
+    it('should swallow a failed request rather than let it reject the watcher', async () => {
       set(mockEthStakingValidators, [validator('0xaaa', 4)]);
-      runTaskResult.mockResolvedValue(err(TaskFailed({ message: 'boom' })));
+      mockQueryEth2Validators.mockRejectedValue(new Error('boom'));
 
       const { modelSelection, total } = create();
       set(modelSelection, { validators: [{ index: 1, publicKey: '0xaaa', status: 'active' }] });
       await flushPromises();
 
       expect(get(total)).toStrictEqual(Zero);
+    });
+
+    it('should recover on the next successful recompute after a failure', async () => {
+      set(mockEthStakingValidators, [validator('0xaaa', 4), validator('0xbbb', 6)]);
+      mockQueryEth2Validators.mockRejectedValue(new Error('boom'));
+
+      const { modelSelection, total } = create();
+      set(modelSelection, { validators: [{ index: 1, publicKey: '0xaaa', status: 'active' }] });
+      await flushPromises();
+
+      mockQueryEth2Validators.mockResolvedValue(answer([{ index: 2, publicKey: '0xbbb', status: 'active' }]));
+      set(modelSelection, { validators: [{ index: 2, publicKey: '0xbbb', status: 'active' }] });
+      await flushPromises();
+
+      expect(get(total).toNumber()).toBe(6);
+    });
+
+    it('should ignore a response the newest filter has already superseded', async () => {
+      set(mockEthStakingValidators, [validator('0xaaa', 4), validator('0xbbb', 6)]);
+      const pending = deferAnswers();
+
+      const { modelSelection, total } = create();
+      set(modelSelection, { validators: [{ index: 1, publicKey: '0xaaa', status: 'active' }] });
+      await flushPromises();
+      set(modelSelection, { validators: [{ index: 2, publicKey: '0xbbb', status: 'active' }] });
+      await flushPromises();
+
+      expect(pending).toHaveLength(2);
+
+      // The newer filter answers first, then the older request arrives late. Nothing serialises
+      // these, so the late one must be dropped rather than allowed to overwrite the newer answer.
+      pending[1](answer([{ index: 2, publicKey: '0xbbb', status: 'active' }]));
+      await flushPromises();
+      pending[0](answer([{ index: 1, publicKey: '0xaaa', status: 'active' }]));
+      await flushPromises();
+
+      expect(get(total).toNumber()).toBe(6);
+    });
+
+    it('should still apply the answer when the same filter is requested twice', async () => {
+      // The premium component re-emits `update:filter` after every change, so an unchanged filter
+      // is re-requested as a matter of course. Both requests carry the same filter, so both answers
+      // are valid: a guard keyed to the call rather than to the filter rejects the first one's
+      // answer and `total` then never updates at all.
+      set(mockEthStakingValidators, [validator('0xaaa', 4), validator('0xbbb', 6)]);
+      const pending = deferAnswers();
+
+      const { modelFilter, modelSelection, total } = create();
+      set(modelSelection, { validators: [{ index: 2, publicKey: '0xbbb', status: 'active' }] });
+      await flushPromises();
+
+      // A distinct object carrying nothing new, which is what the re-emit produces.
+      set(modelFilter, {});
+      await flushPromises();
+
+      pending[0](answer([{ index: 2, publicKey: '0xbbb', status: 'active' }]));
+      await flushPromises();
+
+      expect(get(total).toNumber()).toBe(6);
+    });
+
+    it('should ignore an in-flight response once the total is set directly', async () => {
+      set(mockEthStakingValidators, [validator('0xaaa', 4), validator('0xbbb', 6)]);
+      const pending = deferAnswers();
+
+      const { modelSelection, setTotal, total } = create();
+      set(modelSelection, { validators: [{ index: 1, publicKey: '0xaaa', status: 'active' }] });
+      await flushPromises();
+
+      // What the page refresh does: recompute over everything while a filtered request is open.
+      setTotal();
+      pending[0](answer([{ index: 1, publicKey: '0xaaa', status: 'active' }]));
+      await flushPromises();
+
+      expect(get(total).toNumber()).toBe(10);
     });
   });
 });

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-management.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-management.ts
@@ -1,14 +1,11 @@
 import type { DeepReadonly, Ref } from 'vue';
-import type { TaskError } from '@/modules/core/tasks/task-result';
-import { type BigNumber, type Eth2ValidatorEntry, Eth2Validators, type EthStakingCombinedFilter, type EthStakingFilter, Zero } from '@rotki/common';
+import { type BigNumber, type Eth2ValidatorEntry, type Eth2Validators, type EthStakingCombinedFilter, type EthStakingFilter, Zero } from '@rotki/common';
 import { omit } from 'es-toolkit';
 import { isEmpty } from 'es-toolkit/compat';
-import { map as mapResult, type Result } from 'plainfp/result';
 import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-accounts-api';
 import { nonEmptyProperties } from '@/modules/core/common/data/data';
+import { logger } from '@/modules/core/common/logging/logging';
 import { useBlockchainValidatorsStore } from '@/modules/staking/use-blockchain-validators-store';
-import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
-import { useNativeTask } from '@/modules/task-center/use-native-task';
 
 interface UseEthValidatorManagementReturn {
   fetchValidatorsWithFilter: () => Promise<void>;
@@ -25,12 +22,24 @@ export function useEthValidatorManagement(): UseEthValidatorManagementReturn {
   });
   const total = ref<BigNumber>(Zero);
 
-  const { getEth2Validators } = useBlockchainAccountsApi();
-  const { ethStakingValidators } = storeToRefs(useBlockchainValidatorsStore());
-  const { submitTask } = useNativeTask();
-  const { t } = useI18n({ useScope: 'global' });
+  /**
+   * The filter whose answer `total` should reflect, as the same string the activity id embeds.
+   * Empty means "every validator", which is what a direct {@link setTotal} computes.
+   *
+   * Filter changes are not serialised, so without this the response that happens to land last wins
+   * rather than the one belonging to the newest filter, leaving a total for a filter the user has
+   * moved off.
+   *
+   * Keyed by the filter rather than by the call: the premium component re-emits `update:filter`
+   * after every change, so the same filter is requested twice as a matter of course and both
+   * answers are equally valid.
+   */
+  let wantedFilter = '';
 
-  function setTotal(validators?: Eth2Validators['entries']): void {
+  const { queryEth2Validators } = useBlockchainAccountsApi();
+  const { ethStakingValidators } = storeToRefs(useBlockchainValidatorsStore());
+
+  function applyTotal(validators?: Eth2Validators['entries']): void {
     const publicKeys = validators?.map((validator: Eth2ValidatorEntry) => validator.publicKey);
     const stakingValidators = get(ethStakingValidators);
     const selectedValidators = publicKeys
@@ -38,6 +47,13 @@ export function useEthValidatorManagement(): UseEthValidatorManagementReturn {
       : stakingValidators;
     const totalStakedAmount = selectedValidators.reduce((sum, item) => sum.plus(item.amount), Zero);
     set(total, totalStakedAmount);
+  }
+
+  function setTotal(validators?: Eth2Validators['entries']): void {
+    // Claims the slot, so a request still in flight cannot land on top of a caller that has just
+    // set the total directly (the page refresh does exactly that).
+    wantedFilter = '';
+    applyTotal(validators);
   }
 
   async function fetchValidatorsWithFilter(): Promise<void> {
@@ -56,27 +72,25 @@ export function useEthValidatorManagement(): UseEthValidatorManagementReturn {
       return;
     }
 
-    // Per-request identity: each distinct filter is its own activity, so concurrent filter changes
-    // never dedup onto one promise and clobber each other's `total`. Failures are ignored here as
-    // they were before migration — this is a passive totals widget with no error surface.
-    await submitTask({
-      // A passive totals widget: it re-fires on every filter change and its id embeds the raw
-      // filter, so surfacing it would spam the panel with rows indistinguishable from the real
-      // validator fetch. Tracked like any activity, never rendered.
-      ephemeral: true,
-      id: makeActivityId(ActivityKind.STAKING, ActivityPart.VALIDATORS, JSON.stringify(combinedFilter)),
-      kind: ActivityKind.STAKING,
-      rerunnable: false,
-      run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
-        await runTask<Eth2Validators>(
-          async () => getEth2Validators(combinedFilter),
-        ),
-        (result) => {
-          setTotal(Eth2Validators.parse(result).entries);
-        },
-      ),
-      title: t('task_center.group.staking'),
-    });
+    const filterKey = JSON.stringify(combinedFilter);
+    wantedFilter = filterKey;
+
+    // Deliberately not an async task. This recomputes on every filter change and the query behind
+    // it is a millisecond-scale database read, so going through the task orchestrator only buys the
+    // polling delay: the number lagged the validator count beside it by roughly two seconds.
+    try {
+      const validators = await queryEth2Validators(combinedFilter);
+      // Not `setTotal`: this must not claim the slot, it has to check whether the answer it carries
+      // is still the one being asked for.
+      if (filterKey === wantedFilter)
+        applyTotal(validators.entries);
+    }
+    catch (error: unknown) {
+      // Only logged. A failed recompute leaves the previous filter's number on screen with nothing
+      // on the page saying so, since the card's progress bar tracks performance and balances rather
+      // than this request.
+      logger.error(`failed to compute the staked total for ${filterKey}: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   // Watch for filter changes


### PR DESCRIPTION
Two fixes to the ETH staking page, found while investigating a report that the
staked total disagreed with the validator count next to it.

## The staked total did not follow its filter

Filtering by an exited validator, or by a withdrawal address, left `Total`
showing a number belonging to a different filter. Two separate causes:

**Requests were not ordered.** Filter changes run concurrently, so whichever
response landed last won, rather than the one belonging to the newest filter.
The total is now keyed to the filter it was asked for and a superseded answer
is dropped.

Keyed by *filter* rather than by call on purpose. The premium `EthStaking`
component re-emits `update:filter` after every change, so the same filter is
requested twice as a matter of course and both answers are equally valid; a
guard keyed to the call rejects the first request's own answer and the total
then never updates at all.

**The recompute went through the async task orchestrator.** The query behind it
is a filtered read of `eth2_validators` that answers in 2-3 ms for every filter
shape the page can build, but routed through task polling the answer arrived on
the polling cadence. It now uses a synchronous sibling of the validators query.
The async query is untouched for the actual validator fetch, which is a real
background job.

Measured in the app, against an account with 1 active and 15 exited validators:

| | before | after |
|---|---|---|
| `Total` settles | 2578 ms | 34-61 ms |
| `Validators` chip settles | ~400 ms | ~400 ms (unchanged) |

The total now leads the count beside it instead of trailing it by two seconds.

Verified across every case from the original report — no filter, `status=exited`,
withdrawal address, a single exited validator, and a mixed exited/active
selection — plus rapid filter flips, which previously settled on the wrong
number.

**Not changed:** a selection made only of exited validators still totals zero.
Balances are only reported for validators that have not exited, so that is the
backend contract rather than a display bug. Accepted as a product decision.

## The optional Beaconcha.in prompt was a permanent banner

It occupied a full-width row on every visit, for a key the page works fine
without, directly above a second alert. It now sits in the page header as a
button opening the same guidance on demand, and can be dismissed for good via a
new frontend setting so it does not return on the next login.

Prominence follows severity: a missing consensus RPC means there is no staking
data at all, so that case keeps its inline alert and cannot be dismissed.

`RuiMenu` supplies neither the disclosure semantics nor the focus move, so both
are wired in the new component — the trigger announces `aria-haspopup` and its
expanded state, the panel is a labelled dialog, and focus enters it on open and
returns to the trigger on close. Without the focus move the panel is teleported
to the end of the document and a keyboard user reaches its link only after
tabbing through the whole page. All of this was verified in a browser, not just
in tests.

## Notes for review

- No premium component change is required. The prop contract to `EthStaking` is
  untouched, so there is no bundle rebuild and no release-order constraint.
- The new `dismissedApiKeyNotices` setting deliberately takes no `.catch`: an
  unreadable value should surface rather than silently re-show every prompt.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

  Left unticked because no update is needed: the user guide does not document
  the API key prompt or the staking overview totals, so nothing there is made
  stale by these changes.
