### PR TITLE
fix(gnosis-pay): clear expiry warning on re-auth

### DIFF
--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.spec.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.spec.ts
@@ -1,4 +1,6 @@
 import type { Ref } from 'vue';
+import { type NotificationData, NotificationGroup } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
 import { runSpecWith } from '@test/utils/mocks/native-task';
 import { err, ok, type Result } from 'plainfp/result';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
@@ -12,6 +14,7 @@ const fetchNonce = vi.fn();
 const verifySiweSignature = vi.fn();
 const runTaskResult = vi.fn();
 const showErrorMessage = vi.fn();
+const removeMatching = vi.fn<(predicate: (n: NotificationData) => boolean) => void>();
 
 const submitTask = vi.fn(runSpecWith(runTaskResult));
 const signMessage = vi.fn();
@@ -36,7 +39,7 @@ vi.mock('@/modules/task-center/use-native-task', () => ({
 }));
 
 vi.mock('@/modules/core/notifications/use-notifications', () => ({
-  useNotifications: vi.fn().mockImplementation(() => ({ showErrorMessage })),
+  useNotifications: vi.fn().mockImplementation(() => ({ removeMatching, showErrorMessage })),
 }));
 
 vi.mock('@/modules/wallet/bridge/use-injected-wallet', () => ({
@@ -103,6 +106,7 @@ describe('useGnosisPaySigning', () => {
     runTaskResult.mockReset();
     submitTask.mockClear();
     showErrorMessage.mockReset();
+    removeMatching.mockReset();
     signMessage.mockReset().mockResolvedValue('0xSignature');
     const fakeClient = { signMessage };
     injectedGetWalletClient.mockReset().mockReturnValue(fakeClient);
@@ -165,6 +169,34 @@ describe('useGnosisPaySigning', () => {
     expect(get(harness.signInSuccess)).toBe(true);
     expect(onSignInComplete).toHaveBeenCalled();
     expect(get(harness.signingInProgress)).toBe(false);
+  });
+
+  it('should drop the session-expired warning once the signature is verified', async () => {
+    const harness = makeHarness();
+    runTaskResult.mockImplementationOnce(async () => makeSuccess('nonce'));
+    runTaskResult.mockImplementationOnce(async () => makeSuccess(true));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(removeMatching).toHaveBeenCalledTimes(1);
+
+    // Nothing else in this flow writes to that group, so the predicate has to single it out: the
+    // warning goes and an unrelated notification stays.
+    const predicate = removeMatching.mock.calls[0][0];
+    expect(predicate(createMock<NotificationData>({ group: NotificationGroup.GNOSIS_PAY_SESSION_EXPIRED }))).toBe(true);
+    expect(predicate(createMock<NotificationData>({ group: NotificationGroup.MISSING_API_KEY }))).toBe(false);
+  });
+
+  it('should keep the session-expired warning when verification returns false', async () => {
+    const harness = makeHarness();
+    runTaskResult.mockImplementationOnce(async () => makeSuccess('nonce'));
+    runTaskResult.mockImplementationOnce(async () => makeSuccess(false));
+
+    const { signInWithEthereum } = useGnosisPaySigning(harness);
+    await signInWithEthereum();
+
+    expect(removeMatching).not.toHaveBeenCalled();
   });
 
   it('should put a bare authority on line 1 and the full url in URI', async () => {

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-signing.ts
@@ -1,5 +1,5 @@
-import type { MaybePromise } from '@rotki/common';
 import type { Ref } from 'vue';
+import { type MaybePromise, NotificationGroup } from '@rotki/common';
 import { isErr, map as mapResult, type Result } from 'plainfp/result';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -60,7 +60,7 @@ export function useGnosisPaySigning(options: UseGnosisPaySigningOptions): UseGno
   } = options;
 
   const { t } = useI18n({ useScope: 'global' });
-  const { showErrorMessage } = useNotifications();
+  const { removeMatching, showErrorMessage } = useNotifications();
   const { submitTask } = useNativeTask();
   const { fetchNonce, verifySiweSignature } = useGnosisPaySiweApi();
 
@@ -92,6 +92,16 @@ Issued At: ${issuedAt}`;
       return injectedWallet.getWalletClient();
 
     return walletConnect.getWalletClient();
+  }
+
+  /**
+   * Drops the session-expired warning once the backend has accepted the signature. Nothing else in
+   * this flow writes to that group - progress goes to the task centre and failures to the message
+   * dialog - so the warning is never superseded the way a grouped notification would be, and would
+   * otherwise sit in the list still offering to re-authenticate a session that is now valid.
+   */
+  function clearSessionExpiredWarning(): void {
+    removeMatching(({ group }) => group === NotificationGroup.GNOSIS_PAY_SESSION_EXPIRED);
   }
 
   /**
@@ -173,6 +183,7 @@ Issued At: ${issuedAt}`;
 
       if (verified) {
         set(signInSuccess, true);
+        clearSessionExpiredWarning();
         if (onSignInComplete)
           await onSignInComplete();
       }


### PR DESCRIPTION
## Problem

The Gnosis Pay session-expired notification is in `NotificationGroup.GNOSIS_PAY_SESSION_EXPIRED`, and nothing else in the codebase writes to that group. The SIWE re-auth flow reports through channels that are not the notification list at all:

- progress goes to the task centre (`ActivityKind.GNOSIS_PAY`, nonce + verify)
- failures go to `showErrorMessage`, i.e. the message dialog
- success says nothing; it just sets `signInSuccess`

So the group-update strategy never gets a chance to supersede the warning the way it does for a grouped flow. After a successful re-sign the warning stayed in the list, still offering its persistent "Re-Authenticate" action for a session that had just become valid, until the user dismissed it by hand.

## Change

`useGnosisPaySigning` drops that group once the backend has verified the signature. It lives in the composable rather than the component's `onSignInComplete` so it sits with the flow logic and is covered by the existing spec.

Only the success path clears it. Starting the flow deliberately does not: the SIWE flow can stall at several points (no wallet, wrong chain, rejected signature), and the warning carries the only re-auth affordance, so clearing it on start would strand a user who bails halfway.

## Testing

`test:unit` on the module (6 files, 75 tests), `typecheck`, `lint:file:check` and `knip` all green.

Two negative controls, each landing on exactly one test:

- removing the call leaves only *"should drop the session-expired warning once the signature is verified"* failing
- moving the call above the `if (verified)` guard so it always runs leaves only *"should keep the session-expired warning when verification returns false"* failing

The second matters because that assertion is a "was not called", the kind most likely to pass for the wrong reason. The first test also exercises the predicate directly rather than only asserting the call happened, so a predicate matching every group would fail it.