### PR TITLE
Fix and pin the release workflow's node scripts

### DIFF
--- a/.github/scripts/merge-latest.mjs
+++ b/.github/scripts/merge-latest.mjs
@@ -13,29 +13,54 @@ const file3 = args[2];
 if (!file1 || !file2 || !file3)
     throw new Error('Please provide 3 file paths as arguments: path to file1, to file2 and destination path');
 
-function exitIfNotExists(file) {
-    if (!fs.existsSync(file)) {
-        consola.error(`${file} doesn't exist`);
-        process.exit(1);
-    }
+function fail(message) {
+    consola.error(message);
+    process.exit(1);
 }
 
-// make sure that both input files exist
-exitIfNotExists(file1);
-exitIfNotExists(file2);
+/**
+ * Reads an electron-updater manifest and checks it carries the fields the merge relies on.
+ * A malformed input would otherwise surface as a bare TypeError, or worse, produce a manifest
+ * that silently points auto-update at nothing.
+ */
+function readManifest(file) {
+    if (!fs.existsSync(file))
+        fail(`${file} doesn't exist`);
+
+    consola.info(`reading file: ${file}`);
+
+    let manifest;
+    try {
+        manifest = yaml.load(fs.readFileSync(file, 'utf8'));
+    }
+    catch (error) {
+        fail(`${file} is not valid yaml: ${error.message}`);
+    }
+
+    if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest))
+        fail(`${file} does not contain a yaml mapping`);
+
+    if (typeof manifest.version !== 'string')
+        fail(`${file} has no version`);
+
+    if (!Array.isArray(manifest.files) || manifest.files.length === 0)
+        fail(`${file} has no files entries`);
+
+    consola.debug('file content: \n', manifest);
+    return manifest;
+}
 
 consola.info(`merging ${file1} and ${file2} to ${file3}`);
 
-consola.info(`reading file: ${file1}`);
-const yaml1 = yaml.load(fs.readFileSync(file1, 'utf8'));
-consola.debug('file content: \n', yaml1);
+const yaml1 = readManifest(file1);
+const yaml2 = readManifest(file2);
 
-consola.info(`reading file: ${file2}`);
-const yaml2 = yaml.load(fs.readFileSync(file2, 'utf8'));
-consola.debug('file content: \n', yaml2);
+// merging two manifests of different versions would hand auto-update a mix of builds
+if (yaml1.version !== yaml2.version)
+    fail(`version mismatch: ${file1} is ${yaml1.version} but ${file2} is ${yaml2.version}`);
 
-const merged = { ...yaml1, ...yaml2 };
-merged.files.push(...yaml1.files);
+// yaml2 wins on the top level fields; its files come first, as before
+const merged = { ...yaml1, ...yaml2, files: [...yaml2.files, ...yaml1.files] };
 
 consola.debug('merged content: \n', merged);
 

--- a/.github/scripts/merge-latest.mjs
+++ b/.github/scripts/merge-latest.mjs
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import process from 'node:process';
-import yaml from 'js-yaml';
+import { dump, load } from 'js-yaml';
 import consola from 'consola';
 
 // get two file paths from arguments:
@@ -31,7 +31,7 @@ function readManifest(file) {
 
     let manifest;
     try {
-        manifest = yaml.load(fs.readFileSync(file, 'utf8'));
+        manifest = load(fs.readFileSync(file, 'utf8'));
     }
     catch (error) {
         fail(`${file} is not valid yaml: ${error.message}`);
@@ -65,6 +65,6 @@ const merged = { ...yaml1, ...yaml2, files: [...yaml2.files, ...yaml1.files] };
 consola.debug('merged content: \n', merged);
 
 consola.info(`writing file: ${file3}`);
-const mergedYml = yaml.dump(merged);
+const mergedYml = dump(merged);
 fs.writeFileSync(file3, mergedYml, 'utf8');
 consola.info(`complete`);

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -8,6 +8,6 @@
   "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
   "dependencies": {
     "consola": "3.4.2",
-    "js-yaml": "4.3.1"
+    "js-yaml": "5.3.0"
   }
 }

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@rotki/ci-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Node scripts used by the CI/release workflows",
+  "type": "module",
+  "license": "AGPL-3.0",
+  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
+  "dependencies": {
+    "consola": "3.4.2",
+    "js-yaml": "4.3.1"
+  }
+}

--- a/.github/scripts/pnpm-lock.yaml
+++ b/.github/scripts/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 3.4.2
         version: 3.4.2
       js-yaml:
-        specifier: 4.3.1
-        version: 4.3.1
+        specifier: 5.3.0
+        version: 5.3.0
 
 packages:
 
@@ -24,8 +24,8 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@5.3.0:
+    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
     hasBin: true
 
 snapshots:
@@ -34,6 +34,6 @@ snapshots:
 
   consola@3.4.2: {}
 
-  js-yaml@4.3.1:
+  js-yaml@5.3.0:
     dependencies:
       argparse: 2.0.1

