### PR TITLE
Wait for the first balance load before showing the net worth

### DIFF
--- a/frontend/app/src/modules/dashboard/OverallBalances.spec.ts
+++ b/frontend/app/src/modules/dashboard/OverallBalances.spec.ts
@@ -1,0 +1,117 @@
+import type { NetValueChartData } from '@/modules/dashboard/graph/types';
+import { bigNumberify } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import OverallBalances from '@/modules/dashboard/OverallBalances.vue';
+
+/**
+ * The seam: the header's net worth is a sum, so it reads zero before the first balances land.
+ * This card promises never to render that zero as if it were the user's balance: while the latch
+ * from `useNetWorthLoading` is closed it shows a skeleton instead, and the delta row underneath
+ * follows the same latch so the two do not disagree. It also promises that a refresh, which is
+ * not the latch, leaves the net worth on screen and only skeletons the delta.
+ */
+
+const state = vi.hoisted(() => ({ loading: false, netWorthLoading: false }));
+
+vi.mock('@/modules/balances/use-balance-loading', async () => {
+  const { computed: createComputed } = await import('vue');
+  return {
+    useBalancesLoading: vi.fn(() => ({
+      loadingBlockchainBalances: createComputed<boolean>(() => state.loading),
+    })),
+  };
+});
+
+vi.mock('@/modules/dashboard/use-net-worth-loading', async () => {
+  const { computed: createComputed } = await import('vue');
+  return {
+    useNetWorthLoading: vi.fn(() => createComputed<boolean>(() => state.netWorthLoading)),
+  };
+});
+
+vi.mock('@/modules/statistics/use-statistics-store', async () => {
+  const { defineStore } = await import('pinia');
+  const { ref: createRef } = await import('vue');
+  const emptyNetValue: NetValueChartData = { data: [], snapshotCount: 0, times: [] };
+  return {
+    useStatisticsStore: defineStore('statistics', () => {
+      const totalNetWorth = createRef(bigNumberify('1500.5'));
+      const getNetValue = vi.fn(() => emptyNetValue);
+      return { getNetValue, totalNetWorth };
+    }),
+  };
+});
+
+describe('overallBalances', () => {
+  let wrapper: VueWrapper<InstanceType<typeof OverallBalances>>;
+
+  const netWorthSelector = '[data-testid=overall-balances__net-worth] [data-testid=fiat-display]';
+  const skeletonSelector = '[data-testid=overall-balances__net-worth-loading]';
+  const deltaSkeletonSelector = '[data-testid=overall-balances__delta-loading]';
+
+  function createWrapper(): VueWrapper<InstanceType<typeof OverallBalances>> {
+    return mount(OverallBalances, {
+      global: {
+        stubs: {
+          FiatDisplay: {
+            props: { value: { required: true, type: Object } },
+            template: '<span data-testid="fiat-display">{{ value.toString() }}</span>',
+          },
+          NetWorthChart: true,
+          SnapshotActionButton: true,
+          TimeframeSelector: true,
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    state.loading = false;
+    state.netWorthLoading = false;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should show a skeleton instead of a zero while the first balances load', () => {
+    state.loading = true;
+    state.netWorthLoading = true;
+    wrapper = createWrapper();
+
+    expect(wrapper.find(skeletonSelector).exists()).toBe(true);
+    expect(wrapper.find(netWorthSelector).exists()).toBe(false);
+    expect(wrapper.find(deltaSkeletonSelector).exists()).toBe(true);
+  });
+
+  it('should skeleton the header before any balance work is submitted', () => {
+    state.loading = false;
+    state.netWorthLoading = true;
+    wrapper = createWrapper();
+
+    expect(wrapper.find(skeletonSelector).exists()).toBe(true);
+    expect(wrapper.find(deltaSkeletonSelector).exists()).toBe(true);
+  });
+
+  it('should keep showing a known net worth during a refresh', () => {
+    state.loading = true;
+    state.netWorthLoading = false;
+    wrapper = createWrapper();
+
+    expect(wrapper.find(skeletonSelector).exists()).toBe(false);
+    expect(wrapper.find(netWorthSelector).text()).toBe('1500.5');
+    expect(wrapper.find(deltaSkeletonSelector).exists()).toBe(true);
+  });
+
+  it('should show the net worth and the delta once everything settles', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.find(skeletonSelector).exists()).toBe(false);
+    expect(wrapper.find(netWorthSelector).text()).toBe('1500.5');
+    expect(wrapper.find(deltaSkeletonSelector).exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/dashboard/OverallBalances.vue
+++ b/frontend/app/src/modules/dashboard/OverallBalances.vue
@@ -7,6 +7,7 @@ import { useBalancesLoading } from '@/modules/balances/use-balance-loading';
 import { computeNetValueDelta, type NetValueZoomRange } from '@/modules/dashboard/graph/net-value-stats';
 import NetWorthChart from '@/modules/dashboard/graph/NetWorthChart.vue';
 import SnapshotActionButton from '@/modules/dashboard/SnapshotActionButton.vue';
+import { useNetWorthLoading } from '@/modules/dashboard/use-net-worth-loading';
 import { usePremium } from '@/modules/premium/use-premium';
 import { useSettingsRepo } from '@/modules/settings/settings-repo';
 import { isPeriodAllowed } from '@/modules/settings/settings-utils';
@@ -32,6 +33,13 @@ const { updateFrontendSetting } = useSettingsOperations();
 // Was `initial-loading OR section-loading`; on the ledger the first implies the second, so any
 // balance work in flight is the whole condition.
 const { loadingBlockchainBalances: isLoading } = useBalancesLoading();
+// The header waits for the whole first load, once: see the composable for why this cannot be a
+// live loading read.
+const loadingNetWorth = useNetWorthLoading();
+// The delta and the chart wait for every load, not just the first, because a delta computed from
+// a half-loaded total is a number that is wrong while it moves. The latch is what carries them
+// through the first frames, where no balance activity has been submitted yet.
+const isBusy = computed<boolean>(() => get(loadingNetWorth) || get(isLoading));
 
 const zoomRange = ref<NetValueZoomRange>();
 
@@ -116,7 +124,13 @@ onMounted(() => {
         class="font-medium"
         data-testid="overall-balances__net-worth"
       >
+        <RuiSkeletonLoader
+          v-if="loadingNetWorth"
+          class="my-[0.5rem] w-56 h-[2rem] sm:my-[0.75rem] sm:w-72 sm:h-[2.5rem]"
+          data-testid="overall-balances__net-worth-loading"
+        />
         <FiatDisplay
+          v-else
           class="text-[2rem] leading-[3rem] sm:text-[3rem] sm:leading-[4rem]"
           no-truncate
           :value="totalNetWorth"
@@ -124,8 +138,9 @@ onMounted(() => {
       </div>
 
       <RuiSkeletonLoader
-        v-if="isLoading"
+        v-if="isBusy"
         class="w-48 h-8"
+        data-testid="overall-balances__delta-loading"
       />
       <div
         v-else
@@ -137,15 +152,11 @@ onMounted(() => {
           size="16"
         />
         <PercentageDisplay
-          v-if="!isLoading"
           class="pr-4"
           :value="percentage"
         />
         <span class="whitespace-nowrap before:content-['('] after:content-[')']">
-          <FiatDisplay
-            v-if="!isLoading"
-            :value="balanceDelta"
-          />
+          <FiatDisplay :value="balanceDelta" />
         </span>
       </div>
     </div>
@@ -166,7 +177,7 @@ onMounted(() => {
           :chart-data="timeframeData"
         />
         <div
-          v-if="isLoading"
+          v-if="isBusy"
           class="absolute top-0 h-full w-full flex flex-col gap-3 items-center justify-center text-caption text-rui-text-secondary bg-white/[0.8] dark:bg-dark-elevated/[0.9] z-[6]"
         >
           <RuiProgress

--- a/frontend/app/src/modules/dashboard/use-net-worth-loading.spec.ts
+++ b/frontend/app/src/modules/dashboard/use-net-worth-loading.spec.ts
@@ -1,0 +1,77 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBalancesLoading } from '@/modules/balances/use-balance-loading';
+import { useBalanceStatus } from '@/modules/balances/use-balance-status';
+import { useNetWorthLoading } from '@/modules/dashboard/use-net-worth-loading';
+
+/**
+ * The seam: a latch that starts closed and opens once, when the first load settles. It must not
+ * track liveness in either direction. The balance activities are submitted after the dashboard
+ * renders, so a live read is false on those first frames; and once it has opened a refresh must
+ * not close it again, or the total the user is reading would blank on every refresh.
+ */
+
+vi.mock('@/modules/balances/use-balance-loading', () => ({ useBalancesLoading: vi.fn() }));
+
+vi.mock('@/modules/balances/use-balance-status', () => ({ useBalanceStatus: vi.fn() }));
+
+describe('useNetWorthLoading', () => {
+  const loading = ref<boolean>(false);
+  const cached = ref<boolean>(false);
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    set(loading, false);
+    set(cached, false);
+
+    vi.mocked(useBalancesLoading).mockReturnValue({
+      loadingBalances: computed<boolean>(() => get(loading)),
+      loadingBalancesAndDetection: computed<boolean>(() => get(loading)),
+      loadingBlockchainBalances: computed<boolean>(() => get(loading)),
+    });
+
+    vi.mocked(useBalanceStatus).mockReturnValue({
+      hasCachedData: computed<boolean>(() => get(cached)),
+      isInitialLoading: computed<boolean>(() => get(loading) && !get(cached)),
+      isRefreshing: computed<boolean>(() => get(loading)),
+    });
+  });
+
+  it('should start closed, before any balance work has been submitted', () => {
+    expect(get(useNetWorthLoading())).toBe(true);
+  });
+
+  it('should stay closed while a chain has landed but the load runs on', async () => {
+    set(loading, true);
+    const netWorthLoading = useNetWorthLoading();
+    expect(get(netWorthLoading)).toBe(true);
+
+    set(cached, true);
+    await nextTick();
+
+    expect(get(netWorthLoading)).toBe(true);
+  });
+
+  it('should open when the first load settles', async () => {
+    set(loading, true);
+    set(cached, true);
+    const netWorthLoading = useNetWorthLoading();
+    expect(get(netWorthLoading)).toBe(true);
+
+    set(loading, false);
+    await nextTick();
+
+    expect(get(netWorthLoading)).toBe(false);
+  });
+
+  it('should stay open across a later refresh', async () => {
+    set(cached, true);
+    const netWorthLoading = useNetWorthLoading();
+    expect(get(netWorthLoading)).toBe(false);
+
+    set(loading, true);
+    await nextTick();
+
+    expect(get(netWorthLoading)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/dashboard/use-net-worth-loading.ts
+++ b/frontend/app/src/modules/dashboard/use-net-worth-loading.ts
@@ -1,0 +1,35 @@
+import type { ComputedRef } from 'vue';
+import { useBalancesLoading } from '@/modules/balances/use-balance-loading';
+import { useBalanceStatus } from '@/modules/balances/use-balance-status';
+
+/**
+ * Whether the dashboard header has nothing to put in the net worth yet.
+ *
+ * The net worth is a sum, so it is zero until balances land and then climbs as each chain arrives.
+ * Neither end of that is worth showing: a large "0.00" reads as a real balance, and a total that
+ * ratchets from a fraction of itself is wrong for as long as it moves, with nothing on screen
+ * saying so. The header therefore waits for the whole first load, not for the first value.
+ *
+ * It has to be a latch rather than a live loading read, for two reasons. The balance activities
+ * are submitted after the dashboard has rendered, so a live read is false on the first frames and
+ * the header would flicker value, skeleton, value. And once the first load has settled the number
+ * stays: a later refresh must not blank the total the user is reading.
+ *
+ * So: closed until a load settles with the ledger holding a completed chain, then open for good.
+ */
+export function useNetWorthLoading(): ComputedRef<boolean> {
+  const { loadingBlockchainBalances } = useBalancesLoading();
+  const { hasCachedData } = useBalanceStatus();
+
+  const loaded = shallowRef<boolean>(false);
+
+  watch([loadingBlockchainBalances, hasCachedData], ([loading, cached]) => {
+    if (get(loaded))
+      return;
+
+    if (cached && !loading)
+      set(loaded, true);
+  }, { immediate: true });
+
+  return computed<boolean>(() => !get(loaded));
+}


### PR DESCRIPTION
The overview header renders the sum of all balances. Before anything lands that is a large `0.00`, which reads as a real balance rather than as data still loading; and while the chains arrive it is a total that ratchets up from a fraction of itself, wrong for as long as it moves with nothing on screen saying so. The header now shows a skeleton and waits for the whole first load.

A live loading read cannot express that:

- the balance activities are submitted after the dashboard has rendered, so any liveness read is false on the first frames and the header flickered value, skeleton, value (the delta row underneath did the same);
- gating on liveness would blank the total on every later refresh.

So `useNetWorthLoading` is a latch: closed until a load settles with the ledger holding a completed chain, then open for good. After that a refresh leaves the total on screen.

The delta row and the chart overlay keep waiting for every load, not just the first, since a delta computed from a half-loaded total is wrong while it moves. They now start as a skeleton instead of rendering a real row for the first frames, and their two redundant inner `v-if="!isLoading"` guards, inside a branch that already only renders when not loading, are gone.

### Tests

`use-net-worth-loading.spec.ts` covers the latch (starts closed, stays closed while a chain has landed but the load runs on, opens when the load settles, stays open across a refresh) and `OverallBalances.spec.ts` covers the wiring (skeleton on first load, skeleton before any activity is submitted, net worth kept during a refresh with only the delta skeletoned, both shown once settled).

Negative controls were run on each gate: making the latch re-openable fails the refresh test, opening it on `cached || !loading` fails the other three, and gating the header on plain loading fails the two refresh tests.