### PR TITLE
Finish the test-id gates the BEM removal started

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -613,9 +613,9 @@ the wrappers and unmount them in `afterEach`; ~148 specs already do.
   - `mockT` from `@test/i18n` is the echo translator. `useI18n` is globally mocked in
     `tests/unit/setup-files/setup.ts` to use it, so composables calling `useI18n()` get `t` for free.
   - Other fixtures: `@test/mocks/file`, `@test/utils/create-pinia`, `@test/utils/events`.
-- **Test selectors**: use `data-testid`, in components and in queries alike. `data-cy` is gone from
-  the codebase; do not reintroduce it. `@rotki/ui-library` exposes no test-id attribute of its own,
-  so a `data-testid` on a `Rui*` component falls through `$attrs` onto its root element.
+- **Test selectors**: use `data-testid`, in components and in queries alike. `@rotki/ui-library`
+  exposes no test-id attribute of its own, so a `data-testid` on a `Rui*` component falls through
+  `$attrs` onto its root element.
   Values are kebab-case, scoped by the component the id lives on (`service-key-api-key`), never BEM
   (`service-key__api-key`) and never a DOM path (`service-key__content__api-key`). Lint enforces the
   common cases; a value built at runtime or passed as a prop is review-only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -613,9 +613,9 @@ the wrappers and unmount them in `afterEach`; ~148 specs already do.
   - `mockT` from `@test/i18n` is the echo translator. `useI18n` is globally mocked in
     `tests/unit/setup-files/setup.ts` to use it, so composables calling `useI18n()` get `t` for free.
   - Other fixtures: `@test/mocks/file`, `@test/utils/create-pinia`, `@test/utils/events`.
-- **Test selectors**: use `data-testid`, in components and in queries alike. `data-cy` is gone from
-  the codebase; do not reintroduce it. `@rotki/ui-library` exposes no test-id attribute of its own,
-  so a `data-testid` on a `Rui*` component falls through `$attrs` onto its root element.
+- **Test selectors**: use `data-testid`, in components and in queries alike. `@rotki/ui-library`
+  exposes no test-id attribute of its own, so a `data-testid` on a `Rui*` component falls through
+  `$attrs` onto its root element.
   Values are kebab-case, scoped by the component the id lives on (`service-key-api-key`), never BEM
   (`service-key__api-key`) and never a DOM path (`service-key__content__api-key`). Lint enforces the
   common cases; a value built at runtime or passed as a prop is review-only.

--- a/frontend/app/src/modules/core/common/tabs.spec.ts
+++ b/frontend/app/src/modules/core/common/tabs.spec.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { tabTestId } from '@/modules/core/common/tabs';
+import { tabKey } from '@/modules/core/common/tabs';
 