--- a/.github/scripts/pnpm-lock.yaml
+++ b/.github/scripts/pnpm-lock.yaml
@@ -1,0 +1,39 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      consola:
+        specifier: 3.4.2
+        version: 3.4.2
+      js-yaml:
+        specifier: 4.3.1
+        version: 4.3.1
+
+packages:
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+snapshots:
+
+  argparse@2.0.1: {}
+
+  consola@3.4.2: {}
+
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1

--- a/.github/scripts/pnpm-workspace.yaml
+++ b/.github/scripts/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# Standalone pnpm root for the CI/release scripts.
+# Mirrors the supply-chain hardening used by frontend/pnpm-workspace.yaml so
+# these dependencies get the same treatment as the application ones.
+blockExoticSubdeps: true
+minimumReleaseAge: 10080
+saveExact: true
+strictDepBuilds: true
+trustPolicy: no-downgrade

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -515,6 +515,7 @@ jobs:
       contents: read
       id-token: write
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/rotki_release.yaml
+++ b/.github/workflows/rotki_release.yaml
@@ -315,6 +315,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86  # v6.0.10
+        with:
+          package_json_file: .github/scripts/package.json
+
       - name: Setup node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
@@ -330,7 +335,7 @@ jobs:
 
       - name: Merge latest-mac.yml
         run: |
-          npm i js-yaml consola --prefix ./.github/scripts         
+          pnpm install --dir ./.github/scripts --frozen-lockfile
           node ./.github/scripts/merge-latest.mjs latest-mac/latest-mac-x86_64.yml latest-mac/latest-mac-arm64.yml latest-mac.yml
 
       - name: Upload to release


### PR DESCRIPTION
Both `v1.44.0` tag builds failed in the `Merge latest-mac.yml` job:

```
SyntaxError: The requested module 'js-yaml' does not provide an export named 'default'
```

The job installed its dependencies with an unpinned `npm i js-yaml consola --prefix ./.github/scripts`, and `.github/scripts/` had no `package.json` and no lockfile, so every run resolved whatever npm tagged `latest` at build time. js-yaml moved the `latest` tag onto the 5.x line (4.x now sits on `v4-legacy`), 5.x is ESM-only with no default export, and `merge-latest.mjs` imported it as a default.

The last release that ran before js-yaml 5.0.0 was published was v1.43.2 on 2026-06-18, two days earlier, which is why this only surfaced now. Nothing in the release itself changed.

Everything else in both runs was green: all binaries built and the draft was created. Only this last job died, which is why the first failure was easy to miss.

## Changes

**Pin the release scripts properly.** `.github/scripts/` gets a `package.json` with exact versions, a committed `pnpm-lock.yaml`, and a `pnpm-workspace.yaml` carrying the same supply-chain settings as `frontend/pnpm-workspace.yaml`: `saveExact`, `minimumReleaseAge`, `trustPolicy: no-downgrade`, `blockExoticSubdeps`, `strictDepBuilds`. The job now runs `pnpm install --frozen-lockfile`, so an upstream publish can no longer change what a release build installs. `packageManager` repeats the frontend's pnpm pin and `pnpm/action-setup` reads it from the new `package.json`.

**Grant `docker-merge` the `artifact-metadata: write` permission.** Unrelated to the failure and cosmetic, but it is in the same job block of the same file. `actions/attest-build-provenance` wants three permissions and only two were granted, so every release logs two warnings about a storage record it cannot create. The attestation itself already succeeds and is uploaded to Rekor, to the repo and to the registry as an OCI referrer, so cosign verification works today; only the linked-artifact inventory record is missing.

**Validate the merge script's inputs.** It assumed both manifests were well-formed mappings with a `files` array, so a malformed input surfaced as a bare `TypeError` from `merged.files.push`. It also merged two manifests of different versions without complaint, which would hand auto-update a mix of builds. Each input is now checked for parsing, being a mapping, and having a `version` and a non-empty `files` list, and the two versions are compared before merging. The merged list is built rather than pushed onto the second manifest's array in place.

**Move to js-yaml 5.3.0 with named imports.** `import { dump, load } from 'js-yaml'`. 5.3.0 was published on 2026-08-14 and so is past the seven-day `minimumReleaseAge` the workspace enforces.

## Verification

Local only. The job itself can only be proven by the next tag.

- Downloaded the real `latest-mac-x86_64.yml` and `latest-mac-arm64.yml` artifacts from the failed run 32476741056 and merged them. The output is byte-for-byte identical across js-yaml 4.3.1, the hardened script, and js-yaml 5.3.0.
- `pnpm install --dir ./.github/scripts --frozen-lockfile` from a clean checkout resolves and installs.
- One negative control per new guard: missing file, unparseable YAML, a top-level list, no `version`, empty `files`, and mismatched versions each exit 1 with the filename in the message; a valid pair exits 0.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
