### PR TITLE
fix(gnosis-pay): correct the SIWE domain and explain the wallet warning

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3293,6 +3293,7 @@
         "connected_address": "Connected Address",
         "controlled_safe": "Controlled Gnosis Pay Safe account(s):",
         "disconnect": "Disconnect Wallet",
+        "domain_notice": "Your wallet may warn that the site does not match the domain in the message. This is expected: the page asking for the signature is not served from rotki.com, but Gnosis Pay only accepts rotki.com in the message. Before approving, check that the message names Gnosis Pay and the address is yours.",
         "explanation": "To authenticate with Gnosis Pay, you need to sign a message with an Ethereum wallet that is a controller of the Gnosis Pay Safe.",
         "failed": "Failed to authenticate Gnosis Pay",
         "sign_explanation": "Sign a message with your wallet to authenticate and generate a session token.",

--- a/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPayAuth.vue
+++ b/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPayAuth.vue
@@ -119,7 +119,7 @@ const { currentStep, isStepComplete, isStepCurrent } = useGnosisPayAuthSteps(
 
 // Wallet providers
 const walletStore = useWalletStore();
-const { connectedChainId, isDisconnecting, preparing } = storeToRefs(walletStore);
+const { connectedChainId, isDisconnecting, isWalletConnect, preparing } = storeToRefs(walletStore);
 const { switchNetwork } = walletStore;
 
 const isOnGnosisChain = computed<boolean>(() => get(connectedChainId) === GNOSIS_CHAIN_ID);
@@ -422,6 +422,7 @@ watch(() => isStepComplete(AuthStep.SIGN_MESSAGE), (complete) => {
             :is-on-gnosis-chain="isOnGnosisChain"
             :is-wallet-connected="isWalletConnected"
             :switching-network="switchingNetwork"
+            :is-injected-wallet="!isWalletConnect"
             @sign-in="signInWithEthereum()"
             @cancel="cancelSigning()"
             @switch-to-gnosis="switchToGnosis()"

--- a/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPaySignMessage.spec.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPaySignMessage.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Seam: this component renders step 3 of the Gnosis Pay auth card. It promises its parent that
+ * - the domain notice appears only on an injected-wallet path, where the wallet has a page origin
+ *   to compare against (the packaged app's bridge page, or a self-hosted deployment's own host),
+ * - the sign button is swapped for the chain-switch button when the wallet is on the wrong chain,
+ * - clicking either one emits, rather than acting.
+ */
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import GnosisPaySignMessage from './GnosisPaySignMessage.vue';
+
+const NOTICE = '[data-testid=siwe-domain-notice]';
+
+describe('gnosisPaySignMessage', () => {
+  const wrappers: VueWrapper[] = [];
+
+  function mountComponent(props: Partial<InstanceType<typeof GnosisPaySignMessage>['$props']> = {}): VueWrapper {
+    const wrapper = mount(GnosisPaySignMessage, {
+      props: {
+        isInjectedWallet: true,
+        isOnGnosisChain: true,
+        isWalletConnected: true,
+        primaryActionDisabled: false,
+        signingInProgress: false,
+        switchingNetwork: false,
+        ...props,
+      },
+    });
+    wrappers.push(wrapper);
+    return wrapper;
+  }
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  it('should show the domain notice on an injected-wallet path', () => {
+    expect(mountComponent().find(NOTICE).exists()).toBe(true);
+  });
+
+  it('should hide the domain notice on the walletconnect path', () => {
+    // Negative control for the gate: over WalletConnect there is no origin to mismatch, so the
+    // notice would be noise. A test that only asserts it renders proves nothing about the gate.
+    expect(mountComponent({ isInjectedWallet: false }).find(NOTICE).exists()).toBe(false);
+  });
+
+  it('should emit sign-in when the sign button is clicked', async () => {
+    const wrapper = mountComponent();
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('sign-in')).toHaveLength(1);
+  });
+
+  it('should offer the chain switch instead of signing when on the wrong chain', async () => {
+    const wrapper = mountComponent({ isOnGnosisChain: false });
+    await wrapper.find('button').trigger('click');
+
+    expect(wrapper.emitted('switch-to-gnosis')).toHaveLength(1);
+    expect(wrapper.emitted('sign-in')).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPaySignMessage.vue
+++ b/frontend/app/src/modules/integrations/gnosis-pay/components/GnosisPaySignMessage.vue
@@ -5,6 +5,13 @@ interface Props {
   isOnGnosisChain: boolean;
   isWalletConnected: boolean;
   switchingNetwork: boolean;
+  /**
+   * True whenever the signature is requested through an injected wallet, so the wallet has a real
+   * page origin to compare the message domain against and it can never be `rotki.com`: the packaged
+   * app serves the bridge page from localhost, a self-hosted deployment from its own host. Only
+   * WalletConnect has no origin, and there the notice would be noise.
+   */
+  isInjectedWallet: boolean;
 }
 
 defineProps<Props>();
@@ -23,6 +30,15 @@ const { t } = useI18n({ useScope: 'global' });
     <div class="text-rui-text-secondary text-sm">
       {{ t('external_services.gnosispay.siwe.sign_explanation') }}
     </div>
+
+    <!-- Wallets compare the message domain against the requesting origin, which no injected path can satisfy -->
+    <RuiAlert
+      v-if="isInjectedWallet"
+      type="info"
+      data-testid="siwe-domain-notice"
+    >
+      {{ t('external_services.gnosispay.siwe.domain_notice') }}
+    </RuiAlert>
 
     <!-- Warning when not on Gnosis chain -->
     <RuiAlert

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.spec.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.spec.ts
@@ -167,6 +167,21 @@ describe('useGnosisPaySigning', () => {
     expect(get(harness.signingInProgress)).toBe(false);
   });
 
+  it('should put a bare authority on line 1 and the full url in URI', async () => {
+    const harness = makeHarness();
+    runTaskResult.mockImplementationOnce(async () => makeSuccess('nonce-123'));
+    runTaskResult.mockImplementationOnce(async () => makeSuccess(true));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    // EIP-4361 line 1 is an authority, not a URL. Wallets compare it verbatim against the
+    // requesting origin's host, so a scheme here can never match any origin.
+    const lines = String(signMessage.mock.calls[0][0].message).split('\n');
+    expect(lines[0]).toBe('rotki.com wants you to sign in with your Ethereum account:');
+    expect(lines).toContain('URI: https://rotki.com');
+  });
+
   it('should bail out when fetching the nonce fails actionably', async () => {
     const harness = makeHarness();
     runTaskResult.mockImplementationOnce(async () => makeFailure('nonce error'));

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.ts
@@ -15,6 +15,15 @@ import { getAddress, type ViemWalletClient } from '@/modules/wallet/viem-client'
 import { GnosisPayError, type GnosisPayErrorContext } from './types';
 import { useGnosisPaySiweApi } from './use-gnosis-pay-api';
 
+/**
+ * EIP-4361 line 1 takes an authority (host, optionally with a port), not a URL. Only `URI:` takes a
+ * scheme. Wallets compare this string against the requesting origin's host verbatim, so a `https://`
+ * prefix here can never match any origin.
+ */
+const SIWE_DOMAIN = 'rotki.com';
+
+const SIWE_URI = 'https://rotki.com';
+
 interface UseGnosisPaySigningOptions {
   /** Clears the shared error state before signing, skipped when the pending error is `INVALID_ADDRESS` so that warning stays visible. */
   clearError: () => void;
@@ -60,15 +69,14 @@ export function useGnosisPaySigning(options: UseGnosisPaySigningOptions): UseGno
   const walletConnect = useWalletConnect();
 
   function createSiweMessage(address: string, nonce: string): string {
-    const domain = 'https://rotki.com';
     const issuedAt = new Date().toISOString();
 
-    return `${domain} wants you to sign in with your Ethereum account:
+    return `${SIWE_DOMAIN} wants you to sign in with your Ethereum account:
 ${address}
 
 Sign in with Ethereum to authenticate with Gnosis Pay.
 
-URI: ${domain}
+URI: ${SIWE_URI}
 Version: 1
 Chain ID: 100
 Nonce: ${nonce}


### PR DESCRIPTION
Signing in to Gnosis Pay makes wallets show a domain warning ("the app you are attempting to sign in to does not match the domain in the message"). The warning is correct and cannot be removed. This does the two things we can do about it.

## The spec violation

EIP-4361 line 1 takes an **authority**, not a URL; only `URI:` takes a scheme. We were sending `https://rotki.com` in both slots, so a wallet comparing the message domain against the requesting origin's host could never match **any** origin, including the WalletConnect path where it otherwise would.

Line 1 is now `rotki.com`, `URI:` keeps `https://rotki.com`.

Verified end to end in the app: sign-in completes against the live Gnosis Pay verify endpoint with the corrected message. The backend passes the message through verbatim (`verify_gnosis_pay_siwe_signature`), so nothing there assumed the old form.

## The explanation

The origin of the page requesting the signature is never `rotki.com`: the packaged app serves the bridge page from `localhost`, and a self-hosted deployment serves it from its own host. Gnosis Pay's server-side allowlist accepts only `rotki.com` as the SIWE domain, rejects any domain carrying a port, and drops loopback hosts. The two requirements cannot both be satisfied, so the wallet is right to flag it.

Adds a one-paragraph info alert above the Sign button saying what the warning is and what to check before approving. A blocking modal was considered and rejected: it taxes every sign-in for a warning only some wallets show, and trains people to dismiss dialogs, which is the exact habit that makes the real warning useless.

The alert is gated to the injected-wallet paths. Over WalletConnect there is no browser origin, so the wallet falls back to the session's self-declared peer metadata, the check passes trivially and the notice would be noise.

## Tests

New component spec for `GnosisPaySignMessage`, plus an assertion in the signing spec pinning line 1 and the `URI:` line. Both were negative-controlled: reverting the domain fix, and removing the alert's `v-if`, each fail exactly one test and no others.