### PR TITLE
test(frontend): coverage batch A, extract then test four SFCs

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3311,6 +3311,7 @@
       "auth_failed": "Failed to start authentication flow",
       "authorizing": "Authorizing",
       "connect_to_google": "Connect to Google Calendar",
+      "connected_as": "Connected as {email}",
       "connected_status": "Successfully connected to Google Calendar",
       "description": "Sync rotki calendar events (ENS expirations, CRV locks, airdrops, etc.) to your Google Calendar for notifications and reminders.",
       "disconnect": "Disconnect",

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -6269,7 +6269,6 @@
       "title": "Select Asset"
     },
     "to_address": {
-      "error": "Please input valid ETH address",
       "label": "To address"
     },
     "waiting_for_confirmation": {

--- a/frontend/app/src/locales/ru.json
+++ b/frontend/app/src/locales/ru.json
@@ -4493,7 +4493,6 @@
       "title": "Выберите актив"
     },
     "to_address": {
-      "error": "Пожалуйста, введите корректный адрес ETH",
       "label": "На адрес"
     },
     "waiting_for_confirmation": {

--- a/frontend/app/src/modules/calendar/GoogleCalendarIntegration.spec.ts
+++ b/frontend/app/src/modules/calendar/GoogleCalendarIntegration.spec.ts
@@ -1,0 +1,173 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+import GoogleCalendarIntegration from '@/modules/calendar/GoogleCalendarIntegration.vue';
+
+/**
+ * The seam: this component is wiring. On mount it reads the status and registers the OAuth handler,
+ * on unmount it takes that same handler back off. It shows the connected half or the connect half,
+ * offers the manual token form only where there is no callback channel, and routes clicks to the
+ * composable, which `use-google-calendar-integration.spec.ts` covers.
+ */
+
+const { interop } = vi.hoisted(() => ({ interop: { isPackaged: false, openUrl: vi.fn() } }));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): typeof interop => interop,
+}));
+
+const registerOAuthCallbackHandler = vi.fn();
+const unregisterOAuthCallbackHandler = vi.fn();
+
+vi.mock('@/modules/shell/app/use-backend-messages', () => ({
+  useBackendMessages: (): {
+    registerOAuthCallbackHandler: typeof registerOAuthCallbackHandler;
+    unregisterOAuthCallbackHandler: typeof unregisterOAuthCallbackHandler;
+  } => ({ registerOAuthCallbackHandler, unregisterOAuthCallbackHandler }),
+}));
+
+const handleOAuthCallback = vi.fn();
+
+const calendarApi = {
+  cancelAuthorization: vi.fn(),
+  cancelTokenInput: vi.fn(),
+  checkStatus: vi.fn(async () => Promise.resolve()),
+  connect: vi.fn(async () => Promise.resolve()),
+  connectedUserEmail: ref<string>(''),
+  disconnect: vi.fn(async () => Promise.resolve()),
+  handleOAuthCallback,
+  isAuthorizing: ref<boolean>(false),
+  isConnected: ref<boolean>(false),
+  isSyncing: ref<boolean>(false),
+  modelManualRefreshToken: ref<string>(''),
+  modelManualToken: ref<string>(''),
+  showTokenInput: ref<boolean>(false),
+  submitManualToken: vi.fn(async () => Promise.resolve()),
+  sync: vi.fn(async () => Promise.resolve()),
+};
+
+vi.mock('@/modules/calendar/use-google-calendar-integration', () => ({
+  useGoogleCalendarIntegration: (): typeof calendarApi => calendarApi,
+}));
+
+describe('googleCalendarIntegration', () => {
+  let wrapper: VueWrapper<InstanceType<typeof GoogleCalendarIntegration>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    interop.isPackaged = false;
+    set(calendarApi.isConnected, false);
+    set(calendarApi.isAuthorizing, false);
+    set(calendarApi.isSyncing, false);
+    set(calendarApi.showTokenInput, false);
+    set(calendarApi.connectedUserEmail, '');
+    set(calendarApi.modelManualToken, '');
+    set(calendarApi.modelManualRefreshToken, '');
+    wrapper = mount(GoogleCalendarIntegration);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('should read the status and listen for the callback while it is mounted', () => {
+    expect(calendarApi.checkStatus).toHaveBeenCalledOnce();
+    expect(registerOAuthCallbackHandler).toHaveBeenCalledWith(handleOAuthCallback);
+    expect(unregisterOAuthCallbackHandler).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+
+    // The same handler has to come back off, or the next mount stacks another one on top.
+    expect(unregisterOAuthCallbackHandler).toHaveBeenCalledWith(handleOAuthCallback);
+  });
+
+  it('should offer to connect while disconnected', async () => {
+    expect(wrapper.find('[data-testid=google-calendar-sync]').exists()).toBe(false);
+
+    await wrapper.find('[data-testid=google-calendar-connect]').trigger('click');
+
+    expect(calendarApi.connect).toHaveBeenCalledOnce();
+  });
+
+  it('should offer to cancel only while authorizing', async () => {
+    expect(wrapper.find('[data-testid=google-calendar-cancel-authorization]').exists()).toBe(false);
+
+    set(calendarApi.isAuthorizing, true);
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=google-calendar-connect]').attributes('disabled')).toBeDefined();
+    await wrapper.find('[data-testid=google-calendar-cancel-authorization]').trigger('click');
+
+    expect(calendarApi.cancelAuthorization).toHaveBeenCalledOnce();
+  });
+
+  describe('the manual token form', () => {
+    beforeEach(async () => {
+      set(calendarApi.showTokenInput, true);
+      await nextTick();
+    });
+
+    it('should stay hidden in the packaged app, which gets the tokens back over ipc', async () => {
+      wrapper.unmount();
+      interop.isPackaged = true;
+      wrapper = mount(GoogleCalendarIntegration);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=google-calendar-access-token]').exists()).toBe(false);
+    });
+
+    it('should refuse to submit until both tokens are filled in', async () => {
+      expect(wrapper.find('[data-testid=google-calendar-submit-token]').attributes('disabled')).toBeDefined();
+
+      set(calendarApi.modelManualToken, 'access');
+      await nextTick();
+      expect(wrapper.find('[data-testid=google-calendar-submit-token]').attributes('disabled')).toBeDefined();
+
+      set(calendarApi.modelManualRefreshToken, 'refresh');
+      await nextTick();
+      expect(wrapper.find('[data-testid=google-calendar-submit-token]').attributes('disabled')).toBeUndefined();
+
+      await wrapper.find('[data-testid=google-calendar-submit-token]').trigger('click');
+      expect(calendarApi.submitManualToken).toHaveBeenCalledOnce();
+    });
+
+    it('should hand the cancel back to the composable', async () => {
+      await wrapper.find('[data-testid=google-calendar-cancel-token]').trigger('click');
+
+      expect(calendarApi.cancelTokenInput).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('once connected', () => {
+    beforeEach(async () => {
+      set(calendarApi.isConnected, true);
+      await nextTick();
+    });
+
+    it('should name the connected account when the backend reported one', async () => {
+      expect(wrapper.find('[data-testid=google-calendar-status]').text())
+        .toBe('external_services.google_calendar.connected_status');
+
+      set(calendarApi.connectedUserEmail, 'someone@example.com');
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=google-calendar-status]').text()).toContain('someone@example.com');
+    });
+
+    it('should sync and disconnect through the composable', async () => {
+      await wrapper.find('[data-testid=google-calendar-sync]').trigger('click');
+      await wrapper.find('[data-testid=google-calendar-disconnect]').trigger('click');
+
+      expect(calendarApi.sync).toHaveBeenCalledOnce();
+      expect(calendarApi.disconnect).toHaveBeenCalledOnce();
+      expect(wrapper.find('[data-testid=google-calendar-connect]').exists()).toBe(false);
+    });
+
+    it('should hold the sync button while a sync is running', async () => {
+      set(calendarApi.isSyncing, true);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=google-calendar-sync]').attributes('disabled')).toBeDefined();
+    });
+  });
+});

--- a/frontend/app/src/modules/calendar/GoogleCalendarIntegration.vue
+++ b/frontend/app/src/modules/calendar/GoogleCalendarIntegration.vue
@@ -151,7 +151,9 @@ onUnmounted(() => {
           class="text-body-2"
           data-testid="google-calendar-status"
         >
-          {{ connectedUserEmail ? `Connected as ${connectedUserEmail}` : t('external_services.google_calendar.connected_status') }}
+          {{ connectedUserEmail
+            ? t('external_services.google_calendar.connected_as', { email: connectedUserEmail })
+            : t('external_services.google_calendar.connected_status') }}
         </span>
       </div>
 

--- a/frontend/app/src/modules/calendar/GoogleCalendarIntegration.vue
+++ b/frontend/app/src/modules/calendar/GoogleCalendarIntegration.vue
@@ -1,229 +1,34 @@
 <script setup lang="ts">
-import type { OAuthResult } from '@shared/ipc';
-import { Severity } from '@rotki/common';
-import { get, set } from '@vueuse/core';
-import { onMounted, onUnmounted, ref } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { logger } from '@/modules/core/common/logging/logging';
-import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
-import { useGoogleCalendarApi } from '@/modules/settings/api/use-google-calendar-api';
+import { startPromise } from '@shared/utils';
+import { useGoogleCalendarIntegration } from '@/modules/calendar/use-google-calendar-integration';
 import { useBackendMessages } from '@/modules/shell/app/use-backend-messages';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
 
 const { t } = useI18n({ useScope: 'global' });
 
-const websiteUrl = import.meta.env.VITE_ROTKI_WEBSITE_URL;
-
-const googleCalendarApi = useGoogleCalendarApi();
-const { notify } = useNotificationDispatcher();
-const { isPackaged, openUrl } = useInterop();
+const { isPackaged } = useInterop();
 const { registerOAuthCallbackHandler, unregisterOAuthCallbackHandler } = useBackendMessages();
-const isConnected = ref(false);
-const isSyncing = ref(false);
-const isAuthorizing = ref(false);
-const connectedUserEmail = ref<string>('');
-const manualToken = ref<string>('');
-const manualRefreshToken = ref<string>('');
-const showTokenInput = ref(false);
 
-async function checkGoogleCalendarStatus() {
-  try {
-    const response = await googleCalendarApi.getStatus();
-    set(isConnected, response.authenticated);
-
-    // Update the connected user email
-    if (response.authenticated && response.userEmail) {
-      set(connectedUserEmail, response.userEmail);
-    }
-    else {
-      set(connectedUserEmail, '');
-    }
-  }
-  catch (error: unknown) {
-    logger.error('Failed to check Google Calendar status:', error);
-  }
-}
-
-async function connectToGoogle() {
-  set(isAuthorizing, true);
-  try {
-    // Determine mode based on environment
-    const mode = isPackaged ? 'app' : 'docker';
-    const oauthUrl = `${websiteUrl}/oauth/google?mode=${mode}`;
-
-    if (isPackaged) {
-      await openUrl(oauthUrl);
-    }
-    else {
-      // Docker mode - open OAuth page in new tab for manual token copy
-      window.open(oauthUrl, '_blank');
-      set(isAuthorizing, false); // Reset loading state immediately
-      set(showTokenInput, true); // Show manual token input
-    }
-
-    notify({
-      display: true,
-      message: t('external_services.google_calendar.opening_browser'),
-      severity: Severity.INFO,
-      title: t('external_services.google_calendar.authorizing'),
-    });
-  }
-  catch (error: unknown) {
-    notify({
-      display: true,
-      message: getErrorMessage(error) || t('external_services.google_calendar.auth_failed'),
-      severity: Severity.ERROR,
-      title: t('external_services.google_calendar.error'),
-    });
-    set(isAuthorizing, false);
-  }
-}
-
-function notifyOAuthError(error: unknown): void {
-  logger.error('OAuth failed:', error);
-  notify({
-    display: true,
-    message: getErrorMessage(error) || t('external_services.google_calendar.auth_failed'),
-    severity: Severity.ERROR,
-    title: t('external_services.google_calendar.error'),
-  });
-}
-
-async function handleOAuthCallback(oAuthResult: OAuthResult): Promise<void> {
-  if (oAuthResult.service !== 'google')
-    return;
-
-  try {
-    if (!oAuthResult.success) {
-      notifyOAuthError(oAuthResult.error);
-      return;
-    }
-
-    const { accessToken, refreshToken } = oAuthResult;
-    if (!refreshToken) {
-      notify({
-        display: true,
-        message: t('external_services.google_calendar.auth_failed'),
-        severity: Severity.ERROR,
-        title: t('external_services.google_calendar.error'),
-      });
-      return;
-    }
-    const result = await googleCalendarApi.completeOAuth(accessToken, refreshToken);
-    logger.debug('received oauth result', result);
-
-    if (result.success) {
-      set(isConnected, true);
-
-      const userEmail = result.userEmail || '';
-      set(connectedUserEmail, userEmail);
-
-      await checkGoogleCalendarStatus();
-    }
-    else {
-      notifyOAuthError(result);
-    }
-  }
-  catch (error: unknown) {
-    notifyOAuthError(error);
-  }
-  finally {
-    set(isAuthorizing, false);
-  }
-}
-
-async function syncCalendar() {
-  set(isSyncing, true);
-  try {
-    const result = await googleCalendarApi.syncCalendar();
-
-    // Show appropriate message based on results
-    let message: string;
-    const severity = Severity.INFO;
-
-    if (result.eventsProcessed === 0) {
-      message = t('external_services.google_calendar.no_events_to_sync');
-    }
-    else {
-      message = t('external_services.google_calendar.sync_complete', {
-        created: result.eventsCreated || 0,
-        total: result.eventsProcessed || 0,
-        updated: result.eventsUpdated || 0,
-      });
-    }
-
-    notify({
-      display: true,
-      message,
-      severity,
-      title: t('external_services.google_calendar.success'),
-    });
-  }
-  catch (error: unknown) {
-    notify({
-      display: true,
-      message: getErrorMessage(error) || t('external_services.google_calendar.sync_failed'),
-      severity: Severity.ERROR,
-      title: t('external_services.google_calendar.error'),
-    });
-  }
-  finally {
-    set(isSyncing, false);
-  }
-}
-
-async function submitManualToken() {
-  if (!get(manualToken).trim()) {
-    notify({
-      display: true,
-      message: t('external_services.google_calendar.token_required'),
-      severity: Severity.ERROR,
-      title: t('external_services.google_calendar.error'),
-    });
-    return;
-  }
-
-  set(isAuthorizing, true);
-  try {
-    await handleOAuthCallback({
-      accessToken: get(manualToken).trim(),
-      refreshToken: get(manualRefreshToken).trim(),
-      service: 'google',
-      success: true,
-    });
-    set(manualToken, '');
-    set(showTokenInput, false);
-  }
-  finally {
-    set(isAuthorizing, false);
-  }
-}
-
-function cancelTokenInput() {
-  set(manualToken, '');
-  set(showTokenInput, false);
-}
-
-async function disconnect() {
-  try {
-    await googleCalendarApi.disconnect();
-    set(isConnected, false);
-    set(connectedUserEmail, '');
-  }
-  catch (error: unknown) {
-    notify({
-      display: true,
-      message: getErrorMessage(error) || t('external_services.google_calendar.disconnect_failed'),
-      severity: Severity.ERROR,
-      title: t('external_services.google_calendar.error'),
-    });
-  }
-}
+const {
+  cancelAuthorization,
+  cancelTokenInput,
+  checkStatus,
+  connect,
+  connectedUserEmail,
+  disconnect,
+  handleOAuthCallback,
+  isAuthorizing,
+  isConnected,
+  isSyncing,
+  modelManualRefreshToken,
+  modelManualToken,
+  showTokenInput,
+  submitManualToken,
+  sync,
+} = useGoogleCalendarIntegration();
 
 onMounted(() => {
-  checkGoogleCalendarStatus();
-
+  startPromise(checkStatus());
   registerOAuthCallbackHandler(handleOAuthCallback);
 });
 
@@ -249,9 +54,10 @@ onUnmounted(() => {
         <RuiButton
           color="primary"
           size="sm"
+          data-testid="google-calendar-connect"
           :disabled="isAuthorizing"
           :loading="isAuthorizing"
-          @click="connectToGoogle()"
+          @click="connect()"
         >
           <template #prepend>
             <RuiIcon
@@ -267,7 +73,8 @@ onUnmounted(() => {
           color="primary"
           size="sm"
           variant="outlined"
-          @click="isAuthorizing = false"
+          data-testid="google-calendar-cancel-authorization"
+          @click="cancelAuthorization()"
         >
           {{ t('common.actions.cancel') }}
         </RuiButton>
@@ -282,7 +89,8 @@ onUnmounted(() => {
           {{ t('external_services.google_calendar.paste_token_instruction') }}
         </div>
         <RuiTextArea
-          v-model="manualToken"
+          v-model="modelManualToken"
+          data-testid="google-calendar-access-token"
           :label="t('external_services.google_calendar.access_token')"
           placeholder="ya29.a0AfH6..."
           variant="outlined"
@@ -291,7 +99,8 @@ onUnmounted(() => {
           dense
         />
         <RuiTextArea
-          v-model="manualRefreshToken"
+          v-model="modelManualRefreshToken"
+          data-testid="google-calendar-refresh-token"
           :label="t('external_services.google_calendar.refresh_token')"
           placeholder="1//04abc..."
           variant="outlined"
@@ -303,7 +112,8 @@ onUnmounted(() => {
           <RuiButton
             color="primary"
             size="sm"
-            :disabled="isAuthorizing || !manualToken.trim() || !manualRefreshToken.trim()"
+            data-testid="google-calendar-submit-token"
+            :disabled="isAuthorizing || !modelManualToken.trim() || !modelManualRefreshToken.trim()"
             :loading="isAuthorizing"
             @click="submitManualToken()"
           >
@@ -318,6 +128,7 @@ onUnmounted(() => {
           <RuiButton
             variant="outlined"
             size="sm"
+            data-testid="google-calendar-cancel-token"
             :disabled="isAuthorizing"
             @click="cancelTokenInput()"
           >
@@ -336,7 +147,10 @@ onUnmounted(() => {
           name="lu-circle-check"
           size="16"
         />
-        <span class="text-body-2">
+        <span
+          class="text-body-2"
+          data-testid="google-calendar-status"
+        >
           {{ connectedUserEmail ? `Connected as ${connectedUserEmail}` : t('external_services.google_calendar.connected_status') }}
         </span>
       </div>
@@ -346,9 +160,10 @@ onUnmounted(() => {
           color="primary"
           variant="outlined"
           size="sm"
+          data-testid="google-calendar-sync"
           :loading="isSyncing"
           :disabled="isSyncing"
-          @click="syncCalendar()"
+          @click="sync()"
         >
           <template #prepend>
             <RuiIcon
@@ -363,6 +178,7 @@ onUnmounted(() => {
           color="error"
           variant="outlined"
           size="sm"
+          data-testid="google-calendar-disconnect"
           @click="disconnect()"
         >
           {{ t('external_services.google_calendar.disconnect') }}

--- a/frontend/app/src/modules/calendar/use-google-calendar-integration.spec.ts
+++ b/frontend/app/src/modules/calendar/use-google-calendar-integration.spec.ts
@@ -1,0 +1,254 @@
+import type { GoogleCalendarAuthResult, GoogleCalendarStatus, GoogleCalendarSyncResult } from '@/modules/settings/types/google-calendar';
+import { Severity } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGoogleCalendarIntegration } from '@/modules/calendar/use-google-calendar-integration';
+
+/**
+ * The seam: connecting to Google has two shapes, and this decides which one runs. The packaged app
+ * hands the tokens back over IPC, everywhere else they are pasted in and take the same path. Every
+ * failure is reported, and the flags the buttons read are always put back.
+ */
+
+const notify = vi.fn();
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): { notify: typeof notify } => ({ notify }),
+}));
+
+const completeOAuth = vi.fn<(accessToken: string, refreshToken: string) => Promise<GoogleCalendarAuthResult>>();
+const disconnectApi = vi.fn<() => Promise<{ success: boolean }>>();
+const getStatus = vi.fn<() => Promise<GoogleCalendarStatus>>();
+const syncCalendar = vi.fn<() => Promise<GoogleCalendarSyncResult>>();
+
+const calendarApi = { completeOAuth, disconnect: disconnectApi, getStatus, syncCalendar };
+
+vi.mock('@/modules/settings/api/use-google-calendar-api', () => ({
+  useGoogleCalendarApi: (): typeof calendarApi => calendarApi,
+}));
+
+// `logging.ts` calls `useInterop()` while it is being imported, so the stub has to exist before
+// any import runs.
+const { interop, openUrl } = vi.hoisted(() => {
+  const openUrl = vi.fn<(url: string) => Promise<void>>();
+  return { interop: { isPackaged: false, openUrl }, openUrl };
+});
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): typeof interop => interop,
+}));
+
+describe('useGoogleCalendarIntegration', () => {
+  let calendar: ReturnType<typeof useGoogleCalendarIntegration>;
+
+  /** `isPackaged` is read when the composable is created, so it has to be set before that. */
+  function usePackagedApp(): ReturnType<typeof useGoogleCalendarIntegration> {
+    interop.isPackaged = true;
+    return useGoogleCalendarIntegration();
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    interop.isPackaged = false;
+    getStatus.mockResolvedValue({ authenticated: false });
+    completeOAuth.mockResolvedValue({ message: 'connected', success: true, userEmail: 'someone@example.com' });
+    syncCalendar.mockResolvedValue({ calendarId: 'primary', eventsCreated: 0, eventsProcessed: 0, eventsUpdated: 0 });
+    disconnectApi.mockResolvedValue({ success: true });
+    calendar = useGoogleCalendarIntegration();
+  });
+
+  describe('checkStatus', () => {
+    it('should take the account the backend reports', async () => {
+      getStatus.mockResolvedValue({ authenticated: true, userEmail: 'someone@example.com' });
+
+      await calendar.checkStatus();
+
+      expect(get(calendar.isConnected)).toBe(true);
+      expect(get(calendar.connectedUserEmail)).toBe('someone@example.com');
+    });
+
+    it('should forget the account when the backend reports none', async () => {
+      getStatus.mockResolvedValue({ authenticated: false, userEmail: 'stale@example.com' });
+
+      await calendar.checkStatus();
+
+      expect(get(calendar.isConnected)).toBe(false);
+      expect(get(calendar.connectedUserEmail)).toBe('');
+    });
+
+    it('should stay quiet when the status cannot be read', async () => {
+      getStatus.mockRejectedValue(new Error('offline'));
+
+      await calendar.checkStatus();
+
+      expect(get(calendar.isConnected)).toBe(false);
+      expect(notify).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('connect', () => {
+    it('should hand the consent page to the desktop browser when packaged', async () => {
+      calendar = usePackagedApp();
+
+      await calendar.connect();
+
+      expect(openUrl).toHaveBeenCalledWith(expect.stringContaining('/oauth/google?mode=app'));
+      // Still authorizing: the packaged app waits for the tokens to come back over IPC.
+      expect(get(calendar.isAuthorizing)).toBe(true);
+      expect(get(calendar.showTokenInput)).toBe(false);
+    });
+
+    it('should ask for the tokens by hand when there is no callback channel', async () => {
+      const open = vi.spyOn(window, 'open').mockReturnValue(null);
+
+      await calendar.connect();
+
+      expect(open).toHaveBeenCalledWith(expect.stringContaining('/oauth/google?mode=docker'), '_blank');
+      expect(get(calendar.showTokenInput)).toBe(true);
+      expect(get(calendar.isAuthorizing)).toBe(false);
+      expect(openUrl).not.toHaveBeenCalled();
+    });
+
+    it('should report a failure to open the consent page and stop authorizing', async () => {
+      calendar = usePackagedApp();
+      openUrl.mockRejectedValue(new Error('no browser'));
+
+      await calendar.connect();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'no browser', severity: Severity.ERROR }));
+      expect(get(calendar.isAuthorizing)).toBe(false);
+    });
+  });
+
+  describe('handleOAuthCallback', () => {
+    it('should ignore a callback for another service', async () => {
+      await calendar.handleOAuthCallback({ accessToken: 'a', refreshToken: 'r', service: 'monerium', success: true });
+
+      expect(completeOAuth).not.toHaveBeenCalled();
+    });
+
+    it('should complete the authorization and re-read the status', async () => {
+      getStatus.mockResolvedValue({ authenticated: true, userEmail: 'someone@example.com' });
+
+      await calendar.handleOAuthCallback({ accessToken: 'a', refreshToken: 'r', service: 'google', success: true });
+
+      expect(completeOAuth).toHaveBeenCalledWith('a', 'r');
+      expect(getStatus).toHaveBeenCalledOnce();
+      expect(get(calendar.isConnected)).toBe(true);
+      expect(get(calendar.connectedUserEmail)).toBe('someone@example.com');
+      expect(get(calendar.isAuthorizing)).toBe(false);
+    });
+
+    it('should report the error a failed callback carries', async () => {
+      await calendar.handleOAuthCallback({ error: new Error('denied'), service: 'google', success: false });
+
+      expect(completeOAuth).not.toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'denied', severity: Severity.ERROR }));
+    });
+
+    it('should refuse a success without a refresh token', async () => {
+      await calendar.handleOAuthCallback({ accessToken: 'a', service: 'google', success: true });
+
+      expect(completeOAuth).not.toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'external_services.google_calendar.auth_failed',
+      }));
+    });
+
+    it('should report a rejected exchange and stop authorizing', async () => {
+      completeOAuth.mockRejectedValue(new Error('backend said no'));
+
+      await calendar.handleOAuthCallback({ accessToken: 'a', refreshToken: 'r', service: 'google', success: true });
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'backend said no' }));
+      expect(get(calendar.isConnected)).toBe(false);
+      expect(get(calendar.isAuthorizing)).toBe(false);
+    });
+
+    it('should not connect when the exchange itself reports failure', async () => {
+      completeOAuth.mockResolvedValue({ message: 'token rejected', success: false });
+
+      await calendar.handleOAuthCallback({ accessToken: 'a', refreshToken: 'r', service: 'google', success: true });
+
+      expect(get(calendar.isConnected)).toBe(false);
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ severity: Severity.ERROR }));
+    });
+  });
+
+  describe('submitManualToken', () => {
+    it('should refuse a blank access token', async () => {
+      set(calendar.modelManualToken, '   ');
+
+      await calendar.submitManualToken();
+
+      expect(completeOAuth).not.toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'external_services.google_calendar.token_required',
+      }));
+    });
+
+    it('should send the trimmed tokens and put the form away', async () => {
+      set(calendar.modelManualToken, '  access  ');
+      set(calendar.modelManualRefreshToken, '  refresh  ');
+
+      await calendar.submitManualToken();
+
+      expect(completeOAuth).toHaveBeenCalledWith('access', 'refresh');
+      expect(get(calendar.modelManualToken)).toBe('');
+      expect(get(calendar.showTokenInput)).toBe(false);
+      expect(get(calendar.isAuthorizing)).toBe(false);
+    });
+  });
+
+  describe('sync', () => {
+    it('should say what was synced', async () => {
+      syncCalendar.mockResolvedValue({ calendarId: 'primary', eventsCreated: 2, eventsProcessed: 3, eventsUpdated: 1 });
+
+      await calendar.sync();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining('external_services.google_calendar.sync_complete'),
+        severity: Severity.INFO,
+      }));
+      expect(get(calendar.isSyncing)).toBe(false);
+    });
+
+    it('should say when there was nothing to sync', async () => {
+      await calendar.sync();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'external_services.google_calendar.no_events_to_sync',
+      }));
+    });
+
+    it('should report a failed sync and stop syncing', async () => {
+      syncCalendar.mockRejectedValue(new Error('sync broke'));
+
+      await calendar.sync();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'sync broke', severity: Severity.ERROR }));
+      expect(get(calendar.isSyncing)).toBe(false);
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should forget the connection', async () => {
+      getStatus.mockResolvedValue({ authenticated: true, userEmail: 'someone@example.com' });
+      await calendar.checkStatus();
+
+      await calendar.disconnect();
+
+      expect(get(calendar.isConnected)).toBe(false);
+      expect(get(calendar.connectedUserEmail)).toBe('');
+    });
+
+    it('should keep the connection when disconnecting fails', async () => {
+      getStatus.mockResolvedValue({ authenticated: true, userEmail: 'someone@example.com' });
+      await calendar.checkStatus();
+      disconnectApi.mockRejectedValue(new Error('still connected'));
+
+      await calendar.disconnect();
+
+      expect(get(calendar.isConnected)).toBe(true);
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'still connected' }));
+    });
+  });
+});

