### PR TITLE
perf(balances): gate protocol activity queries

### DIFF
--- a/rotkehlchen/chain/ethereum/interfaces/balances.py
+++ b/rotkehlchen/chain/ethereum/interfaces/balances.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 from collections import defaultdict
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Final, Literal
 
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.api.v1.types import IncludeExcludeFilterData
@@ -67,6 +67,10 @@ PROTOCOLS_WITH_BALANCES = Literal[
     'yearn-vesting',
 ]
 BalancesSheetType = dict[ChecksumEvmAddress, BalanceSheet]
+# The only entry type addresses_with_activity() can ever match. Shared with the caller that
+# builds the counterparty gate so the two cannot drift apart: a gate computed over fewer entry
+# types than the query it short-circuits would skip protocols the user actually has.
+ACTIVITY_ENTRY_TYPES: Final = (HistoryBaseEntryType.EVM_EVENT,)
 
 
 class ProtocolWithBalance(abc.ABC):
@@ -91,6 +95,25 @@ class ProtocolWithBalance(abc.ABC):
         self.tx_decoder = tx_decoder
         self.deposit_event_types = deposit_event_types
         self.excluded_addresses = excluded_addresses
+        # Counterparties the user has any events for on this chain, or None when the caller did
+        # not supply them. Set by query_protocols_with_balance so that the protocols the user
+        # never touched skip their activity query. None means "unknown", not "none": every
+        # query runs, which is what a caller constructing this class on its own gets.
+        self.chain_counterparties: set[str] | None = None
+
+    def counterparty_is_absent_from_chain(self) -> bool:
+        """Whether the chain is known to hold no events for this protocol's counterparty.
+
+        Guards the event queries that filter on `counterparty = self.counterparty`: those can
+        only come back empty here, and skipping them is what makes a balance refresh cost one
+        events query per chain rather than one per protocol.
+
+        False when the caller supplied no counterparties, since unknown is not absent.
+        """
+        return (
+            self.chain_counterparties is not None and
+            self.counterparty not in self.chain_counterparties
+        )
 
     def addresses_with_activity(
             self,
@@ -102,12 +125,15 @@ class ProtocolWithBalance(abc.ABC):
         Query events for addresses having performed a certain activity. It returns
         a mapping of the address that made the activity to the event returned by the filter.
         """
+        if self.counterparty_is_absent_from_chain():
+            return {}
+
         db_filter = EvmEventFilterQuery.make(
             assets=assets,
             counterparties=[self.counterparty],
             type_and_subtype_combinations=event_types,
             location=Location.from_chain_id(self.evm_inquirer.chain_id),
-            entry_types=IncludeExcludeFilterData(values=[HistoryBaseEntryType.EVM_EVENT]),
+            entry_types=IncludeExcludeFilterData(values=list(ACTIVITY_ENTRY_TYPES)),
             excluded_addresses=self.excluded_addresses,
             location_labels=[str(address) for address in location_labels],
         )

--- a/rotkehlchen/chain/ethereum/modules/curve/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/curve/balances.py
@@ -58,6 +58,9 @@ class CurveBalances(ProtocolWithGauges):
     def query_balances(self, addresses: list[ChecksumEvmAddress]) -> BalancesSheetType:
         """Query gauge balances and CRV deposited in the veCRV contract"""
         balances = super().query_balances(addresses=addresses)  # gauge balances
+        if self.counterparty_is_absent_from_chain():
+            return balances  # no curve events at all, so nothing locked in veCRV either
+
         db_filter = EvmEventFilterQuery.make(
             assets=(A_CRV,),
             counterparties=[self.counterparty],

--- a/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
+++ b/rotkehlchen/chain/ethereum/modules/eigenlayer/balances.py
@@ -128,6 +128,9 @@ class EigenlayerBalances(ProtocolWithBalance):
             addresses: list[ChecksumEvmAddress],
     ) -> BalancesSheetType:
         """Query any balances that are being withdrawn from Eigenlayer and are on the fly"""
+        if self.counterparty_is_absent_from_chain():
+            return balances  # no eigenlayer events at all, so no withdrawals in flight
+
         # First find if there is any completed withdrawals unmatched,
         # as that would lead to double counting of balances
         db_filter = EvmEventFilterQuery.make(

--- a/rotkehlchen/chain/evm/manager.py
+++ b/rotkehlchen/chain/evm/manager.py
@@ -7,6 +7,7 @@ from web3.exceptions import BadFunctionCallOutput
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet
 from rotkehlchen.chain.aggregator import CHAIN_TO_BALANCE_PROTOCOLS
 from rotkehlchen.chain.constants import PROXY_BALANCE_PROTOCOL_TEMPLATE
+from rotkehlchen.chain.ethereum.interfaces.balances import ACTIVITY_ENTRY_TYPES
 from rotkehlchen.chain.evm.active_management.manager import ActiveManager
 from rotkehlchen.chain.evm.decoding.curve.curve_cache import (
     query_curve_data,
@@ -18,11 +19,12 @@ from rotkehlchen.chain.manager import (
     ChainWithEoA,
 )
 from rotkehlchen.constants import DEFAULT_BALANCE_LABEL, ZERO
+from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import EthSyncError, InputError, RemoteError
 from rotkehlchen.inquirer import Inquirer
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import CacheType, ChecksumEvmAddress, Price, Timestamp
+from rotkehlchen.types import CacheType, ChecksumEvmAddress, Location, Price, Timestamp
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -218,11 +220,25 @@ class EvmManager(
         Legacy Curve gauges in ethereum, Convex and Velodrome.
         """
         queried_addresses = list(addresses)
+        # Read the chain's counterparties once and hand them to every protocol. Each protocol
+        # otherwise opens with its own `counterparty = X` query before it can find out it has
+        # nothing to do, which on ethereum is 18 scans of the events table per refresh for a
+        # user who may hold none of these positions. Read here rather than per protocol so the
+        # window in which a concurrent decode could add the first event of a protocol - and so
+        # have it skipped until the next refresh - is as small as it already was.
+        with self.node_inquirer.database.conn.read_ctx() as cursor:
+            chain_counterparties = DBHistoryEvents.get_counterparties_at_location(
+                cursor=cursor,
+                location=Location.from_chain_id(self.node_inquirer.chain_id),
+                entry_types=ACTIVITY_ENTRY_TYPES,
+            )
+
         for protocol in CHAIN_TO_BALANCE_PROTOCOLS[self.node_inquirer.chain_id]:
             protocol_with_balance: ProtocolWithBalance = protocol(
                 evm_inquirer=self.node_inquirer,  # type: ignore  # mypy can't match all possibilities here
                 tx_decoder=self.transactions_decoder,  # type: ignore  # mypy can't match all possibilities here
             )
+            protocol_with_balance.chain_counterparties = chain_counterparties
             try:
                 protocol_balances = protocol_with_balance.query_balances(
                     addresses=queried_addresses,

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -2011,6 +2011,27 @@ class DBHistoryEvents:
                 )
         return assets
 
+    @staticmethod
+    def get_counterparties_at_location(
+            cursor: DBCursor,
+            location: Location,
+            entry_types: Sequence[HistoryBaseEntryType],
+    ) -> set[str]:
+        """Return the distinct counterparties the user has events of `entry_types` for at
+        `location`.
+
+        One scan answering "which protocols appear at all on this chain", so a caller with a
+        long list of protocols to check can skip the ones that cannot match instead of running
+        a narrow per-protocol query only to get an empty result back.
+        """
+        placeholders = ','.join(['?'] * len(entry_types))
+        return {row[0] for row in cursor.execute(
+            'SELECT DISTINCT counterparty FROM history_events INNER JOIN chain_events_info ON '
+            'history_events.identifier=chain_events_info.identifier '
+            f'WHERE location=? AND entry_type IN ({placeholders}) AND counterparty IS NOT NULL',
+            (location.serialize_for_db(), *(x.serialize_for_db() for x in entry_types)),
+        )}
+
     def get_history_event_group_position(
             self,
             group_identifier: str,

--- a/rotkehlchen/tests/db/test_history_events.py
+++ b/rotkehlchen/tests/db/test_history_events.py
@@ -11,6 +11,7 @@ from rotkehlchen.api.v1.types import IncludeExcludeFilterData
 from rotkehlchen.chain.bitcoin.btc.constants import BTC_GROUP_IDENTIFIER_PREFIX
 from rotkehlchen.chain.bitcoin.types import BitcoinTx
 from rotkehlchen.chain.decoding.constants import CPT_GAS
+from rotkehlchen.chain.evm.decoding.aave.constants import CPT_AAVE_V3
 from rotkehlchen.chain.evm.decoding.oneinch.constants import CPT_ONEINCH_V6
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE
@@ -2223,3 +2224,69 @@ def test_delete_events_by_tx_ref_is_scoped_to_the_location(database: DBHandler) 
         assert write_cursor.execute('SELECT location FROM history_events').fetchall() == [
             (Location.BITCOIN_CASH.serialize_for_db(),),
         ]
+
+
+def test_get_counterparties_at_location_scopes_by_location_and_entry_type(
+        database: DBHandler,
+) -> None:
+    """Test that the counterparty gate only reports counterparties it can actually stand in for.
+
+    It is used to skip the per-protocol activity queries, which each filter on
+    counterparty + location + entry_type, so reporting a counterparty that is only present on
+    another chain (or on an entry type those queries never match) would keep a useless query,
+    while omitting one that is present would skip a protocol the user really holds.
+    """
+    db_events = DBHistoryEvents(database)
+    with database.user_write() as write_cursor:
+        db_events.add_history_events(
+            write_cursor=write_cursor,
+            history=[
+                make_ethereum_event(index=1, counterparty=CPT_ONEINCH_V6),
+                make_ethereum_event(index=2, counterparty=CPT_GAS),
+                make_ethereum_event(index=3, counterparty=None),
+                EvmEvent(  # same counterparty, different chain
+                    tx_ref=make_evm_tx_hash(),
+                    sequence_index=0,
+                    timestamp=TimestampMS(1),
+                    location=Location.OPTIMISM,
+                    event_type=HistoryEventType.TRADE,
+                    event_subtype=HistoryEventSubType.SPEND,
+                    asset=A_ETH,
+                    amount=ONE,
+                    counterparty=CPT_ONEINCH_V6,
+                ),
+                EvmSwapEvent(  # right chain, entry type the activity queries never match
+                    tx_ref=make_evm_tx_hash(),
+                    sequence_index=0,
+                    timestamp=TimestampMS(1),
+                    location=Location.ETHEREUM,
+                    event_type=HistoryEventType.TRADE,
+                    event_subtype=HistoryEventSubType.SPEND,
+                    asset=A_ETH,
+                    amount=ONE,
+                    counterparty=CPT_AAVE_V3,
+                ),
+            ],
+        )
+
+    with database.conn.read_ctx() as cursor:
+        assert DBHistoryEvents.get_counterparties_at_location(
+            cursor=cursor,
+            location=Location.ETHEREUM,
+            entry_types=(HistoryBaseEntryType.EVM_EVENT,),
+        ) == {CPT_ONEINCH_V6, CPT_GAS}
+        assert DBHistoryEvents.get_counterparties_at_location(
+            cursor=cursor,
+            location=Location.OPTIMISM,
+            entry_types=(HistoryBaseEntryType.EVM_EVENT,),
+        ) == {CPT_ONEINCH_V6}
+        assert DBHistoryEvents.get_counterparties_at_location(
+            cursor=cursor,
+            location=Location.ETHEREUM,
+            entry_types=(HistoryBaseEntryType.EVM_EVENT, HistoryBaseEntryType.EVM_SWAP_EVENT),
+        ) == {CPT_ONEINCH_V6, CPT_GAS, CPT_AAVE_V3}
+        assert DBHistoryEvents.get_counterparties_at_location(
+            cursor=cursor,
+            location=Location.BASE,
+            entry_types=(HistoryBaseEntryType.EVM_EVENT,),
+        ) == set()

--- a/rotkehlchen/tests/unit/test_protocol_balances.py
+++ b/rotkehlchen/tests/unit/test_protocol_balances.py
@@ -26,7 +26,11 @@ from rotkehlchen.chain.base.modules.extrafi.balances import ExtrafiBalances as E
 from rotkehlchen.chain.base.modules.morpho_blue.balances import MorphoBlueBalances
 from rotkehlchen.chain.base.modules.runmoney.balances import RunmoneyBalances
 from rotkehlchen.chain.base.modules.runmoney.constants import CPT_RUNMONEY
-from rotkehlchen.chain.ethereum.interfaces.balances import ProtocolWithBalance, ProtocolWithGauges
+from rotkehlchen.chain.ethereum.interfaces.balances import (
+    BalancesSheetType,
+    ProtocolWithBalance,
+    ProtocolWithGauges,
+)
 from rotkehlchen.chain.ethereum.modules.aave.balances import AaveBalances
 from rotkehlchen.chain.ethereum.modules.across.balances import AcrossBalances
 from rotkehlchen.chain.ethereum.modules.blur.balances import BlurBalances
@@ -134,7 +138,11 @@ from rotkehlchen.tests.utils.ethereum import (
     get_decoded_events_of_transaction,
     wait_until_all_nodes_connected,
 )
-from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
+from rotkehlchen.tests.utils.factories import (
+    make_ethereum_event,
+    make_evm_address,
+    make_evm_tx_hash,
+)
 from rotkehlchen.types import (
     CacheType,
     ChainID,
@@ -157,11 +165,14 @@ if TYPE_CHECKING:
     from rotkehlchen.chain.base.node_inquirer import BaseInquirer
     from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
+    from rotkehlchen.chain.evm.decoding.decoder import EVMTransactionDecoder
+    from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
     from rotkehlchen.chain.evm.tokens import TokenBalancesType
     from rotkehlchen.chain.gnosis.node_inquirer import GnosisInquirer
     from rotkehlchen.chain.hyperliquid.node_inquirer import HyperliquidInquirer
     from rotkehlchen.chain.optimism.decoding.decoder import OptimismTransactionDecoder
     from rotkehlchen.chain.optimism.node_inquirer import OptimismInquirer
+    from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.inquirer import Inquirer
 
 
@@ -1872,3 +1883,163 @@ def test_kinetiq_earn_pending_withdrawal_balances(
     )
     khype = Asset('eip155:999/erc20:0xfD739d4e423301CE9385c1fb8850539D657C296D')
     assert protocol_balances[hyperliquid_accounts[0]].assets[khype][CPT_KINETIQ] == expected_balance  # noqa: E501
+
+
+class _GateProbeBalances(ProtocolWithBalance):
+    """Minimal concrete protocol used to exercise the counterparty gate on its own."""
+
+    def query_balances(self, addresses: list[ChecksumEvmAddress]) -> BalancesSheetType:
+        raise NotImplementedError  # the gate lives in addresses_with_activity
+
+
+def _make_gate_probe(database: DBHandler, counterparty: str) -> _GateProbeBalances:
+    return _GateProbeBalances(
+        evm_inquirer=Mock(database=database, chain_id=ChainID.ETHEREUM),
+        tx_decoder=Mock(),
+        counterparty=counterparty,  # type: ignore[arg-type]  # any string works at runtime
+        deposit_event_types={(HistoryEventType.DEPOSIT, HistoryEventSubType.DEPOSIT_ASSET)},
+    )
+
+
+def test_activity_query_is_gated_by_the_chain_counterparties(database: DBHandler) -> None:
+    """Test the seam that lets a balance refresh cost one events query per chain.
+
+    Every protocol opens its balance query with addresses_with_activity, so what is asserted
+    here is that a counterparty absent from the chain's set skips the DB entirely, that a
+    present one is unaffected, and that not supplying a set at all (the default for anything
+    constructing these classes on its own) leaves every query running.
+    """
+    user_address = make_evm_address()
+    with database.user_write() as write_cursor:
+        DBHistoryEvents(database).add_history_events(
+            write_cursor=write_cursor,
+            history=[make_ethereum_event(
+                index=1,
+                location_label=user_address,
+                counterparty=CPT_OCTANT,
+                event_type=HistoryEventType.DEPOSIT,
+                event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
+            )],
+        )
+
+    def activity_of(counterparty: str, gate: set[str] | None) -> tuple[dict, int]:
+        probe = _make_gate_probe(database=database, counterparty=counterparty)
+        probe.chain_counterparties = gate
+        with patch.object(
+            DBHistoryEvents,
+            'get_history_events_internal',
+            side_effect=DBHistoryEvents.get_history_events_internal,
+            autospec=True,
+        ) as query_mock:
+            result = probe.addresses_with_deposits(location_labels=[user_address])
+        return result, query_mock.call_count
+
+    gate = {CPT_OCTANT}
+    # present in the gate: queried, and the events come back
+    result, calls = activity_of(CPT_OCTANT, gate)
+    assert list(result) == [user_address]
+    assert calls == 1
+
+    # absent from the gate: no query at all
+    result, calls = activity_of(CPT_BLUR, gate)
+    assert result == {}
+    assert calls == 0
+
+    # no gate supplied: the query runs even though it comes back empty
+    result, calls = activity_of(CPT_BLUR, None)
+    assert result == {}
+    assert calls == 1
+
+
+def test_query_protocols_with_balance_hands_down_the_chain_counterparties(
+        blockchain: ChainsAggregator,
+) -> None:
+    """Test that the manager reads the chain's counterparties once and passes them on.
+
+    Without this the gate in addresses_with_activity is never armed in production, and every
+    protocol keeps paying for its own query - which the per-protocol tests would not notice,
+    since they construct the balance classes directly.
+    """
+    with blockchain.database.user_write() as write_cursor:
+        DBHistoryEvents(blockchain.database).add_history_events(
+            write_cursor=write_cursor,
+            history=[make_ethereum_event(
+                index=1,
+                location_label=make_evm_address(),
+                counterparty=CPT_OCTANT,
+                event_type=HistoryEventType.DEPOSIT,
+                event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
+            )],
+        )
+
+    received: list[set[str] | None] = []
+
+    class _RecordingBalances(ProtocolWithBalance):
+        def __init__(
+                self,
+                evm_inquirer: EvmNodeInquirer,
+                tx_decoder: EVMTransactionDecoder,
+        ) -> None:
+            super().__init__(
+                evm_inquirer=evm_inquirer,
+                tx_decoder=tx_decoder,
+                counterparty=CPT_OCTANT,
+                deposit_event_types=set(),
+            )
+
+        def query_balances(self, addresses: list[ChecksumEvmAddress]) -> BalancesSheetType:
+            received.append(self.chain_counterparties)
+            return {}
+
+    with patch.dict(
+        'rotkehlchen.chain.evm.manager.CHAIN_TO_BALANCE_PROTOCOLS',
+        {ChainID.ETHEREUM: (_RecordingBalances,)},
+    ):
+        blockchain.get_evm_manager(chain_id=ChainID.ETHEREUM).query_protocols_with_balance(
+            balances=defaultdict(BalanceSheet),
+            addresses=[],
+        )
+
+    assert received == [{CPT_OCTANT}]
+
+
+def test_protocol_balances_skip_the_events_query_for_absent_counterparties(
+        blockchain: ChainsAggregator,
+) -> None:
+    """Test that a refresh only queries the events table for protocols the user has.
+
+    This is the whole point of the gate, and it is asserted over the real ethereum protocol
+    list rather than a stub so that a protocol added later without routing its event lookup
+    through the gate shows up here. The second half is the control: with one protocol's events
+    present that protocol must still query, or the gate would be switching everything off.
+    """
+    manager = blockchain.get_evm_manager(chain_id=ChainID.ETHEREUM)
+
+    def refresh_query_count() -> int:
+        with patch.object(
+            DBHistoryEvents,
+            'get_history_events_internal',
+            side_effect=DBHistoryEvents.get_history_events_internal,
+            autospec=True,
+        ) as spy:
+            manager.query_protocols_with_balance(
+                balances=defaultdict(BalanceSheet),
+                addresses=[],
+            )
+        return spy.call_count
+
+    assert refresh_query_count() == 0
+
+    with blockchain.database.user_write() as write_cursor:
+        DBHistoryEvents(blockchain.database).add_history_events(
+            write_cursor=write_cursor,
+            history=[make_ethereum_event(
+                index=1,
+                location_label=make_evm_address(),
+                counterparty=CPT_OCTANT,
+                event_type=HistoryEventType.DEPOSIT,
+                event_subtype=HistoryEventSubType.DEPOSIT_ASSET,
+            )],
+        )
+
+    assert refresh_query_count() == 1


### PR DESCRIPTION
Every protocol in CHAIN_TO_BALANCE_PROTOCOLS opened its balance query with its own addresses_with_activity call - an events query filtering on counterparty + location + entry_type - before it could find out it had nothing to do. On ethereum that is 18 protocols, so a refresh cost 23 scans of the events table for a user who may hold none of those positions, and it repeats per chain on every refresh and every periodic snapshot.

query_protocols_with_balance now reads the chain's counterparties once via the new DBHistoryEvents.get_counterparties_at_location and hands the set to each protocol, which skips its query when its counterparty is absent. The gate is only ever a superset of what it short-circuits: it is computed over the same location and entry types those queries filter on, with the entry type list shared as ACTIVITY_ENTRY_TYPES so the two cannot drift. None means unknown rather than none, so anything constructing a balance class on its own keeps querying as before.

Counting real get_history_events_internal calls through the ethereum protocol list with no protocol events present: 23 queries before, 0 after plus the single gate query. On a 200k event database that is about 0.54s of query time per refresh replaced by 0.03s.

Curve and eigenlayer build one more counterparty filtered query each outside addresses_with_activity, so they take the same guard. LidoCsm is left alone: it reads its own node operator table rather than events, so the gate's premise does not hold there.
