### PR TITLE
fix(history): treat an empty counterparty as none

### DIFF
--- a/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.spec.ts
+++ b/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.spec.ts
@@ -1,0 +1,113 @@
+import type { HistoryEventTypeData } from '@/modules/history/events/event-type';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { withSetup } from '@test/utils/with-setup';
+import { flushPromises } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
+
+const getTransactionTypeMappings = vi.fn<() => Promise<HistoryEventTypeData>>();
+
+vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
+  useHistoryEventsApi: (): { getTransactionTypeMappings: typeof getTransactionTypeMappings } => ({
+    getTransactionTypeMappings,
+  }),
+}));
+
+const mappings: HistoryEventTypeData = {
+  accountingEventsIcons: {},
+  entryTypeMappings: {},
+  eventCategoryDetails: {
+    'bridge receive': {
+      counterpartyMappings: { default: { icon: 'lu-download', label: 'bridge receive' } },
+      direction: 'in',
+      group: 'bridge',
+    },
+    'receive': {
+      counterpartyMappings: {
+        'aave-v3': { icon: 'lu-coins', label: 'receive from aave' },
+        'default': { icon: 'lu-download', label: 'receive' },
+      },
+      direction: 'in',
+      group: 'receive',
+    },
+  },
+  eventCategoryGroups: {},
+  globalMappings: {
+    receive: {
+      bridge: { default: 'bridge receive' },
+      none: { default: 'receive' },
+    },
+  },
+};
+
+describe('useHistoryEventMappings', () => {
+  const wrappers: { unmount: () => void }[] = [];
+
+  beforeEach(() => {
+    setActivePinia(createCustomPinia());
+    getTransactionTypeMappings.mockResolvedValue(mappings);
+  });
+
+  afterEach(() => {
+    // the composable is shared, so its state only resets once every user is gone
+    while (wrappers.length > 0) wrappers.pop()?.unmount();
+    vi.clearAllMocks();
+  });
+
+  async function setup(): Promise<ReturnType<typeof useHistoryEventMappings>> {
+    const { result, wrapper } = withSetup(() => useHistoryEventMappings());
+    wrappers.push(wrapper);
+    await flushPromises();
+    return result;
+  }
+
+  describe('findEventTypeData', () => {
+    it('should resolve a combination that has no counterparty', async () => {
+      const { findEventTypeData } = await setup();
+
+      expect(findEventTypeData({ counterparty: null, eventSubtype: 'bridge', eventType: 'receive' })).toMatchObject({
+        direction: 'in',
+        identifier: 'bridge receive',
+      });
+    });
+
+    it('should resolve a combination whose counterparty is an empty string', async () => {
+      const { findEventTypeData } = await setup();
+
+      // the event forms model "no counterparty" as '', and callers treat an empty
+      // identifier as an unknown combination
+      expect(findEventTypeData({ counterparty: '', eventSubtype: 'bridge', eventType: 'receive' })).toMatchObject({
+        direction: 'in',
+        identifier: 'bridge receive',
+      });
+    });
+
+    it('should prefer the counterparty specific details when there are any', async () => {
+      const { findEventTypeData } = await setup();
+
+      expect(findEventTypeData({ counterparty: 'aave-v3', eventSubtype: 'none', eventType: 'receive' })).toMatchObject({
+        identifier: 'aave-v3',
+        label: 'backend_mappings.events.type.receive_from_aave',
+      });
+    });
+
+    it('should keep the counterparty identifier when only default details exist', async () => {
+      const { findEventTypeData } = await setup();
+
+      expect(findEventTypeData({ counterparty: 'hop', eventSubtype: 'bridge', eventType: 'receive' })).toMatchObject({
+        identifier: 'hop',
+        label: 'backend_mappings.events.type.bridge_receive',
+      });
+    });
+
+    it('should fall back to an empty identifier for an unmapped combination', async () => {
+      const { findEventTypeData } = await setup();
+
+      expect(findEventTypeData({ counterparty: '', eventSubtype: 'reward', eventType: 'receive' })).toMatchObject({
+        identifier: '',
+        label: 'reward',
+      });
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.ts
+++ b/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.ts
@@ -185,7 +185,10 @@ export const useHistoryEventMappings = createSharedComposable(() => {
     const defaultKey = 'default';
     const type = findEventType(event);
     const { counterparty, eventSubtype, eventType } = event;
-    const counterpartyVal = counterparty ?? defaultKey;
+    // The event forms model "no counterparty" as an empty string rather than null, so collapse
+    // that to undefined and let the nullish fallback pick the default mapping. Without it the
+    // identifier below comes back empty and callers read a valid combination as unknown.
+    const counterpartyVal = (counterparty === '' ? undefined : counterparty) ?? defaultKey;
     const data = type && get(transactionEventTypesData)[type];
 
     if (type && data) {

--- a/frontend/app/src/modules/history/management/forms/HistoryEventTypeForm.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/HistoryEventTypeForm.spec.ts
@@ -1,9 +1,11 @@
+import type { HistoryEventCategoryDetailWithId } from '@/modules/history/events/event-type';
 import { mount, type VueWrapper } from '@vue/test-utils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import HistoryEventTypeForm from '@/modules/history/management/forms/HistoryEventTypeForm.vue';
 
 const push = vi.fn(async (): Promise<void> => {});
 const show = vi.fn<(options: unknown, onConfirm: () => void) => void>();
+const findEventTypeData = vi.fn<() => HistoryEventCategoryDetailWithId>();
 
 vi.mock('vue-router', () => ({
   useRouter: (): { push: typeof push } => ({ push }),
@@ -14,19 +16,28 @@ vi.mock('@/modules/core/common/use-confirm-store', () => ({
 }));
 
 vi.mock('@/modules/history/events/mapping/use-history-event-mappings', () => ({
-  useHistoryEventMappings: (): unknown => ({
-    findEventTypeData: (): { value: { identifier: string } } => ({ value: { identifier: 'receive' } }),
-  }),
+  useHistoryEventMappings: (): unknown => ({ findEventTypeData }),
 }));
 
+function categoryDetail(identifier: string): HistoryEventCategoryDetailWithId {
+  return { direction: 'in', icon: 'lu-download', identifier, label: 'Claim reward' };
+}
+
 describe('forms/HistoryEventTypeForm.vue', () => {
+  const wrappers: VueWrapper[] = [];
+
   beforeEach(() => {
     push.mockClear();
     show.mockClear();
+    findEventTypeData.mockReturnValue(categoryDetail('claim reward'));
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0) wrappers.pop()?.unmount();
   });
 
   function mountForm(props: Record<string, unknown>): VueWrapper {
-    return mount(HistoryEventTypeForm, {
+    const wrapper = mount(HistoryEventTypeForm, {
       global: {
         stubs: { HistoryEventActionPicker: true },
       },
@@ -37,7 +48,43 @@ describe('forms/HistoryEventTypeForm.vue', () => {
         ...props,
       },
     });
+    wrappers.push(wrapper);
+    return wrapper;
   }
+
+  it('should not warn when the combination resolves for an empty counterparty', () => {
+    const wrapper = mountForm({ counterparty: '' });
+
+    expect(findEventTypeData).toHaveBeenCalledWith(
+      { counterparty: '', eventSubtype: 'reward', eventType: 'staking', location: null },
+      false,
+    );
+    expect(wrapper.find('[data-testid="alert"]').exists()).toBe(false);
+  });
+
+  it('should warn when the combination resolves to no identifier', () => {
+    findEventTypeData.mockReturnValue(categoryDetail(''));
+
+    const wrapper = mountForm({});
+
+    expect(wrapper.find('[data-testid="alert"]').attributes('data-type')).toBe('warning');
+  });
+
+  it('should not warn until both the type and the subtype are set', () => {
+    findEventTypeData.mockReturnValue(categoryDetail(''));
+
+    const wrapper = mountForm({ eventSubtype: '' });
+
+    expect(wrapper.find('[data-testid="alert"]').exists()).toBe(false);
+  });
+
+  it('should not warn when the parent disables the warning', () => {
+    findEventTypeData.mockReturnValue(categoryDetail(''));
+
+    const wrapper = mountForm({ disableWarning: true });
+
+    expect(wrapper.find('[data-testid="alert"]').exists()).toBe(false);
+  });
 
   it('should not render the accounting rule link by default', () => {
     const wrapper = mountForm({});


### PR DESCRIPTION
## Problem

Editing any EVM event without a counterparty showed *"The resulting combination is unknown, this event won't be processed correctly."*, even for perfectly valid combinations such as `receive` + `bridge` (Bridge receive) or a plain `receive` + `none`.

`findEventTypeData` collapsed a **null** counterparty onto the `default` mapping key, but left an **empty string** alone:

```ts
const counterpartyVal = counterparty ?? defaultKey;   // '' stays ''
...
identifier: counterpartyVal !== defaultKey ? counterpartyVal : type,   // '' !== 'default' => ''
```

The event forms model "no counterparty" as `''` (`evm-event-form.ts` initial state and `entry.counterparty ?? ''`), so the category resolved correctly but the identifier came back empty, and `HistoryEventTypeForm`'s warning gate reads an empty identifier as an unknown combination.

## Fix

Collapse the empty string to `undefined` so the nullish fallback picks the default mapping.

## Tests

- New `use-history-event-mappings.spec.ts` covering `findEventTypeData`: empty-string counterparty, null counterparty, counterparty-specific details, a counterparty with default-only details, and a genuinely unmapped combination. Reverting the fix fails only the empty-string test.
- `HistoryEventTypeForm.spec.ts`: added coverage for the warning gate (resolves => no alert, empty identifier => warning, nothing before both fields are set, `disableWarning` respected), fixed the mocked `findEventTypeData` which returned a `{ value: ... }` wrapper that `get()` does not unwrap (so the gate was never actually exercised), and unmounted the mounted wrappers.

Verified in the running app: the warning appears on a counterparty-less EVM receive before the change and is gone after it, including the Bridge receive case.