--- a/frontend/app/src/modules/calendar/use-google-calendar-integration.ts
+++ b/frontend/app/src/modules/calendar/use-google-calendar-integration.ts
@@ -1,0 +1,235 @@
+import type { OAuthResult } from '@shared/ipc';
+import type { Ref } from 'vue';
+import { Severity } from '@rotki/common';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { useGoogleCalendarApi } from '@/modules/settings/api/use-google-calendar-api';
+import { useInterop } from '@/modules/shell/app/use-electron-interop';
+
+interface UseGoogleCalendarIntegrationReturn {
+  /** Both bound with `v-model` by the manual token fields, so they stay writable. */
+  modelManualToken: Ref<string>;
+  modelManualRefreshToken: Ref<string>;
+  isConnected: Readonly<Ref<boolean>>;
+  isSyncing: Readonly<Ref<boolean>>;
+  isAuthorizing: Readonly<Ref<boolean>>;
+  /** The account the backend reports, empty when it reports none. */
+  connectedUserEmail: Readonly<Ref<string>>;
+  /** Only the packaged app gets the tokens back over IPC; elsewhere they are pasted in. */
+  showTokenInput: Readonly<Ref<boolean>>;
+  checkStatus: () => Promise<void>;
+  connect: () => Promise<void>;
+  cancelAuthorization: () => void;
+  /** Handed to the backend message bus, which calls it for every service. */
+  handleOAuthCallback: (oAuthResult: OAuthResult) => Promise<void>;
+  submitManualToken: () => Promise<void>;
+  cancelTokenInput: () => void;
+  sync: () => Promise<void>;
+  disconnect: () => Promise<void>;
+}
+
+/**
+ * Connecting rotki to a Google calendar, and syncing to it.
+ *
+ * The authorization has two shapes. The packaged app opens the consent page in the system browser
+ * and is handed the tokens back over IPC, so `handleOAuthCallback` finishes the job. Anywhere else
+ * (docker, web) there is no callback channel: the page opens in a tab and the user pastes the two
+ * tokens in, which takes the same path with a hand-made success result.
+ */
+export function useGoogleCalendarIntegration(): UseGoogleCalendarIntegrationReturn {
+  const websiteUrl = import.meta.env.VITE_ROTKI_WEBSITE_URL;
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { completeOAuth, disconnect: disconnectApi, getStatus, syncCalendar } = useGoogleCalendarApi();
+  const { notify } = useNotificationDispatcher();
+  const { isPackaged, openUrl } = useInterop();
+
+  const isConnected = shallowRef<boolean>(false);
+  const isSyncing = shallowRef<boolean>(false);
+  const isAuthorizing = shallowRef<boolean>(false);
+  const connectedUserEmail = shallowRef<string>('');
+  const showTokenInput = shallowRef<boolean>(false);
+  const modelManualToken = shallowRef<string>('');
+  const modelManualRefreshToken = shallowRef<string>('');
+
+  function notifyMessage(message: string): void {
+    notify({
+      display: true,
+      message,
+      severity: Severity.ERROR,
+      title: t('external_services.google_calendar.error'),
+    });
+  }
+
+  function notifyError(error: unknown, fallback: string): void {
+    notifyMessage(getErrorMessage(error) || fallback);
+  }
+
+  async function checkStatus(): Promise<void> {
+    try {
+      const response = await getStatus();
+      set(isConnected, response.authenticated);
+      set(connectedUserEmail, response.authenticated ? response.userEmail ?? '' : '');
+    }
+    catch (error: unknown) {
+      logger.error('Failed to check Google Calendar status:', error);
+    }
+  }
+
+  async function connect(): Promise<void> {
+    set(isAuthorizing, true);
+    try {
+      const oauthUrl = `${websiteUrl}/oauth/google?mode=${isPackaged ? 'app' : 'docker'}`;
+
+      if (isPackaged) {
+        await openUrl(oauthUrl);
+      }
+      else if (typeof window !== 'undefined') {
+        // No callback channel outside the packaged app, so the tokens come back by hand.
+        window.open(oauthUrl, '_blank');
+        set(isAuthorizing, false);
+        set(showTokenInput, true);
+      }
+
+      notify({
+        display: true,
+        message: t('external_services.google_calendar.opening_browser'),
+        severity: Severity.INFO,
+        title: t('external_services.google_calendar.authorizing'),
+      });
+    }
+    catch (error: unknown) {
+      notifyError(error, t('external_services.google_calendar.auth_failed'));
+      set(isAuthorizing, false);
+    }
+  }
+
+  function cancelAuthorization(): void {
+    set(isAuthorizing, false);
+  }
+
+  function notifyOAuthError(error: unknown): void {
+    logger.error('OAuth failed:', error);
+    notifyError(error, t('external_services.google_calendar.auth_failed'));
+  }
+
+  async function handleOAuthCallback(oAuthResult: OAuthResult): Promise<void> {
+    if (oAuthResult.service !== 'google')
+      return;
+
+    try {
+      if (!oAuthResult.success) {
+        notifyOAuthError(oAuthResult.error);
+        return;
+      }
+
+      const { accessToken, refreshToken } = oAuthResult;
+      if (!refreshToken) {
+        notifyMessage(t('external_services.google_calendar.auth_failed'));
+        return;
+      }
+
+      const result = await completeOAuth(accessToken, refreshToken);
+      logger.debug('received oauth result', result);
+
+      if (!result.success) {
+        notifyOAuthError(result);
+        return;
+      }
+
+      set(isConnected, true);
+      set(connectedUserEmail, result.userEmail ?? '');
+      await checkStatus();
+    }
+    catch (error: unknown) {
+      notifyOAuthError(error);
+    }
+    finally {
+      set(isAuthorizing, false);
+    }
+  }
+
+  async function submitManualToken(): Promise<void> {
+    const accessToken = get(modelManualToken).trim();
+    if (!accessToken) {
+      notifyMessage(t('external_services.google_calendar.token_required'));
+      return;
+    }
+
+    set(isAuthorizing, true);
+    try {
+      await handleOAuthCallback({
+        accessToken,
+        refreshToken: get(modelManualRefreshToken).trim(),
+        service: 'google',
+        success: true,
+      });
+      set(modelManualToken, '');
+      set(showTokenInput, false);
+    }
+    finally {
+      set(isAuthorizing, false);
+    }
+  }
+
+  function cancelTokenInput(): void {
+    set(modelManualToken, '');
+    set(showTokenInput, false);
+  }
+
+  async function sync(): Promise<void> {
+    set(isSyncing, true);
+    try {
+      const result = await syncCalendar();
+
+      notify({
+        display: true,
+        message: result.eventsProcessed === 0
+          ? t('external_services.google_calendar.no_events_to_sync')
+          : t('external_services.google_calendar.sync_complete', {
+              created: result.eventsCreated || 0,
+              total: result.eventsProcessed || 0,
+              updated: result.eventsUpdated || 0,
+            }),
+        severity: Severity.INFO,
+        title: t('external_services.google_calendar.success'),
+      });
+    }
+    catch (error: unknown) {
+      notifyError(error, t('external_services.google_calendar.sync_failed'));
+    }
+    finally {
+      set(isSyncing, false);
+    }
+  }
+
+  async function disconnect(): Promise<void> {
+    try {
+      await disconnectApi();
+      set(isConnected, false);
+      set(connectedUserEmail, '');
+    }
+    catch (error: unknown) {
+      notifyError(error, t('external_services.google_calendar.disconnect_failed'));
+    }
+  }
+
+  return {
+    cancelAuthorization,
+    cancelTokenInput,
+    checkStatus,
+    connect,
+    connectedUserEmail: readonly(connectedUserEmail),
+    disconnect,
+    handleOAuthCallback,
+    isAuthorizing: readonly(isAuthorizing),
+    isConnected: readonly(isConnected),
+    isSyncing: readonly(isSyncing),
+    modelManualRefreshToken,
+    modelManualToken,
+    showTokenInput: readonly(showTokenInput),
+    submitManualToken,
+    sync,
+  };
+}

