### PR TITLE
Don't show balance values before their prices arrive

### DIFF
--- a/frontend/app/src/modules/assets/AssetLocations.vue
+++ b/frontend/app/src/modules/assets/AssetLocations.vue
@@ -4,6 +4,7 @@ import { type BigNumber, Blockchain } from '@rotki/common';
 import { FiatDisplay, ValueDisplay } from '@/modules/assets/amount-display/components';
 import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
 import { assetLocationParams } from '@/modules/assets/asset-location-fields';
+import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
 import { useAssetLocationFields } from '@/modules/assets/use-asset-location-fields';
 import { type AssetLocation, useAssetLocationsData } from '@/modules/assets/use-asset-locations-data';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
@@ -31,6 +32,12 @@ const pagination = ref({
 const onlyTags = ref<string[]>([]);
 const locationFilter = ref<string>('');
 const addresses = ref<string[]>([]);
+
+const { isPricePending } = usePriceUtils();
+
+// Every row here is the same asset in a different place, so one price decides all of them. Without
+// it a row shows the value the chain that reported attached to it, next to the full amount.
+const valuePending = computed<boolean>(() => isPricePending(identifier));
 
 const {
   assetLocations,
@@ -192,7 +199,10 @@ watch([onlyTags, locationFilter, addresses], () => {
         <ValueDisplay :value="row.amount" />
       </template>
       <template #item.value="{ row }">
-        <FiatDisplay :value="row.value" />
+        <FiatDisplay
+          :value="row.value"
+          :loading="valuePending"
+        />
       </template>
       <template #item.percentage="{ row }">
         <PercentageDisplay

--- a/frontend/app/src/modules/assets/prices/use-price-utils.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-price-utils.spec.ts
@@ -118,4 +118,46 @@ describe('usePriceUtils', () => {
       expect(utils.getAssetPriceOracle('BTC')).toBe('');
     });
   });
+
+  /**
+   * A price reads zero-ish in three situations and only one of them is an answer. Value cells key
+   * their loading state off this, so conflating them either prints a zero for an unpriced holding
+   * or leaves an unpriceable one loading forever.
+   */
+  describe('isPricePending', () => {
+    beforeAll(() => {
+      const { prices } = storeToRefs(store);
+      set(prices, {
+        ...get(prices),
+        NEGATIVE: { isManualPrice: false, oracle: '', value: bigNumberify(-1) },
+        SEEDED: { isManualPrice: false, oracle: '', value: bigNumberify(5) },
+        ZERO_MISSING: { isManualPrice: false, oracle: 'blockchain', priceMissing: true, value: bigNumberify(0) },
+        ZERO_QUEUED: { isManualPrice: false, oracle: 'coingecko', value: bigNumberify(0) },
+      });
+    });
+
+    it('should be pending for an asset that has never been fetched', () => {
+      expect(utils.isPricePending('BTC')).toBe(true);
+    });
+
+    it('should be pending for the negative no-price sentinel', () => {
+      expect(utils.isPricePending('NEGATIVE')).toBe(true);
+    });
+
+    it('should be pending for a plain zero, which is a queued refresh', () => {
+      expect(utils.isPricePending('ZERO_QUEUED')).toBe(true);
+    });
+
+    it('should not be pending for a zero no oracle could price', () => {
+      expect(utils.isPricePending('ZERO_MISSING')).toBe(false);
+    });
+
+    it('should not be pending for a seeded price', () => {
+      expect(utils.isPricePending('SEEDED')).toBe(false);
+    });
+
+    it('should not be pending for a live price', () => {
+      expect(utils.isPricePending('DAI')).toBe(false);
+    });
+  });
 });

--- a/frontend/app/src/modules/assets/prices/use-price-utils.ts
+++ b/frontend/app/src/modules/assets/prices/use-price-utils.ts
@@ -22,6 +22,7 @@ interface UsePriceUtilsReturn {
   getAssetPriceOracle: (asset: string) => string;
   isManualAssetPrice: (asset: string) => boolean;
   hasCachedPrice: (asset: string) => boolean;
+  isPricePending: (asset: string) => boolean;
 }
 
 export function usePriceUtils(): UsePriceUtilsReturn {
@@ -75,12 +76,38 @@ export function usePriceUtils(): UsePriceUtilsReturn {
     return get(prices)[asset]?.value !== undefined;
   }
 
+  /**
+   * Whether the asset's price has not arrived yet, as opposed to being known.
+   *
+   * This is the question every value cell has to ask, because a value is only trustworthy once a
+   * price exists: with one, a balance is valued as `amount × price` over the whole holding
+   * (`price-utils.ts`); without one it falls back to the values the backend attached to whichever
+   * chains have reported so far, which is a fraction of the amount shown beside it.
+   *
+   * A price reads zero-ish in three different situations and only one of them is an answer:
+   * absent or negative means nothing has been fetched; a plain zero means a refresh is coming,
+   * since `usePriceRefresh` queues exactly the assets with no cached price; a zero carrying
+   * `priceMissing` means every oracle was asked and none could price it, which is knowledge and
+   * renders as "unknown" rather than as a wait.
+   */
+  function isPricePending(asset: string): boolean {
+    const price = get(prices)[asset];
+    if (!price)
+      return true;
+
+    if (price.value.isNegative())
+      return true;
+
+    return price.value.isZero() && price.priceMissing !== true;
+  }
+
   return {
     getAssetPrice,
     getAssetPriceOracle,
     getExchangeRate,
     hasCachedPrice,
     isManualAssetPrice,
+    isPricePending,
     useAssetPrice,
     useAssetPriceOracle,
     useExchangeRate,

--- a/frontend/app/src/modules/balances/AssetBalances.vue
+++ b/frontend/app/src/modules/balances/AssetBalances.vue
@@ -10,6 +10,7 @@ import { useAssetBalanceSearch } from '@/modules/assets/use-asset-balance-search
 import { useAssetSelectInfo } from '@/modules/assets/use-asset-select-info';
 import BalanceTopProtocols from '@/modules/balances/protocols/BalanceTopProtocols.vue';
 import AssetRowDetails from '@/modules/balances/protocols/components/AssetRowDetails.vue';
+import { useValuePending } from '@/modules/balances/value-pending';
 import { bigNumberSum, calculatePercentage } from '@/modules/core/common/data/calculation';
 import { sortAssetBalances } from '@/modules/core/common/display/balances';
 import { TableColumn } from '@/modules/core/table/table-column';
@@ -61,6 +62,7 @@ const { matches, prioritizeExactMatches } = useAssetBalanceSearch(() => balances
 const currencySymbol = useSetting('currencySymbol');
 const statistics = useStatisticsStore();
 const { totalNetWorth } = storeToRefs(statistics);
+const { isTotalPending, isValuePending } = useValuePending();
 
 const isExpanded = (asset: string) => some(get(expanded), { asset });
 
@@ -76,6 +78,8 @@ function expand(item: AssetBalanceWithPrice) {
 }
 
 const total = computed<BigNumber>(() => bigNumberSum(get(matches).map(({ value }) => value)));
+
+const totalPending = computed<boolean>(() => isTotalPending(get(matches)));
 
 function percentageOfTotalNetValue(val: BigNumber): string {
   return calculatePercentage(val, get(totalNetWorth));
@@ -216,6 +220,7 @@ const sorted = computed<AssetBalanceWithPrice[]>(() =>
         :amount="row.amount"
         :price="row.price"
         :value="row.value"
+        :loading="isValuePending(row)"
       />
     </template>
     <template #item.percentageOfTotalNetValue="{ row }">
@@ -241,7 +246,10 @@ const sorted = computed<AssetBalanceWithPrice[]>(() =>
         :right-patch-colspan="2"
         class-name="[&>td]:p-4 text-sm"
       >
-        <FiatDisplay :value="total" />
+        <FiatDisplay
+          :value="total"
+          :loading="totalPending"
+        />
       </RowAppend>
     </template>
     <template #expanded-item="{ row }">

--- a/frontend/app/src/modules/balances/blockchain/use-blockchain-total-summary.spec.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-blockchain-total-summary.spec.ts
@@ -4,9 +4,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useBlockchainTotalSummary } from './use-blockchain-total-summary';
 
 const balances = ref<Balances>({});
+const pendingAssets = ref<Set<string>>(new Set());
 
 vi.mock('@/modules/balances/use-balances-store', () => ({
   useBalancesStore: vi.fn(() => ({ balances })),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-utils', () => ({
+  usePriceUtils: vi.fn(() => ({
+    isPricePending: (asset: string): boolean => get(pendingAssets).has(asset),
+  })),
 }));
 
 function chain(...assets: { amount: number; value: number }[]): Balances[string] {
@@ -20,6 +27,7 @@ function chain(...assets: { amount: number; value: number }[]): Balances[string]
 describe('useBlockchainTotalSummary', () => {
   beforeEach(() => {
     set(balances, {});
+    set(pendingAssets, new Set());
   });
 
   it('should return no totals for empty balances', () => {
@@ -44,6 +52,34 @@ describe('useBlockchainTotalSummary', () => {
     });
     const { blockchainTotals } = useBlockchainTotalSummary();
     expect(get(blockchainTotals).map(t => t.chain)).toEqual(['eth']);
+  });
+
+  it('should report a chain as loading while any of its assets is unpriced', () => {
+    set(balances, {
+      eth: chain({ amount: 1, value: 100 }, { amount: 2, value: 0 }),
+    });
+    set(pendingAssets, new Set(['ASSET_1']));
+
+    const { blockchainTotals } = useBlockchainTotalSummary();
+
+    expect(get(blockchainTotals)).toEqual([
+      { chain: 'eth', loading: true, value: bigNumberify(100) },
+    ]);
+  });
+
+  it('should keep a chain that sums to zero while its assets are unpriced', () => {
+    set(balances, {
+      eth: chain({ amount: 1, value: 100 }),
+      gnosis: chain({ amount: 5, value: 0 }),
+    });
+    set(pendingAssets, new Set(['ASSET_0']));
+
+    const { blockchainTotals } = useBlockchainTotalSummary();
+
+    expect(get(blockchainTotals).map(total => [total.chain, total.loading])).toEqual([
+      ['eth', true],
+      ['gnosis', true],
+    ]);
   });
 
   it('should sort chains by descending value', () => {

--- a/frontend/app/src/modules/balances/blockchain/use-blockchain-total-summary.ts
+++ b/frontend/app/src/modules/balances/blockchain/use-blockchain-total-summary.ts
@@ -1,7 +1,9 @@
 import type { BigNumber } from '@rotki/common';
 import type { ComputedRef } from 'vue';
+import type { Balances } from '@/modules/accounts/blockchain-accounts';
 import type { BlockchainTotal } from '@/modules/balances/blockchain-types';
 import { isEmpty } from 'es-toolkit/compat';
+import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
 import { useBalancesStore } from '@/modules/balances/use-balances-store';
 import { sortDesc } from '@/modules/core/common/data/bignumbers';
 
@@ -9,39 +11,43 @@ interface UseBlockchainTotalSummaryReturn { blockchainTotals: ComputedRef<Blockc
 
 export function useBlockchainTotalSummary(): UseBlockchainTotalSummaryReturn {
   const { balances } = storeToRefs(useBalancesStore());
+  const { isPricePending } = usePriceUtils();
 
   const blockchainTotals = computed<BlockchainTotal[]>(() => {
     const balanceData = get(balances);
     const sums: Record<string, BigNumber> = {};
+    // A chain's card sums the values its assets carry, so one unpriced asset leaves the card short
+    // by that asset's whole holding, with nothing to say so.
+    const pending: Record<string, boolean> = {};
 
-    for (const chain in balanceData) {
-      const chainBalance = balanceData[chain];
-      if (!chainBalance)
-        continue;
-
+    const collectChain = (chain: string, chainBalance: Balances[string]): void => {
       for (const { assets } of Object.values(chainBalance)) {
         if (!assets || isEmpty(assets))
           continue;
 
-        for (const protocol of Object.values(assets)) {
-          for (const { value } of Object.values(protocol)) {
-            if (!sums[chain]) {
-              sums[chain] = value;
-            }
-            else {
-              sums[chain] = sums[chain].plus(value);
-            }
-          }
+        for (const [asset, protocol] of Object.entries(assets)) {
+          pending[chain] = (pending[chain] ?? false) || isPricePending(asset);
+
+          for (const { value } of Object.values(protocol))
+            sums[chain] = sums[chain] ? sums[chain].plus(value) : value;
         }
       }
+    };
+
+    for (const chain in balanceData) {
+      const chainBalance = balanceData[chain];
+      if (chainBalance)
+        collectChain(chain, chainBalance);
     }
 
     return Object.entries(sums)
-      .filter(([, sum]) => sum.gt(0))
+      // A chain whose assets are all unpriced sums to zero, and dropping it would make the card
+      // vanish and pop back in once prices land, rather than sit there loading.
+      .filter(([chain, sum]) => sum.gt(0) || pending[chain])
       .sort(([, aValue], [, bValue]) => sortDesc(aValue, bValue))
       .map(([chain, value]) => ({
         chain,
-        loading: false,
+        loading: pending[chain] ?? false,
         value,
       }) satisfies BlockchainTotal);
   });

--- a/frontend/app/src/modules/balances/value-pending.spec.ts
+++ b/frontend/app/src/modules/balances/value-pending.spec.ts
@@ -1,0 +1,58 @@
+import { One } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { isRowValuePending, isTotalValuePending } from '@/modules/balances/value-pending';
+
+/**
+ * The seam: a row's value is only as known as the prices behind it, and a group's is only as known
+ * as its worst member. Everything else about a balance can be complete while this is not.
+ */
+
+const pending = (asset: string): boolean => asset.startsWith('PENDING');
+
+describe('isRowValuePending', () => {
+  it('should be pending when the row has no price yet', () => {
+    expect(isRowValuePending({ asset: 'PENDING_ETH' }, pending)).toBe(true);
+  });
+
+  it('should not be pending when the row is priced', () => {
+    expect(isRowValuePending({ asset: 'ETH' }, pending)).toBe(false);
+  });
+
+  it('should be pending when one member of a group is unpriced', () => {
+    const row = {
+      asset: 'USDC',
+      breakdown: [
+        { amount: One, asset: 'USDC', price: One, value: One },
+        { amount: One, asset: 'PENDING_USDC_BASE', price: One, value: One },
+      ],
+    };
+
+    expect(isRowValuePending(row, pending)).toBe(true);
+  });
+
+  it('should not be pending when every member of a group is priced', () => {
+    const row = {
+      asset: 'USDC',
+      breakdown: [
+        { amount: One, asset: 'USDC', price: One, value: One },
+        { amount: One, asset: 'USDC_BASE', price: One, value: One },
+      ],
+    };
+
+    expect(isRowValuePending(row, pending)).toBe(false);
+  });
+});
+
+describe('isTotalValuePending', () => {
+  it('should be pending when any row it sums is', () => {
+    expect(isTotalValuePending([{ asset: 'ETH' }, { asset: 'PENDING_DAI' }], pending)).toBe(true);
+  });
+
+  it('should not be pending when every row is priced', () => {
+    expect(isTotalValuePending([{ asset: 'ETH' }, { asset: 'DAI' }], pending)).toBe(false);
+  });
+
+  it('should not be pending with nothing to sum', () => {
+    expect(isTotalValuePending([], pending)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/balances/value-pending.ts
+++ b/frontend/app/src/modules/balances/value-pending.ts
@@ -1,0 +1,46 @@
+import type { AssetBalanceWithPrice } from '@rotki/common';
+import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
+
+type PricePendingCheck = (asset: string) => boolean;
+
+type ValueRow = Pick<AssetBalanceWithPrice, 'asset' | 'breakdown'>;
+
+interface UseValuePendingReturn {
+  /** Whether a row's value should render as a loading state rather than a number. */
+  isValuePending: (row: ValueRow) => boolean;
+  /** Whether a total summed over `rows` is short of any of them. */
+  isTotalPending: (rows: ValueRow[]) => boolean;
+}
+
+/**
+ * A group is only as known as its worst member: a collection row sums several assets, so one
+ * member without a price leaves the total short by that member's whole holding, with nothing in
+ * the row to say so.
+ */
+export function isRowValuePending(row: ValueRow, isPricePending: PricePendingCheck): boolean {
+  if (isPricePending(row.asset))
+    return true;
+
+  return (row.breakdown ?? []).some(member => isPricePending(member.asset));
+}
+
+export function isTotalValuePending(rows: ValueRow[], isPricePending: PricePendingCheck): boolean {
+  return rows.some(row => isRowValuePending(row, isPricePending));
+}
+
+/**
+ * Whether balance values can be shown yet.
+ *
+ * A value is only trustworthy once its price is. With a price a holding is valued as
+ * `amount × price` over the whole of it; without one it falls back to the values the backend
+ * attached to whichever chains have reported so far, which is a fraction of the amount rendered
+ * beside it, and looks just as settled.
+ */
+export function useValuePending(): UseValuePendingReturn {
+  const { isPricePending } = usePriceUtils();
+
+  return {
+    isTotalPending: (rows: ValueRow[]): boolean => isTotalValuePending(rows, isPricePending),
+    isValuePending: (row: ValueRow): boolean => isRowValuePending(row, isPricePending),
+  };
+}

--- a/frontend/app/src/modules/dashboard/DashboardAssetTable.spec.ts
+++ b/frontend/app/src/modules/dashboard/DashboardAssetTable.spec.ts
@@ -1,0 +1,144 @@
+import { type AssetBalanceWithPrice, bigNumberify, Zero } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Component, type ComputedRef, defineComponent, h, type VNode } from 'vue';
+import DashboardAssetTable from '@/modules/dashboard/DashboardAssetTable.vue';
+import { DashboardTableType } from '@/modules/settings/types/frontend-settings';
+
+/**
+ * The seam: the value column and the table total are only shown once the prices behind them are
+ * known. Without a price a balance is valued from whichever chains have reported so far, so the
+ * cell would print a fraction of the amount printed next to it, as a settled-looking number.
+ */
+
+const pendingAssets = ref<Set<string>>(new Set());
+
+vi.mock('@/modules/assets/prices/use-price-utils', async () => {
+  const { computed: createComputed } = await import('vue');
+  const { One } = await import('@rotki/common');
+  return {
+    usePriceUtils: vi.fn(() => ({
+      getAssetPrice: (): typeof One => One,
+      getAssetPriceOracle: (): string => '',
+      getExchangeRate: (): typeof One => One,
+      hasCachedPrice: (): boolean => true,
+      isManualAssetPrice: (): boolean => false,
+      isPricePending: (asset: string): boolean => get(pendingAssets).has(asset),
+      useAssetPrice: (): ComputedRef<typeof One> => createComputed(() => One),
+      useAssetPriceOracle: (): ComputedRef<string> => createComputed(() => ''),
+      useExchangeRate: (): ComputedRef<typeof One> => createComputed(() => One),
+      useIsManualAssetPrice: (): ComputedRef<boolean> => createComputed(() => false),
+    })),
+  };
+});
+
+/** Renders only the slots under test, so the assertions do not depend on RuiDataTable internals. */
+const RuiDataTableStub = defineComponent({
+  props: { rows: { default: () => [], type: Array } },
+  setup(props, { slots }): () => VNode {
+    return () => h('div', [
+      ...props.rows.map(row => h('div', slots['item.value']?.({ row }))),
+      h('div', slots['body.append']?.({})),
+    ]);
+  },
+});
+
+function valueStub(testId: string): Component {
+  return defineComponent({
+    props: {
+      asset: { default: '', type: String },
+      loading: { default: false, type: Boolean },
+      value: { default: undefined, type: Object },
+    },
+    setup(props): () => VNode {
+      return () => h('span', {
+        'data-asset': props.asset,
+        'data-loading': props.loading ? 'true' : 'false',
+        'data-testid': testId,
+      });
+    },
+  });
+}
+
+function createBalance(asset: string, overrides: Partial<AssetBalanceWithPrice> = {}): AssetBalanceWithPrice {
+  return {
+    amount: bigNumberify(3),
+    asset,
+    price: bigNumberify(2),
+    value: bigNumberify(6),
+    ...overrides,
+  };
+}
+
+describe('dashboardAssetTable', () => {
+  let wrapper: VueWrapper<InstanceType<typeof DashboardAssetTable>>;
+
+  function createWrapper(balances: AssetBalanceWithPrice[]): VueWrapper<InstanceType<typeof DashboardAssetTable>> {
+    return mount(DashboardAssetTable, {
+      global: {
+        plugins: [createPinia()],
+        stubs: {
+          AssetValueDisplay: valueStub('row-value'),
+          DashboardExpandableTable: { template: '<div><slot /></div>' },
+          FiatDisplay: valueStub('total-value'),
+          RowAppend: { template: '<div><slot /></div>' },
+          RuiDataTable: RuiDataTableStub,
+          VisibleColumnsSelector: true,
+        },
+      },
+      props: {
+        balances,
+        tableType: DashboardTableType.ASSETS,
+        title: 'Assets',
+      },
+    });
+  }
+
+  const rowValues = (): Record<string, string> => Object.fromEntries(
+    wrapper.findAll('[data-testid=row-value]').map(el => [el.attributes('data-asset') ?? '', el.attributes('data-loading') ?? '']),
+  );
+  const totalValues = (): string[] => wrapper.findAll('[data-testid=total-value]').map(el => el.attributes('data-loading') ?? '');
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    set(pendingAssets, new Set());
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should show the value once every price is known', () => {
+    wrapper = createWrapper([createBalance('ETH'), createBalance('DAI')]);
+
+    expect(rowValues()).toEqual({ DAI: 'false', ETH: 'false' });
+    expect(totalValues().every(loading => loading === 'false')).toBe(true);
+  });
+
+  it('should load the value of a row whose price has not arrived', () => {
+    set(pendingAssets, new Set(['ETH']));
+    wrapper = createWrapper([
+      createBalance('ETH', { price: bigNumberify(-1), value: Zero }),
+      createBalance('DAI'),
+    ]);
+
+    expect(rowValues()).toEqual({ DAI: 'false', ETH: 'true' });
+  });
+
+  it('should load a group whose member is unpriced, even when the group itself is priced', () => {
+    set(pendingAssets, new Set(['USDC_BASE']));
+    wrapper = createWrapper([
+      createBalance('USDC', { breakdown: [createBalance('USDC'), createBalance('USDC_BASE')] }),
+    ]);
+
+    expect(rowValues()).toEqual({ USDC: 'true' });
+  });
+
+  it('should load the total while any row is unpriced', () => {
+    set(pendingAssets, new Set(['ETH']));
+    wrapper = createWrapper([createBalance('ETH'), createBalance('DAI')]);
+
+    expect(totalValues()).toContain('true');
+  });
+});

--- a/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
@@ -4,6 +4,7 @@ import { AssetValueDisplay, FiatDisplay, ValueDisplay } from '@/modules/assets/a
 import BalanceTopProtocols from '@/modules/balances/protocols/BalanceTopProtocols.vue';
 import AssetRowDetails from '@/modules/balances/protocols/components/AssetRowDetails.vue';
 import { useBalancePricesStore } from '@/modules/balances/use-balance-prices-store';
+import { useValuePending } from '@/modules/balances/value-pending';
 import DashboardAssetWarnings from '@/modules/dashboard/DashboardAssetWarnings.vue';
 import DashboardExpandableTable from '@/modules/dashboard/DashboardExpandableTable.vue';
 import { useDashboardAssetData } from '@/modules/dashboard/use-dashboard-asset-data';
@@ -27,6 +28,7 @@ const { t } = useI18n({ useScope: 'global' });
 // Stores
 const { totalNetWorth } = useDashboardStores();
 const { prices } = storeToRefs(useBalancePricesStore());
+const { isTotalPending, isValuePending } = useValuePending();
 
 // Use composables - sort needs to be defined first for the computed dependency
 const { modelSort, pagination, setPage, setTablePagination, tableHeaders } = useDashboardTableConfig(
@@ -53,6 +55,8 @@ const emptyDescription = computed<string>(() => tableType === DashboardTableType
 function isPriceMissing(asset: string): boolean {
   return get(prices)[asset]?.priceMissing === true;
 }
+
+const totalPending = computed<boolean>(() => isTotalPending(get(sorted)));
 
 // Watch search to reset pagination
 watch(modelSearch, () => setPage(1));
@@ -85,6 +89,7 @@ watch(modelSearch, () => setPage(1));
     <template #shortDetails>
       <FiatDisplay
         :value="total"
+        :loading="totalPending"
         class="text-h6 font-bold"
       />
     </template>
@@ -157,6 +162,7 @@ watch(modelSearch, () => setPage(1));
           :amount="row.amount"
           :price="row.price"
           :value="row.value"
+          :loading="isValuePending(row)"
         />
       </template>
       <template #item.percentageOfTotalNetValue="{ row }">
@@ -189,7 +195,10 @@ watch(modelSearch, () => setPage(1));
           :right-patch-colspan="tableHeaders.length - 4"
           class-name="text-sm [&_td]:p-4"
         >
-          <FiatDisplay :value="total" />
+          <FiatDisplay
+            :value="total"
+            :loading="totalPending"
+          />
         </RowAppend>
       </template>
       <template #expanded-item="{ row }">


### PR DESCRIPTION
A balance value is only trustworthy once its price is. With a price, a holding is valued as `amount × price` over the whole of it (`price-utils.ts`); without one it falls back to the values the backend attached to whichever chains have reported so far. So a row printed a fraction of the amount rendered beside it, as a settled-looking number.

The ETH row read **38.96 €** for **< 3.49 ETH** while only optimism had landed, sitting next to a price cell that was already rendering a skeleton for exactly the same missing price. In one session 38 of 42 assets had no price for 2m19s.

### The rule

`isPricePending(asset)` on `usePriceUtils`. A price reads zero-ish in three situations and only one of them is an answer:

| price | means | value |
|---|---|---|
| absent or negative | nothing fetched yet | pending |
| plain `0` | a refresh is queued for it (`usePriceRefresh` queues exactly the assets with no cached price) | pending |
| `0` with `priceMissing` | every oracle was asked, none could price it | not pending, keeps the existing "unknown" tooltip |
| `> 0`, seeded or live | known | shown |

A group waits for its worst member, since a collection row sums several assets and one unpriced member leaves the total short by that member's whole holding. A table total waits for any row it sums.

### Where it binds

Nothing new was needed in the display components: `AssetValueDisplay` and `FiatDisplay` already OR a `loading` prop into their own state, and `BlockchainTotal` already carries a `loading` field the card renders.

- `DashboardAssetTable`: the value column and both totals
- `AssetBalances`: the same
- `AssetLocations`: one asset per panel, so one price decides every row
- `use-blockchain-total-summary`: `loading` was hardcoded `false`. A chain whose assets are all unpriced sums to zero, so it used to be dropped from the list and pop back in once prices landed; it now stays and renders as loading

### Tests

`isPricePending` across the four price states, `isRowValuePending`/`isTotalValuePending` including the collection fold, a `DashboardAssetTable` spec covering row, group and total, and the chain summary. Negative controls were run on each gate: dropping the group fold fails the collection test, disabling the total gate fails the total test.

### Not covered

If prices ever land before a chain does, a priced row still ticks upward as legs arrive, with amount and value moving together. That is data arriving rather than a wrong number. The dashboard header keeps its own first-load latch from #12979, so the headline total does not ratchet.