### PR TITLE
Take the balance snapshot on the login load when it is due

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Logging in again takes the balance snapshot your net worth graph is built from, when one is due by your balance save frequency. Since 1.44.0 that snapshot was only taken if you left rotki open for ten minutes or synced your history, so opening rotki for a quick look and closing it left a gap in the graph.
 * :bug:`-` The buttons that ignore or unignore the selected assets in the asset manager, in non-fungible balances and in the blockchain accounts selection mode are labelled "Ignore" and "Unignore" again, and their tooltips say what they do. They read "Exclude" and "Include" and claimed to add or remove actions from the profit and loss report, which is not what they do to an asset.
 * :release:`1.44.0 <2026-08-21>`
 * :feature:`12171` rotki now includes a local Model Context Protocol server that lets compatible AI assistants run read only analysis over your history events and balances, look up asset details and cached historical prices, and use rotki's event taxonomy.

--- a/frontend/app/src/modules/balances/use-balance-fetching.spec.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.spec.ts
@@ -1,14 +1,19 @@
 import { runSpecWith } from '@test/utils/mocks/native-task';
+import { flushPromises } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useBalanceFetching } from './use-balance-fetching';
 import '@test/i18n';
 
-const { refreshBlockchainBalances, detectDue, fetchAccounts, withDetection, skipReason, willDetect, queryBalancesAsync } = vi.hoisted(() => {
+const { refreshBlockchainBalances, detectDue, fetchAccounts, withDetection, skipReason, willDetect, queryBalancesAsync, snapshotDue, isSnapshotDue } = vi.hoisted(() => {
   // Whether a detection sweep is due this run. The real composable decides it from the cooldown
   // settings; here a test sets it directly and `withDetection` hands it to the pass.
   const detectDue = { value: false };
+  // Whether the backend's snapshot schedule is due; `useSnapshotSchedule` is tested on its own.
+  const snapshotDue = { value: true };
   return {
     detectDue,
+    isSnapshotDue: vi.fn(async () => snapshotDue.value),
+    snapshotDue,
     fetchAccounts: vi.fn().mockResolvedValue(undefined),
     queryBalancesAsync: vi.fn().mockResolvedValue({ taskId: 1 }),
     refreshBlockchainBalances: vi.fn().mockResolvedValue(undefined),
@@ -23,6 +28,10 @@ vi.mock('@/modules/balances/use-blockchain-balances', () => ({
     fetchBlockchainBalances: vi.fn().mockResolvedValue({}),
     refreshBlockchainBalances,
   }),
+}));
+
+vi.mock('@/modules/balances/use-snapshot-schedule', () => ({
+  useSnapshotSchedule: (): { isSnapshotDue: typeof isSnapshotDue } => ({ isSnapshotDue }),
 }));
 
 vi.mock('@/modules/balances/blockchain/use-auto-token-detection', () => ({
@@ -129,13 +138,6 @@ describe('useBalanceFetching', () => {
     });
   });
 
-  describe('fetch', () => {
-    it('should coordinate fetching of all balance types', async () => {
-      const { fetch } = useBalanceFetching();
-      await expect(fetch()).resolves.not.toThrow();
-    });
-  });
-
   describe('autoRefresh', () => {
     it('should perform auto refresh of balances and prices', async () => {
       const { autoRefresh } = useBalanceFetching();
@@ -166,6 +168,7 @@ describe('useBalanceFetching', () => {
       queryBalancesAsync.mockClear();
       withDetection.mockClear();
       detectDue.value = false;
+      snapshotDue.value = true;
     });
 
     it('should refresh every chain, without detection, when none is due', async () => {
@@ -199,17 +202,34 @@ describe('useBalanceFetching', () => {
       );
     });
 
-    /**
-     * ⭐ Replaces "should query all balances only after the chain refresh completes", which pinned
-     * an ordering that only mattered because the refresh asked for a snapshot at all.
-     *
-     * `GET /balances` persists on the backend's own schedule, so ending a refresh with it meant
-     * requesting a snapshot while the per-chain queries were still clearing and repopulating
-     * chains — the 0-value row. Nothing is lost by not asking: the backend takes automatic
-     * snapshots itself (`_maybe_update_snapshot_balances`), and explicit ones go through
-     * `forceSave`, which calls `fetchBalances` directly with `saveData: true`.
-     */
-    it('should not query all balances', async () => {
+    it('should query all balances when the snapshot schedule is due', async () => {
+      const { refreshFromChain } = useBalanceFetching();
+
+      await refreshFromChain();
+
+      expect(queryBalancesAsync).toHaveBeenCalledOnce();
+    });
+
+    it('should query all balances when detecting too', async () => {
+      detectDue.value = true;
+      const { refreshFromChain } = useBalanceFetching();
+
+      await refreshFromChain();
+
+      expect(queryBalancesAsync).toHaveBeenCalledOnce();
+    });
+
+    /** The backend saves on `requested_save_data or should_save_balances`; a refresh only asks. */
+    it('should ask for a snapshot rather than force one', async () => {
+      const { refreshFromChain } = useBalanceFetching();
+
+      await refreshFromChain();
+
+      expect(queryBalancesAsync).toHaveBeenCalledWith({});
+    });
+
+    it('should not query all balances when the snapshot schedule is not due', async () => {
+      snapshotDue.value = false;
       const { refreshFromChain } = useBalanceFetching();
 
       await refreshFromChain();
@@ -218,13 +238,33 @@ describe('useBalanceFetching', () => {
       expect(queryBalancesAsync).not.toHaveBeenCalled();
     });
 
-    it('should not query all balances when detecting either', async () => {
-      detectDue.value = true;
+    it('should not ask for a snapshot when the chain refresh throws', async () => {
+      refreshBlockchainBalances.mockRejectedValueOnce(new Error('chains failed'));
       const { refreshFromChain } = useBalanceFetching();
 
-      await refreshFromChain();
+      await expect(refreshFromChain()).rejects.toThrow('chains failed');
 
       expect(queryBalancesAsync).not.toHaveBeenCalled();
+    });
+
+    /** Querying while chains were still repopulating is what wrote 0-value rows to net worth. */
+    it('should query all balances only after every chain has settled', async () => {
+      let settleChains: () => void = () => {};
+      refreshBlockchainBalances.mockImplementationOnce(async () => new Promise<void>((resolve) => {
+        settleChains = resolve;
+      }));
+      const { refreshFromChain } = useBalanceFetching();
+
+      const refreshing = refreshFromChain();
+      await flushPromises();
+
+      expect(refreshBlockchainBalances).toHaveBeenCalledOnce();
+      expect(queryBalancesAsync).not.toHaveBeenCalled();
+
+      settleChains();
+      await refreshing;
+
+      expect(queryBalancesAsync).toHaveBeenCalledOnce();
     });
   });
 });

--- a/frontend/app/src/modules/balances/use-balance-fetching.ts
+++ b/frontend/app/src/modules/balances/use-balance-fetching.ts
@@ -1,5 +1,4 @@
 import type { AllBalancePayload } from '@/modules/accounts/blockchain-accounts';
-import { startPromise } from '@shared/utils';
 import { map as mapResult, type Result } from 'plainfp/result';
 import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchain-account-management';
 import { usePriceRefresh } from '@/modules/assets/prices/use-price-refresh';
@@ -10,6 +9,7 @@ import { useExchanges } from '@/modules/balances/exchanges/use-exchanges';
 import { useManualBalances } from '@/modules/balances/manual/use-manual-balances';
 import { RefreshMode } from '@/modules/balances/types/refresh-mode';
 import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balances';
+import { useSnapshotSchedule } from '@/modules/balances/use-snapshot-schedule';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { onActionableError, type TaskError } from '@/modules/core/tasks/task-result';
@@ -30,6 +30,7 @@ export const useBalanceFetching = createSharedComposable(() => {
   const { fetchNetValue } = useStatisticsDataFetching();
   const { refreshBlockchainBalances } = useBlockchainBalances();
   const { skipReason: autoDetectSkipReason, withDetection } = useAutoTokenDetection();
+  const { isSnapshotDue } = useSnapshotSchedule();
 
   const fetchBalances = async (payload: Partial<AllBalancePayload> = {}): Promise<void> => {
     const description = payload.ignoreErrors
@@ -68,19 +69,14 @@ export const useBalanceFetching = createSharedComposable(() => {
   };
 
   /**
-   * ⭐ A refresh never snapshots. It used to end in `fetchBalances()` with an empty payload —
-   * `GET /balances` reads the shared in-memory balances and persists on the backend's own
-   * schedule, so a refresh was implicitly asking for a snapshot while its own per-chain queries
-   * were still clearing and repopulating chains. That is how a 0-value row could reach the user's
-   * net-worth history, and it forced the whole refresh to be ordered around it.
+   * The login load: every chain, then the day's snapshot if the schedule is due.
    *
-   * Nothing is lost by dropping it: the backend takes automatic snapshots itself
-   * (`tasks/manager.py::_maybe_update_snapshot_balances`, which checks `balance_save_frequency`,
-   * runs `maybe_detect_new_tokens` first and passes `requested_save_data=True`). Explicit user
-   * snapshots go through {@link fetchBalances} from `forceSave`, which is unchanged.
+   * The aggregate query must run after the batch, never alongside it — querying while the per-chain
+   * queries were still repopulating chains is what wrote 0-value rows into the net-worth history.
    *
-   * ⚠️ The result of that call was discarded anyway (`mapResult(…, () => {})`) — it was only ever
-   * made for the backend side effect, never for data this app reads.
+   * It carries no payload on purpose: `save_data` defaults to false and the backend saves when
+   * `requested_save_data or should_save_balances(...)`, so this asks for a snapshot rather than
+   * forcing one. Forcing is {@link fetchBalances} from `forceSave`.
    */
   const refreshFromChain = async (): Promise<void> => withDetection(async (detect) => {
     logger.debug(detect
@@ -94,12 +90,16 @@ export const useBalanceFetching = createSharedComposable(() => {
     // split has nothing left to express — a chain that cannot hold tokens simply has no detect
     // stage.
     await refreshBlockchainBalances({}, RefreshMode.BACKGROUND, { detect });
-  });
 
-  const fetch = async (): Promise<void> => {
-    await fetchCached();
-    startPromise(refreshFromChain());
-  };
+    const due = await isSnapshotDue();
+
+    if (!due) {
+      logger.debug('refreshFromChain: snapshot not due, skipping the aggregate query');
+      return;
+    }
+
+    await fetchBalances();
+  });
 
   /**
    * §6's periodic flow: every chain, entering at the job, no detection.
@@ -130,7 +130,6 @@ export const useBalanceFetching = createSharedComposable(() => {
 
   return {
     autoRefresh,
-    fetch,
     fetchBalances,
     fetchCached,
     refreshFromChain,

--- a/frontend/app/src/modules/balances/use-snapshot-schedule.spec.ts
+++ b/frontend/app/src/modules/balances/use-snapshot-schedule.spec.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, type Ref } from 'vue';
+import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
+import { useSnapshotSchedule } from './use-snapshot-schedule';
+
+const { frequency, useSetting, fetchPeriodicData } = vi.hoisted(() => {
+  const frequency = { value: 24 };
+  return { fetchPeriodicData: vi.fn(), frequency, useSetting: vi.fn() };
+});
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: useSetting.mockImplementation((): Ref<number> => computed<number>(() => frequency.value)),
+}));
+
+vi.mock('@/modules/session/api/use-session-api', () => ({
+  useSessionApi: (): { fetchPeriodicData: typeof fetchPeriodicData } => ({ fetchPeriodicData }),
+}));
+
+const NOW = new Date('2026-08-25T12:00:00Z');
+const NOW_SECONDS = Math.floor(NOW.getTime() / 1000);
+const HOUR = 60 * 60;
+
+/** Pins the arithmetic to `DBHandler.should_save_balances`, so a drift between them fails here. */
+describe('useSnapshotSchedule', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    frequency.value = 24;
+    useSetting.mockClear();
+    fetchPeriodicData.mockReset();
+    fetchPeriodicData.mockResolvedValue({ lastBalanceSave: NOW_SECONDS - 25 * HOUR });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const withLastSave = (secondsAgo: number): ReturnType<typeof useSnapshotSchedule> => {
+    const { lastBalanceSave } = storeToRefs(useSessionMetadataStore());
+    set(lastBalanceSave, NOW_SECONDS - secondsAgo);
+    return useSnapshotSchedule();
+  };
+
+  it('should be due when the last snapshot is older than the frequency', async () => {
+    const { isSnapshotDue } = withLastSave(25 * HOUR);
+
+    await expect(isSnapshotDue()).resolves.toBe(true);
+  });
+
+  it('should not be due when the last snapshot is within the frequency', async () => {
+    const { isSnapshotDue } = withLastSave(20 * HOUR);
+
+    await expect(isSnapshotDue()).resolves.toBe(false);
+  });
+
+  /** The backend compares strictly, so `>=` here would query on every login and save nothing. */
+  it('should not be due exactly on the boundary', async () => {
+    const { isSnapshotDue } = withLastSave(24 * HOUR);
+
+    await expect(isSnapshotDue()).resolves.toBe(false);
+  });
+
+  it('should follow the configured frequency, not a fixed day', async () => {
+    frequency.value = 12;
+    const { isSnapshotDue } = withLastSave(13 * HOUR);
+
+    await expect(isSnapshotDue()).resolves.toBe(true);
+  });
+
+  it('should not re-read the snapshot time when it is already known', async () => {
+    const { isSnapshotDue } = withLastSave(20 * HOUR);
+
+    await isSnapshotDue();
+
+    expect(fetchPeriodicData).not.toHaveBeenCalled();
+  });
+
+  describe('when the snapshot time is not known yet', () => {
+    /**
+     * 🔴 Only the `/periodic` poll writes `lastBalanceSave`, and it races the login load: measured
+     * in the app, the poll landed *after* the aggregate query, so reading the unset 0 answered
+     * "due" on a login minutes after a snapshot.
+     */
+    it('should read it rather than treat the unset value as due', async () => {
+      fetchPeriodicData.mockResolvedValue({ lastBalanceSave: NOW_SECONDS - 20 * HOUR });
+      const { isSnapshotDue } = useSnapshotSchedule();
+
+      await expect(isSnapshotDue()).resolves.toBe(false);
+
+      expect(fetchPeriodicData).toHaveBeenCalledOnce();
+    });
+
+    it('should be due when the read says the snapshot is old', async () => {
+      const { isSnapshotDue } = useSnapshotSchedule();
+
+      await expect(isSnapshotDue()).resolves.toBe(true);
+    });
+
+    it('should be due when the read fails', async () => {
+      fetchPeriodicData.mockRejectedValue(new Error('backend is down'));
+      const { isSnapshotDue } = useSnapshotSchedule();
+
+      await expect(isSnapshotDue()).resolves.toBe(true);
+    });
+
+    it('should keep what it read for the next question', async () => {
+      fetchPeriodicData.mockResolvedValue({ lastBalanceSave: NOW_SECONDS - 20 * HOUR });
+      const { isSnapshotDue } = useSnapshotSchedule();
+
+      await isSnapshotDue();
+      await isSnapshotDue();
+
+      expect(fetchPeriodicData).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('should read the balance save frequency setting', () => {
+    useSnapshotSchedule();
+
+    expect(useSetting).toHaveBeenCalledWith('balanceSaveFrequency');
+  });
+});

--- a/frontend/app/src/modules/balances/use-snapshot-schedule.ts
+++ b/frontend/app/src/modules/balances/use-snapshot-schedule.ts
@@ -1,0 +1,49 @@
+import dayjs from 'dayjs';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useSessionApi } from '@/modules/session/api/use-session-api';
+import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
+import { useSetting } from '@/modules/settings/use-setting';
+
+const SECONDS_PER_HOUR = 60 * 60;
+
+interface UseSnapshotScheduleReturn {
+  isSnapshotDue: () => Promise<boolean>;
+}
+
+/**
+ * Whether the backend's balance snapshot schedule is due, mirroring
+ * `DBHandler.should_save_balances`: `now - lastBalanceSave > balanceSaveFrequency`, strict.
+ *
+ * The backend stays the authority; this only avoids an aggregate query it would decline to save.
+ *
+ * `lastBalanceSave` is written by the `/periodic` poll alone, and that poll races the login load,
+ * so an unknown value is settled here rather than read as 0 (which every period clears, making the
+ * check always answer "due"). `GET /settings` cannot serve as the seed: its `last_balance_save`
+ * is a different field that nothing updates and reads 0 with snapshots present. A failed read
+ * still errs towards due, since an extra cached read costs less than a missed snapshot.
+ */
+export function useSnapshotSchedule(): UseSnapshotScheduleReturn {
+  const { lastBalanceSave } = storeToRefs(useSessionMetadataStore());
+  const balanceSaveFrequency = useSetting('balanceSaveFrequency');
+  const { fetchPeriodicData } = useSessionApi();
+
+  const settleLastBalanceSave = async (): Promise<void> => {
+    try {
+      set(lastBalanceSave, (await fetchPeriodicData()).lastBalanceSave);
+    }
+    catch (error: unknown) {
+      logger.warn('[snapshot-schedule] could not read the last snapshot time', error);
+    }
+  };
+
+  const isSnapshotDue = async (): Promise<boolean> => {
+    if (get(lastBalanceSave) === 0)
+      await settleLastBalanceSave();
+
+    return dayjs().unix() - get(lastBalanceSave) > get(balanceSaveFrequency) * SECONDS_PER_HOUR;
+  };
+
+  return {
+    isSnapshotDue,
+  };
+}


### PR DESCRIPTION
Logging in after a day no longer misses the balance snapshot the net worth graph is built from.

### The problem

733bc8f365 (in 1.44.0) removed the trailing `fetchBalances()` from `refreshFromChain`. It was fixing a real bug: that call fired while the per-chain queries were still clearing and repopulating chains, which is how 0-value rows reached the net worth history. Its reasoning for removing rather than reordering was that the backend snapshots on its own schedule.

It does not, unaided. `_maybe_update_snapshot_balances` only runs once `task_manager.should_schedule` is true, and the only thing that sets it is the frontend, either ten minutes after the balances load or when a history sync finishes. Open rotki, look at the dashboard, close it three minutes later, and the day has no snapshot. `GET /balances` was the app's only scheduled snapshot request; `forceSave`, the one caller left, always passes `save_data=true`.

### The change

The request goes back where the original should have been: after `refreshBlockchainBalances` has awaited its whole activity batch, so every chain is terminal and the aggregate read sees a complete picture rather than one still being repopulated.

It carries no payload, so `save_data` stays false and the backend decides via `requested_save_data or should_save_balances(...)`. The app asks for a snapshot; it never forces one.

`useSnapshotSchedule` asks the same question locally first, mirroring `should_save_balances` down to the strict comparison, so a read the backend would decline is skipped. Only the `/periodic` poll writes `lastBalanceSave` and it races the login load, so an unknown value is read once rather than taken as 0. The settings payload cannot seed it: its `last_balance_save` is a different field that nothing updates and reads 0 with snapshots present. A failed read errs towards due, an extra cached read being cheaper than a missed snapshot.

Also drops `fetch()`, the only other caller of `refreshFromChain`, which had none of its own.

### Verification

Unit: 21 specs across the two files, including that the query happens only after the batch settles, that it is skipped when not due, that it never forces, and that a throwing batch asks for nothing. Four negative controls run and reverted: the query moved before the batch, `>` weakened to `>=`, the call deleted, and the batch rejection swallowed. Each failed exactly the tests it should have.

In the app, on a `dev:web` instance with a manual balance:

| Login | last snapshot | `GET /balances` | result |
|---|---|---|---|
| fresh login | none | yes, after the chain walk | snapshot written, real value, not a 0-row |
| reload, 25 min later | 25 min old | no | unchanged |
| reload, snapshot deleted | none | yes | snapshot written |

### Not addressed here

The scheduler-enable path has its own holes, which is why this bug was invisible: the ten minute fallback is cancelled when a history sync *starts* and only re-armed when one finishes, and a failed enable call is never retried. Separate fix. Also, a brand-new account never runs the login load at all (`shouldFetchData` is false), so it takes no snapshot until its second login.