--- a/frontend/app/src/modules/history/events/CustomizedEventDuplicatesDialog.spec.ts
+++ b/frontend/app/src/modules/history/events/CustomizedEventDuplicatesDialog.spec.ts
@@ -1,0 +1,232 @@
+import type { DuplicateRow } from '@/modules/history/events/use-customized-event-duplicates';
+import { createMock } from '@test/utils/create-mock';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, nextTick, type VNode } from 'vue';
+import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import CustomizedEventDuplicatesDialog from '@/modules/history/events/CustomizedEventDuplicatesDialog.vue';
+import DuplicateRowActions from '@/modules/history/events/DuplicateRowActions.vue';
+import { DuplicatesTab } from '@/modules/history/events/use-customized-event-duplicates-dialog';
+
+/**
+ * The seam: this dialog is wiring. It loads on mount, gives each tab its rows and loading state,
+ * shows the actions that belong to the tab being viewed, and routes every click to the composable.
+ * What those actions do is covered by `use-customized-event-duplicates-dialog.spec.ts`.
+ */
+
+const dialogApi = {
+  autoFixLoading: ref<boolean>(false),
+  autoFixRows: ref<DuplicateRow[]>([]),
+  fixSelected: vi.fn(),
+  fixSingle: vi.fn(),
+  ignoredLoading: ref<boolean>(false),
+  ignoredRows: ref<DuplicateRow[]>([]),
+  ignoreSelected: vi.fn(),
+  ignoreSingle: vi.fn(),
+  initialize: vi.fn(async () => Promise.resolve()),
+  manualReviewLoading: ref<boolean>(false),
+  manualReviewRows: ref<DuplicateRow[]>([]),
+  modelActiveTab: ref<number>(DuplicatesTab.AUTO_FIX),
+  modelSelectedAutoFix: ref<string[]>([]),
+  modelSelectedIgnored: ref<string[]>([]),
+  modelSelectedManualReview: ref<string[]>([]),
+  restoreSelected: vi.fn(),
+  restoreSingle: vi.fn(),
+  showInHistoryEvents: vi.fn(),
+};
+
+vi.mock('@/modules/history/events/use-customized-event-duplicates-dialog', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/modules/history/events/use-customized-event-duplicates-dialog')>();
+  return {
+    DuplicatesTab: original.DuplicatesTab,
+    useCustomizedEventDuplicatesDialog: (): typeof dialogApi => dialogApi,
+  };
+});
+
+const autoFixGroupIds = ref<string[]>(['auto-1']);
+const manualReviewGroupIds = ref<string[]>(['manual-1']);
+const ignoredGroupIds = ref<string[]>(['ignored-1']);
+
+const duplicatesApi = {
+  autoFixCount: computed<number>(() => get(autoFixGroupIds).length),
+  autoFixGroupIds,
+  fixLoading: ref<boolean>(false),
+  ignoredCount: computed<number>(() => get(ignoredGroupIds).length),
+  ignoredGroupIds,
+  ignoreLoading: ref<boolean>(false),
+  manualReviewCount: computed<number>(() => get(manualReviewGroupIds).length),
+  manualReviewGroupIds,
+};
+
+vi.mock('@/modules/history/events/use-customized-event-duplicates', () => ({
+  useCustomizedEventDuplicates: (): typeof duplicatesApi => duplicatesApi,
+}));
+
+// RuiDialog teleports; stub it so its contents can be queried.
+const RuiDialogStub = defineComponent({
+  name: 'RuiDialog',
+  props: { modelValue: { default: false, type: Boolean } },
+  emits: ['update:modelValue'],
+  template: '<div v-if="modelValue"><slot /></div>',
+});
+
+/** Renders the actions slot with the first row, which is where the per-row buttons live. */
+const listStub = defineComponent({
+  name: 'CustomizedEventDuplicatesList',
+  props: {
+    description: { default: '', type: String },
+    loading: { default: false, type: Boolean },
+    rows: { default: () => [], type: Array },
+    selected: { default: () => [], type: Array },
+  },
+  emits: ['update:selected', 'show-in-history'],
+  setup(props, { slots }): () => VNode {
+    return () => h('div', slots.actions?.({ row: props.rows[0] }));
+  },
+});
+
+function row(groupIdentifier: string): DuplicateRow {
+  return {
+    entry: createMock<DuplicateRow['entry']>({ groupIdentifier }),
+    groupIdentifier,
+    location: 'ethereum',
+    locationLabel: null,
+    timestamp: 1,
+    txHash: '0xdead',
+  };
+}
+
+async function createWrapper(): Promise<VueWrapper<InstanceType<typeof CustomizedEventDuplicatesDialog>>> {
+  const wrapper = mount(CustomizedEventDuplicatesDialog, {
+    global: {
+      stubs: {
+        CustomizedEventDuplicatesList: listStub,
+        RuiDialog: RuiDialogStub,
+      },
+    },
+    props: { modelValue: true },
+  });
+
+  await nextTick();
+  return wrapper;
+}
+
+describe('customizedEventDuplicatesDialog', () => {
+  let wrapper: VueWrapper<InstanceType<typeof CustomizedEventDuplicatesDialog>>;
+
+  /**
+   * A tab panel is mounted the first time it is shown and then stays in the tree, so the lists are
+   * told apart by the description each one was given rather than by position.
+   */
+  function list(tab: 'auto_fix' | 'manual_review' | 'non_duplicated'): VueWrapper<InstanceType<typeof listStub>> {
+    const found = wrapper.findAllComponents(listStub)
+      .find(candidate => candidate.props('description') === `customized_event_duplicates.dialog.${tab}_description`);
+    assert(found, `the ${tab} list is not rendered`);
+    return found;
+  }
+
+  async function showTab(tab: number): Promise<void> {
+    set(dialogApi.modelActiveTab, tab);
+    await flushPromises();
+    await nextTick();
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    set(dialogApi.modelActiveTab, DuplicatesTab.AUTO_FIX);
+    set(dialogApi.autoFixRows, [row('auto-1')]);
+    set(dialogApi.manualReviewRows, [row('manual-1')]);
+    set(dialogApi.ignoredRows, [row('ignored-1')]);
+    set(dialogApi.modelSelectedAutoFix, []);
+    set(dialogApi.modelSelectedManualReview, []);
+    set(dialogApi.modelSelectedIgnored, []);
+    set(dialogApi.autoFixLoading, false);
+    wrapper = await createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('should load the duplicates when it opens', () => {
+    expect(dialogApi.initialize).toHaveBeenCalledOnce();
+  });
+
+  it('should give each tab its own rows and loading state', async () => {
+    set(dialogApi.autoFixLoading, true);
+    await nextTick();
+
+    expect(list('auto_fix').props('rows')).toBe(get(dialogApi.autoFixRows));
+    expect(list('auto_fix').props('loading')).toBe(true);
+
+    await showTab(DuplicatesTab.MANUAL_REVIEW);
+    expect(list('manual_review').props('rows')).toBe(get(dialogApi.manualReviewRows));
+    expect(list('manual_review').props('loading')).toBe(false);
+
+    await showTab(DuplicatesTab.IGNORED);
+    expect(list('non_duplicated').props('rows')).toBe(get(dialogApi.ignoredRows));
+  });
+
+  it('should ask to show a tab in history events with that tab groups', async () => {
+    list('auto_fix').vm.$emit('show-in-history');
+    expect(dialogApi.showInHistoryEvents).toHaveBeenCalledWith(['auto-1'], DuplicateHandlingStatus.AUTO_FIX);
+
+    await showTab(DuplicatesTab.MANUAL_REVIEW);
+    list('manual_review').vm.$emit('show-in-history');
+
+    expect(dialogApi.showInHistoryEvents).toHaveBeenCalledWith(['manual-1'], DuplicateHandlingStatus.MANUAL_REVIEW);
+  });
+
+  it('should route the per-row actions to the row they belong to', async () => {
+    const autoFixActions = list('auto_fix').findComponent(DuplicateRowActions);
+    autoFixActions.vm.$emit('fix');
+    autoFixActions.vm.$emit('ignore');
+
+    await showTab(DuplicatesTab.IGNORED);
+    list('non_duplicated').findComponent(DuplicateRowActions).vm.$emit('restore');
+
+    expect(dialogApi.fixSingle).toHaveBeenCalledWith('auto-1');
+    expect(dialogApi.ignoreSingle).toHaveBeenCalledWith('auto-1');
+    expect(dialogApi.restoreSingle).toHaveBeenCalledWith('ignored-1');
+  });
+
+  it('should keep the bulk actions disabled until something is selected', async () => {
+    expect(wrapper.find('[data-testid=fix-selected]').attributes('disabled')).toBeDefined();
+
+    set(dialogApi.modelSelectedAutoFix, ['auto-1']);
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=fix-selected]').attributes('disabled')).toBeUndefined();
+    await wrapper.find('[data-testid=fix-selected]').trigger('click');
+    await wrapper.find('[data-testid=ignore-selected]').trigger('click');
+
+    expect(dialogApi.fixSelected).toHaveBeenCalledOnce();
+    expect(dialogApi.ignoreSelected).toHaveBeenCalledOnce();
+  });
+
+  it('should show only the actions of the tab being viewed', async () => {
+    expect(wrapper.find('[data-testid=fix-selected]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=restore-selected]').exists()).toBe(false);
+
+    set(dialogApi.modelActiveTab, DuplicatesTab.MANUAL_REVIEW);
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=fix-selected]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=ignore-selected]').exists()).toBe(true);
+
+    set(dialogApi.modelActiveTab, DuplicatesTab.IGNORED);
+    set(dialogApi.modelSelectedIgnored, ['ignored-1']);
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=ignore-selected]').exists()).toBe(false);
+    await wrapper.find('[data-testid=restore-selected]').trigger('click');
+
+    expect(dialogApi.restoreSelected).toHaveBeenCalledOnce();
+  });
+
+  it('should close on the close button', async () => {
+    await wrapper.find('[data-testid=close-dialog]').trigger('click');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+});

--- a/frontend/app/src/modules/history/events/CustomizedEventDuplicatesDialog.vue
+++ b/frontend/app/src/modules/history/events/CustomizedEventDuplicatesDialog.vue
@@ -1,29 +1,18 @@
 <script setup lang="ts">
-import type { ComputedRef, Ref } from 'vue';
-import { Severity } from '@rotki/common';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { logger } from '@/modules/core/common/logging/logging';
-import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
 import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
 import CustomizedEventDuplicatesList from '@/modules/history/events/CustomizedEventDuplicatesList.vue';
 import DuplicateRowActions from '@/modules/history/events/DuplicateRowActions.vue';