-describe('tabTestId', () => {
-  // The e2e suite writes these ids as literals, so the shape is a contract.
+describe('tabKey', () => {
+  // The e2e suite writes these keys as literals, so the shape is a contract.
   it('should drop the leading slash and join segments with a dash', () => {
-    expect(tabTestId('/settings/rpc')).toBe('settings-rpc');
-    expect(tabTestId('/asset-manager/more/cex-mapping')).toBe('asset-manager-more-cex-mapping');
+    expect(tabKey('/settings/rpc')).toBe('settings-rpc');
+    expect(tabKey('/asset-manager/more/cex-mapping')).toBe('asset-manager-more-cex-mapping');
   });
 
   it('should lower-case the path', () => {
-    expect(tabTestId('/Settings/RPC')).toBe('settings-rpc');
+    expect(tabKey('/Settings/RPC')).toBe('settings-rpc');
   });
 
   it('should never emit a BEM separator', () => {
-    expect(tabTestId('/settings/general')).not.toContain('__');
+    expect(tabKey('/settings/general')).not.toContain('__');
   });
 });

--- a/frontend/app/src/modules/core/common/tabs.ts
+++ b/frontend/app/src/modules/core/common/tabs.ts
@@ -8,9 +8,11 @@ export interface TabContent {
 }
 
 /**
- * Derives a tab's `data-testid` from its resolved route path, so
- * `/settings/rpc` becomes `settings-rpc`.
+ * Derives a tab's `data-key` from its resolved route path.
+ *
+ * @param route - a resolved route path, e.g. `/settings/rpc`
+ * @returns the key, e.g. `settings-rpc`
  */
-export function tabTestId(route: string): string {
+export function tabKey(route: string): string {
   return route.toLowerCase().replace(/^\//, '').replace(/\//g, '-');
 }

--- a/frontend/app/src/modules/shell/components/TabNavigation.vue
+++ b/frontend/app/src/modules/shell/components/TabNavigation.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { RouteLocationRaw } from 'vue-router';
-import { type TabContent, tabTestId } from '@/modules/core/common/tabs';
+import { type TabContent, tabKey } from '@/modules/core/common/tabs';
 
 const { tabs, hideRouterView = false, child = false, plain = false } = defineProps<{
   tabs: TabContent[];
@@ -13,8 +13,8 @@ const model = ref<string>('');
 
 const router = useRouter();
 
-function getTabTestId(route: RouteLocationRaw): string {
-  return tabTestId(router.resolve(route).path);
+function getTabKey(route: RouteLocationRaw): string {
+  return tabKey(router.resolve(route).path);
 }
 </script>
 
@@ -36,7 +36,8 @@ function getTabTestId(route: RouteLocationRaw): string {
         link
         :to="tab.route"
         :exact-path="false"
-        :data-testid="getTabTestId(tab.route)"
+        data-testid="nav-tab"
+        :data-key="getTabKey(tab.route)"
       >
         <template #prepend>
           <RuiIcon

--- a/frontend/app/tests/e2e/helpers/utils.ts
+++ b/frontend/app/tests/e2e/helpers/utils.ts
@@ -27,7 +27,7 @@ export async function openSettingsTab(page: Page, tab: string): Promise<void> {
   await page.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
   await page.locator('[data-testid=settings-button]').click();
   await page.locator('[data-testid=user-dropdown]').waitFor({ state: 'detached' });
-  await page.locator(`[data-testid="settings-${tab}"]`).click();
+  await page.locator(`[data-testid=nav-tab][data-key="settings-${tab}"]`).click();
 }
 
 /**

--- a/frontend/app/tests/e2e/pages/account-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/account-settings-page.ts
@@ -8,7 +8,7 @@ export class AccountSettingsPage {
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
     await this.page.locator('[data-testid=settings-button]').click();
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'detached' });
-    await this.page.locator('[data-testid="settings-account"]').click();
+    await this.page.locator('[data-testid=nav-tab][data-key="settings-account"]').click();
     await this.page.locator('[data-testid=current-password]').waitFor({ state: 'visible' });
   }
 

--- a/frontend/app/tests/e2e/pages/accounting-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/accounting-settings-page.ts
@@ -91,7 +91,7 @@ export class AccountingSettingsPage {
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
     await this.page.locator('[data-testid=settings-button]').click();
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'detached' });
-    await this.page.locator('[data-testid="settings-accounting"]').click();
+    await this.page.locator('[data-testid=nav-tab][data-key="settings-accounting"]').click();
     await this.page.locator('[data-testid=crypto2crypto-switch]').waitFor({ state: 'visible' });
   }
 

--- a/frontend/app/tests/e2e/pages/chains-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/chains-settings-page.ts
@@ -10,7 +10,7 @@ export class ChainsSettingsPage {
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
     await this.page.locator('[data-testid=settings-button]').click();
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'detached' });
-    await this.page.locator('[data-testid="settings-chains"]').click();
+    await this.page.locator('[data-testid=nav-tab][data-key="settings-chains"]').click();
     await this.page.locator('[data-testid=chains-to-skip-detection]').waitFor({ state: 'visible' });
   }
 

--- a/frontend/app/tests/e2e/pages/general-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/general-settings-page.ts
@@ -10,7 +10,7 @@ export class GeneralSettingsPage {
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
     await this.page.locator('[data-testid=settings-button]').click();
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'detached' });
-    await this.page.locator('[data-testid="settings-general"]').click();
+    await this.page.locator('[data-testid=nav-tab][data-key="settings-general"]').click();
     await this.page.locator('[data-testid=floating-precision-settings]').waitFor({ state: 'visible' });
   }
 

--- a/frontend/app/tests/e2e/pages/purge-data-page.ts
+++ b/frontend/app/tests/e2e/pages/purge-data-page.ts
@@ -16,7 +16,7 @@ export class PurgeDataPage {
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
     await this.page.locator('[data-testid=settings-button]').click();
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'detached' });
-    await this.page.locator('[data-testid=settings-database]').click();
+    await this.page.locator('[data-testid=nav-tab][data-key="settings-database"]').click();
     await this.page.getByTestId('purge-source').waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
   }
 

--- a/frontend/app/tests/e2e/pages/rpc-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/rpc-settings-page.ts
@@ -9,7 +9,7 @@ export class RpcSettingsPage {
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
     await this.page.locator('[data-testid=settings-button]').click();
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'detached' });
-    await this.page.locator('[data-testid="settings-rpc"]').click();
+    await this.page.locator('[data-testid=nav-tab][data-key="settings-rpc"]').click();
     // Default Playwright viewport is wide enough to show the rail.
     await this.page.getByTestId('rpc-settings-rail').waitFor({ state: 'visible' });
   }

--- a/frontend/app/tests/e2e/pages/settings-search-page.ts
+++ b/frontend/app/tests/e2e/pages/settings-search-page.ts
@@ -8,7 +8,7 @@ export class SettingsSearchPage {
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
     await this.page.locator('[data-testid=settings-button]').click();
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'detached' });
-    await this.page.locator('[data-testid="settings-general"]').click();
+    await this.page.locator('[data-testid=nav-tab][data-key="settings-general"]').click();
     await this.page.locator('[data-testid=settings-search]').waitFor({ state: 'visible' });
   }
 

--- a/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/rpc.spec.ts
@@ -93,7 +93,7 @@ test.describe.serial('settings::rpc narrow viewport', () => {
     await ctx.sharedPage.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
     await ctx.sharedPage.locator('[data-testid=settings-button]').click();
     await ctx.sharedPage.locator('[data-testid=user-dropdown]').waitFor({ state: 'detached' });
-    await ctx.sharedPage.locator('[data-testid="settings-rpc"]').click();
+    await ctx.sharedPage.locator('[data-testid=nav-tab][data-key="settings-rpc"]').click();
     await ctx.sharedPage.getByTestId('rpc-settings-dropdowns').waitFor({ state: 'visible' });
   });
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -130,22 +130,13 @@ export default rotki({
     'vue/max-props': ['error', { maxProps: 12 }],
   },
 }, {
-  // `data-testid` values are kebab-case. The `__` separator is a leftover from the Vuetify/`data-cy`
-  // era: it encodes a DOM hierarchy that has since been refactored away, and because a BEM id looks
-  // structural, a wrong block name reads as plausible - one form shipped another form's id, and its
-  // spec asserted the same wrong value and passed.
-  //
-  // The `key` option is passed through `toRegExp`, so this covers the components that forward a test
-  // id under their own attribute name too - `switch-test-id` / `field-test-id` on
-  // settings/controls/SettingToggleNumber.vue, whose only caller is accounting/TaxFreeSetting.vue.
-  //
-  // One shape is genuinely unlintable: an id built at runtime, which today means `tabTestId`. Its own
-  // spec asserts the generated value never contains `__`, which is the closest thing to a gate.
+  // Test ids are kebab-case; `__` is a Vuetify-era BEM leftover. `key` is a regex, so the rule also
+  // covers ids forwarded under a component's own `*-test-id` attribute. A bound `:data-testid` is
+  // invisible to all of this: keep the attribute static and put anything variable on `data-key`.
   files: ['**/*.vue'],
   rules: {
     'no-restricted-syntax': ['error', {
-      // The object-literal form of the same thing: `testId: 'a__b'` in a `<script setup>`, which is
-      // how CreateAccountIntroduction.vue carries the ids for its two mode cards.
+      // The object-literal form: `testId: 'a__b'` in a `<script setup>`.
       message: 'data-testid values are kebab-case; `__` is a BEM leftover.',
       selector: 'Property[key.name=/[Tt]est[Ii]d$/] > Literal[value=/__/]',
     }],
@@ -156,18 +147,16 @@ export default rotki({
     }],
   },
 }, {
-  // The template rule above cannot see a selector string in a page object, so the e2e side gets its
-  // own. Specs are covered by the `no-restricted-syntax` block further down - a flat config replaces
-  // a rule's options rather than merging them, so the selector has to join that array rather than
-  // arrive in a block of its own.
+  // The template rule cannot see a selector string in a page object, so the e2e side gets its own.
+  // A flat config replaces a rule's options rather than merging them, so specs join the
+  // `no-restricted-syntax` array further down instead of getting a block of their own.
   files: ['**/tests/e2e/**/*.ts'],
   rules: {
     'no-restricted-syntax': ['error', {
       message: 'data-testid selectors are kebab-case; `__` is a BEM leftover.',
       selector: 'Literal[value=/data-testid[^_\\]]*__/]',
     }, {
-      // `Literal` does not match a `TemplateLiteral`, and page objects build selectors that way -
-      // `[data-testid=settings-${tab}]` in helpers/utils.ts is the pattern. Match the static chunks.
+      // `Literal` does not match a `TemplateLiteral`, and page objects build selectors that way.
       message: 'data-testid selectors are kebab-case; `__` is a BEM leftover.',
       selector: 'TemplateElement[value.raw=/data-testid[^_\\]]*__/]',
     }],
@@ -232,9 +221,7 @@ export default rotki({
       message: 'Do not sleep on the real clock in a spec. Use fake timers (vi.advanceTimersByTimeAsync), poll a condition (vi.waitUntil/vi.waitFor), or resolve a promise the test controls.',
       selector: 'AwaitExpression > NewExpression[callee.name=\'Promise\']:has(CallExpression[callee.name=\'setTimeout\'])',
     }, {
-      // Kebab-case test ids, same rule the `**/*.vue` block applies to the components. A spec that
-      // holds the id in a bare constant (`const USERNAME = '...'`) is not matched - it carries no
-      // `data-testid` prefix to anchor on - so that shape stays review-only.
+      // Anchored on the `data-testid` prefix, so an id held in a bare constant stays review-only.
       message: 'data-testid selectors are kebab-case; `__` is a BEM leftover.',
       selector: 'Literal[value=/data-testid[^_\\]]*__/]',
     }, {

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -144,6 +144,10 @@ export default rotki({
       key: '/(^data-testid$|-test-id$)/',
       message: 'data-testid values are kebab-case. The BEM `__` separator is a Vuetify-era leftover.',
       value: '/__/',
+    }, {
+      // No `value`, so any use at all is an error.
+      key: 'data-cy',
+      message: 'Use `data-testid`. `data-cy` is a Cypress-era leftover.',
     }],
   },
 }, {
@@ -159,6 +163,12 @@ export default rotki({
       // `Literal` does not match a `TemplateLiteral`, and page objects build selectors that way.
       message: 'data-testid selectors are kebab-case; `__` is a BEM leftover.',
       selector: 'TemplateElement[value.raw=/data-testid[^_\\]]*__/]',
+    }, {
+      message: 'Query on `data-testid`. `data-cy` is a Cypress-era leftover.',
+      selector: 'Literal[value=/data-cy/]',
+    }, {
+      message: 'Query on `data-testid`. `data-cy` is a Cypress-era leftover.',
+      selector: 'TemplateElement[value.raw=/data-cy/]',
     }],
   },
 }, {
@@ -227,6 +237,12 @@ export default rotki({
     }, {
       message: 'data-testid selectors are kebab-case; `__` is a BEM leftover.',
       selector: 'TemplateElement[value.raw=/data-testid[^_\\]]*__/]',
+    }, {
+      message: 'Query on `data-testid`. `data-cy` is a Cypress-era leftover.',
+      selector: 'Literal[value=/data-cy/]',
+    }, {
+      message: 'Query on `data-testid`. `data-cy` is a Cypress-era leftover.',
+      selector: 'TemplateElement[value.raw=/data-cy/]',
     }],
   },
 }, {


### PR DESCRIPTION
Follow-up to #12993. Two changes, one theme: replace a convention nobody enforces with a rule that fails the build.

### Make the tab test id static

`TabNavigation` minted its `data-testid` at runtime from the resolved route path. That is the one shape none of the rules added in #12993 can see, and the ids it produced (`settings-rpc`, `asset-manager-more-cex-mapping`) existed as literals nowhere in `app/src` while eight e2e files read them.

It now binds the static `data-testid="nav-tab"` and carries the route identity on `data-key`, which is where the project's own schema puts it. `tabTestId` becomes `tabKey` with its body unchanged, so the key is still `settings-rpc`; only the attribute it lands on changes. The e2e readers move to `[data-testid=nav-tab][data-key="settings-rpc"]`.

Three tab bars consume the component (settings, `asset-manager/more`, `price-manager`), so all three change shape; only the settings ids are read by e2e today.

### Lint `data-cy` instead of documenting it

`data-cy` left with the Cypress runner in #12855, but the only thing keeping it out was a sentence in `CLAUDE.md`. It is now an eslint error in components (`vue/no-restricted-static-attribute` with no `value`, so any use at all is an error), in specs, and in e2e page objects. The sentence is deleted from `CLAUDE.md` and `AGENTS.md`.

Known gap: the attribute rule only covers the static form, so a bound `:data-cy="x"` still slips through. Nothing uses that shape and the rule has no bound equivalent.

### Verification

- `lint`, `typecheck`, `knip` clean; `tabs.spec.ts` green.
- Settings e2e (`test:e2e:shards -n 1 tests/e2e/specs/settings`): 50 passed. A locator matching nothing would time out on `.click()`, so this exercises the new selectors for real.
- Five negative controls, each firing only the intended rule with no false positives across a full lint: `data-cy` in a `.vue`; `data-testid="nav__tab"`, which the BEM rule now catches and could not before; `data-cy` in an e2e page object; `data-cy` in a spec as both a literal and a template literal; and breaking `tabKey` to emit `__`, which reddens its spec.