### PR TITLE
feat: structured bridge data for monerium legs

### DIFF
--- a/rotkehlchen/api/services/history.py
+++ b/rotkehlchen/api/services/history.py
@@ -48,6 +48,7 @@ from rotkehlchen.history.events.utils import (
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.premium.premium import (
+    ASSET_MOVEMENT_MATCHING_CAPABILITY,
     GNOSIS_PAY_CAPABILITY,
     MONERIUM_CAPABILITY,
     UserLimitType,
@@ -56,6 +57,7 @@ from rotkehlchen.premium.premium import (
     has_premium_check,
 )
 from rotkehlchen.serialization.serialize import PreSerializedList
+from rotkehlchen.tasks.bridges import process_bridge_transactions
 from rotkehlchen.types import (
     EVM_CHAIN_IDS_WITH_TRANSACTIONS,
     EVM_CHAINS_WITH_TRANSACTIONS,
@@ -335,7 +337,14 @@ class HistoryService:
                     self.rotkehlchen.monerium is not None and
                     self.rotkehlchen.monerium.oauth_client.is_authenticated()
                 ):
-                    self.rotkehlchen.monerium.get_and_process_orders()
+                    if self.rotkehlchen.monerium.get_and_process_orders():
+                        process_bridge_transactions(  # match the legs this run created
+                            database=self.rotkehlchen.data.db,
+                            should_auto_match=has_premium_capability(
+                                premium=self.rotkehlchen.premium,
+                                capability_name=ASSET_MOVEMENT_MATCHING_CAPABILITY,
+                            ),
+                        )
                     return {'result': True, 'message': ''}
                 return {
                     'result': None,

--- a/rotkehlchen/api/services/integrations.py
+++ b/rotkehlchen/api/services/integrations.py
@@ -13,7 +13,12 @@ from rotkehlchen.externalapis.gnosispay import (
 )
 from rotkehlchen.externalapis.google_calendar import GoogleCalendarAPI
 from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.premium.premium import (
+    ASSET_MOVEMENT_MATCHING_CAPABILITY,
+    has_premium_capability,
+)
 from rotkehlchen.serialization.serialize import process_result
+from rotkehlchen.tasks.bridges import process_bridge_transactions
 from rotkehlchen.types import ApiKey, ExternalService, ExternalServiceApiCredentials
 
 if TYPE_CHECKING:
@@ -209,9 +214,28 @@ class IntegrationsService:
             after_seconds=None,
             task_name='Query monerium orders after oauth',
             exception_is_error=True,
-            method=self.rotkehlchen.monerium.get_and_process_orders,
+            method=self._query_monerium_orders,
         )
         return {'result': result, 'message': '', 'status_code': HTTPStatus.OK}
+
+    def _query_monerium_orders(self) -> None:
+        """Process all monerium orders and match any bridge legs the run creates.
+
+        Decoding, and the bridge matching that follows it, have both already happened by
+        the time credentials are (re)authorized here, so the chain to chain legs this run
+        creates would otherwise sit unmatched until something else moved history events.
+        """
+        assert self.rotkehlchen.monerium is not None, 'Monerium should be initialized after login'
+        if self.rotkehlchen.monerium.get_and_process_orders() is False:
+            return
+
+        process_bridge_transactions(
+            database=self.rotkehlchen.data.db,
+            should_auto_match=has_premium_capability(
+                premium=self.rotkehlchen.premium,
+                capability_name=ASSET_MOVEMENT_MATCHING_CAPABILITY,
+            ),
+        )
 
     def disconnect_monerium(self) -> dict[str, Any]:
         assert self.rotkehlchen.monerium is not None, 'Monerium should be initialized after login'

--- a/rotkehlchen/chain/evm/decoding/utils.py
+++ b/rotkehlchen/chain/evm/decoding/utils.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.fval import FVal
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
     from rotkehlchen.inquirer import Inquirer
 
@@ -113,7 +114,7 @@ def make_bridge_extra_data(
 
 
 def set_bridge_extra_data(
-        event: EvmEvent,
+        event: HistoryBaseEntry,
         from_chain: ChainID | int | None,
         to_chain: ChainID | int | None,
         from_address: ChecksumEvmAddress | None = None,
@@ -126,6 +127,8 @@ def set_bridge_extra_data(
     Merges into any bridge data already present on the event, so decoders that learn
     different parts of the bridge context from different logs (e.g. the recipient from
     the transfer log and the source chain from a messaging log) can each contribute.
+    Takes any history event since bridge legs are not all evm events, e.g. the monerium
+    ones the orders API labels and the synthetic counterparts rotki manufactures.
     """
     existing_data = {} if event.extra_data is None else event.extra_data
     bridge_data = make_bridge_extra_data(

--- a/rotkehlchen/externalapis/monerium.py
+++ b/rotkehlchen/externalapis/monerium.py
@@ -10,6 +10,7 @@ import requests
 from oauthlib.oauth2 import WebApplicationClient
 
 from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
+from rotkehlchen.chain.evm.decoding.utils import set_bridge_extra_data
 from rotkehlchen.constants.timing import HOUR_IN_SECONDS
 from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.filtering import EvmEventFilterQuery
@@ -21,13 +22,20 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.externalapis.utils import notify_reauthentication_required
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import EVMTxHash, Location, deserialize_evm_tx_hash
+from rotkehlchen.serialization.deserialize import deserialize_evm_address
+from rotkehlchen.types import (
+    ChecksumEvmAddress,
+    EVMTxHash,
+    Location,
+    deserialize_evm_tx_hash,
+)
 from rotkehlchen.utils.misc import set_user_agent, ts_now
 from rotkehlchen.utils.network import create_session
 from rotkehlchen.utils.serialization import jsonloads_dict
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.history.events.structures.base import HistoryBaseEntry
     from rotkehlchen.history.events.structures.evm_event import EvmEvent
 
 logger = logging.getLogger(__name__)
@@ -99,7 +107,58 @@ class Monerium:
                 f'Monerium API returned invalid JSON response: {response.text}',
             ) from e
 
-    def get_and_process_orders(self, tx_hash: EVMTxHash | None = None) -> None:
+    @staticmethod
+    def _set_bridge_extra_data(
+            event: HistoryBaseEntry,
+            order: dict[str, Any],
+            tx_hashes: list[str],
+            location: Location,
+            is_source: bool,
+    ) -> None:
+        """Record the structured cross-chain data of one leg of a monerium chain to chain move.
+
+        Monerium creates two orders per move, a redeem on the source chain and an issue
+        on the destination one, and both carry the same pair of tx hashes. Joining that
+        pair yields an id that is shared by the two legs and unique to the transfer, so
+        the bridge matcher can pair them exactly instead of guessing from amount and time.
+
+        The chain and address of the other leg come from the order's counterpart
+        identifier. Anything monerium does not give us in a usable form is simply left
+        out: each entry is only a matching hint and the transfer id carries the match.
+        """
+        counterpart = order['counterpart']['identifier']
+        counterpart_location = SUPPORTED_MONERIUM_CHAINS.get(counterpart.get('chain'))
+        addresses: dict[str, ChecksumEvmAddress | None] = {}
+        for key, raw_address in (
+                ('from_address' if is_source else 'to_address', order.get('address')),
+                ('to_address' if is_source else 'from_address', counterpart.get('address')),
+        ):
+            addresses[key] = None
+            if isinstance(raw_address, str):
+                try:
+                    addresses[key] = deserialize_evm_address(raw_address)
+                except DeserializationError:
+                    log.error(
+                        'Monerium order %s has an invalid %s %s',
+                        order.get('id'),
+                        key,
+                        raw_address,
+                    )
+
+        source_location, destination_location = (
+            (location, counterpart_location) if is_source
+            else (counterpart_location, location)
+        )
+        set_bridge_extra_data(
+            event=event,
+            from_chain=source_location.to_chain_id() if source_location is not None else None,
+            to_chain=destination_location.to_chain_id() if destination_location is not None else None,  # noqa: E501
+            from_address=addresses['from_address'],
+            to_address=addresses['to_address'],
+            transfer_id='-'.join(sorted(x.lower() for x in tx_hashes)),
+        )
+
+    def get_and_process_orders(self, tx_hash: EVMTxHash | None = None) -> bool:
         """Gets all monerium orders and processes them
 
         Find all on-chain transactions that match those orders and enrich them appropriately.
@@ -116,6 +175,10 @@ class Monerium:
         a stack trace in the logs.
 
         At the moment monerium has no fees, so this is not processing any fees.
+
+        Returns whether any event was turned into a bridge leg, so the caller can have
+        those legs matched. Chain to chain orders are the only bridge legs created
+        outside of decoding, so nothing else would run the matcher over them.
         """
         with self.database.conn.write_ctx() as write_cursor:
             write_cursor.execute(  # remember last time task ran
@@ -132,7 +195,7 @@ class Monerium:
             log.error(f'Failed to authenticate monerium request due to {e}')
             raise RemoteError('Monerium authentication failed. Check logs for more details') from e
 
-        dbevents = DBHistoryEvents(self.database)
+        dbevents, created_bridge_leg = DBHistoryEvents(self.database), False
         for order in response['orders']:
             log.debug(f'Processing monerium order {order}')
             if (kind := order['kind']) not in ('redeem', 'issue'):
@@ -231,11 +294,23 @@ class Monerium:
                     event.event_type = new_type
                     event.event_subtype = new_subtype  # type: ignore  # both type/subtype are set
 
+                if new_subtype == HistoryEventSubType.BRIDGE:
+                    created_bridge_leg = True
+                    self._set_bridge_extra_data(
+                        event=event,
+                        order=order,
+                        tx_hashes=tx_hashes,
+                        location=location,
+                        is_source=kind == 'redeem',
+                    )
+
                 dbevents.edit_history_event(
                     write_cursor=write_cursor,
                     event=event,
                     mapping_state=None,
                 )
+
+        return created_bridge_leg
 
     def update_events(self, events: list[EvmEvent]) -> None:
         """Query and update the event txs individually.

--- a/rotkehlchen/tests/api/test_external_services.py
+++ b/rotkehlchen/tests/api/test_external_services.py
@@ -338,7 +338,8 @@ def test_complete_monerium_oauth_triggers_background_refresh(
     )
     spawn_mock.assert_called_once()
     spawned_fn = spawn_mock.call_args.kwargs['method']
-    assert spawned_fn.__name__ == 'get_and_process_orders'
+    # queries the orders and matches any bridge legs that run creates
+    assert spawned_fn.__name__ == '_query_monerium_orders'
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/api/test_query_online_events.py
+++ b/rotkehlchen/tests/api/test_query_online_events.py
@@ -52,8 +52,8 @@ def test_refresh_gnosis_pay_and_monerium(
         with (
             patch(
                 'rotkehlchen.api.services.history.has_premium_capability',
-                side_effect=lambda premium, capability, expected=capability_name: (
-                    capability == expected and start_with_valid_premium
+                side_effect=lambda premium, capability_name, expected=capability_name: (
+                    capability_name == expected and start_with_valid_premium
                 ),
             ),
             patch(patch_path) as mock_query_service,

--- a/rotkehlchen/tests/external_apis/test_monerium.py
+++ b/rotkehlchen/tests/external_apis/test_monerium.py
@@ -22,7 +22,7 @@ from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.externalapis.monerium import Monerium, MoneriumOAuthClient
 from rotkehlchen.fval import FVal
-from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.evm_event import BRIDGE_EXTRA_DATA_KEY, EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tests.fixtures.messages import MockedWsMessage
 from rotkehlchen.tests.utils.api import api_url_for, assert_proper_response
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
 
 
-def mock_monerium_and_run_periodic_task(database: DBHandler, contents: str) -> None:
+def mock_monerium_and_run_periodic_task(database: DBHandler, contents: str) -> bool:
     def mock_orders(*_args: Any, **_kwargs: Any) -> MockResponse:
         return MockResponse(
             status_code=HTTPStatus.OK,
@@ -56,7 +56,7 @@ def mock_monerium_and_run_periodic_task(database: DBHandler, contents: str) -> N
     ):
         monerium = Monerium(database)
         assert monerium.oauth_client.is_authenticated()
-        monerium.get_and_process_orders()
+        return monerium.get_and_process_orders()
 
 
 def test_send_bank_transfer(database: DBHandler, monerium_credentials: Any) -> None:  # pylint: disable=unused-argument
@@ -83,10 +83,10 @@ def test_send_bank_transfer(database: DBHandler, monerium_credentials: Any) -> N
     with database.user_write() as write_cursor:
         dbevents.add_history_event(write_cursor=write_cursor, event=event)
 
-    mock_monerium_and_run_periodic_task(
+    assert mock_monerium_and_run_periodic_task(  # a bank transfer creates no bridge leg
         database=database,
         contents='[{"id": "xx-yy", "profile": "zz-yy", "accountId": "aa-yy", "address": "0x99a0618B846D43E29C15ac468Eae06d03C9243C7", "kind": "redeem", "amount": "1500", "currency": "eur", "totalFee": "0", "fees": [], "counterpart": {"details": {"name": "Finanzamt Charlottenburg", "country": "DE", "companyName": "Finanzamt Charlottenburg"}, "identifier": {"iban": "DE94 1005 0000 6600 0464 63", "standard": "iban"}}, "memo": "LohnsteuerQ1", "supportingDocumentId": "", "chain": "ethereum", "network": "mainnet", "meta": {"state": "processed", "txHashes": ["0x10d953610921f39d9d20722082077e03ec8db8d9c75e4b301d0d552119fd0354"], "placedBy": "qq-yy", "placedAt": "2023-10-18T12:09:42.621469Z", "processedAt": "2023-10-18T12:09:43.621469Z", "approvedAt": "2023-10-18T12:09:44.621469Z", "confirmedAt": "2023-10-18T12:09:44.921469Z", "receivedAmount": "1500", "sentAmount": "1500"}}]',  # noqa: E501
-    )
+    ) is False
 
     # Set the expected changes in the event
     event.notes = 'Send 1500 EURe via bank transfer to Finanzamt Charlottenburg (DE94 1005 0000 6600 0464 63) with memo "LohnsteuerQ1"'  # noqa: E501
@@ -134,10 +134,10 @@ def test_receive_bank_transfer(database: DBHandler, monerium_credentials: Any) -
     with database.user_write() as write_cursor:
         dbevents.add_history_event(write_cursor=write_cursor, event=event)
 
-    mock_monerium_and_run_periodic_task(
+    assert mock_monerium_and_run_periodic_task(  # a bank transfer creates no bridge leg
         database=database,
         contents='[{"id": "xx-yy", "profile": "zz-yy", "accountId": "aa-yy", "address": "0xbCCeE6Ff2bCAfA95300D222D316A29140c4746da", "kind": "issue", "amount": "1500", "currency": "eur", "totalFee": "0", "fees": [], "counterpart": {"details": {"name": "Payward Ltd", "country": "GB"}, "identifier": {"iban": "GB60 CLJU 0099 7129 9001 60", "standard": "iban"}}, "memo": "Kraken Tx AAA-BBB", "supportingDocumentId": "", "chain": "ethereum", "network": "mainnet", "meta": {"state": "processed", "txHashes": ["0x4ed9db44c5ee4ba6a4cf3e8e9b386f0b857afebad8339a92666e175c747bdd74"], "placedBy": "qq-yy", "placedAt": "2023-10-18T12:09:42.621469Z", "processedAt": "2023-10-18T12:09:43.621469Z", "approvedAt": "2023-10-18T12:09:44.621469Z", "confirmedAt": "2023-10-18T12:09:44.921469Z", "receivedAmount": "1500", "sentAmount": "1500"}}]',  # noqa: E501
-    )
+    ) is False
 
     # Set the expected changes in the event
     event.notes = 'Receive 1500 EURe via bank transfer from Payward Ltd (GB60 CLJU 0099 7129 9001 60) with memo "Kraken Tx AAA-BBB"'  # noqa: E501
@@ -191,20 +191,31 @@ def test_bridge_via_monerium(database: DBHandler, monerium_credentials: Any) -> 
     with database.user_write() as write_cursor:
         dbevents.add_history_events(write_cursor=write_cursor, history=[eth_event, gnosis_event])
 
-    mock_monerium_and_run_periodic_task(
+    assert mock_monerium_and_run_periodic_task(  # the caller matches the legs this creates
         database=database,
         contents='[{"id": "xx-yy", "profile": "zz-yy", "accountId": "aa-yy", "address": "0xbCCeE6Ff2bCAfA95300D222D316A29140c4746da", "kind": "issue", "amount": "1500", "currency": "eur", "totalFee": "0", "fees": [], "counterpart": {"details": {}, "identifier": {"chain": "ethereum", "address": "0x99a0618B846D43E29C15ac468Eae06d03C9243C7", "network": "mainnet", "standard": "chain"}}, "memo": "Move to Gnosis Chain", "supportingDocumentId": "", "chain": "gnosis", "network": "mainnet", "meta": {"state": "processed", "txHashes": ["0x4ed9db44c5ee4ba6a4cf3e8e9b386f0b857afebad8339a92666e175c747bdd74", "0x10d953610921f39d9d20722082077e03ec8db8d9c75e4b301d0d552119fd0354"], "placedBy": "qq-yy", "placedAt": "2023-10-18T12:09:42.621469Z", "processedAt": "2023-10-18T12:09:43.621469Z", "approvedAt": "2023-10-18T12:09:44.621469Z", "confirmedAt": "2023-10-18T12:09:44.921469Z", "receivedAmount": "1500", "sentAmount": "1500"}},{"id": "pp-yy", "profile": "ll-yy", "accountId": "kk-yy", "address": "0x99a0618B846D43E29C15ac468Eae06d03C9243C7", "kind": "redeem", "amount": "1500", "currency": "eur", "totalFee": "0", "fees": [], "counterpart": {"details": {}, "identifier": {"chain": "gnosis", "address": "0xbCCeE6Ff2bCAfA95300D222D316A29140c4746da", "network": "mainnet", "standard": "chain"}}, "memo": "Move to Gnosis Chain", "supportingDocumentId": "", "chain": "ethereum", "network": "mainnet", "meta": {"state": "processed", "placedBy": "qq-yy", "txHashes": ["0x4ed9db44c5ee4ba6a4cf3e8e9b386f0b857afebad8339a92666e175c747bdd74", "0x10d953610921f39d9d20722082077e03ec8db8d9c75e4b301d0d552119fd0354"], "placedAt": "2023-10-18T12:09:42.621469Z", "processedAt": "2023-10-18T12:09:43.621469Z", "approvedAt": "2023-10-18T12:09:44.621469Z", "confirmedAt": "2023-10-18T12:09:44.921469Z", "receivedAmount": "1500", "sentAmount": "1500"}}]',  # noqa: E501
-    )
+    ) is True
 
-    # Set the expected changes in the events
+    # Set the expected changes in the events. Both legs get the same structured bridge
+    # data, keyed by the pair of tx hashes the two orders of the move share, so the
+    # bridge matcher can pair them exactly instead of guessing from amount and time.
+    bridge_data = {BRIDGE_EXTRA_DATA_KEY: {
+        'from_chain': ChainID.ETHEREUM.serialize(),
+        'to_chain': ChainID.GNOSIS.serialize(),
+        'from_address': eth_user_address,
+        'to_address': gnosis_user_address,
+        'transfer_id': f'{gnosishash!s}-{ethhash!s}',
+    }}
     eth_event.identifier = 1
     eth_event.notes = 'Bridge 1500 EURe to gnosis with memo "Move to Gnosis Chain"'
     eth_event.event_type = HistoryEventType.DEPOSIT
     eth_event.event_subtype = HistoryEventSubType.BRIDGE
+    eth_event.extra_data = bridge_data
     gnosis_event.identifier = 2
     gnosis_event.notes = 'Bridge 1500 EURe from ethereum with memo "Move to Gnosis Chain"'
     gnosis_event.event_type = HistoryEventType.WITHDRAWAL
     gnosis_event.event_subtype = HistoryEventSubType.BRIDGE
+    gnosis_event.extra_data = bridge_data
     with database.conn.read_ctx() as cursor:
         new_events = dbevents.get_history_events_internal(
             cursor=cursor,

--- a/rotkehlchen/tests/unit/events/test_match_bridge_transactions.py
+++ b/rotkehlchen/tests/unit/events/test_match_bridge_transactions.py
@@ -14,6 +14,7 @@ from rotkehlchen.chain.evm.decoding.across.constants import CPT_ACROSS
 from rotkehlchen.chain.evm.decoding.cctp.constants import CPT_CCTP
 from rotkehlchen.chain.evm.decoding.hop.constants import CPT_HOP
 from rotkehlchen.chain.evm.decoding.lifi.constants import CPT_LIFI
+from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.chain.evm.decoding.relay.constants import CPT_RELAY
 from rotkehlchen.chain.evm.decoding.socket_bridge.constants import CPT_SOCKET
 from rotkehlchen.chain.evm.decoding.stakedao.v2.constants import CPT_STAKEDAO_V2
@@ -886,5 +887,110 @@ def test_sunset_claim_resynthesis_reuses_orphaned_counterpart(database: DBHandle
             (synthetic_group,),
         ).fetchone()[0] == 1
 
+    deposits, withdrawals = get_unmatched_bridge_events(database=database)
+    assert len(deposits) == len(withdrawals) == 0
+
+
+@pytest.mark.parametrize('function_scope_initialize_mock_rotki_notifier', [True])
+def test_match_monerium_bridge_legs_by_transfer_id(database: DBHandler) -> None:
+    """Monerium chain to chain moves match on the tx hash pair its API reports for both
+    legs of a move, not on the amount and time heuristic.
+
+    Both moves below are real gnosis <-> arbitrum EURe transfers. Their destination legs
+    land seconds after the source ones onchain but are placed a day later here, well past
+    the heuristic window, so a match can only come from the shared transfer id.
+    """
+    events_db = DBHistoryEvents(database)
+    gnosis_eure = Asset('eip155:100/erc20:0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430')
+    arbitrum_eure = Asset('eip155:42161/erc20:0x0c06cCF38114ddfc35e07427B9424adcca9F44F8')
+    # gnosis -> arbitrum: burn 0xff00dec3..., mint 0x88d55171...
+    out_user = '0x8EaeD0c875d0aF5134EEac3dA91BeCf8dE505e2b'
+    out_transfer_id = '0x88d55171adb39b33c8b3b1802cf7873d6c04120d38de414800b8905a720a5e21-0xff00dec38e08377a18075e35c6b755da9f24882ec9aa5aa0de4ea6ebdedcb381'  # noqa: E501
+    # arbitrum -> gnosis: burn 0x0262c273..., mint 0xcb922e79...
+    in_user = '0xE53464166D9DaB175E9c290209d5eab9cF98eec5'
+    in_transfer_id = '0x0262c273b8bd935e467e67f32b779aea6b0c3e294de335486180a62cbafed797-0xcb922e794da9d77dc2c3a395f5ba09f9e6e63040c1af90565a027839cdaff36e'  # noqa: E501
+    with database.conn.write_ctx() as write_cursor:
+        events_db.add_history_events(
+            write_cursor=write_cursor,
+            history=[(out_deposit := EvmEvent(
+                tx_ref=make_evm_tx_hash(),
+                sequence_index=0,
+                timestamp=TimestampMS(1787090645000),
+                location=Location.GNOSIS,
+                event_type=HistoryEventType.DEPOSIT,
+                event_subtype=HistoryEventSubType.BRIDGE,
+                asset=gnosis_eure,
+                amount=FVal('2000'),
+                location_label=out_user,
+                counterparty=CPT_MONERIUM,
+                extra_data={'bridge': {
+                    'from_chain': 100,
+                    'to_chain': 42161,
+                    'from_address': out_user,
+                    'to_address': out_user,
+                    'transfer_id': out_transfer_id,
+                }},
+            )), (out_withdrawal := EvmEvent(
+                tx_ref=make_evm_tx_hash(),
+                sequence_index=0,
+                timestamp=TimestampMS(1787090648000 + DAY_IN_SECONDS * 1000),
+                location=Location.ARBITRUM_ONE,
+                event_type=HistoryEventType.WITHDRAWAL,
+                event_subtype=HistoryEventSubType.BRIDGE,
+                asset=arbitrum_eure,
+                amount=FVal('2000'),
+                location_label=out_user,
+                counterparty=CPT_MONERIUM,
+                extra_data={'bridge': {
+                    'from_chain': 100,
+                    'to_chain': 42161,
+                    'from_address': out_user,
+                    'to_address': out_user,
+                    'transfer_id': out_transfer_id,
+                }},
+            )), (in_deposit := EvmEvent(
+                tx_ref=make_evm_tx_hash(),
+                sequence_index=0,
+                timestamp=TimestampMS(1787216450000),
+                location=Location.ARBITRUM_ONE,
+                event_type=HistoryEventType.DEPOSIT,
+                event_subtype=HistoryEventSubType.BRIDGE,
+                asset=arbitrum_eure,
+                amount=FVal('196.34'),
+                location_label=in_user,
+                counterparty=CPT_MONERIUM,
+                extra_data={'bridge': {
+                    'from_chain': 42161,
+                    'to_chain': 100,
+                    'from_address': in_user,
+                    'to_address': in_user,
+                    'transfer_id': in_transfer_id,
+                }},
+            )), (in_withdrawal := EvmEvent(
+                tx_ref=make_evm_tx_hash(),
+                sequence_index=0,
+                timestamp=TimestampMS(1787216455000 + DAY_IN_SECONDS * 1000),
+                location=Location.GNOSIS,
+                event_type=HistoryEventType.WITHDRAWAL,
+                event_subtype=HistoryEventSubType.BRIDGE,
+                asset=gnosis_eure,
+                amount=FVal('196.34'),
+                location_label=in_user,
+                counterparty=CPT_MONERIUM,
+                extra_data={'bridge': {
+                    'from_chain': 42161,
+                    'to_chain': 100,
+                    'from_address': in_user,
+                    'to_address': in_user,
+                    'transfer_id': in_transfer_id,
+                }},
+            ))],
+        )
+
+    match_bridge_transactions(database=database)
+    assert _get_bridge_links(database) == {  # source leg is always the left side of the link
+        (_event_id(database, out_deposit), _event_id(database, out_withdrawal)),
+        (_event_id(database, in_deposit), _event_id(database, in_withdrawal)),
+    }
     deposits, withdrawals = get_unmatched_bridge_events(database=database)
     assert len(deposits) == len(withdrawals) == 0


### PR DESCRIPTION
Monerium was the only bridge whose legs carried no extra_data['bridge'], so match_bridge_transactions could only pair them through the weakest tier: asset collection, a 1% amount tolerance, a 4h window and a unique candidate.

Its API gives us everything needed for an exact match. A chain to chain move produces two orders, a redeem on the source chain and an issue on the destination one, and both carry the same pair of tx hashes. Joining that pair yields an id shared by the two legs and unique to the transfer, and the counterpart identifier holds the other leg's chain and address. Record all of it through set_bridge_extra_data, the same entry point the decoders use, so the exact transfer id tier does the matching.

Also match monerium legs created after decoding