-import { type DuplicateRow, useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
+import { useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
+import { DuplicatesTab, useCustomizedEventDuplicatesDialog } from '@/modules/history/events/use-customized-event-duplicates-dialog';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 
 const modelValue = defineModel<boolean>({ default: false });
 
 const { t } = useI18n({ useScope: 'global' });
-const router = useRouter();
-const { notify } = useNotificationDispatcher();
 
 const {
   autoFixCount,
   autoFixGroupIds,
-  confirmAndFixDuplicate,
-  confirmAndMarkNonDuplicated,
-  confirmAndRestore,
-  fetchCustomizedEventDuplicates,
-  fetchDuplicateEvents,
   fixLoading,
   ignoreLoading,
   ignoredCount,
@@ -32,137 +21,33 @@ const {
   manualReviewGroupIds,
 } = useCustomizedEventDuplicates();
 
-const activeTab = ref<number>(0);
-
-const selectedAutoFix = ref<string[]>([]);
-const selectedManualReview = ref<string[]>([]);
-const selectedIgnored = ref<string[]>([]);
-
-const autoFixRows = ref<DuplicateRow[]>([]);
-const manualReviewRows = ref<DuplicateRow[]>([]);
-const ignoredRows = ref<DuplicateRow[]>([]);
-
-const autoFixDataLoading = ref<boolean>(false);
-const manualReviewDataLoading = ref<boolean>(false);
-const ignoredDataLoading = ref<boolean>(false);
-
-async function loadRows(
-  groupIds: ComputedRef<string[]>,
-  rows: Ref<DuplicateRow[]>,
-  loadingRef: Ref<boolean>,
-): Promise<void> {
-  set(loadingRef, true);
-  try {
-    const ids = get(groupIds);
-    const result = await fetchDuplicateEvents({
-      groupIds: ids,
-      limit: ids.length || 1,
-      offset: 0,
-    });
-    set(rows, result.data);
-  }
-  catch (error: unknown) {
-    logger.error('Failed to load duplicate event rows:', error);
-    notify({
-      display: true,
-      message: t('actions.customized_event_duplicates.fetch_events_error.description', { error: getErrorMessage(error) }),
-      severity: Severity.ERROR,
-      title: t('actions.customized_event_duplicates.fetch_events_error.title'),
-    });
-  }
-  finally {
-    set(loadingRef, false);
-  }
-}
-
-async function loadAllRows(): Promise<void> {
-  await Promise.all([
-    loadRows(autoFixGroupIds, autoFixRows, autoFixDataLoading),
-    loadRows(manualReviewGroupIds, manualReviewRows, manualReviewDataLoading),
-    loadRows(ignoredGroupIds, ignoredRows, ignoredDataLoading),
-  ]);
-}
-
 function closeDialog(): void {
   set(modelValue, false);
 }
 
-async function showInHistoryEvents(groupIds: string[], status: DuplicateHandlingStatus): Promise<void> {
-  if (groupIds.length === 0)
-    return;
-
-  closeDialog();
-  await router.push({
-    name: '/history/events/',
-    query: {
-      duplicateHandlingStatus: status,
-      groupIdentifiers: groupIds.join(','),
-    },
-  });
-}
-
-function confirmFixSingle(groupId: string): void {
-  confirmAndFixDuplicate([groupId], async () => {
-    set(selectedAutoFix, get(selectedAutoFix).filter(id => id !== groupId));
-    await loadRows(autoFixGroupIds, autoFixRows, autoFixDataLoading);
-  });
-}
-
-function confirmFixSelected(): void {
-  const selected = get(selectedAutoFix);
-  if (selected.length === 0)
-    return;
-
-  confirmAndFixDuplicate(selected, async () => {
-    set(selectedAutoFix, []);
-    await loadRows(autoFixGroupIds, autoFixRows, autoFixDataLoading);
-  });
-}
-
-function confirmIgnoreSingle(groupId: string): void {
-  confirmAndMarkNonDuplicated([groupId], async () => {
-    set(selectedAutoFix, get(selectedAutoFix).filter(id => id !== groupId));
-    set(selectedManualReview, get(selectedManualReview).filter(id => id !== groupId));
-    await loadAllRows();
-  });
-}
-
-function confirmIgnoreSelected(): void {
-  const tab = get(activeTab);
-  const selected = tab === 0 ? get(selectedAutoFix) : get(selectedManualReview);
-  if (selected.length === 0)
-    return;
-
-  confirmAndMarkNonDuplicated(selected, async () => {
-    if (tab === 0)
-      set(selectedAutoFix, []);
-    else
-      set(selectedManualReview, []);
-    await loadAllRows();
-  });
-}
-
-function confirmRestoreSingle(groupId: string): void {
-  confirmAndRestore([groupId], async () => {
-    set(selectedIgnored, get(selectedIgnored).filter(id => id !== groupId));
-    await loadAllRows();
-  });
-}
-
-function confirmRestoreSelected(): void {
-  const selected = get(selectedIgnored);
-  if (selected.length === 0)
-    return;
-
-  confirmAndRestore(selected, async () => {
-    set(selectedIgnored, []);
-    await loadAllRows();
-  });
-}
+const {
+  autoFixLoading,
+  autoFixRows,
+  fixSelected,
+  fixSingle,
+  ignoreSelected,
+  ignoreSingle,
+  ignoredLoading,
+  ignoredRows,
+  initialize,
+  manualReviewLoading,
+  manualReviewRows,
+  modelActiveTab,
+  modelSelectedAutoFix,
+  modelSelectedIgnored,
+  modelSelectedManualReview,
+  restoreSelected,
+  restoreSingle,
+  showInHistoryEvents,
+} = useCustomizedEventDuplicatesDialog({ close: closeDialog });
 
 onBeforeMount(async () => {
-  await fetchCustomizedEventDuplicates();
-  await loadAllRows();
+  await initialize();
 });
 </script>
 
@@ -191,7 +76,7 @@ onBeforeMount(async () => {
       </template>
 
       <RuiTabs
-        v-model="activeTab"
+        v-model="modelActiveTab"
         class="border-b border-default"
         color="primary"
       >
@@ -231,15 +116,15 @@ onBeforeMount(async () => {
       </RuiTabs>
 
       <RuiTabItems
-        v-model="activeTab"
+        v-model="modelActiveTab"
         class="my-4"
       >
         <RuiTabItem>
           <CustomizedEventDuplicatesList
-            v-model:selected="selectedAutoFix"
+            v-model:selected="modelSelectedAutoFix"
             :description="t('customized_event_duplicates.dialog.auto_fix_description')"
             :rows="autoFixRows"
-            :loading="autoFixDataLoading"
+            :loading="autoFixLoading"
             @show-in-history="showInHistoryEvents(autoFixGroupIds, DuplicateHandlingStatus.AUTO_FIX)"
           >
             <template #actions="{ row }">
@@ -247,8 +132,8 @@ onBeforeMount(async () => {
                 mode="auto-fix"
                 :fix-loading="fixLoading"
                 :ignore-loading="ignoreLoading"
-                @fix="confirmFixSingle(row.groupIdentifier)"
-                @ignore="confirmIgnoreSingle(row.groupIdentifier)"
+                @fix="fixSingle(row.groupIdentifier)"
+                @ignore="ignoreSingle(row.groupIdentifier)"
               />
             </template>
           </CustomizedEventDuplicatesList>
@@ -256,17 +141,17 @@ onBeforeMount(async () => {
 
         <RuiTabItem>
           <CustomizedEventDuplicatesList
-            v-model:selected="selectedManualReview"
+            v-model:selected="modelSelectedManualReview"
             :description="t('customized_event_duplicates.dialog.manual_review_description')"
             :rows="manualReviewRows"
-            :loading="manualReviewDataLoading"
+            :loading="manualReviewLoading"
             @show-in-history="showInHistoryEvents(manualReviewGroupIds, DuplicateHandlingStatus.MANUAL_REVIEW)"
           >
             <template #actions="{ row }">
               <DuplicateRowActions
                 mode="manual-review"
                 :ignore-loading="ignoreLoading"
-                @ignore="confirmIgnoreSingle(row.groupIdentifier)"
+                @ignore="ignoreSingle(row.groupIdentifier)"
               />
             </template>
           </CustomizedEventDuplicatesList>
@@ -274,17 +159,17 @@ onBeforeMount(async () => {
 
         <RuiTabItem>
           <CustomizedEventDuplicatesList
-            v-model:selected="selectedIgnored"
+            v-model:selected="modelSelectedIgnored"
             :description="t('customized_event_duplicates.dialog.non_duplicated_description')"
             :rows="ignoredRows"
-            :loading="ignoredDataLoading"
+            :loading="ignoredLoading"
             @show-in-history="showInHistoryEvents(ignoredGroupIds, DuplicateHandlingStatus.IGNORED)"
           >
             <template #actions="{ row }">
               <DuplicateRowActions
                 mode="ignored"
                 :ignore-loading="ignoreLoading"
-                @restore="confirmRestoreSingle(row.groupIdentifier)"
+                @restore="restoreSingle(row.groupIdentifier)"
               />
             </template>
           </CustomizedEventDuplicatesList>
@@ -293,15 +178,16 @@ onBeforeMount(async () => {
 
       <div class="w-full flex justify-between gap-2 pb-4">
         <div
-          v-if="activeTab === 0"
+          v-if="modelActiveTab === DuplicatesTab.AUTO_FIX"
           class="flex gap-2"
         >
           <RuiButton
             variant="outlined"
             color="primary"
-            :disabled="selectedAutoFix.length === 0 || fixLoading"
+            data-testid="fix-selected"
+            :disabled="modelSelectedAutoFix.length === 0 || fixLoading"
             :loading="fixLoading"
-            @click="confirmFixSelected()"
+            @click="fixSelected()"
           >
             <template #prepend>
               <RuiIcon
@@ -311,19 +197,20 @@ onBeforeMount(async () => {
             </template>
             {{ t('customized_event_duplicates.actions.fix_selected') }}
             <RuiChip
-              v-if="selectedAutoFix.length > 0"
+              v-if="modelSelectedAutoFix.length > 0"
               size="sm"
               color="primary"
               class="ml-2 !py-0"
             >
-              {{ selectedAutoFix.length }}
+              {{ modelSelectedAutoFix.length }}
             </RuiChip>
           </RuiButton>
           <RuiButton
             variant="outlined"
-            :disabled="selectedAutoFix.length === 0 || ignoreLoading"
+            data-testid="ignore-selected"
+            :disabled="modelSelectedAutoFix.length === 0 || ignoreLoading"
             :loading="ignoreLoading"
-            @click="confirmIgnoreSelected()"
+            @click="ignoreSelected()"
           >
             <template #prepend>
               <RuiIcon
@@ -335,14 +222,15 @@ onBeforeMount(async () => {
           </RuiButton>
         </div>
         <div
-          v-else-if="activeTab === 1"
+          v-else-if="modelActiveTab === DuplicatesTab.MANUAL_REVIEW"
           class="flex gap-2"
         >
           <RuiButton
             variant="outlined"
-            :disabled="selectedManualReview.length === 0 || ignoreLoading"
+            data-testid="ignore-selected"
+            :disabled="modelSelectedManualReview.length === 0 || ignoreLoading"
             :loading="ignoreLoading"
-            @click="confirmIgnoreSelected()"
+            @click="ignoreSelected()"
           >
             <template #prepend>
               <RuiIcon
@@ -352,12 +240,12 @@ onBeforeMount(async () => {
             </template>
             {{ t('customized_event_duplicates.actions.mark_non_duplicated_selected') }}
             <RuiChip
-              v-if="selectedManualReview.length > 0"
+              v-if="modelSelectedManualReview.length > 0"
               size="sm"
               color="primary"
               class="ml-2 !py-0"
             >
-              {{ selectedManualReview.length }}
+              {{ modelSelectedManualReview.length }}
             </RuiChip>
           </RuiButton>
         </div>
@@ -368,9 +256,10 @@ onBeforeMount(async () => {
           <RuiButton
             variant="outlined"
             color="primary"
-            :disabled="selectedIgnored.length === 0 || ignoreLoading"
+            data-testid="restore-selected"
+            :disabled="modelSelectedIgnored.length === 0 || ignoreLoading"
             :loading="ignoreLoading"
-            @click="confirmRestoreSelected()"
+            @click="restoreSelected()"
           >
             <template #prepend>
               <RuiIcon
@@ -380,17 +269,18 @@ onBeforeMount(async () => {
             </template>
             {{ t('customized_event_duplicates.actions.restore_selected') }}
             <RuiChip
-              v-if="selectedIgnored.length > 0"
+              v-if="modelSelectedIgnored.length > 0"
               size="sm"
               color="primary"
               class="ml-2 !py-0"
             >
-              {{ selectedIgnored.length }}
+              {{ modelSelectedIgnored.length }}
             </RuiChip>
           </RuiButton>
         </div>
         <RuiButton
           variant="text"
+          data-testid="close-dialog"
           @click="closeDialog()"
         >
           {{ t('common.actions.close') }}

--- a/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.spec.ts
+++ b/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.spec.ts
@@ -1,0 +1,271 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { DuplicateRow, FetchDuplicateEventsPayload } from '@/modules/history/events/use-customized-event-duplicates';
+import { Severity } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { flushPromises } from '@vue/test-utils';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import { DuplicatesTab, useCustomizedEventDuplicatesDialog } from '@/modules/history/events/use-customized-event-duplicates-dialog';
+
+/**
+ * The seam: the dialog reads the events behind the duplicate group ids the domain composable found,
+ * one set of rows per tab. Actions are handed to that composable with a callback, and only when the
+ * user confirms does the callback run: the acted-on ids leave the selection, and the tabs whose
+ * contents can have moved are re-read.
+ */
+
+const push = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: (): { push: typeof push } => ({ push }),
+}));
+
+const notify = vi.fn();
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): { notify: typeof notify } => ({ notify }),
+}));
+
+type ConfirmMock = ReturnType<typeof vi.fn<(groupIdentifiers: string[], onSuccess?: () => void) => void>>;
+
+const confirmAndFixDuplicate: ConfirmMock = vi.fn();
+const confirmAndMarkNonDuplicated: ConfirmMock = vi.fn();
+const confirmAndRestore: ConfirmMock = vi.fn();
+const fetchCustomizedEventDuplicates = vi.fn<() => Promise<void>>();
+const fetchDuplicateEvents = vi.fn<(payload: FetchDuplicateEventsPayload) => Promise<Collection<DuplicateRow>>>();
+
+const autoFixGroupIds = ref<string[]>([]);
+const manualReviewGroupIds = ref<string[]>([]);
+const ignoredGroupIds = ref<string[]>([]);
+
+const duplicatesApi = {
+  autoFixGroupIds,
+  confirmAndFixDuplicate,
+  confirmAndMarkNonDuplicated,
+  confirmAndRestore,
+  fetchCustomizedEventDuplicates,
+  fetchDuplicateEvents,
+  ignoredGroupIds,
+  manualReviewGroupIds,
+};
+
+vi.mock('@/modules/history/events/use-customized-event-duplicates', () => ({
+  useCustomizedEventDuplicates: (): typeof duplicatesApi => duplicatesApi,
+}));
+
+function row(groupIdentifier: string): DuplicateRow {
+  return {
+    entry: createMock<DuplicateRow['entry']>({ groupIdentifier }),
+    groupIdentifier,
+    location: 'ethereum',
+    locationLabel: null,
+    timestamp: 1,
+    txHash: '0xdead',
+  };
+}
+
+function collection(data: DuplicateRow[]): Collection<DuplicateRow> {
+  return { data, found: data.length, limit: data.length, total: data.length, totalValue: undefined };
+}
+
+/** The rows each group id was asked for, so a re-read can be told apart from the initial load. */
+function rowsFor(payload: FetchDuplicateEventsPayload): Collection<DuplicateRow> {
+  return collection(payload.groupIds.map(row));
+}
+
+describe('useCustomizedEventDuplicatesDialog', () => {
+  const close = vi.fn();
+  let dialog: ReturnType<typeof useCustomizedEventDuplicatesDialog>;
+
+  /**
+   * Runs the callback the dialog handed to a confirmation, i.e. the user confirmed. The callback
+   * starts the re-reads rather than awaiting them, so the promises are flushed here.
+   */
+  async function confirm(mock: ConfirmMock, call = 0): Promise<void> {
+    const onSuccess = mock.mock.calls[call]?.[1];
+    assert(onSuccess, 'no confirmation was requested');
+    onSuccess();
+    await flushPromises();
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(autoFixGroupIds, ['auto-1', 'auto-2']);
+    set(manualReviewGroupIds, ['manual-1']);
+    set(ignoredGroupIds, ['ignored-1']);
+    fetchDuplicateEvents.mockImplementation(async payload => rowsFor(payload));
+    dialog = useCustomizedEventDuplicatesDialog({ close });
+  });
+
+  describe('initialize', () => {
+    it('should read the group ids, then the events behind each tab', async () => {
+      await dialog.initialize();
+
+      expect(fetchCustomizedEventDuplicates).toHaveBeenCalledOnce();
+      expect(fetchDuplicateEvents).toHaveBeenCalledTimes(3);
+      expect(fetchDuplicateEvents).toHaveBeenCalledWith({ groupIds: ['auto-1', 'auto-2'], limit: 2, offset: 0 });
+      expect(fetchDuplicateEvents).toHaveBeenCalledWith({ groupIds: ['manual-1'], limit: 1, offset: 0 });
+      expect(fetchDuplicateEvents).toHaveBeenCalledWith({ groupIds: ['ignored-1'], limit: 1, offset: 0 });
+
+      expect(get(dialog.autoFixRows).map(entry => entry.groupIdentifier)).toEqual(['auto-1', 'auto-2']);
+      expect(get(dialog.manualReviewRows).map(entry => entry.groupIdentifier)).toEqual(['manual-1']);
+      expect(get(dialog.ignoredRows).map(entry => entry.groupIdentifier)).toEqual(['ignored-1']);
+      expect(get(dialog.autoFixLoading)).toBe(false);
+    });
+
+    it('should ask for a limit of one when a tab has no groups', async () => {
+      set(manualReviewGroupIds, []);
+
+      await dialog.initialize();
+
+      expect(fetchDuplicateEvents).toHaveBeenCalledWith({ groupIds: [], limit: 1, offset: 0 });
+    });
+
+    it('should notify and stop loading when the events cannot be read', async () => {
+      fetchDuplicateEvents.mockRejectedValue(new Error('boom'));
+
+      await dialog.initialize();
+
+      expect(notify).toHaveBeenCalledTimes(3);
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({
+        display: true,
+        severity: Severity.ERROR,
+        title: 'actions.customized_event_duplicates.fetch_events_error.title',
+      }));
+      expect(get(dialog.autoFixRows)).toEqual([]);
+      expect(get(dialog.autoFixLoading)).toBe(false);
+      expect(get(dialog.manualReviewLoading)).toBe(false);
+      expect(get(dialog.ignoredLoading)).toBe(false);
+    });
+  });
+
+  describe('fixing', () => {
+    it('should do nothing when nothing is selected', () => {
+      dialog.fixSelected();
+
+      expect(confirmAndFixDuplicate).not.toHaveBeenCalled();
+    });
+
+    it('should clear the selection and re-read only the auto-fix tab', async () => {
+      set(dialog.modelSelectedAutoFix, ['auto-1', 'auto-2']);
+
+      dialog.fixSelected();
+      expect(confirmAndFixDuplicate).toHaveBeenCalledWith(['auto-1', 'auto-2'], expect.any(Function));
+
+      await confirm(confirmAndFixDuplicate);
+
+      expect(get(dialog.modelSelectedAutoFix)).toEqual([]);
+      expect(fetchDuplicateEvents).toHaveBeenCalledOnce();
+      expect(fetchDuplicateEvents).toHaveBeenCalledWith(expect.objectContaining({ groupIds: ['auto-1', 'auto-2'] }));
+    });
+
+    it('should drop only the fixed row from the selection', async () => {
+      set(dialog.modelSelectedAutoFix, ['auto-1', 'auto-2']);
+
+      dialog.fixSingle('auto-1');
+      expect(confirmAndFixDuplicate).toHaveBeenCalledWith(['auto-1'], expect.any(Function));
+
+      await confirm(confirmAndFixDuplicate);
+
+      expect(get(dialog.modelSelectedAutoFix)).toEqual(['auto-2']);
+    });
+  });
+
+  describe('marking as non-duplicated', () => {
+    it('should drop the row from both actionable tabs and re-read all three', async () => {
+      set(dialog.modelSelectedAutoFix, ['auto-1', 'shared']);
+      set(dialog.modelSelectedManualReview, ['manual-1', 'shared']);
+
+      dialog.ignoreSingle('shared');
+      await confirm(confirmAndMarkNonDuplicated);
+
+      expect(get(dialog.modelSelectedAutoFix)).toEqual(['auto-1']);
+      expect(get(dialog.modelSelectedManualReview)).toEqual(['manual-1']);
+      expect(fetchDuplicateEvents).toHaveBeenCalledTimes(3);
+    });
+
+    it('should act on the auto-fix selection while that tab is showing', async () => {
+      set(dialog.modelSelectedAutoFix, ['auto-1']);
+      set(dialog.modelSelectedManualReview, ['manual-1']);
+
+      dialog.ignoreSelected();
+      expect(confirmAndMarkNonDuplicated).toHaveBeenCalledWith(['auto-1'], expect.any(Function));
+
+      await confirm(confirmAndMarkNonDuplicated);
+
+      expect(get(dialog.modelSelectedAutoFix)).toEqual([]);
+      expect(get(dialog.modelSelectedManualReview)).toEqual(['manual-1']);
+    });
+
+    it('should act on the manual review selection while that tab is showing', async () => {
+      set(dialog.modelActiveTab, DuplicatesTab.MANUAL_REVIEW);
+      set(dialog.modelSelectedAutoFix, ['auto-1']);
+      set(dialog.modelSelectedManualReview, ['manual-1']);
+
+      dialog.ignoreSelected();
+      expect(confirmAndMarkNonDuplicated).toHaveBeenCalledWith(['manual-1'], expect.any(Function));
+
+      await confirm(confirmAndMarkNonDuplicated);
+
+      expect(get(dialog.modelSelectedManualReview)).toEqual([]);
+      expect(get(dialog.modelSelectedAutoFix)).toEqual(['auto-1']);
+    });
+
+    it('should do nothing when the showing tab has no selection', () => {
+      set(dialog.modelSelectedManualReview, ['manual-1']);
+
+      dialog.ignoreSelected();
+
+      expect(confirmAndMarkNonDuplicated).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('restoring', () => {
+    it('should clear the ignored selection and re-read all three tabs', async () => {
+      set(dialog.modelSelectedIgnored, ['ignored-1']);
+
+      dialog.restoreSelected();
+      expect(confirmAndRestore).toHaveBeenCalledWith(['ignored-1'], expect.any(Function));
+
+      await confirm(confirmAndRestore);
+
+      expect(get(dialog.modelSelectedIgnored)).toEqual([]);
+      expect(fetchDuplicateEvents).toHaveBeenCalledTimes(3);
+    });
+
+    it('should drop only the restored row from the selection', async () => {
+      set(dialog.modelSelectedIgnored, ['ignored-1', 'ignored-2']);
+
+      dialog.restoreSingle('ignored-2');
+      await confirm(confirmAndRestore);
+
+      expect(get(dialog.modelSelectedIgnored)).toEqual(['ignored-1']);
+    });
+
+    it('should do nothing when nothing is selected', () => {
+      dialog.restoreSelected();
+
+      expect(confirmAndRestore).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('showInHistoryEvents', () => {
+    it('should close the dialog and carry the groups into the query', async () => {
+      await dialog.showInHistoryEvents(['auto-1', 'auto-2'], DuplicateHandlingStatus.AUTO_FIX);
+
+      expect(close).toHaveBeenCalledOnce();
+      expect(push).toHaveBeenCalledWith({
+        name: '/history/events/',
+        query: {
+          duplicateHandlingStatus: DuplicateHandlingStatus.AUTO_FIX,
+          groupIdentifiers: 'auto-1,auto-2',
+        },
+      });
+    });
+
+    it('should stay put when there are no groups to show', async () => {
+      await dialog.showInHistoryEvents([], DuplicateHandlingStatus.IGNORED);
+
+      expect(close).not.toHaveBeenCalled();
+      expect(push).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.ts
+++ b/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.ts
@@ -1,0 +1,238 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import { Severity } from '@rotki/common';
+import { startPromise } from '@shared/utils';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { type DuplicateRow, useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
+
+/** The tabs, in the order the dialog renders them. */
+export const DuplicatesTab = {
+  AUTO_FIX: 0,
+  IGNORED: 2,
+  MANUAL_REVIEW: 1,
+} as const;
+
+interface DuplicateGroup {
+  /** The group ids the domain composable found for this tab. */
+  groupIds: ComputedRef<string[]>;
+  loading: Ref<boolean>;
+  rows: Ref<DuplicateRow[]>;
+  /** Bound with `v-model:selected` by the list, so it stays writable. */
+  selected: Ref<string[]>;
+}
+
+interface UseCustomizedEventDuplicatesDialogOptions {
+  /** Closes the dialog, which navigating away from it has to do first. */
+  close: () => void;
+}
+
+interface UseCustomizedEventDuplicatesDialogReturn {
+  /** All bound with `v-model`, so they stay writable. */
+  modelActiveTab: Ref<number>;
+  modelSelectedAutoFix: Ref<string[]>;
+  modelSelectedManualReview: Ref<string[]>;
+  modelSelectedIgnored: Ref<string[]>;
+  /**
+   * Shallow: the rows go straight into a prop typed `DuplicateRow[]`, which a deep `readonly()`
+   * would turn into a `DeepReadonly` the prop cannot accept.
+   */
+  autoFixRows: Readonly<Ref<DuplicateRow[]>>;
+  manualReviewRows: Readonly<Ref<DuplicateRow[]>>;
+  ignoredRows: Readonly<Ref<DuplicateRow[]>>;
+  autoFixLoading: Readonly<Ref<boolean>>;
+  manualReviewLoading: Readonly<Ref<boolean>>;
+  ignoredLoading: Readonly<Ref<boolean>>;
+  /** Reads the duplicate group ids, then the events behind them. */
+  initialize: () => Promise<void>;
+  fixSingle: (groupId: string) => void;
+  fixSelected: () => void;
+  ignoreSingle: (groupId: string) => void;
+  ignoreSelected: () => void;
+  restoreSingle: (groupId: string) => void;
+  restoreSelected: () => void;
+  showInHistoryEvents: (groupIds: string[], status: DuplicateHandlingStatus) => Promise<void>;
+}
+
+/**
+ * The duplicates dialog: three tabs over the same set of duplicate groups, each with its own rows,
+ * its own selection and its own loading state.
+ *
+ * Every action goes through a confirmation the domain composable owns, and only its success callback
+ * touches the dialog: the acted-on ids leave the selection and the affected tabs are re-read. Fixing
+ * only moves rows within the auto-fix tab, while ignoring and restoring move rows *between* tabs, so
+ * those re-read all three.
+ */
+export function useCustomizedEventDuplicatesDialog(
+  options: UseCustomizedEventDuplicatesDialogOptions,
+): UseCustomizedEventDuplicatesDialogReturn {
+  const { close } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+  const router = useRouter();
+  const { notify } = useNotificationDispatcher();
+
+  const {
+    autoFixGroupIds,
+    confirmAndFixDuplicate,
+    confirmAndMarkNonDuplicated,
+    confirmAndRestore,
+    fetchCustomizedEventDuplicates,
+    fetchDuplicateEvents,
+    ignoredGroupIds,
+    manualReviewGroupIds,
+  } = useCustomizedEventDuplicates();
+
+  const modelActiveTab = shallowRef<number>(DuplicatesTab.AUTO_FIX);
+
+  const autoFix: DuplicateGroup = {
+    groupIds: autoFixGroupIds,
+    loading: shallowRef<boolean>(false),
+    rows: ref<DuplicateRow[]>([]),
+    selected: ref<string[]>([]),
+  };
+
+  const manualReview: DuplicateGroup = {
+    groupIds: manualReviewGroupIds,
+    loading: shallowRef<boolean>(false),
+    rows: ref<DuplicateRow[]>([]),
+    selected: ref<string[]>([]),
+  };
+
+  const ignored: DuplicateGroup = {
+    groupIds: ignoredGroupIds,
+    loading: shallowRef<boolean>(false),
+    rows: ref<DuplicateRow[]>([]),
+    selected: ref<string[]>([]),
+  };
+
+  async function loadGroup(group: DuplicateGroup): Promise<void> {
+    set(group.loading, true);
+    try {
+      const ids = get(group.groupIds);
+      const result = await fetchDuplicateEvents({
+        groupIds: ids,
+        limit: ids.length || 1,
+        offset: 0,
+      });
+      set(group.rows, result.data);
+    }
+    catch (error: unknown) {
+      logger.error('Failed to load duplicate event rows:', error);
+      notify({
+        display: true,
+        message: t('actions.customized_event_duplicates.fetch_events_error.description', { error: getErrorMessage(error) }),
+        severity: Severity.ERROR,
+        title: t('actions.customized_event_duplicates.fetch_events_error.title'),
+      });
+    }
+    finally {
+      set(group.loading, false);
+    }
+  }
+
+  async function loadAllGroups(): Promise<void> {
+    await Promise.all([loadGroup(autoFix), loadGroup(manualReview), loadGroup(ignored)]);
+  }
+
+  function deselect(group: DuplicateGroup, groupId: string): void {
+    set(group.selected, get(group.selected).filter(id => id !== groupId));
+  }
+
+  async function initialize(): Promise<void> {
+    await fetchCustomizedEventDuplicates();
+    await loadAllGroups();
+  }
+
+  function fixSingle(groupId: string): void {
+    confirmAndFixDuplicate([groupId], () => {
+      deselect(autoFix, groupId);
+      startPromise(loadGroup(autoFix));
+    });
+  }
+
+  function fixSelected(): void {
+    const selected = get(autoFix.selected);
+    if (selected.length === 0)
+      return;
+
+    confirmAndFixDuplicate(selected, () => {
+      set(autoFix.selected, []);
+      startPromise(loadGroup(autoFix));
+    });
+  }
+
+  function ignoreSingle(groupId: string): void {
+    confirmAndMarkNonDuplicated([groupId], () => {
+      deselect(autoFix, groupId);
+      deselect(manualReview, groupId);
+      startPromise(loadAllGroups());
+    });
+  }
+
+  function ignoreSelected(): void {
+    const group = get(modelActiveTab) === DuplicatesTab.AUTO_FIX ? autoFix : manualReview;
+    const selected = get(group.selected);
+    if (selected.length === 0)
+      return;
+
+    confirmAndMarkNonDuplicated(selected, () => {
+      set(group.selected, []);
+      startPromise(loadAllGroups());
+    });
+  }
+
+  function restoreSingle(groupId: string): void {
+    confirmAndRestore([groupId], () => {
+      deselect(ignored, groupId);
+      startPromise(loadAllGroups());
+    });
+  }
+
+  function restoreSelected(): void {
+    const selected = get(ignored.selected);
+    if (selected.length === 0)
+      return;
+
+    confirmAndRestore(selected, () => {
+      set(ignored.selected, []);
+      startPromise(loadAllGroups());
+    });
+  }
+
+  async function showInHistoryEvents(groupIds: string[], status: DuplicateHandlingStatus): Promise<void> {
+    if (groupIds.length === 0)
+      return;
+
+    close();
+    await router.push({
+      name: '/history/events/',
+      query: {
+        duplicateHandlingStatus: status,
+        groupIdentifiers: groupIds.join(','),
+      },
+    });
+  }
+
+  return {
+    autoFixLoading: readonly(autoFix.loading),
+    autoFixRows: shallowReadonly(autoFix.rows),
+    fixSelected,
+    fixSingle,
+    ignoreSelected,
+    ignoreSingle,
+    ignoredLoading: readonly(ignored.loading),
+    ignoredRows: shallowReadonly(ignored.rows),
+    initialize,
+    manualReviewLoading: readonly(manualReview.loading),
+    manualReviewRows: shallowReadonly(manualReview.rows),
+    modelActiveTab,
+    modelSelectedAutoFix: autoFix.selected,
+    modelSelectedIgnored: ignored.selected,
+    modelSelectedManualReview: manualReview.selected,
+    restoreSelected,
+    restoreSingle,
+    showInHistoryEvents,
+  };
+}

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshSelection.spec.ts
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshSelection.spec.ts
@@ -1,0 +1,164 @@
+import type { ChainAddress } from '@/modules/history/events/event-payloads';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Component, defineComponent, h, nextTick, type VNode } from 'vue';
+import HistoryRefreshSelection from '@/modules/history/refresh/HistoryRefreshSelection.vue';
+
+/**
+ * The seam: this component is wiring. It owns the menu's open state, hands the shared selection
+ * down to whichever tab is showing, routes "select all" to that tab's own toggle, and emits the
+ * active tab's picks as the refresh payload before clearing and closing.
+ *
+ * What each tab does with its picks belongs to the tab components, and the selection state itself
+ * is covered by `use-history-refresh-selection.spec.ts`.
+ */
+
+// RuiMenu teleports its content lazily; stub it so the activator and the panel are both in the
+// tree without opening it, while still recording the open state the component drives.
+const RuiMenuStub = defineComponent({
+  name: 'RuiMenu',
+  props: { modelValue: { default: false, type: Boolean } },
+  emits: ['update:modelValue'],
+  template: '<div><slot name="activator" :attrs="{}" /><slot /></div>',
+});
+
+const toggles = {
+  chains: vi.fn(),
+  events: vi.fn(),
+  exchanges: vi.fn(),
+  protocols: vi.fn(),
+};
+
+function tabStub(name: string, toggleSelectAll: () => void): Component {
+  return defineComponent({
+    name,
+    props: {
+      chain: { default: undefined, type: String },
+      modelValue: { default: () => [], type: Array },
+      processing: { default: false, type: Boolean },
+      search: { default: '', type: String },
+    },
+    emits: ['update:modelValue', 'update:search', 'update:chain', 'update:all-selected'],
+    setup(_, { expose }): () => VNode {
+      expose({ toggleSelectAll });
+      return () => h('div', { 'data-testid': `${name}-stub` });
+    },
+  });
+}
+
+const accounts: ChainAddress[] = [{ address: '0x1', chain: 'eth' }];
+
+async function createWrapper(props: { processing?: boolean; disabled?: boolean } = {}): Promise<VueWrapper<InstanceType<typeof HistoryRefreshSelection>>> {
+  const wrapper = mount(HistoryRefreshSelection, {
+    global: {
+      stubs: {
+        HistoryRefreshChains: tabStub('HistoryRefreshChains', toggles.chains),
+        HistoryRefreshExchanges: tabStub('HistoryRefreshExchanges', toggles.exchanges),
+        HistoryRefreshProtocolEvents: tabStub('HistoryRefreshProtocolEvents', toggles.protocols),
+        HistoryRefreshStakingEvents: tabStub('HistoryRefreshStakingEvents', toggles.events),
+        RuiMenu: RuiMenuStub,
+      },
+    },
+    props: { processing: false, ...props },
+  });
+
+  // The tab items only render their content after the first tick, and the template refs the
+  // component routes "select all" through are only populated once they have.
+  await nextTick();
+  return wrapper;
+}
+
+describe('historyRefreshSelection', () => {
+  let wrapper: VueWrapper<InstanceType<typeof HistoryRefreshSelection>>;
+
+  /** Makes the active tab report a partial selection, which is what enables the refresh button. */
+  async function selectAccounts(): Promise<void> {
+    const chains = wrapper.findComponent({ name: 'HistoryRefreshChains' });
+    chains.vm.$emit('update:modelValue', accounts);
+    await nextTick();
+  }
+
+  /** Clicks a tab header, the way a user switches tabs. */
+  async function openTab(tab: string): Promise<void> {
+    const header = wrapper.findAll('button').find(button => button.text() === `history_refresh_selection.tabs.${tab}`);
+    assert(header, `no tab header for ${tab}`);
+    await header.trigger('click');
+    await nextTick();
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    wrapper = await createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('should keep the refresh button disabled until something is picked', async () => {
+    const refresh = wrapper.find('[data-testid=refresh-selection-refresh]');
+    expect(refresh.attributes('disabled')).toBeDefined();
+
+    await selectAccounts();
+
+    expect(wrapper.find('[data-testid=refresh-selection-refresh]').attributes('disabled')).toBeUndefined();
+  });
+
+  it('should emit the active tab picks and close the menu on refresh', async () => {
+    const menu = wrapper.findComponent(RuiMenuStub);
+    menu.vm.$emit('update:modelValue', true);
+    await nextTick();
+    await selectAccounts();
+
+    await wrapper.find('[data-testid=refresh-selection-refresh]').trigger('click');
+
+    expect(wrapper.emitted('refresh')).toEqual([[{ accounts }]]);
+    expect(menu.props('modelValue')).toBe(false);
+    expect(wrapper.findComponent({ name: 'HistoryRefreshChains' }).props('modelValue')).toEqual([]);
+  });
+
+  it('should clear the picks without emitting when cancelled', async () => {
+    expect(wrapper.find('[data-testid=refresh-selection-cancel]').exists()).toBe(false);
+
+    await selectAccounts();
+    await wrapper.find('[data-testid=refresh-selection-cancel]').trigger('click');
+
+    expect(wrapper.emitted('refresh')).toBeUndefined();
+    expect(wrapper.findComponent({ name: 'HistoryRefreshChains' }).props('modelValue')).toEqual([]);
+    expect(wrapper.find('[data-testid=refresh-selection-cancel]').exists()).toBe(false);
+  });
+
+  it('should route select all to the tab that is showing', async () => {
+    await wrapper.find('[data-testid=refresh-selection-select-all] input').trigger('click');
+
+    expect(toggles.chains).toHaveBeenCalledOnce();
+    expect(toggles.exchanges).not.toHaveBeenCalled();
+
+    await openTab('exchanges');
+    await wrapper.find('[data-testid=refresh-selection-select-all] input').trigger('click');
+
+    expect(toggles.exchanges).toHaveBeenCalledOnce();
+    expect(toggles.chains).toHaveBeenCalledOnce();
+  });
+
+  it('should forward the search text to the tab components', async () => {
+    await wrapper.find('[data-testid=refresh-selection-search] input').setValue('eth');
+
+    expect(wrapper.findComponent({ name: 'HistoryRefreshChains' }).props('search')).toBe('eth');
+  });
+
+  it('should forward processing to the tab components and the select all checkbox', async () => {
+    wrapper.unmount();
+    wrapper = await createWrapper({ processing: true });
+
+    expect(wrapper.findComponent({ name: 'HistoryRefreshChains' }).props('processing')).toBe(true);
+    expect(wrapper.find('[data-testid=refresh-selection-select-all] input').attributes('disabled')).toBeDefined();
+  });
+
+  it('should disable the activator when disabled', async () => {
+    wrapper.unmount();
+    wrapper = await createWrapper({ disabled: true });
+
+    expect(wrapper.find('button').attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshSelection.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshSelection.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import type { ComponentExposed } from 'vue-component-type-helpers';
-import type { Exchange } from '@/modules/balances/types/exchanges';
-import type { ChainAddress } from '@/modules/history/events/event-payloads';
-import type { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
 import type { HistoryRefreshEventData } from '@/modules/history/refresh/types';
 import HistoryRefreshChains from '@/modules/history/refresh/HistoryRefreshChains.vue';
 import HistoryRefreshExchanges from '@/modules/history/refresh/HistoryRefreshExchanges.vue';
 import HistoryRefreshProtocolEvents from '@/modules/history/refresh/HistoryRefreshProtocolEvents.vue';
 import HistoryRefreshStakingEvents from '@/modules/history/refresh/HistoryRefreshStakingEvents.vue';
+import { HistoryRefreshTab, useHistoryRefreshSelection } from '@/modules/history/refresh/use-history-refresh-selection';
 
 const {
   processing,
@@ -22,21 +20,6 @@ const emit = defineEmits<{
 }>();
 
 const open = ref<boolean>(false);
-const search = ref<string>('');
-const tab = ref<'chains' | 'exchanges' | 'events' | 'protocols'>('chains');
-
-const selectedAccounts = ref<ChainAddress[]>([]);
-const allAccountsSelected = ref<boolean>(false);
-const selectedChain = ref<string>();
-
-const selectedExchanges = ref<Exchange[]>([]);
-const allExchangesSelected = ref<boolean>(false);
-
-const selectedQueries = ref<OnlineHistoryEventsQueryType[]>([]);
-const allQueriesSelected = ref<boolean>(false);
-
-const selectedProtocolQueries = ref<OnlineHistoryEventsQueryType[]>([]);
-const allProtocolQueriesSelected = ref<boolean>(false);
 
 const chains = useTemplateRef<ComponentExposed<typeof HistoryRefreshChains>>('chains');
 const exchanges = useTemplateRef<ComponentExposed<typeof HistoryRefreshExchanges>>('exchanges');
@@ -45,143 +28,40 @@ const protocols = useTemplateRef<ComponentExposed<typeof HistoryRefreshProtocolE
 
 const { t } = useI18n({ useScope: 'global' });
 
-const indeterminate = computed<boolean>(() => {
-  switch (get(tab)) {
-    case 'chains':
-      return get(selectedAccounts).length > 0 && !get(allAccountsSelected);
-    case 'exchanges':
-      return get(selectedExchanges).length > 0 && !get(allExchangesSelected);
-    case 'events':
-      return get(selectedQueries).length > 0 && !get(allQueriesSelected);
-    case 'protocols':
-      return get(selectedProtocolQueries).length > 0 && !get(allProtocolQueriesSelected);
-    default:
-      return false;
-  }
-});
+const {
+  getRefreshPayload,
+  indeterminate,
+  modelSearch,
+  modelSelectedAccounts,
+  modelSelectedChain,
+  modelSelectedExchanges,
+  modelSelectedProtocolQueries,
+  modelSelectedQueries,
+  modelTab,
+  reset,
+  searchLabel,
+  selected,
+  setAllSelected,
+  totalSelected,
+  typeText,
+} = useHistoryRefreshSelection();
 
-const selected = computed<boolean>(() => {
-  switch (get(tab)) {
-    case 'chains':
-      return get(selectedAccounts).length > 0 && get(allAccountsSelected);
-    case 'exchanges':
-      return get(selectedExchanges).length > 0 && get(allExchangesSelected);
-    case 'events':
-      return get(selectedQueries).length > 0 && get(allQueriesSelected);
-    case 'protocols':
-      return get(selectedProtocolQueries).length > 0 && get(allProtocolQueriesSelected);
-    default:
-      return false;
-  }
-});
-
-const totalSelected = computed<number>(() => {
-  switch (get(tab)) {
-    case 'chains':
-      return get(selectedAccounts).length;
-    case 'exchanges':
-      return get(selectedExchanges).length;
-    case 'events':
-      return get(selectedQueries).length;
-    case 'protocols':
-      return get(selectedProtocolQueries).length;
-    default:
-      return 0;
-  }
-});
-
-const searchLabel = computed<string>(() => {
-  switch (get(tab)) {
-    case 'chains':
-      return isDefined(selectedChain)
-        ? t('history_refresh_selection.search_address')
-        : t('history_refresh_selection.search_chain');
-    case 'exchanges':
-      return t('history_refresh_selection.search_exchanges');
-    case 'events':
-      return t('history_refresh_selection.search_events');
-    case 'protocols':
-      return t('history_refresh_selection.search_protocols');
-    default:
-      return '';
-  }
-});
-
-const typeText = computed<string>(() => {
-  const total = get(totalSelected);
-  switch (get(tab)) {
-    case 'chains':
-      return t('history_refresh_selection.type.accounts', total);
-    case 'exchanges':
-      return t('history_refresh_selection.type.exchanges', total);
-    case 'events':
-      return t('history_refresh_selection.type.events', total);
-    case 'protocols':
-      return t('history_refresh_selection.type.protocols', total);
-    default:
-      return '';
-  }
-});
-
-function reset() {
-  set(search, '');
-  set(selectedChain, undefined);
-  set(selectedAccounts, []);
-  set(allAccountsSelected, false);
-  set(selectedExchanges, []);
-  set(allExchangesSelected, false);
-  set(selectedQueries, []);
-  set(allQueriesSelected, false);
-  set(selectedProtocolQueries, []);
-  set(allProtocolQueriesSelected, false);
-}
-
-function refresh() {
-  switch (get(tab)) {
-    case 'chains':
-      emit('refresh', { accounts: get(selectedAccounts) });
-      break;
-    case 'exchanges':
-      emit('refresh', { exchanges: get(selectedExchanges) });
-      break;
-    case 'events':
-      emit('refresh', { queries: get(selectedQueries) });
-      break;
-    case 'protocols':
-      emit('refresh', { queries: get(selectedProtocolQueries) });
-      break;
-    default:
-      return '';
-  }
-
+function refresh(): void {
+  emit('refresh', getRefreshPayload());
   reset();
   set(open, false);
 }
 
-function toggleSelectAll() {
-  switch (get(tab)) {
-    case 'chains':
-      get(chains)?.toggleSelectAll();
-      break;
-    case 'exchanges':
-      get(exchanges)?.toggleSelectAll();
-      break;
-    case 'events':
-      get(validatorEvents)?.toggleSelectAll();
-      break;
-    case 'protocols':
-      get(protocols)?.toggleSelectAll();
-      break;
-  }
+function toggleSelectAll(): void {
+  const tabs: Record<HistoryRefreshTab, { toggleSelectAll: () => void } | null> = {
+    [HistoryRefreshTab.CHAINS]: get(chains),
+    [HistoryRefreshTab.EVENTS]: get(validatorEvents),
+    [HistoryRefreshTab.EXCHANGES]: get(exchanges),
+    [HistoryRefreshTab.PROTOCOLS]: get(protocols),
+  };
+
+  tabs[get(modelTab)]?.toggleSelectAll();
 }
-
-watch(tab, () => {
-  reset();
-});
-
-onMounted(() => {
-  reset();
-});
 </script>
 
 <template>
@@ -206,7 +86,8 @@ onMounted(() => {
     <div class="w-[450px]">
       <div class="p-4 border-b border-default">
         <RuiTextField
-          v-model="search"
+          v-model="modelSearch"
+          data-testid="refresh-selection-search"
           dense
           color="primary"
           variant="outlined"
@@ -216,17 +97,17 @@ onMounted(() => {
           clearable
         />
       </div>
-      <RuiTabs v-model="tab">
-        <RuiTab value="chains">
+      <RuiTabs v-model="modelTab">
+        <RuiTab :value="HistoryRefreshTab.CHAINS">
           {{ t('history_refresh_selection.tabs.chains') }}
         </RuiTab>
-        <RuiTab value="exchanges">
+        <RuiTab :value="HistoryRefreshTab.EXCHANGES">
           {{ t('history_refresh_selection.tabs.exchanges') }}
         </RuiTab>
-        <RuiTab value="events">
+        <RuiTab :value="HistoryRefreshTab.EVENTS">
           {{ t('history_refresh_selection.tabs.events') }}
         </RuiTab>
-        <RuiTab value="protocols">
+        <RuiTab :value="HistoryRefreshTab.PROTOCOLS">
           {{ t('history_refresh_selection.tabs.protocols') }}
         </RuiTab>
       </RuiTabs>
@@ -235,42 +116,42 @@ onMounted(() => {
         {{ t('history_refresh_selection.selection') }}
       </div>
 
-      <RuiTabItems v-model="tab">
-        <RuiTabItem value="chains">
+      <RuiTabItems v-model="modelTab">
+        <RuiTabItem :value="HistoryRefreshTab.CHAINS">
           <HistoryRefreshChains
             ref="chains"
-            v-model:search="search"
-            v-model:chain="selectedChain"
-            v-model="selectedAccounts"
+            v-model:search="modelSearch"
+            v-model:chain="modelSelectedChain"
+            v-model="modelSelectedAccounts"
             :processing="processing"
-            @update:all-selected="allAccountsSelected = $event"
+            @update:all-selected="setAllSelected('chains', $event)"
           />
         </RuiTabItem>
-        <RuiTabItem value="exchanges">
+        <RuiTabItem :value="HistoryRefreshTab.EXCHANGES">
           <HistoryRefreshExchanges
             ref="exchanges"
-            v-model:search="search"
-            v-model="selectedExchanges"
+            v-model:search="modelSearch"
+            v-model="modelSelectedExchanges"
             :processing="processing"
-            @update:all-selected="allExchangesSelected = $event"
+            @update:all-selected="setAllSelected('exchanges', $event)"
           />
         </RuiTabItem>
-        <RuiTabItem value="events">
+        <RuiTabItem :value="HistoryRefreshTab.EVENTS">
           <HistoryRefreshStakingEvents
             ref="validatorEvents"
-            v-model="selectedQueries"
-            v-model:search="search"
+            v-model="modelSelectedQueries"
+            v-model:search="modelSearch"
             :processing="processing"
-            @update:all-selected="allQueriesSelected = $event"
+            @update:all-selected="setAllSelected('events', $event)"
           />
         </RuiTabItem>
-        <RuiTabItem value="protocols">
+        <RuiTabItem :value="HistoryRefreshTab.PROTOCOLS">
           <HistoryRefreshProtocolEvents
             ref="protocols"
-            v-model="selectedProtocolQueries"
-            v-model:search="search"
+            v-model="modelSelectedProtocolQueries"
+            v-model:search="modelSearch"
             :processing="processing"
-            @update:all-selected="allProtocolQueriesSelected = $event"
+            @update:all-selected="setAllSelected('protocols', $event)"
           />
         </RuiTabItem>
       </RuiTabItems>
@@ -278,6 +159,7 @@ onMounted(() => {
       <div class="px-4 py-2 border-t border-default flex items-center justify-between">
         <RuiCheckbox
           color="primary"
+          data-testid="refresh-selection-select-all"
           :disabled="processing"
           :indeterminate="indeterminate"
           :model-value="selected"
@@ -290,6 +172,7 @@ onMounted(() => {
         <div class="flex items-center gap-2">
           <RuiButton
             v-if="indeterminate || selected"
+            data-testid="refresh-selection-cancel"
             variant="text"
             @click="reset()"
           >
@@ -297,6 +180,7 @@ onMounted(() => {
           </RuiButton>
           <RuiButton
             color="primary"
+            data-testid="refresh-selection-refresh"
             :disabled="!(indeterminate || selected)"
             :loading="processing"
             @click="refresh()"

--- a/frontend/app/src/modules/history/refresh/use-history-refresh-selection.spec.ts
+++ b/frontend/app/src/modules/history/refresh/use-history-refresh-selection.spec.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
+import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
+import { type HistoryRefreshTab, useHistoryRefreshSelection } from '@/modules/history/refresh/use-history-refresh-selection';
+
+/**
+ * The seam: the four tabs each hold their own picks, and everything the menu shows (the select-all
+ * state, the counter, the search label) reads the *active* tab only. Switching tabs throws the
+ * picks away, and the refresh payload is the active tab's picks in the shape the parent expects.
+ */
+describe('useHistoryRefreshSelection', () => {
+  let selection: ReturnType<typeof useHistoryRefreshSelection>;
+
+  beforeEach(() => {
+    selection = useHistoryRefreshSelection();
+  });
+
+  async function switchTo(tab: HistoryRefreshTab): Promise<void> {
+    set(selection.modelTab, tab);
+    await nextTick();
+  }
+
+  it('should start on the chains tab with nothing picked', () => {
+    const { indeterminate, modelTab, selected, totalSelected } = selection;
+
+    expect(get(modelTab)).toBe('chains');
+    expect(get(totalSelected)).toBe(0);
+    expect(get(indeterminate)).toBe(false);
+    expect(get(selected)).toBe(false);
+  });
+
+  it('should count only the active tab', async () => {
+    const { modelSelectedAccounts, modelSelectedExchanges, totalSelected } = selection;
+
+    set(modelSelectedAccounts, [{ address: '0x1', chain: 'eth' }, { address: '0x2', chain: 'eth' }]);
+    expect(get(totalSelected)).toBe(2);
+
+    await switchTo('exchanges');
+    set(modelSelectedExchanges, [{ location: 'kraken', name: 'Kraken 1' }]);
+    expect(get(totalSelected)).toBe(1);
+  });
+
+  it('should be indeterminate for a partial pick and selected once the tab reports all', () => {
+    const { indeterminate, modelSelectedAccounts, selected, setAllSelected } = selection;
+
+    set(modelSelectedAccounts, [{ address: '0x1', chain: 'eth' }]);
+    expect(get(indeterminate)).toBe(true);
+    expect(get(selected)).toBe(false);
+
+    setAllSelected('chains', true);
+    expect(get(indeterminate)).toBe(false);
+    expect(get(selected)).toBe(true);
+  });
+
+  it('should stay unselected when a tab reports all with nothing picked', () => {
+    const { indeterminate, selected, setAllSelected } = selection;
+
+    setAllSelected('chains', true);
+
+    expect(get(indeterminate)).toBe(false);
+    expect(get(selected)).toBe(false);
+  });
+
+  it('should read the select-all state from the active tab', async () => {
+    const { modelSelectedExchanges, selected, setAllSelected } = selection;
+
+    await switchTo('exchanges');
+    set(modelSelectedExchanges, [{ location: 'kraken', name: 'Kraken 1' }]);
+    setAllSelected('exchanges', true);
+    expect(get(selected)).toBe(true);
+
+    await switchTo('protocols');
+    expect(get(selected)).toBe(false);
+  });
+
+  it('should drop every pick when the tab changes', async () => {
+    const { modelSearch, modelSelectedAccounts, modelSelectedChain, selected, setAllSelected } = selection;
+
+    set(modelSearch, 'eth');
+    set(modelSelectedChain, 'eth');
+    set(modelSelectedAccounts, [{ address: '0x1', chain: 'eth' }]);
+    setAllSelected('chains', true);
+
+    await switchTo('events');
+
+    expect(get(modelSearch)).toBe('');
+    expect(get(modelSelectedChain)).toBeUndefined();
+    expect(get(modelSelectedAccounts)).toEqual([]);
+
+    // Back on the tab that had reported "all selected", to prove that flag was cleared too.
+    await switchTo('chains');
+    expect(get(selected)).toBe(false);
+  });
+
+  it('should clear every tab on reset', async () => {
+    const {
+      modelSelectedExchanges,
+      modelSelectedProtocolQueries,
+      modelSelectedQueries,
+      reset,
+      selected,
+      setAllSelected,
+    } = selection;
+
+    await switchTo('protocols');
+    set(modelSelectedExchanges, [{ location: 'kraken', name: 'Kraken 1' }]);
+    set(modelSelectedQueries, [OnlineHistoryEventsQueryType.ETH_WITHDRAWALS]);
+    set(modelSelectedProtocolQueries, [OnlineHistoryEventsQueryType.GNOSIS_PAY]);
+    setAllSelected('protocols', true);
+
+    reset();
+
+    expect(get(modelSelectedExchanges)).toEqual([]);
+    expect(get(modelSelectedQueries)).toEqual([]);
+    expect(get(modelSelectedProtocolQueries)).toEqual([]);
+    expect(get(selected)).toBe(false);
+  });
+
+  describe('searchLabel', () => {
+    it('should ask for a chain until one is picked, then for an address', () => {
+      const { modelSelectedChain, searchLabel } = selection;
+
+      expect(get(searchLabel)).toBe('history_refresh_selection.search_chain');
+
+      set(modelSelectedChain, 'eth');
+      expect(get(searchLabel)).toBe('history_refresh_selection.search_address');
+    });
+
+    it.each<[HistoryRefreshTab, string]>([
+      ['exchanges', 'history_refresh_selection.search_exchanges'],
+      ['events', 'history_refresh_selection.search_events'],
+      ['protocols', 'history_refresh_selection.search_protocols'],
+    ])('should label the search for the %s tab', async (tab, expected) => {
+      await switchTo(tab);
+      expect(get(selection.searchLabel)).toBe(expected);
+    });
+  });
+
+  describe('typeText', () => {
+    it.each<[HistoryRefreshTab, string]>([
+      ['chains', 'history_refresh_selection.type.accounts'],
+      ['exchanges', 'history_refresh_selection.type.exchanges'],
+      ['events', 'history_refresh_selection.type.events'],
+      ['protocols', 'history_refresh_selection.type.protocols'],
+    ])('should name what the %s tab refreshes', async (tab, expected) => {
+      await switchTo(tab);
+      expect(get(selection.typeText)).toBe(expected);
+    });
+
+    it('should pluralize by how many are picked', () => {
+      const { modelSelectedAccounts, typeText } = selection;
+
+      set(modelSelectedAccounts, [{ address: '0x1', chain: 'eth' }, { address: '0x2', chain: 'eth' }]);
+
+      // `mockT` marks a key it was given a pluralization argument for with a trailing `::`.
+      expect(get(typeText)).toBe('history_refresh_selection.type.accounts::');
+    });
+  });
+
+  describe('getRefreshPayload', () => {
+    it('should send the picked accounts from the chains tab', () => {
+      const accounts = [{ address: '0x1', chain: 'eth' }];
+      set(selection.modelSelectedAccounts, accounts);
+
+      expect(selection.getRefreshPayload()).toEqual({ accounts });
+    });
+
+    it('should send the picked exchanges from the exchanges tab', async () => {
+      const exchanges = [{ location: 'kraken', name: 'Kraken 1' }];
+      await switchTo('exchanges');
+      set(selection.modelSelectedExchanges, exchanges);
+
+      expect(selection.getRefreshPayload()).toEqual({ exchanges });
+    });
+
+    it('should send the staking queries from the events tab', async () => {
+      const queries = [OnlineHistoryEventsQueryType.ETH_WITHDRAWALS];
+      await switchTo('events');
+      set(selection.modelSelectedQueries, queries);
+
+      expect(selection.getRefreshPayload()).toEqual({ queries });
+    });
+
+    it('should send the protocol queries from the protocols tab', async () => {
+      const queries = [OnlineHistoryEventsQueryType.GNOSIS_PAY];
+      await switchTo('protocols');
+      set(selection.modelSelectedProtocolQueries, queries);
+
+      expect(selection.getRefreshPayload()).toEqual({ queries });
+    });
+  });
+});

--- a/frontend/app/src/modules/history/refresh/use-history-refresh-selection.ts
+++ b/frontend/app/src/modules/history/refresh/use-history-refresh-selection.ts
@@ -1,0 +1,184 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { Exchange } from '@/modules/balances/types/exchanges';
+import type { ChainAddress } from '@/modules/history/events/event-payloads';
+import type { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
+import type { HistoryRefreshEventData } from '@/modules/history/refresh/types';
+
+export const HistoryRefreshTab = {
+  CHAINS: 'chains',
+  EVENTS: 'events',
+  EXCHANGES: 'exchanges',
+  PROTOCOLS: 'protocols',
+} as const;
+
+export type HistoryRefreshTab = typeof HistoryRefreshTab[keyof typeof HistoryRefreshTab];
+
+interface TabState {
+  /** How many entries the tab currently has picked. */
+  count: ComputedRef<number>;
+  /** Whether the tab reported that its picks cover everything it offers. */
+  allSelected: Ref<boolean>;
+}
+
+interface UseHistoryRefreshSelectionReturn {
+  /** All bound with `v-model`, so they stay writable. */
+  modelTab: Ref<HistoryRefreshTab>;
+  modelSearch: Ref<string>;
+  modelSelectedChain: Ref<string | undefined>;
+  modelSelectedAccounts: Ref<ChainAddress[]>;
+  modelSelectedExchanges: Ref<Exchange[]>;
+  modelSelectedQueries: Ref<OnlineHistoryEventsQueryType[]>;
+  modelSelectedProtocolQueries: Ref<OnlineHistoryEventsQueryType[]>;
+  /** How a tab reports that its picks cover everything it offers. */
+  setAllSelected: (tab: HistoryRefreshTab, allSelected: boolean) => void;
+  /** Some, but not all, of what the active tab offers is picked. */
+  indeterminate: ComputedRef<boolean>;
+  /** Everything the active tab offers is picked. */
+  selected: ComputedRef<boolean>;
+  totalSelected: ComputedRef<number>;
+  searchLabel: ComputedRef<string>;
+  typeText: ComputedRef<string>;
+  /** The active tab's picks, in the shape the parent refreshes by. */
+  getRefreshPayload: () => HistoryRefreshEventData;
+  reset: () => void;
+}
+
+/**
+ * The picks behind the history refresh menu.
+ *
+ * Each of the four tabs keeps its own selection and reports back whether that selection covers
+ * everything it offers, which is what the "select all" checkbox and the refresh button read. The
+ * tabs are independent on purpose: switching tabs resets, because a selection made against one
+ * tab's entries says nothing about another's.
+ */
+export function useHistoryRefreshSelection(): UseHistoryRefreshSelectionReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const modelTab = shallowRef<HistoryRefreshTab>(HistoryRefreshTab.CHAINS);
+  const modelSearch = shallowRef<string>('');
+
+  const modelSelectedChain = shallowRef<string>();
+  const modelSelectedAccounts = ref<ChainAddress[]>([]);
+  const allAccountsSelected = shallowRef<boolean>(false);
+
+  const modelSelectedExchanges = ref<Exchange[]>([]);
+  const allExchangesSelected = shallowRef<boolean>(false);
+
+  const modelSelectedQueries = ref<OnlineHistoryEventsQueryType[]>([]);
+  const allQueriesSelected = shallowRef<boolean>(false);
+
+  const modelSelectedProtocolQueries = ref<OnlineHistoryEventsQueryType[]>([]);
+  const allProtocolQueriesSelected = shallowRef<boolean>(false);
+
+  const tabStates: Record<HistoryRefreshTab, TabState> = {
+    [HistoryRefreshTab.CHAINS]: {
+      allSelected: allAccountsSelected,
+      count: computed<number>(() => get(modelSelectedAccounts).length),
+    },
+    [HistoryRefreshTab.EVENTS]: {
+      allSelected: allQueriesSelected,
+      count: computed<number>(() => get(modelSelectedQueries).length),
+    },
+    [HistoryRefreshTab.EXCHANGES]: {
+      allSelected: allExchangesSelected,
+      count: computed<number>(() => get(modelSelectedExchanges).length),
+    },
+    [HistoryRefreshTab.PROTOCOLS]: {
+      allSelected: allProtocolQueriesSelected,
+      count: computed<number>(() => get(modelSelectedProtocolQueries).length),
+    },
+  };
+
+  const activeTabState = computed<TabState>(() => tabStates[get(modelTab)]);
+
+  const totalSelected = computed<number>(() => get(get(activeTabState).count));
+
+  const indeterminate = computed<boolean>(
+    () => get(totalSelected) > 0 && !get(get(activeTabState).allSelected),
+  );
+
+  const selected = computed<boolean>(
+    () => get(totalSelected) > 0 && get(get(activeTabState).allSelected),
+  );
+
+  const searchLabel = computed<string>(() => {
+    switch (get(modelTab)) {
+      case HistoryRefreshTab.CHAINS:
+        return isDefined(modelSelectedChain)
+          ? t('history_refresh_selection.search_address')
+          : t('history_refresh_selection.search_chain');
+      case HistoryRefreshTab.EXCHANGES:
+        return t('history_refresh_selection.search_exchanges');
+      case HistoryRefreshTab.EVENTS:
+        return t('history_refresh_selection.search_events');
+      case HistoryRefreshTab.PROTOCOLS:
+        return t('history_refresh_selection.search_protocols');
+    }
+  });
+
+  const typeText = computed<string>(() => {
+    const total = get(totalSelected);
+    switch (get(modelTab)) {
+      case HistoryRefreshTab.CHAINS:
+        return t('history_refresh_selection.type.accounts', total);
+      case HistoryRefreshTab.EXCHANGES:
+        return t('history_refresh_selection.type.exchanges', total);
+      case HistoryRefreshTab.EVENTS:
+        return t('history_refresh_selection.type.events', total);
+      case HistoryRefreshTab.PROTOCOLS:
+        return t('history_refresh_selection.type.protocols', total);
+    }
+  });
+
+  function setAllSelected(tab: HistoryRefreshTab, allSelected: boolean): void {
+    set(tabStates[tab].allSelected, allSelected);
+  }
+
+  function getRefreshPayload(): HistoryRefreshEventData {
+    switch (get(modelTab)) {
+      case HistoryRefreshTab.CHAINS:
+        return { accounts: get(modelSelectedAccounts) };
+      case HistoryRefreshTab.EXCHANGES:
+        return { exchanges: get(modelSelectedExchanges) };
+      case HistoryRefreshTab.EVENTS:
+        return { queries: get(modelSelectedQueries) };
+      case HistoryRefreshTab.PROTOCOLS:
+        return { queries: get(modelSelectedProtocolQueries) };
+    }
+  }
+
+  function reset(): void {
+    set(modelSearch, '');
+    set(modelSelectedChain, undefined);
+    set(modelSelectedAccounts, []);
+    set(allAccountsSelected, false);
+    set(modelSelectedExchanges, []);
+    set(allExchangesSelected, false);
+    set(modelSelectedQueries, []);
+    set(allQueriesSelected, false);
+    set(modelSelectedProtocolQueries, []);
+    set(allProtocolQueriesSelected, false);
+  }
+
+  watch(modelTab, () => {
+    reset();
+  });
+
+  return {
+    getRefreshPayload,
+    indeterminate,
+    modelSearch,
+    modelSelectedAccounts,
+    modelSelectedChain,
+    modelSelectedExchanges,
+    modelSelectedProtocolQueries,
+    modelSelectedQueries,
+    modelTab,
+    reset,
+    searchLabel,
+    selected,
+    setAllSelected,
+    totalSelected,
+    typeText,
+  };
+}

--- a/frontend/app/src/modules/wallet/send/TradeRecipientAddress.spec.ts
+++ b/frontend/app/src/modules/wallet/send/TradeRecipientAddress.spec.ts
@@ -1,0 +1,200 @@
+import type { RecipientOption } from '@/modules/wallet/send/use-trade-recipient-address';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, nextTick } from 'vue';
+import TradeRecipientAddress from '@/modules/wallet/send/TradeRecipientAddress.vue';
+
+/**
+ * The seam: this component is wiring plus the two shapes the field takes. With a recipient it shows
+ * that address and a way to clear it; without one it shows the search input, the suggestions and
+ * the address book. Everything it does with an address goes through the composable, which
+ * `use-trade-recipient-address.spec.ts` covers.
+ */
+
+const ALICE = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+
+const recipientApi = {
+  applySearchInput: vi.fn(),
+  directOptions: ref<RecipientOption[]>([]),
+  filteredAddressBookOptions: ref<string[]>([]),
+  handleFocusChange: vi.fn(),
+  modelAddressBookSearch: ref<string>(''),
+  modelOpenOptionsDialog: ref<boolean>(false),
+  modelOpenSuggestionsMenu: ref<boolean>(false),
+  modelSearchValue: ref<string>(''),
+  reset: vi.fn(),
+  resolvingEns: ref<boolean>(false),
+  searchAddresses: vi.fn(),
+  select: vi.fn(),
+  trackedAddresses: ref<string[]>([]),
+  valid: ref<boolean>(true),
+};
+
+vi.mock('@/modules/wallet/send/use-trade-recipient-address', () => ({
+  useTradeRecipientAddress: (): typeof recipientApi => recipientApi,
+}));
+
+const connected = ref<boolean>(false);
+
+vi.mock('@/modules/wallet/use-wallet-store', () => ({
+  useWalletStore: (): { connected: typeof connected } => ({ connected }),
+}));
+
+// RuiMenu renders its content in a popper; stub it so the suggestions are in the tree.
+const RuiMenuStub = defineComponent({
+  name: 'RuiMenu',
+  props: { modelValue: { default: false, type: Boolean } },
+  emits: ['update:modelValue'],
+  template: '<div><slot name="activator" :attrs="{}" /><slot :width="300" /></div>',
+});
+
+const RuiDialogStub = defineComponent({
+  name: 'RuiDialog',
+  props: { modelValue: { default: false, type: Boolean } },
+  emits: ['update:modelValue'],
+  template: '<div v-if="modelValue"><slot /></div>',
+});
+
+// The real display resolves names through pinia; here only what it is handed matters.
+const addressDisplayStub = defineComponent({
+  name: 'TradeAddressDisplay',
+  props: {
+    address: { default: '', type: String },
+    chain: { default: '', type: String },
+    name: { default: '', type: String },
+  },
+  template: '<div class="address-display">{{ address }}</div>',
+});
+
+async function createWrapper(props: { model?: string; showWarning?: boolean } = {}): Promise<VueWrapper<InstanceType<typeof TradeRecipientAddress>>> {
+  const wrapper = mount(TradeRecipientAddress, {
+    global: {
+      stubs: {
+        RuiDialog: RuiDialogStub,
+        RuiMenu: RuiMenuStub,
+        TradeAddressDisplay: addressDisplayStub,
+      },
+    },
+    props: {
+      chain: 'eth',
+      modelValue: props.model ?? '',
+      showWarning: props.showWarning ?? false,
+    },
+  });
+
+  await nextTick();
+  return wrapper;
+}
+
+describe('tradeRecipientAddress', () => {
+  let wrapper: VueWrapper<InstanceType<typeof TradeRecipientAddress>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(connected, false);
+    set(recipientApi.valid, true);
+    set(recipientApi.directOptions, []);
+    set(recipientApi.trackedAddresses, []);
+    set(recipientApi.filteredAddressBookOptions, []);
+    set(recipientApi.modelOpenOptionsDialog, false);
+    set(recipientApi.modelSearchValue, '');
+    set(recipientApi.resolvingEns, false);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  describe('without a recipient', () => {
+    beforeEach(async () => {
+      wrapper = await createWrapper();
+    });
+
+    it('should search as the user types and take what was typed on blur', async () => {
+      const input = wrapper.find('[data-testid=recipient-search]');
+      await input.setValue(ALICE);
+
+      expect(get(recipientApi.modelSearchValue)).toBe(ALICE);
+
+      await input.trigger('blur');
+
+      expect(recipientApi.applySearchInput).toHaveBeenCalledOnce();
+    });
+
+    it('should offer what the search found and pick the one that is clicked', async () => {
+      set(recipientApi.directOptions, [{ address: ALICE, name: 'alice.eth' }]);
+      await nextTick();
+
+      const option = wrapper.findAllComponents(addressDisplayStub)
+        .find(candidate => candidate.props('address') === ALICE);
+      expect(option?.props('name')).toBe('alice.eth');
+
+      await option?.trigger('click');
+
+      expect(recipientApi.select).toHaveBeenCalledWith(ALICE);
+    });
+
+    it('should say it is resolving instead of offering anything', async () => {
+      set(recipientApi.directOptions, [{ address: ALICE }]);
+      set(recipientApi.resolvingEns, true);
+      await nextTick();
+
+      expect(wrapper.text()).toContain('trade.recipient.resolving_ens');
+      expect(wrapper.findAllComponents(addressDisplayStub)).toHaveLength(0);
+    });
+
+    it('should open the address book on request', async () => {
+      await wrapper.find('[data-testid=recipient-open-address-book]').trigger('click');
+
+      expect(get(recipientApi.modelOpenOptionsDialog)).toBe(true);
+    });
+
+    it('should say when the address book has nothing to offer', async () => {
+      set(recipientApi.modelOpenOptionsDialog, true);
+      await nextTick();
+
+      expect(wrapper.text()).toContain('trade.recipient.no_addresses_found');
+    });
+
+    it('should mark the field when what is in it is not an address', async () => {
+      expect(wrapper.text()).toContain('trade.to_address.label');
+      expect(wrapper.find('[data-testid=recipient-field]').classes()).not.toContain('!border-rui-error');
+
+      await wrapper.setProps({ modelValue: 'not-an-address' });
+      set(recipientApi.valid, false);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=recipient-field]').classes()).toContain('!border-rui-error');
+    });
+  });
+
+  describe('with a recipient', () => {
+    beforeEach(async () => {
+      wrapper = await createWrapper({ model: ALICE });
+    });
+
+    it('should show the recipient instead of the search input', () => {
+      expect(wrapper.find('[data-testid=recipient-search]').exists()).toBe(false);
+      expect(wrapper.findComponent(addressDisplayStub).props('address')).toBe(ALICE);
+    });
+
+    it('should clear the recipient on request', async () => {
+      await wrapper.find('[data-testid=recipient-clear]').trigger('click');
+
+      expect(recipientApi.reset).toHaveBeenCalledOnce();
+    });
+
+    it('should warn about an address the wallet never interacted with, only while connected', async () => {
+      await wrapper.setProps({ showWarning: true });
+      expect(wrapper.text()).not.toContain('trade.never_interacted');
+
+      set(connected, true);
+      await nextTick();
+
+      expect(wrapper.text()).toContain('trade.never_interacted');
+
+      await wrapper.setProps({ showWarning: false });
+      expect(wrapper.text()).not.toContain('trade.never_interacted');
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/send/TradeRecipientAddress.vue
+++ b/frontend/app/src/modules/wallet/send/TradeRecipientAddress.vue
@@ -90,26 +90,9 @@ const { containerProps: addressBookContainerProps, list: addressBookList, wrappe
         </div>
         <template v-else>
           <label class="flex flex-col flex-1 p-3">
-            <Transition
-              mode="out-in"
-              enter-active-class="transition-all duration-50"
-              leave-active-class="transition-all duration-50"
-              enter-from-class="opacity-0 -translate-x-1"
-              leave-to-class="opacity-0 translate-x-1"
-            >
-              <span
-                v-if="!model || valid"
-                class="text-sm text-rui-grey-500 font-medium block"
-              >
-                {{ t('trade.to_address.label') }}
-              </span>
-              <span
-                v-else
-                class="text-sm text-rui-error font-medium block"
-              >
-                {{ t('trade.to_address.error') }}
-              </span>
-            </Transition>
+            <span class="text-sm text-rui-grey-500 font-medium block">
+              {{ t('trade.to_address.label') }}
+            </span>
             <input
               ref="searchInputRef"
               v-model="modelSearchValue"

--- a/frontend/app/src/modules/wallet/send/TradeRecipientAddress.vue
+++ b/frontend/app/src/modules/wallet/send/TradeRecipientAddress.vue
@@ -1,13 +1,8 @@
 <script setup lang="ts">
-import { isValidEthAddress } from '@rotki/common';
-import { startPromise } from '@shared/utils';
 import { useTemplateRef } from 'vue';
-import { useAddressBookOperations } from '@/modules/accounts/address-book/use-address-book-operations';
-import { useEnsOperations } from '@/modules/accounts/address-book/use-ens-operations';
-import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
-import { uniqueObjects } from '@/modules/core/common/data/data';
 import { useRefWithDebounce } from '@/modules/core/common/use-ref-debounce';
 import TradeAddressDisplay from '@/modules/wallet/send/TradeAddressDisplay.vue';
+import { useTradeRecipientAddress } from '@/modules/wallet/send/use-trade-recipient-address';
 import { useWalletStore } from '@/modules/wallet/use-wallet-store';
 
 const model = defineModel<string>({ required: true });
@@ -19,138 +14,34 @@ defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const openOptionsDialog = ref<boolean>(false);
-
-const resolvingEns = ref<boolean>(false);
-const addressBookOptions = ref<string[]>([]);
-const addressBookSearch = ref<string>('');
-const addressBookSearchDebounced = refDebounced(addressBookSearch, 200);
-
-const openSuggestionsMenu = ref<boolean>(false);
-const searchValue = ref<string>('');
-const directOptions = ref<{ address: string; name: string }[]>([]);
-const debouncedSearchValue = refDebounced(searchValue, 200);
-
 const searchInputRef = useTemplateRef<InstanceType<typeof HTMLInputElement>>('searchInputRef');
 const menuContainerRef = useTemplateRef<InstanceType<typeof HTMLDivElement>>('menuContainerRef');
 const { focused: searchInputFocused } = useFocus(searchInputRef);
 const { focused: menuFocusedWithin } = useFocusWithin(menuContainerRef);
 
-const { connected, connectedAddress } = storeToRefs(useWalletStore());
-const { addresses } = useAccountAddresses();
-const { getAddressBook } = useAddressBookOperations();
-const { fetchEnsNames, resolveEnsToAddress } = useEnsOperations();
+const { connected } = storeToRefs(useWalletStore());
 
-function isNotConnectedAddress(address: string) {
-  const connected = get(connectedAddress);
-  return !connected || address !== connected;
-}
-
-const trackedAddresses = computed<string[]>(() => {
-  const accountsAddresses = [...new Set(Object.values(get(addresses)).flat())];
-  return accountsAddresses.filter(address => isValidEthAddress(address) && isNotConnectedAddress(address));
-});
-
-const filteredAddressBookOptions = computed<string[]>(() => get(addressBookOptions).filter(isNotConnectedAddress));
-
-const valid = computed<boolean>(() => {
-  const value = get(model);
-  return !value || isValidEthAddress(value);
-});
+const {
+  applySearchInput,
+  directOptions,
+  filteredAddressBookOptions,
+  handleFocusChange,
+  modelAddressBookSearch,
+  modelOpenOptionsDialog,
+  modelOpenSuggestionsMenu,
+  modelSearchValue,
+  reset,
+  resolvingEns,
+  select,
+  trackedAddresses,
+  valid,
+} = useTradeRecipientAddress(model);
 
 const anyFocused = logicOr(searchInputFocused, menuFocusedWithin);
 const usedAnyFocused = useRefWithDebounce(anyFocused, 200);
 
-function select(address: string) {
-  if (isNotConnectedAddress(address)) {
-    set(model, address);
-  }
-  set(openOptionsDialog, false);
-  set(openSuggestionsMenu, false);
-  set(searchValue, '');
-}
-
-async function getAddressBookData(name: string): Promise<{ address: string; name: string }[]> {
-  const data = await getAddressBook('private', {
-    limit: 10,
-    nameSubstring: name,
-    offset: 0,
-  });
-
-  return data.data
-    .filter(item => isValidEthAddress(item.address))
-    .map(item => ({ address: item.address, name: item.name }));
-}
-
-async function fetchAddressBookAddresses(name: string) {
-  const data = await getAddressBookData(name);
-  const addresses = data.map(item => item.address);
-  set(addressBookOptions, addresses);
-}
-
-function resetModelValue() {
-  set(model, '');
-}
-
-watch([addressBookSearchDebounced, openOptionsDialog], ([search, openOptionsDialog]) => {
-  if (openOptionsDialog) {
-    fetchAddressBookAddresses(search);
-  }
-  else {
-    set(addressBookSearch, '');
-  }
-});
-
-watch(usedAnyFocused, (focus) => {
-  set(openSuggestionsMenu, focus);
-  if (!focus) {
-    const search = get(searchValue);
-    if (search && isValidEthAddress(search)) {
-      set(model, search);
-    }
-    else {
-      set(searchValue, '');
-    }
-  }
-});
-
-watch(debouncedSearchValue, async (value) => {
-  const values = [];
-  const privateBooks = await getAddressBookData(value);
-  if (privateBooks.length > 0) {
-    values.push(...privateBooks);
-  }
-
-  const tracked = get(trackedAddresses).filter(item => item.includes(value));
-  if (tracked.length > 0) {
-    values.push(...tracked.map(item => ({ address: item })));
-  }
-
-  if (value.endsWith('.eth')) {
-    set(resolvingEns, true);
-    const address = await resolveEnsToAddress(value);
-    set(resolvingEns, false);
-    if (address) {
-      values.push({
-        address,
-        name: value,
-      });
-    }
-  }
-  else if (isValidEthAddress(value)) {
-    startPromise(fetchEnsNames([{ address: value, blockchain: null }]));
-    values.push({
-      address: value,
-    });
-  }
-
-  set(directOptions, uniqueObjects(values.filter(item => isNotConnectedAddress(item.address)), item => item.address));
-});
-
-watch(connectedAddress, (connectedAddress) => {
-  if (connectedAddress && connectedAddress === get(model)) {
-    set(model, '');
-  }
+watch(usedAnyFocused, (focused) => {
+  handleFocusChange(focused);
 });
 
 const { containerProps: trackedContainerProps, list: trackedList, wrapperProps: trackedWrapperProps } = useVirtualList(trackedAddresses, {
@@ -160,29 +51,17 @@ const { containerProps: trackedContainerProps, list: trackedList, wrapperProps: 
 const { containerProps: addressBookContainerProps, list: addressBookList, wrapperProps: addressBookWrapperProps } = useVirtualList(filteredAddressBookOptions, {
   itemHeight: 56,
 });
-
-function applySearchInput() {
-  const value = get(searchValue);
-  if (isValidEthAddress(value)) {
-    select(value);
-  }
-}
-
-watch(openSuggestionsMenu, (curr, prev) => {
-  if (!curr && prev) {
-    applySearchInput();
-  }
-});
 </script>
 
 <template>
   <RuiMenu
-    v-model="openSuggestionsMenu"
+    v-model="modelOpenSuggestionsMenu"
     wrapper-class="w-full"
   >
     <template #activator>
       <div
         class="flex items-center bg-rui-grey-50 dark:bg-rui-grey-900 rounded-lg border border-default mt-1 duration-50 w-full"
+        data-testid="recipient-field"
         :class="{
           '!border-rui-error': !valid,
         }"
@@ -200,7 +79,8 @@ watch(openSuggestionsMenu, (curr, prev) => {
           <RuiButton
             icon
             variant="text"
-            @click="resetModelValue()"
+            data-testid="recipient-clear"
+            @click="reset()"
           >
             <RuiIcon
               name="lu-x"
@@ -232,11 +112,12 @@ watch(openSuggestionsMenu, (curr, prev) => {
             </Transition>
             <input
               ref="searchInputRef"
-              v-model="searchValue"
+              v-model="modelSearchValue"
+              data-testid="recipient-search"
               type="text"
               class="outline-none w-full bg-transparent text-sm placeholder:text-rui-grey-400 dark:placeholder:text-rui-grey-700"
               placeholder="E.g. 0x9531c059098e3d194ff87febb587ab07b30b1306"
-              @click="openSuggestionsMenu = true"
+              @click="modelOpenSuggestionsMenu = true"
               @blur="applySearchInput()"
             />
           </label>
@@ -245,7 +126,8 @@ watch(openSuggestionsMenu, (curr, prev) => {
               variant="outlined"
               color="primary"
               class="!p-3"
-              @click="openOptionsDialog = true"
+              data-testid="recipient-open-address-book"
+              @click="modelOpenOptionsDialog = true"
             >
               <RuiIcon
                 name="lu-book-user"
@@ -291,7 +173,7 @@ watch(openSuggestionsMenu, (curr, prev) => {
     {{ t('trade.never_interacted') }}
   </RuiAlert>
   <RuiDialog
-    v-model="openOptionsDialog"
+    v-model="modelOpenOptionsDialog"
     max-width="500"
   >
     <RuiCard
@@ -306,7 +188,7 @@ watch(openSuggestionsMenu, (curr, prev) => {
         variant="text"
         class="absolute top-2 right-2"
         icon
-        @click="openOptionsDialog = false"
+        @click="modelOpenOptionsDialog = false"
       >
         <RuiIcon
           class="text-white"
@@ -346,7 +228,7 @@ watch(openSuggestionsMenu, (curr, prev) => {
           </div>
           <div class="p-4">
             <RuiTextField
-              v-model="addressBookSearch"
+              v-model="modelAddressBookSearch"
               prepend-icon="lu-search"
               variant="outlined"
               dense

--- a/frontend/app/src/modules/wallet/send/use-trade-recipient-address.spec.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-recipient-address.spec.ts
@@ -1,0 +1,272 @@
+import type { Ref } from 'vue';
+import type { AddressBookEntry } from '@/modules/accounts/address-book/eth-names';
+import type { Collection } from '@/modules/core/common/collection';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTradeRecipientAddress } from '@/modules/wallet/send/use-trade-recipient-address';
+
+/**
+ * The seam: what a typed search turns into, and which of those the recipient can end up being.
+ * Three sources feed the suggestions (the private address book, the tracked accounts and ENS), the
+ * connected account is never among them, and only a real address is ever taken as the recipient.
+ */
+
+const ALICE = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+const BOB = '0x2B888954421b424C5D3D9Ce9bB67c9bD47537d12';
+const CONNECTED = '0x1234567890123456789012345678901234567890';
+
+const getAddressBook = vi.fn<() => Promise<Collection<AddressBookEntry>>>();
+const fetchEnsNames = vi.fn<() => Promise<void>>();
+const resolveEnsToAddress = vi.fn<(name: string) => Promise<string | null>>();
+
+vi.mock('@/modules/accounts/address-book/use-address-book-operations', () => ({
+  useAddressBookOperations: (): { getAddressBook: typeof getAddressBook } => ({ getAddressBook }),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-ens-operations', () => ({
+  useEnsOperations: (): {
+    fetchEnsNames: typeof fetchEnsNames;
+    resolveEnsToAddress: typeof resolveEnsToAddress;
+  } => ({ fetchEnsNames, resolveEnsToAddress }),
+}));
+
+const addresses = ref<Record<string, string[]>>({});
+
+vi.mock('@/modules/balances/blockchain/use-account-addresses', () => ({
+  useAccountAddresses: (): { addresses: typeof addresses } => ({ addresses }),
+}));
+
+const connectedAddress = ref<string>('');
+
+vi.mock('@/modules/wallet/use-wallet-store', () => ({
+  useWalletStore: (): { connectedAddress: typeof connectedAddress } => ({ connectedAddress }),
+}));
+
+function bookEntries(...entries: { address: string; name: string }[]): Collection<AddressBookEntry> {
+  return {
+    data: entries.map(entry => ({ address: entry.address, blockchain: null, name: entry.name })),
+    found: entries.length,
+    limit: 10,
+    total: entries.length,
+    totalValue: undefined,
+  };
+}
+
+describe('useTradeRecipientAddress', () => {
+  let model: Ref<string>;
+  let recipient: ReturnType<typeof useTradeRecipientAddress>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(addresses, {});
+    set(connectedAddress, '');
+    getAddressBook.mockResolvedValue(bookEntries());
+    resolveEnsToAddress.mockResolvedValue(null);
+    fetchEnsNames.mockResolvedValue();
+    model = ref<string>('');
+    recipient = useTradeRecipientAddress(model);
+  });
+
+  describe('valid', () => {
+    it('should accept an empty recipient and a real address, and nothing else', () => {
+      expect(get(recipient.valid)).toBe(true);
+
+      set(model, ALICE);
+      expect(get(recipient.valid)).toBe(true);
+
+      set(model, 'not-an-address');
+      expect(get(recipient.valid)).toBe(false);
+    });
+  });
+
+  describe('searchAddresses', () => {
+    it('should offer the address book entries it found', async () => {
+      getAddressBook.mockResolvedValue(bookEntries({ address: ALICE, name: 'Alice' }));
+
+      await recipient.searchAddresses('ali');
+
+      expect(getAddressBook).toHaveBeenCalledWith('private', { limit: 10, nameSubstring: 'ali', offset: 0 });
+      expect(get(recipient.directOptions)).toEqual([{ address: ALICE, name: 'Alice' }]);
+    });
+
+    it('should skip an address book entry that is not an address', async () => {
+      getAddressBook.mockResolvedValue(bookEntries({ address: 'nonsense', name: 'Broken' }));
+
+      await recipient.searchAddresses('bro');
+
+      expect(get(recipient.directOptions)).toEqual([]);
+    });
+
+    it('should offer the tracked accounts that match', async () => {
+      set(addresses, { eth: [ALICE, BOB], optimism: [ALICE] });
+
+      await recipient.searchAddresses(ALICE.slice(0, 6));
+
+      expect(get(recipient.directOptions)).toEqual([{ address: ALICE }]);
+    });
+
+    it('should resolve an ens name and offer it under that name', async () => {
+      resolveEnsToAddress.mockResolvedValue(ALICE);
+
+      await recipient.searchAddresses('alice.eth');
+
+      expect(resolveEnsToAddress).toHaveBeenCalledWith('alice.eth');
+      expect(get(recipient.directOptions)).toEqual([{ address: ALICE, name: 'alice.eth' }]);
+      expect(get(recipient.resolvingEns)).toBe(false);
+    });
+
+    it('should offer nothing extra for an ens name that resolves to nobody', async () => {
+      await recipient.searchAddresses('nobody.eth');
+
+      expect(get(recipient.directOptions)).toEqual([]);
+      expect(get(recipient.resolvingEns)).toBe(false);
+    });
+
+    it('should offer a pasted address as-is and look its name up in the background', async () => {
+      await recipient.searchAddresses(ALICE);
+
+      expect(fetchEnsNames).toHaveBeenCalledWith([{ address: ALICE, blockchain: null }]);
+      expect(get(recipient.directOptions)).toEqual([{ address: ALICE }]);
+    });
+
+    it('should offer an address found twice only once', async () => {
+      getAddressBook.mockResolvedValue(bookEntries({ address: ALICE, name: 'Alice' }));
+      set(addresses, { eth: [ALICE] });
+
+      await recipient.searchAddresses(ALICE);
+
+      // The later, nameless entry wins the deduplication, so pasting an address you have in the
+      // address book shows it without its name. Pre-existing, kept here as the record of it.
+      expect(get(recipient.directOptions)).toEqual([{ address: ALICE }]);
+    });
+
+    it('should never offer the connected account', async () => {
+      set(connectedAddress, CONNECTED);
+      getAddressBook.mockResolvedValue(bookEntries({ address: CONNECTED, name: 'Me' }));
+      set(addresses, { eth: [CONNECTED, ALICE] });
+
+      await recipient.searchAddresses('');
+
+      expect(get(recipient.directOptions)).toEqual([{ address: ALICE }]);
+    });
+  });
+
+  describe('trackedAddresses', () => {
+    it('should list every tracked address once, minus the connected one', () => {
+      set(addresses, { eth: [ALICE, BOB, CONNECTED], optimism: [ALICE], bitcoin: ['bc1qsomething'] });
+      set(connectedAddress, CONNECTED);
+
+      expect(get(recipient.trackedAddresses)).toEqual([ALICE, BOB]);
+    });
+  });
+
+  describe('select', () => {
+    it('should take the address and put both menus away', () => {
+      set(recipient.modelOpenOptionsDialog, true);
+      set(recipient.modelSearchValue, 'ali');
+
+      recipient.select(ALICE);
+
+      expect(get(model)).toBe(ALICE);
+      expect(get(recipient.modelOpenOptionsDialog)).toBe(false);
+      expect(get(recipient.modelOpenSuggestionsMenu)).toBe(false);
+      expect(get(recipient.modelSearchValue)).toBe('');
+    });
+
+    it('should refuse the connected account', () => {
+      set(connectedAddress, CONNECTED);
+
+      recipient.select(CONNECTED);
+
+      expect(get(model)).toBe('');
+    });
+  });
+
+  describe('applySearchInput', () => {
+    it('should take a typed address as the recipient', () => {
+      set(recipient.modelSearchValue, ALICE);
+
+      recipient.applySearchInput();
+
+      expect(get(model)).toBe(ALICE);
+    });
+
+    it('should leave a half-typed address alone', () => {
+      set(recipient.modelSearchValue, '0x123');
+
+      recipient.applySearchInput();
+
+      expect(get(model)).toBe('');
+      expect(get(recipient.modelSearchValue)).toBe('0x123');
+    });
+  });
+
+  describe('handleFocusChange', () => {
+    it('should open the suggestions while the input has focus', () => {
+      recipient.handleFocusChange(true);
+
+      expect(get(recipient.modelOpenSuggestionsMenu)).toBe(true);
+    });
+
+    it('should keep a typed address when focus leaves', () => {
+      set(recipient.modelSearchValue, ALICE);
+
+      recipient.handleFocusChange(false);
+
+      expect(get(model)).toBe(ALICE);
+      expect(get(recipient.modelOpenSuggestionsMenu)).toBe(false);
+    });
+
+    it('should throw away anything else when focus leaves', () => {
+      set(recipient.modelSearchValue, 'half-typed');
+
+      recipient.handleFocusChange(false);
+
+      expect(get(model)).toBe('');
+      expect(get(recipient.modelSearchValue)).toBe('');
+    });
+  });
+
+  it('should drop the recipient when it becomes the connected account', async () => {
+    set(model, CONNECTED);
+
+    set(connectedAddress, CONNECTED);
+    await nextTick();
+
+    expect(get(model)).toBe('');
+  });
+
+  it('should keep a recipient that is not the connected account', async () => {
+    set(model, ALICE);
+
+    set(connectedAddress, CONNECTED);
+    await nextTick();
+
+    expect(get(model)).toBe(ALICE);
+  });
+
+  describe('the address book dialog', () => {
+    it('should read the address book while the dialog is open', async () => {
+      vi.useFakeTimers();
+      getAddressBook.mockResolvedValue(bookEntries({ address: ALICE, name: 'Alice' }));
+
+      set(recipient.modelOpenOptionsDialog, true);
+      set(recipient.modelAddressBookSearch, 'ali');
+      await vi.advanceTimersByTimeAsync(250);
+
+      expect(getAddressBook).toHaveBeenCalledWith('private', { limit: 10, nameSubstring: 'ali', offset: 0 });
+      expect(get(recipient.filteredAddressBookOptions)).toEqual([ALICE]);
+      vi.useRealTimers();
+    });
+
+    it('should forget the search when the dialog closes', async () => {
+      set(recipient.modelOpenOptionsDialog, true);
+      set(recipient.modelAddressBookSearch, 'ali');
+      await nextTick();
+
+      set(recipient.modelOpenOptionsDialog, false);
+      await nextTick();
+
+      expect(get(recipient.modelAddressBookSearch)).toBe('');
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/send/use-trade-recipient-address.ts
+++ b/frontend/app/src/modules/wallet/send/use-trade-recipient-address.ts
@@ -1,0 +1,201 @@
+import type { ComputedRef, Ref } from 'vue';
+import { isValidEthAddress } from '@rotki/common';
+import { startPromise } from '@shared/utils';
+import { useAddressBookOperations } from '@/modules/accounts/address-book/use-address-book-operations';
+import { useEnsOperations } from '@/modules/accounts/address-book/use-ens-operations';
+import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
+import { uniqueObjects } from '@/modules/core/common/data/data';
+import { useWalletStore } from '@/modules/wallet/use-wallet-store';
+
+export interface RecipientOption {
+  address: string;
+  name?: string;
+}
+
+interface UseTradeRecipientAddressReturn {
+  /** All bound with `v-model`, so they stay writable. */
+  modelSearchValue: Ref<string>;
+  modelAddressBookSearch: Ref<string>;
+  modelOpenSuggestionsMenu: Ref<boolean>;
+  modelOpenOptionsDialog: Ref<boolean>;
+  /** Empty is allowed; anything else has to be an address. */
+  valid: ComputedRef<boolean>;
+  resolvingEns: Readonly<Ref<boolean>>;
+  /**
+   * What the typed search found, ready to be picked. Shallow: a deep `readonly()` would turn the
+   * options into a `DeepReadonly` the display component's prop cannot take.
+   */
+  directOptions: Readonly<Ref<RecipientOption[]>>;
+  /** Every tracked address that could receive, so never the connected one. */
+  trackedAddresses: ComputedRef<string[]>;
+  filteredAddressBookOptions: ComputedRef<string[]>;
+  select: (address: string) => void;
+  reset: () => void;
+  /** Takes a typed address as the recipient, ignoring anything that is not one. */
+  applySearchInput: () => void;
+  /** The input and the menu gaining or losing focus together. */
+  handleFocusChange: (focused: boolean) => void;
+  searchAddresses: (value: string) => Promise<void>;
+}
+
+/**
+ * Picking who a trade is sent to.
+ *
+ * There are three ways in: typing, which searches the private address book, the tracked accounts
+ * and ENS at once; the address book dialog; and pasting an address, which is taken as-is. The
+ * connected account is filtered out of all of them, because sending to yourself is not the intent
+ * here, and it is dropped from the model if it becomes the connected account later.
+ */
+export function useTradeRecipientAddress(model: Ref<string>): UseTradeRecipientAddressReturn {
+  const modelSearchValue = shallowRef<string>('');
+  const modelAddressBookSearch = shallowRef<string>('');
+  const modelOpenSuggestionsMenu = shallowRef<boolean>(false);
+  const modelOpenOptionsDialog = shallowRef<boolean>(false);
+  const resolvingEns = shallowRef<boolean>(false);
+  const addressBookOptions = ref<string[]>([]);
+  const directOptions = ref<RecipientOption[]>([]);
+
+  const debouncedSearchValue = refDebounced(modelSearchValue, 200);
+  const debouncedAddressBookSearch = refDebounced(modelAddressBookSearch, 200);
+
+  const { connectedAddress } = storeToRefs(useWalletStore());
+  const { addresses } = useAccountAddresses();
+  const { getAddressBook } = useAddressBookOperations();
+  const { fetchEnsNames, resolveEnsToAddress } = useEnsOperations();
+
+  function isNotConnectedAddress(address: string): boolean {
+    const connected = get(connectedAddress);
+    return !connected || address !== connected;
+  }
+
+  const trackedAddresses = computed<string[]>(() => {
+    const accountsAddresses = [...new Set(Object.values(get(addresses)).flat())];
+    return accountsAddresses.filter(address => isValidEthAddress(address) && isNotConnectedAddress(address));
+  });
+
+  const filteredAddressBookOptions = computed<string[]>(
+    () => get(addressBookOptions).filter(isNotConnectedAddress),
+  );
+
+  const valid = computed<boolean>(() => {
+    const value = get(model);
+    return !value || isValidEthAddress(value);
+  });
+
+  function select(address: string): void {
+    if (isNotConnectedAddress(address)) {
+      set(model, address);
+    }
+    set(modelOpenOptionsDialog, false);
+    set(modelOpenSuggestionsMenu, false);
+    set(modelSearchValue, '');
+  }
+
+  function reset(): void {
+    set(model, '');
+  }
+
+  function applySearchInput(): void {
+    const value = get(modelSearchValue);
+    if (isValidEthAddress(value)) {
+      select(value);
+    }
+  }
+
+  function handleFocusChange(focused: boolean): void {
+    set(modelOpenSuggestionsMenu, focused);
+    if (focused)
+      return;
+
+    const search = get(modelSearchValue);
+    if (search && isValidEthAddress(search)) {
+      set(model, search);
+    }
+    else {
+      set(modelSearchValue, '');
+    }
+  }
+
+  async function getAddressBookData(name: string): Promise<RecipientOption[]> {
+    const data = await getAddressBook('private', {
+      limit: 10,
+      nameSubstring: name,
+      offset: 0,
+    });
+
+    return data.data
+      .filter(item => isValidEthAddress(item.address))
+      .map(item => ({ address: item.address, name: item.name }));
+  }
+
+  async function searchAddresses(value: string): Promise<void> {
+    const values: RecipientOption[] = [...await getAddressBookData(value)];
+
+    values.push(...get(trackedAddresses)
+      .filter(item => item.includes(value))
+      .map(item => ({ address: item })));
+
+    if (value.endsWith('.eth')) {
+      set(resolvingEns, true);
+      const address = await resolveEnsToAddress(value);
+      set(resolvingEns, false);
+      if (address) {
+        values.push({ address, name: value });
+      }
+    }
+    else if (isValidEthAddress(value)) {
+      // The name is looked up for display only, so it does not hold the option up.
+      startPromise(fetchEnsNames([{ address: value, blockchain: null }]));
+      values.push({ address: value });
+    }
+
+    set(directOptions, uniqueObjects(values.filter(item => isNotConnectedAddress(item.address)), item => item.address));
+  }
+
+  async function fetchAddressBookAddresses(name: string): Promise<void> {
+    const data = await getAddressBookData(name);
+    set(addressBookOptions, data.map(item => item.address));
+  }
+
+  watch([debouncedAddressBookSearch, modelOpenOptionsDialog], ([search, dialogOpen]) => {
+    if (dialogOpen) {
+      startPromise(fetchAddressBookAddresses(search));
+    }
+    else {
+      set(modelAddressBookSearch, '');
+    }
+  });
+
+  watch(debouncedSearchValue, (value) => {
+    startPromise(searchAddresses(value));
+  });
+
+  watch(modelOpenSuggestionsMenu, (curr, prev) => {
+    if (!curr && prev) {
+      applySearchInput();
+    }
+  });
+
+  watch(connectedAddress, (address) => {
+    if (address && address === get(model)) {
+      reset();
+    }
+  });
+
+  return {
+    applySearchInput,
+    directOptions: shallowReadonly(directOptions),
+    filteredAddressBookOptions,
+    handleFocusChange,
+    modelAddressBookSearch,
+    modelOpenOptionsDialog,
+    modelOpenSuggestionsMenu,
+    modelSearchValue,
+    reset,
+    resolvingEns: readonly(resolvingEns),
+    searchAddresses,
+    select,
+    trackedAddresses,
+    valid,
+  };
+}


### PR DESCRIPTION
Closes #12989. Batch A of #12964: the four SFCs that hold real logic in their script block, each extracted to a composable and then tested. One commit pair per file, in the order the issue lists them.

## What changed

| File | Composable | Uncovered before | Statements now |
|---|---|---|---|
| `history/refresh/HistoryRefreshSelection.vue` | `use-history-refresh-selection.ts` | 131 | 57/57 + 40/55 |
| `history/events/CustomizedEventDuplicatesDialog.vue` | `use-customized-event-duplicates-dialog.ts` | 116 | 63/63 + 49/60 |
| `calendar/GoogleCalendarIntegration.vue` | `use-google-calendar-integration.ts` | 111 | 80/83 + 33/35 |
| `wallet/send/TradeRecipientAddress.vue` | `use-trade-recipient-address.ts` | 108 | 76/78 + 37/47 |

101 specs in total, 65 on the composables and 36 on what the components still own. What is left in each component is the part that genuinely belongs there: menu and dialog wiring, template refs, focus tracking and the virtual lists.

The extractions also collapsed repetition that only existed because the state was inline: four parallel `switch` statements over the active tab in the refresh menu, three copies of rows/selection/loading in the duplicates dialog, and five notification call sites in the calendar integration.

## Behaviour changes, deliberate

- **Refresh menu**: `onMounted(reset)` dropped. `reset()` sets exactly the initial values and none of the four tab children writes to the selection while mounting, so it never did anything.
- **Duplicates dialog**: the confirmation callbacks start their reload with `startPromise` instead of being `async` callbacks passed where a `void` return is expected. Nothing awaited them before either, so the timing is unchanged; the tab indices also got a name (`DuplicatesTab`).
- **Calendar**: the status check on mount goes through `startPromise` rather than being a floating promise, and the two "no token" cases keep their own message instead of passing `undefined` through `getErrorMessage`, which would have rendered them as "Unknown error occurred".

## Found while testing

Three pre-existing issues the specs ran into. Two are fixed in the last two commits, one is left alone:

1. **Fixed.** `TradeRecipientAddress.vue` had a dead branch: the `trade.to_address.error` label lived inside the `v-else` that only renders when there is **no** recipient, while its condition needed `model && !valid`, so it could never appear. Rendering the component with an invalid recipient confirmed it: the field shows the address and the clear button, no error text. Removed, along with the now-unused locale key and the `Transition` that only ever wrapped a single static label. An invalid address is still marked by the red border.
2. **Fixed.** `GoogleCalendarIntegration.vue` rendered a hardcoded English `Connected as {email}`. It now uses `external_services.google_calendar.connected_as`, the same key and wording the Monerium integration already has for that sentence.
3. **Left as is.** In `TradeRecipientAddress.vue`, deduplication keeps the last match, so pasting an address that is in your private address book shows it **without** its name. The spec asserts the current behaviour and says why.

## Gates

`pnpm run test:unit` (921 files / 9473 tests), `typecheck`, `lint:file`, `lint:style` and `knip` all green.

Every claim was negative-controlled: routing select-all to a fixed tab, removing the tab-change reset, emptying the chains payload, dropping the second deselect in ignore-single, making ignore-selected ignore the active tab, misrouting a per-row restore, keeping a stale account email, letting a missing refresh token through, never unregistering the OAuth handler, unfiltering the connected account, and accepting a non-address on blur. Each broke exactly the specs that claim to cover it, and each was restored.
