### PR TITLE
fix: report bridge and monerium outcomes inline

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -526,17 +526,9 @@
         "description": "Failed to match bridge transaction: {error}",
         "title": "Bridge Transaction Matching"
       },
-      "external_success": {
-        "description": "Bridge deposit marked as a payment to an external address.",
-        "title": "Bridge Transaction Resolved"
-      },
       "fetch_error": {
         "description": "Failed to fetch unmatched bridge transactions: {error}",
         "title": "Fetching Unmatched Bridge Transactions"
-      },
-      "ignored": {
-        "description": "It moved to the ignored list.",
-        "title": "Transaction ignored"
       },
       "success": {
         "description": "Bridge transaction successfully matched to its counterpart event.",
@@ -1878,6 +1870,7 @@
     "dialog": {
       "confirm_ignore": "Ignore this transaction?",
       "confirm_mark_external": "Resolve as an external payment?",
+      "confirm_mark_external_in": "Resolve as external income?",
       "create_counterpart": "Create Counterpart",
       "create_counterpart_in_tooltip": "Create a synthetic mirror event on the source chain and link it to this bridge withdrawal. Use this when the source chain can no longer be queried, so the transfer stays a movement of your own funds.",
       "create_counterpart_tooltip": "Create a synthetic mirror event on the destination chain and link it to this bridge deposit. Use this when the destination chain can no longer be queried, so the transfer stays a movement of your own funds.",
@@ -1907,6 +1900,11 @@
     "premium": {
       "free_tooltip": "Bridge transaction matching requires a minimum of {tier} tier. {link} to unlock this feature.",
       "premium_tooltip": "Bridge transaction matching requires a minimum of {tier} tier. Your current tier is {currentTier}. {link} to unlock it."
+    },
+    "resolved": {
+      "external_deposit": "Bridge deposit resolved as a payment to an external address.",
+      "external_withdrawal": "Bridge withdrawal resolved as income from an external address.",
+      "ignored": "Bridge transaction marked as having no counterpart. It moved to the ignored list."
     }
   },
   "calendar": {

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
@@ -3,6 +3,7 @@ import { startPromise } from '@shared/utils';
 import AssetMovementMatchingSettingsMenu from '@/modules/history/events/AssetMovementMatchingSettingsMenu.vue';
 import { UNMATCHED_ACTIONS, type UnmatchedActionPayload } from '@/modules/history/events/unmatched-actions';
 import UnmatchedBridgesList from '@/modules/history/events/UnmatchedBridgesList.vue';
+import UnmatchedResolutionStrip from '@/modules/history/events/UnmatchedResolutionStrip.vue';
 import { useBridgeTransactionActions } from '@/modules/history/events/use-bridge-transaction-actions';
 import { type UnmatchedBridgeTransaction, useUnmatchedBridgeTransactions } from '@/modules/history/events/use-unmatched-bridge-transactions';
 
@@ -39,12 +40,15 @@ const {
   confirmCreateCounterpart,
   confirmIgnoreSelected,
   confirmRestoreSelected,
+  dismissResolution,
   ignoreLoading,
   ignoreTransaction,
   markExternal,
   restoreTransaction,
+  resolutionNotice,
   modelSelectedIgnored,
   modelSelectedUnmatched,
+  undoResolution,
 } = useBridgeTransactionActions({ onActionComplete });
 
 const buttonSize = computed<'sm' | 'lg'>(() => isPinned ? 'sm' : 'lg');
@@ -106,6 +110,20 @@ onBeforeMount(async () => {
       </RuiChip>
     </RuiTab>
   </RuiTabs>
+
+  <!-- A resolution reports itself here rather than as a notification: the outcome and its undo
+       belong next to the list they changed, and the panel the action was taken from is still
+       open. It sits above both branches so it shows on either tab, since an undo puts the leg
+       back in the unmatched one. -->
+  <UnmatchedResolutionStrip
+    v-if="resolutionNotice"
+    :message="resolutionNotice.message"
+    :loading="ignoreLoading"
+    class="shrink-0"
+    :class="isPinned ? 'mx-3 mt-3' : 'mt-4'"
+    @undo="startPromise(undoResolution())"
+    @dismiss="dismissResolution()"
+  />
 
   <!-- Pinned bypasses RuiTabItems: it sizes itself from its content and hides the overflow, so
        in a bounded column the bottom of the panel - the pager - is silently cut off. Rendering

--- a/frontend/app/src/modules/history/events/UnmatchedResolutionStrip.spec.ts
+++ b/frontend/app/src/modules/history/events/UnmatchedResolutionStrip.spec.ts
@@ -1,0 +1,48 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import UnmatchedResolutionStrip from '@/modules/history/events/UnmatchedResolutionStrip.vue';
+
+/**
+ * The seam: the strip renders the message it is handed and reports the two things the panel
+ * can act on - undo the resolution, or dismiss the notice. It decides neither the wording nor
+ * what undo does, so those belong to the actions composable, not here.
+ */
+
+describe('modules/history/events/UnmatchedResolutionStrip', () => {
+  let wrapper: VueWrapper<InstanceType<typeof UnmatchedResolutionStrip>> | undefined;
+
+  function mountStrip(props: { message: string; loading?: boolean }): VueWrapper<InstanceType<typeof UnmatchedResolutionStrip>> {
+    wrapper = mount(UnmatchedResolutionStrip, { props });
+    return wrapper;
+  }
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should render the message it is given', () => {
+    const strip = mountStrip({ message: 'Bridge withdrawal resolved as income from an external address.' });
+
+    expect(strip.find('[data-testid="unmatched-resolution-strip"]').text())
+      .toContain('Bridge withdrawal resolved as income from an external address.');
+  });
+
+  it('should report an undo', async () => {
+    const strip = mountStrip({ message: 'resolved' });
+
+    await strip.find('[data-testid="unmatched-resolution-undo"]').trigger('click');
+
+    expect(strip.emitted('undo')).toHaveLength(1);
+    expect(strip.emitted('dismiss')).toBeUndefined();
+  });
+
+  it('should report a dismiss without undoing anything', async () => {
+    const strip = mountStrip({ message: 'resolved' });
+
+    await strip.find('[data-testid="unmatched-resolution-dismiss"]').trigger('click');
+
+    expect(strip.emitted('dismiss')).toHaveLength(1);
+    expect(strip.emitted('undo')).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/history/events/UnmatchedResolutionStrip.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedResolutionStrip.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+const { message, loading = false } = defineProps<{
+  message: string;
+  loading?: boolean;
+}>();
+
+const emit = defineEmits<{
+  dismiss: [];
+  undo: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+</script>
+
+<template>
+  <!-- info, not amber: the confirm strip asks before reversible work, this one reports work
+       that already happened and keeps its undo within reach of the list it changed -->
+  <div
+    class="flex items-center gap-2 rounded px-2 py-1 bg-rui-info/10 border border-rui-info/40"
+    data-testid="unmatched-resolution-strip"
+  >
+    <span class="flex-1 min-w-0 text-caption text-rui-text">
+      {{ message }}
+    </span>
+    <RuiButton
+      size="sm"
+      variant="text"
+      class="!h-[26px] !py-0 shrink-0"
+      :loading="loading"
+      data-testid="unmatched-resolution-undo"
+      @click="emit('undo')"
+    >
+      {{ t('common.actions.undo') }}
+    </RuiButton>
+    <RuiButton
+      size="sm"
+      variant="text"
+      icon
+      class="!h-[26px] !w-[26px] shrink-0"
+      :aria-label="t('common.actions.dismiss')"
+      data-testid="unmatched-resolution-dismiss"
+      @click="emit('dismiss')"
+    >
+      <RuiIcon
+        name="lu-x"
+        size="16"
+      />
+    </RuiButton>
+  </div>
+</template>

--- a/frontend/app/src/modules/history/events/use-bridge-transaction-actions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-bridge-transaction-actions.spec.ts
@@ -15,7 +15,6 @@ const { spies } = vi.hoisted(() => ({
     showErrorMessage: vi.fn(),
     getChainName: vi.fn((chain: string) => chain.toUpperCase()),
     isCounterpartUntracked: vi.fn<() => boolean>(() => false),
-    notify: vi.fn(),
   },
 }));
 
@@ -60,7 +59,6 @@ vi.mock('@/modules/history/events/use-untracked-bridge-counterpart', () => ({
 vi.mock('@/modules/core/notifications/use-notifications', () => ({
   getErrorMessage: (error: unknown): string => error instanceof Error ? error.message : String(error),
   useNotifications: (): object => ({
-    notify: spies.notify,
     showErrorMessage: spies.showErrorMessage,
   }),
 }));
@@ -135,6 +133,20 @@ describe('use-bridge-transaction-actions', () => {
       expect(get(composable.ignoreLoading)).toBe(false);
     });
 
+    it('should report the ignore in place, with an undo that restores it', async () => {
+      const composable = useBridgeTransactionActions();
+
+      await composable.ignoreTransaction(createMockTransaction({ identifier: 42 }));
+
+      expect(get(composable.resolutionNotice)).toMatchObject({
+        message: 'bridge_matching.resolved.ignored',
+      });
+
+      await composable.undoResolution();
+
+      expect(spies.unlinkBridgeTransaction).toHaveBeenCalledWith(42);
+    });
+
     it('should drop the ignored leg from the current selection', async () => {
       const composable = useBridgeTransactionActions();
       set(composable.modelSelectedUnmatched, ['42', '55']);
@@ -177,31 +189,71 @@ describe('use-bridge-transaction-actions', () => {
       expect(spies.refreshUnmatchedBridgeTransactions).toHaveBeenCalledOnce();
     });
 
-    it('should report the result with an undo that unlinks it again', async () => {
-      const { markExternal } = useBridgeTransactionActions();
+    it('should report the result in place, with an undo that unlinks it again', async () => {
+      const composable = useBridgeTransactionActions();
 
-      await markExternal(createMockTransaction({ identifier: 21 }));
+      await composable.markExternal(createMockTransaction({ identifier: 21 }));
 
-      expect(spies.notify).toHaveBeenCalledOnce();
-      const [notification] = spies.notify.mock.calls[0];
-      expect(notification).toMatchObject({
-        action: { label: 'common.actions.undo' },
-        title: 'actions.bridge_matching.external_success.title',
+      expect(get(composable.resolutionNotice)).toMatchObject({
+        message: 'bridge_matching.resolved.external_deposit',
       });
 
-      await notification.action.action();
+      await composable.undoResolution();
 
       expect(spies.unlinkBridgeTransaction).toHaveBeenCalledWith(21);
+      expect(get(composable.resolutionNotice)).toBeUndefined();
+    });
+
+    // The regression this pair pins: a withdrawal is resolved as income from an untracked
+    // source, not as a payment out, and the backend event ends up a receive. Reporting the
+    // deposit wording for both directions describes half of them as the opposite transfer.
+    it('should describe a resolved withdrawal as income rather than a payment', async () => {
+      const composable = useBridgeTransactionActions();
+
+      await composable.markExternal(createMockTransaction({ direction: 'withdrawal' }));
+
+      expect(get(composable.resolutionNotice)).toMatchObject({
+        message: 'bridge_matching.resolved.external_withdrawal',
+      });
     });
 
     it('should not refresh or report when resolving as external fails', async () => {
       spies.resolveExternal.mockResolvedValueOnce({ message: 'nope', success: false });
-      const { markExternal } = useBridgeTransactionActions();
+      const composable = useBridgeTransactionActions();
 
-      await markExternal(createMockTransaction());
+      await composable.markExternal(createMockTransaction());
 
       expect(spies.refreshUnmatchedBridgeTransactions).not.toHaveBeenCalled();
-      expect(spies.notify).not.toHaveBeenCalled();
+      expect(get(composable.resolutionNotice)).toBeUndefined();
+    });
+
+    it('should drop the notice once the leg it describes is restored from its row', async () => {
+      const composable = useBridgeTransactionActions();
+      const transaction = createMockTransaction({ identifier: 21 });
+
+      await composable.markExternal(transaction);
+      await composable.restoreTransaction(transaction);
+
+      expect(get(composable.resolutionNotice)).toBeUndefined();
+    });
+
+    it('should keep the notice when an unrelated leg is restored', async () => {
+      const composable = useBridgeTransactionActions();
+
+      await composable.markExternal(createMockTransaction({ identifier: 21 }));
+      await composable.restoreTransaction(createMockTransaction({ identifier: 99 }));
+
+      expect(get(composable.resolutionNotice)).toBeDefined();
+    });
+
+    it('should drop the notice when it is dismissed', async () => {
+      const composable = useBridgeTransactionActions();
+
+      await composable.markExternal(createMockTransaction());
+      composable.dismissResolution();
+
+      expect(get(composable.resolutionNotice)).toBeUndefined();
+      expect(spies.unlinkBridgeTransaction).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/app/src/modules/history/events/use-bridge-transaction-actions.ts
+++ b/frontend/app/src/modules/history/events/use-bridge-transaction-actions.ts
@@ -1,5 +1,4 @@
-import type { Ref } from 'vue';
-import { NotificationCategory, Priority, Severity } from '@rotki/common';
+import type { ComputedRef, Ref } from 'vue';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -12,16 +11,29 @@ interface UseBridgeTransactionActionsOptions {
   onActionComplete?: () => Promise<void>;
 }
 
+/**
+ * What the panel says about the resolution the user just made, and the leg an undo would
+ * restore. The wording is decided here rather than by the presentation, since it depends on
+ * the leg's direction: a resolved deposit is a payment out, a resolved withdrawal is income.
+ */
+interface BridgeResolutionNotice {
+  message: string;
+  transaction: UnmatchedBridgeTransaction;
+}
+
 interface UseBridgeTransactionActionsReturn {
   ignoreLoading: Readonly<Ref<boolean>>;
   modelSelectedIgnored: Ref<string[]>;
   modelSelectedUnmatched: Ref<string[]>;
+  resolutionNotice: ComputedRef<BridgeResolutionNotice | undefined>;
   confirmCreateCounterpart: (transaction: UnmatchedBridgeTransaction) => void;
   confirmIgnoreSelected: () => void;
   confirmRestoreSelected: () => void;
+  dismissResolution: () => void;
   markExternal: (transaction: UnmatchedBridgeTransaction) => Promise<void>;
   ignoreTransaction: (transaction: UnmatchedBridgeTransaction) => Promise<void>;
   restoreTransaction: (transaction: UnmatchedBridgeTransaction) => Promise<void>;
+  undoResolution: () => Promise<void>;
 }
 
 export function useBridgeTransactionActions(
@@ -41,12 +53,16 @@ export function useBridgeTransactionActions(
 
   const { matchBridgeTransactions, unlinkBridgeTransaction } = useBridgeMatchingApi();
   const { show } = useConfirmStore();
-  const { notify, showErrorMessage } = useNotifications();
+  const { showErrorMessage } = useNotifications();
   const { getChainName } = useSupportedChains();
 
   const ignoreLoading = shallowRef<boolean>(false);
   const modelSelectedUnmatched = ref<string[]>([]);
   const modelSelectedIgnored = ref<string[]>([]);
+  const notice = shallowRef<BridgeResolutionNotice>();
+  // Exposed through a computed rather than readonly(): the notice carries the leg itself, and
+  // deep-readonly does not survive the BigNumber fields its events hold.
+  const resolutionNotice = computed<BridgeResolutionNotice | undefined>(() => get(notice));
 
   /**
    * A row that just left the list must not stay selected, otherwise the "ignore selected"
@@ -71,20 +87,27 @@ export function useBridgeTransactionActions(
    * Reversible work reports itself with an undo affordance instead of asking first with a
    * modal: both ignoring and resolving as external are undone by the same unlink call,
    * which the backend uses to clear the marker and restore the event from its backup.
+   *
+   * It reports in the panel the action was taken from rather than as a notification, so the
+   * outcome and its undo sit next to the list they changed. Only the latest resolution is
+   * held, which costs nothing durable: resolving as external also writes the leg to
+   * `history_event_link_ignores`, so it lands in the ignored tab and keeps a Restore there
+   * long after the notice is gone.
    */
-  function notifyUndoable(title: string, message: string, transaction: UnmatchedBridgeTransaction): void {
-    notify({
-      action: {
-        action: async () => restoreTransaction(transaction),
-        label: t('common.actions.undo'),
-      },
-      category: NotificationCategory.DEFAULT,
-      display: true,
-      message,
-      priority: Priority.ACTION,
-      severity: Severity.INFO,
-      title,
-    });
+  function reportResolution(message: string, transaction: UnmatchedBridgeTransaction): void {
+    set(notice, { message, transaction });
+  }
+
+  function dismissResolution(): void {
+    set(notice, undefined);
+  }
+
+  async function undoResolution(): Promise<void> {
+    const current = get(notice);
+    if (!current)
+      return;
+
+    await restoreTransaction(current.transaction);
   }
 
   function formatChain(chain: string | number | undefined): string | undefined {
@@ -100,11 +123,7 @@ export function useBridgeTransactionActions(
       deselect(transaction);
       await refreshUnmatchedBridgeTransactions();
       await onActionComplete?.();
-      notifyUndoable(
-        t('actions.bridge_matching.ignored.title'),
-        t('actions.bridge_matching.ignored.description'),
-        transaction,
-      );
+      reportResolution(t('bridge_matching.resolved.ignored'), transaction);
     }
     catch (error: unknown) {
       notifyActionFailure('Failed to ignore bridge transaction:', error);
@@ -119,6 +138,11 @@ export function useBridgeTransactionActions(
     try {
       await unlinkBridgeTransaction(transaction.identifier);
       deselect(transaction);
+      // Whether the restore came from the notice's undo or from the row's own action, the
+      // notice now describes something that is no longer true.
+      if (get(notice)?.transaction.identifier === transaction.identifier)
+        dismissResolution();
+
       await refreshUnmatchedBridgeTransactions();
       await onActionComplete?.();
     }
@@ -138,9 +162,10 @@ export function useBridgeTransactionActions(
         deselect(transaction);
         await refreshUnmatchedBridgeTransactions();
         await onActionComplete?.();
-        notifyUndoable(
-          t('actions.bridge_matching.external_success.title'),
-          t('actions.bridge_matching.external_success.description'),
+        reportResolution(
+          transaction.direction === 'deposit'
+            ? t('bridge_matching.resolved.external_deposit')
+            : t('bridge_matching.resolved.external_withdrawal'),
           transaction,
         );
       }
@@ -245,11 +270,14 @@ export function useBridgeTransactionActions(
     confirmCreateCounterpart,
     confirmIgnoreSelected,
     confirmRestoreSelected,
+    dismissResolution,
     markExternal,
     ignoreLoading: readonly(ignoreLoading),
     ignoreTransaction,
     restoreTransaction,
+    resolutionNotice,
     modelSelectedIgnored,
     modelSelectedUnmatched,
+    undoResolution,
   };
 }

--- a/frontend/app/src/modules/history/events/use-unmatched-bridge-rows.spec.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-bridge-rows.spec.ts
@@ -1,0 +1,93 @@
+import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UNMATCHED_ACTIONS, type UnmatchedRowActionSpec } from '@/modules/history/events/unmatched-actions';
+import { type UnmatchedBridgeRow, useUnmatchedBridgeRows } from '@/modules/history/events/use-unmatched-bridge-rows';
+
+/**
+ * The seam: the row model decides what a leg is called and what may be done to it, and every
+ * word it picks depends on the leg's direction. A deposit leaves the tracked side (a payment
+ * out), a withdrawal arrives on it (income in), which is also what the backend writes when
+ * either is resolved as external. Anything here that reads the same for both directions
+ * describes half the rows wrongly.
+ */
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    isCounterpartUntracked: vi.fn<() => boolean>(() => false),
+  },
+}));
+
+vi.mock('@/modules/history/events/use-untracked-bridge-counterpart', () => ({
+  canCreateBridgeCounterpart: (): boolean => false,
+  getBridgeCounterpartAddress: (): string | undefined => undefined,
+  isCounterpartUnqueryable: (): boolean => false,
+  useUntrackedBridgeCounterpart: (): object => ({
+    isCounterpartUntracked: spies.isCounterpartUntracked,
+  }),
+}));
+
+function createMockTransaction(direction: 'deposit' | 'withdrawal'): UnmatchedBridgeTransaction {
+  return {
+    asset: 'ETH',
+    direction,
+    // @ts-expect-error partial mock: the row only reads the leg's entry
+    events: { entry: { identifier: 1, location: 'ethereum', timestamp: 1700000000000 } },
+    groupIdentifier: 'group1',
+    identifier: 1,
+  };
+}
+
+function rowFor(direction: 'deposit' | 'withdrawal'): { row: UnmatchedBridgeRow; spec: UnmatchedRowActionSpec } {
+  const { rows, specFor } = useUnmatchedBridgeRows({
+    matchDisabled: false,
+    showRestore: false,
+    transactions: [createMockTransaction(direction)],
+  });
+  const row = get(rows)[0];
+  return { row, spec: specFor(row) };
+}
+
+describe('use-unmatched-bridge-rows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spies.isCounterpartUntracked.mockReturnValue(false);
+  });
+
+  describe('mark external', () => {
+    it('should ask about a payment out when confirming a deposit', () => {
+      const { spec } = rowFor('deposit');
+
+      expect(spec.confirms?.[UNMATCHED_ACTIONS.MARK_EXTERNAL]?.message).toBe(
+        'bridge_matching.dialog.confirm_mark_external',
+      );
+    });
+
+    it('should ask about income in when confirming a withdrawal', () => {
+      const { spec } = rowFor('withdrawal');
+
+      expect(spec.confirms?.[UNMATCHED_ACTIONS.MARK_EXTERNAL]?.message).toBe(
+        'bridge_matching.dialog.confirm_mark_external_in',
+      );
+    });
+
+    it('should describe the action itself by direction too', () => {
+      expect(rowFor('deposit').spec.markExternal?.tooltip).toBe('bridge_matching.dialog.mark_external_tooltip');
+      expect(rowFor('withdrawal').spec.markExternal?.tooltip).toBe('bridge_matching.dialog.mark_external_in_tooltip');
+    });
+
+    it('should skip the confirm when the counterpart is known to be untracked', () => {
+      spies.isCounterpartUntracked.mockReturnValue(true);
+
+      const { spec } = rowFor('withdrawal');
+
+      expect(spec.confirms?.[UNMATCHED_ACTIONS.MARK_EXTERNAL]).toBeUndefined();
+      // ...but the row still asks before ignoring, so the skip is specific, not a missing map
+      expect(spec.confirms?.[UNMATCHED_ACTIONS.IGNORE]).toBeDefined();
+    });
+  });
+
+  it('should label the row by direction', () => {
+    expect(rowFor('deposit').row.directionLabel).toBe('bridge_matching.dialog.direction_out');
+    expect(rowFor('withdrawal').row.directionLabel).toBe('bridge_matching.dialog.direction_in');
+  });
+});

--- a/frontend/app/src/modules/history/events/use-unmatched-bridge-rows.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-bridge-rows.ts
@@ -133,7 +133,11 @@ export function useUnmatchedBridgeRows(options: UseUnmatchedBridgeRowsOptions): 
     if (!row.untrackedCounterpart) {
       confirms[UNMATCHED_ACTIONS.MARK_EXTERNAL] = {
         confirmLabel: t('bridge_matching.dialog.mark_external'),
-        message: t('bridge_matching.dialog.confirm_mark_external'),
+        // A deposit is resolved as a payment out, a withdrawal as income in. Asking about a
+        // payment either way misdescribes half of what the user is about to confirm.
+        message: row.direction === 'deposit'
+          ? t('bridge_matching.dialog.confirm_mark_external')
+          : t('bridge_matching.dialog.confirm_mark_external_in'),
       };
     }
 

--- a/frontend/app/src/modules/integrations/monerium/MoneriumAuth.spec.ts
+++ b/frontend/app/src/modules/integrations/monerium/MoneriumAuth.spec.ts
@@ -10,19 +10,27 @@ import MoneriumAuth from './MoneriumAuth.vue';
 /**
  * The seam: every notification this card raises belongs to one connection flow, so it must be
  * dispatched under the shared Monerium group. Grouping is what makes the dispatcher replace the
- * previous step instead of leaving "Authorizing...", "Successfully authenticated" and a stale
- * "session key expired" warning stacked in the notification panel.
+ * previous step instead of leaving "Authorizing..." and a stale "session key expired" warning
+ * stacked in the notification panel.
+ *
+ * Success is the exception, and deliberately raises nothing: the card itself flips to the
+ * connected state, so the outcome is already on screen and the flow only clears what its earlier
+ * steps left behind.
  */
 
-const { mockCompleteOAuth, mockNotify, mockOpenUrl } = vi.hoisted(() => ({
+const { mockCompleteOAuth, mockNotify, mockOpenUrl, mockRemoveMatching } = vi.hoisted(() => ({
   mockCompleteOAuth: vi.fn(),
   mockNotify: vi.fn(),
   mockOpenUrl: vi.fn(),
+  mockRemoveMatching: vi.fn<(predicate: (notification: { group?: NotificationGroup }) => boolean) => void>(),
 }));
 let oAuthHandler: ((result: OAuthResult) => Promise<void> | void) | undefined;
 
-vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
-  useNotificationDispatcher: vi.fn(() => ({ notify: mockNotify })),
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn(() => ({
+    notify: mockNotify,
+    removeMatching: mockRemoveMatching,
+  })),
 }));
 
 vi.mock('@/modules/shell/app/use-electron-interop', () => ({
@@ -96,7 +104,7 @@ describe('moneriumAuth', () => {
     }));
   });
 
-  it('should group the notification for a completed authorization', async () => {
+  it('should raise no notification when the authorization completes', async () => {
     expect(oAuthHandler).toBeDefined();
     await oAuthHandler?.({
       accessToken: 'access',
@@ -105,11 +113,26 @@ describe('moneriumAuth', () => {
       success: true,
     });
 
-    expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({
-      group: NotificationGroup.MONERIUM_AUTH,
-      message: 'connected',
-      severity: Severity.INFO,
-    }));
+    // the card reports this inline by flipping to its connected state
+    expect(mockCompleteOAuth).toHaveBeenCalledOnce();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('should clear the flow notifications when the authorization completes', async () => {
+    await oAuthHandler?.({
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      service: 'monerium',
+      success: true,
+    });
+
+    expect(mockRemoveMatching).toHaveBeenCalledOnce();
+    const [predicate] = mockRemoveMatching.mock.calls[0];
+    // the earlier steps of this flow go, including the session-expired warning that shares the
+    // group and is what the re-authentication just resolved; nothing else does
+    expect(predicate({ group: NotificationGroup.MONERIUM_AUTH })).toBe(true);
+    expect(predicate({ group: NotificationGroup.MISSING_API_KEY })).toBe(false);
+    expect(predicate({})).toBe(false);
   });
 
   it('should group the notification for a failed authorization', async () => {

--- a/frontend/app/src/modules/integrations/monerium/MoneriumAuth.vue
+++ b/frontend/app/src/modules/integrations/monerium/MoneriumAuth.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import type { OAuthResult } from '@shared/ipc';
-import { NotificationGroup, type NotificationPayload, type SemiPartial, Severity } from '@rotki/common';
+import { type Notification, NotificationGroup, Severity } from '@rotki/common';
 import { getPublicServiceImagePath } from '@/modules/core/common/file/file';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
-import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import ServiceKeyCard, { type FeatureGate, type ServiceKeyAction } from '@/modules/settings/api-keys/ServiceKeyCard.vue';
 import { useBackendMessages } from '@/modules/shell/app/use-backend-messages';
@@ -32,7 +32,7 @@ const manualAccessToken = ref<string>('');
 const manualRefreshToken = ref<string>('');
 
 const { isPackaged, openUrl } = useInterop();
-const { notify } = useNotificationDispatcher();
+const { notify, removeMatching } = useNotifications();
 const { registerOAuthCallbackHandler, unregisterOAuthCallbackHandler } = useBackendMessages();
 const { authenticated, completeOAuth, disconnect: disconnectOAuth, status } = useMoneriumOAuth();
 
@@ -53,12 +53,24 @@ const cardAction = computed<ServiceKeyAction>(() => ({
  * the same group carries the session-expired warning, which a successful re-authentication is
  * meant to clear.
  */
-function notifyAuthStep(payload: SemiPartial<NotificationPayload, 'title' | 'message'>): void {
+function notifyAuthStep(payload: Notification): void {
   notify({
     ...payload,
     display: true,
     group: NotificationGroup.MONERIUM_AUTH,
   });
+}
+
+/**
+ * A successful authorization already reports itself where the user is looking: the card flips to
+ * the connected state naming the account. Saying it again in the notification area would leave an
+ * entry to dismiss for something already on screen, so success instead clears the flow's own
+ * trail - the "opening browser" step, and the session-expired warning that shares this group and
+ * is exactly what the re-authentication just resolved. One call is enough because a group holds a
+ * single entry: the dispatcher replaces it rather than appending.
+ */
+function clearAuthNotifications(): void {
+  removeMatching(({ group }) => group === NotificationGroup.MONERIUM_AUTH);
 }
 
 function notifyOAuthError(error: unknown): void {
@@ -87,17 +99,13 @@ async function handleOAuthCallback(oAuthResult: OAuthResult): Promise<void> {
     }
 
     set(isAuthorizing, true);
-    const result = await completeOAuth(
+    await completeOAuth(
       accessToken,
       refreshToken,
       expiresIn ?? 3600,
     );
 
-    notifyAuthStep({
-      message: result.message,
-      severity: Severity.INFO,
-      title: t('external_services.monerium.success'),
-    });
+    clearAuthNotifications();
     set(showTokenInput, false);
     set(manualAccessToken, '');
     set(manualRefreshToken, '');


### PR DESCRIPTION
Two independent fixes, one per commit, that both move an outcome out of the notification area and into the surface the action was taken from.

## Bridge legs resolved as external were described by direction

Resolving a bridge leg as external always reported *"Bridge deposit marked as a payment to an external address"*, so a resolved **withdrawal** was described as the opposite transfer. The backend never conflated them: a deposit becomes a `SPEND`, a withdrawal a `RECEIVE` whose notes read *"bridged from an external address"*.

The string predates the withdrawal case. `feat: bridge transaction matching UI` added it when the action existed for deposits only, and `feat: resolve bridge legs as external on both sides` then gave every other affected string an `_in` variant (`mark_external_in`, `mark_external_in_tooltip`, four `mark_external_in_confirm*`) but not the success message or the confirm prompt. A later refactor carried both over unchanged.

Both now pick by direction:

| | deposit | withdrawal |
|---|---|---|
| result | Bridge deposit resolved as a payment to an external address. | Bridge withdrawal resolved as income from an external address. |
| confirm | Resolve as an external payment? | Resolve as external income? |

The result is also reported **in the panel** rather than as a notification, as a strip in the same idiom as the existing confirm strip, so the outcome and its undo sit next to the list they changed. Ignore reports the same way, since the two share the undo path. Only the latest resolution is held, which loses nothing durable: an external resolution is also written to `history_event_link_ignores`, so it keeps a Restore in the ignored tab.

## A successful Monerium authorization says nothing

It raised a notification announcing success for something already on screen, since the card flips to its connected state naming the account. That entry then had to be dismissed by hand, and it shared a group with the "opening browser" step and the session-expired warning, so the flow's trail outlived the flow.

Success now raises nothing and clears the group instead, which also retires the expiry warning the re-authentication just resolved. Failures still report, since nothing on the card shows them. The card drops to one notification composable on the way past: `useNotifications` covers both `notify` and `removeMatching`.

## Verification

Driven in a seeded dev instance against real bridge data, in both the dialog and the pinned rail: the confirm reads "Resolve as external income?" for a withdrawal, the strip reports income rather than a payment, Undo restores the leg and clears the strip, and the deposit half still reads as a payment. The resolved event came back from the backend as `receive/bridge` with `matched_bridge: {resolution: external, direction: withdrawal}`. The Monerium half was verified in-app separately.

New tests cover the direction split in both the actions composable and the row model, the strip's undo/dismiss emits, and the Monerium success path. Each was negative-controlled by restoring the old behaviour and confirming only the intended tests went red.