### PR TITLE
test(frontend): coverage batch B, the history/events cluster

### DIFF
--- a/frontend/app/src/modules/history/events/HistoryEventsAction.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventsAction.spec.ts
@@ -1,0 +1,329 @@
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import type { UseHistoryEventActionMenuOptions } from '@/modules/history/events/use-history-event-action-menu';
+import { HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import HistoryEventsAction from '@/modules/history/events/HistoryEventsAction.vue';
+
+/**
+ * The seam: which actions the menu offers for a row, and what each one emits. Working out what
+ * applies to a row - the transaction behind it, the event a re-decode runs on, what a delete
+ * removes - belongs to `use-history-event-action-menu`, which has its own spec.
+ */
+
+const evmEvent = createMock<HistoryEventEntry>({
+  entryType: HistoryEventEntryType.EVM_EVENT,
+  identifier: 1,
+  ignoredInAccounting: false,
+  location: 'ethereum',
+  txRef: '0xabc',
+});
+
+const blockEvent = createMock<HistoryEventEntry>({
+  blockNumber: 1234,
+  entryType: HistoryEventEntryType.ETH_BLOCK_EVENT,
+  identifier: 2,
+  ignoredInAccounting: false,
+});
+
+const redecodePayload = { data: { location: 'ethereum', txRef: '0xabc' }, type: HistoryEventEntryType.EVM_EVENT };
+
+const menu = {
+  blockEvent: ref<HistoryEventEntry | undefined>(),
+  canAddEvent: ref<boolean>(true),
+  canDeleteEvents: ref<boolean>(false),
+  confirmFixDuplicate: vi.fn(),
+  confirmIgnoreDuplicate: vi.fn(),
+  decodableEvmEvent: ref<HistoryEventEntry | undefined>(evmEvent),
+  deletableEventIds: vi.fn().mockReturnValue([7, 9]),
+  ethBlockEventsDecoding: ref<boolean>(false),
+  eventWithDecoding: ref<HistoryEventEntry | undefined>(evmEvent),
+  eventWithTxRef: ref<{ location: string; txRef: string } | undefined>(),
+  fixLoading: ref<boolean>(false),
+  ignoreLoading: ref<boolean>(false),
+  isAutoFixable: ref<boolean>(false),
+  isDuplicate: ref<boolean>(false),
+  openReportDialog: vi.fn(),
+  toRedecodePayload: vi.fn().mockReturnValue(redecodePayload),
+  txEventsDecoding: ref<boolean>(false),
+};
+
+let options: UseHistoryEventActionMenuOptions;
+
+vi.mock('@/modules/history/events/use-history-event-action-menu', () => ({
+  useHistoryEventActionMenu: (opts: UseHistoryEventActionMenuOptions): unknown => {
+    options = opts;
+    return menu;
+  },
+}));
+
+const MenuStub = defineComponent({
+  emits: ['update:modelValue'],
+  name: 'RuiMenu',
+  props: { modelValue: { default: false, type: Boolean } },
+  setup: (_props, { slots }) => (): unknown => h('div', [slots.activator?.({ attrs: {} }), slots.default?.()]),
+});
+
+const RedecodeStub = defineComponent({
+  emits: ['redecode', 'redecode-with-options'],
+  name: 'RedecodeEventsButton',
+  props: {
+    disabled: { default: false, type: Boolean },
+    hasOptions: { default: false, type: Boolean },
+  },
+  setup: () => (): unknown => h('div', { 'data-testid': 'redecode-button' }),
+});
+
+describe('modules/history/events/HistoryEventsAction', () => {
+  let wrapper: VueWrapper | undefined;
+
+  function mountAction(props: Record<string, unknown> = {}): VueWrapper {
+    wrapper = mount(HistoryEventsAction, {
+      global: {
+        stubs: {
+          RedecodeEventsButton: RedecodeStub,
+          RuiMenu: MenuStub,
+        },
+      },
+      props: { event: evmEvent, loading: false, ...props },
+    });
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(menu.blockEvent, undefined);
+    set(menu.canAddEvent, true);
+    set(menu.canDeleteEvents, false);
+    set(menu.decodableEvmEvent, evmEvent);
+    set(menu.ethBlockEventsDecoding, false);
+    set(menu.eventWithDecoding, evmEvent);
+    set(menu.eventWithTxRef, undefined);
+    set(menu.fixLoading, false);
+    set(menu.ignoreLoading, false);
+    set(menu.isAutoFixable, false);
+    set(menu.isDuplicate, false);
+    set(menu.txEventsDecoding, false);
+    menu.deletableEventIds.mockReturnValue([7, 9]);
+    menu.toRedecodePayload.mockReturnValue(redecodePayload);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should hand the row and its group to the composable', () => {
+    const group = [evmEvent];
+    mountAction({ groupEvents: group });
+
+    expect(options.event()).toBe(evmEvent);
+    expect(options.groupEvents()).toStrictEqual(group);
+    expect(options.duplicateHandlingStatus()).toBeUndefined();
+  });
+
+  describe('the duplicate actions', () => {
+    it('should show neither while the row is not a duplicate', () => {
+      const view = mountAction();
+
+      expect(view.find('[data-testid="event-fix-duplicate"]').exists()).toBe(false);
+      expect(view.find('[data-testid="event-ignore-duplicate"]').exists()).toBe(false);
+    });
+
+    it('should fix the duplicate through the composable', async () => {
+      set(menu.isAutoFixable, true);
+      const view = mountAction();
+
+      await view.find('[data-testid="event-fix-duplicate"]').trigger('click');
+
+      expect(menu.confirmFixDuplicate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should dismiss the duplicate through the composable', async () => {
+      set(menu.isDuplicate, true);
+      const view = mountAction();
+
+      await view.find('[data-testid="event-ignore-duplicate"]').trigger('click');
+
+      expect(menu.confirmIgnoreDuplicate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report each action back once it is done', () => {
+      const view = mountAction();
+
+      options.onFixDuplicate();
+      options.onIgnoreDuplicate();
+
+      expect(view.emitted('fix-duplicate')).toHaveLength(1);
+      expect(view.emitted('ignore-duplicate')).toHaveLength(1);
+    });
+  });
+
+  describe('the menu items', () => {
+    it('should add an event next to the row', async () => {
+      const view = mountAction();
+
+      await view.find('[data-testid="event-add"]').trigger('click');
+
+      expect(view.emitted('add-event')).toStrictEqual([[evmEvent]]);
+    });
+
+    it('should hide the add action when the composable refuses it', () => {
+      set(menu.canAddEvent, false);
+      const view = mountAction();
+
+      expect(view.find('[data-testid="event-add"]').exists()).toBe(false);
+    });
+
+    it('should toggle the row out of accounting', async () => {
+      const view = mountAction();
+
+      const toggle = view.find('[data-testid="event-toggle-ignore"]');
+      // The icon name is part of the rendered text, which is what shows the eye is crossed out.
+      expect(toggle.text()).toBe('lu-eye-off transactions.ignore');
+      await toggle.trigger('click');
+
+      expect(view.emitted('toggle-ignore')).toStrictEqual([[evmEvent]]);
+    });
+
+    it('should offer to bring an ignored row back', () => {
+      const ignored = createMock<HistoryEventEntry>({
+        entryType: HistoryEventEntryType.EVM_EVENT,
+        identifier: 1,
+        ignoredInAccounting: true,
+      });
+      const view = mountAction({ event: ignored });
+
+      expect(view.find('[data-testid="event-toggle-ignore"]').text()).toBe('lu-eye transactions.unignore');
+    });
+
+    it('should report an issue about the row', async () => {
+      const view = mountAction();
+
+      await view.find('[data-testid="event-report-issue"]').trigger('click');
+
+      expect(menu.openReportDialog).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('re-decoding', () => {
+    it('should re-decode a block event by its own action', async () => {
+      set(menu.blockEvent, blockEvent);
+      const blockPayload = { data: [1234], type: HistoryEventEntryType.ETH_BLOCK_EVENT };
+      menu.toRedecodePayload.mockReturnValue(blockPayload);
+      const view = mountAction();
+
+      expect(view.findComponent(RedecodeStub).exists()).toBe(false);
+      await view.find('[data-testid="event-redecode-block"]').trigger('click');
+
+      expect(menu.toRedecodePayload).toHaveBeenCalledWith(blockEvent);
+      expect(view.emitted('redecode')).toStrictEqual([[blockPayload]]);
+    });
+
+    it.each([
+      ['the table is loading', { loading: true }],
+      ['this group is already re-decoding', { redecoding: true }],
+    ] as const)('should disable the block re-decode while %s', (_, props) => {
+      set(menu.blockEvent, blockEvent);
+      const view = mountAction(props);
+
+      expect(view.find('[data-testid="event-redecode-block"]').attributes('disabled')).toBeDefined();
+    });
+
+    it('should disable the block re-decode while every block event is decoding', () => {
+      set(menu.blockEvent, blockEvent);
+      set(menu.ethBlockEventsDecoding, true);
+      const view = mountAction();
+
+      expect(view.find('[data-testid="event-redecode-block"]').attributes('disabled')).toBeDefined();
+    });
+
+    it('should re-decode everything else through the redecode button', async () => {
+      const view = mountAction();
+      const button = view.findComponent(RedecodeStub);
+
+      expect(button.props('hasOptions')).toBe(true);
+      expect(button.props('disabled')).toBe(false);
+      button.vm.$emit('redecode');
+      await nextTick();
+
+      expect(menu.toRedecodePayload).toHaveBeenCalledWith(evmEvent);
+      expect(view.emitted('redecode')).toStrictEqual([[redecodePayload]]);
+    });
+
+    it('should offer no options when the event a re-decode runs on is not an evm one', () => {
+      set(menu.decodableEvmEvent, undefined);
+      const view = mountAction();
+
+      expect(view.findComponent(RedecodeStub).props('hasOptions')).toBe(false);
+    });
+
+    it('should disable the redecode button while transactions are decoding', () => {
+      set(menu.txEventsDecoding, true);
+      const view = mountAction();
+
+      expect(view.findComponent(RedecodeStub).props('disabled')).toBe(true);
+    });
+
+    it('should re-decode with options and close the menu', async () => {
+      const view = mountAction();
+      expect(view.findComponent(MenuStub).props('modelValue')).toBe(false);
+
+      view.findComponent(MenuStub).vm.$emit('update:modelValue', true);
+      await nextTick();
+      expect(view.findComponent(MenuStub).props('modelValue')).toBe(true);
+
+      view.findComponent(RedecodeStub).vm.$emit('redecode-with-options');
+      await nextTick();
+
+      expect(view.emitted('redecode-with-options')).toStrictEqual([[redecodePayload]]);
+      expect(view.findComponent(MenuStub).props('modelValue')).toBe(false);
+    });
+
+    it('should render nothing to re-decode when the composable found no event for it', () => {
+      set(menu.eventWithDecoding, undefined);
+      const view = mountAction();
+
+      expect(view.findComponent(RedecodeStub).exists()).toBe(false);
+      expect(view.find('[data-testid="event-redecode-block"]').exists()).toBe(false);
+    });
+  });
+
+  describe('deleting', () => {
+    it('should delete the transaction when the row belongs to one', async () => {
+      set(menu.eventWithTxRef, { location: 'ethereum', txRef: '0xabc' });
+      const view = mountAction();
+
+      expect(view.find('[data-testid="event-delete-events"]').exists()).toBe(false);
+      await view.find('[data-testid="event-delete-tx"]').trigger('click');
+
+      expect(view.emitted('delete-tx')).toStrictEqual([[{ location: 'ethereum', txRef: '0xabc' }]]);
+    });
+
+    it('should delete every event the composable names when there is no transaction', async () => {
+      set(menu.canDeleteEvents, true);
+      const view = mountAction();
+
+      expect(view.find('[data-testid="event-delete-tx"]').exists()).toBe(false);
+      await view.find('[data-testid="event-delete-events"]').trigger('click');
+
+      expect(view.emitted('delete-events')).toStrictEqual([[[7, 9]]]);
+    });
+
+    it('should offer no delete when neither applies', () => {
+      const view = mountAction();
+
+      expect(view.find('[data-testid="event-delete-tx"]').exists()).toBe(false);
+      expect(view.find('[data-testid="event-delete-events"]').exists()).toBe(false);
+    });
+
+    it('should disable the delete while the table is loading', () => {
+      set(menu.canDeleteEvents, true);
+      const view = mountAction({ loading: true });
+
+      expect(view.find('[data-testid="event-delete-events"]').attributes('disabled')).toBeDefined();
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/HistoryEventsAction.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsAction.vue
@@ -1,37 +1,16 @@
 <script setup lang="ts">
+import type { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
 import type {
   LocationAndTxRef,
   PullEventPayload,
 } from '@/modules/history/events/event-payloads';
 import type {
-  EthBlockEvent,
-  EvmHistoryEvent,
-  EvmSwapEvent,
-  HistoryEvent,
   HistoryEventEntry,
-  SolanaEvent,
-  SolanaSwapEvent,
   StandaloneEditableEvents,
 } from '@/modules/history/events/schemas';
-import { useReportIssue } from '@/modules/core/common/use-report-issue';
-import {
-  isEthBlockEvent,
-  isEthBlockEventRef,
-  isEvmEvent,
-  isEvmSwapEvent,
-  isOnlineHistoryEvent,
-  isSolanaEvent,
-  isSolanaSwapEvent,
-  toLocationAndTxRef,
-} from '@/modules/history/event-utils';
-import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
 import RedecodeEventsButton from '@/modules/history/events/RedecodeEventsButton.vue';
-import { useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
-import { useHistoryEventsStatus } from '@/modules/history/events/use-history-events-status';
-import {
-  type DecodableEventType,
-  isGroupEditableHistoryEvent,
-} from '@/modules/history/management/forms/form-guards';
+import { useHistoryEventActionMenu } from '@/modules/history/events/use-history-event-action-menu';
+import { type DecodableEventType, isGroupEditableHistoryEvent } from '@/modules/history/management/forms/form-guards';
 
 const { event, loading, redecoding, duplicateHandlingStatus, groupEvents } = defineProps<{
   event: HistoryEventEntry;
@@ -56,169 +35,52 @@ const emit = defineEmits<{
   'ignore-duplicate': [];
 }>();
 
-const {
-  ethBlockEventsDecoding,
-  txEventsDecoding,
-} = useHistoryEventsStatus();
-
-const { confirmAndFixDuplicate, confirmAndMarkNonDuplicated, fixLoading, ignoreLoading } = useCustomizedEventDuplicates();
-
-const isAutoFixable = computed<boolean>(() => duplicateHandlingStatus === DuplicateHandlingStatus.AUTO_FIX);
-const isDuplicate = computed<boolean>(() => !!duplicateHandlingStatus && duplicateHandlingStatus !== DuplicateHandlingStatus.IGNORED);
+const { t } = useI18n({ useScope: 'global' });
 
 const showMenu = ref<boolean>(false);
 
-const evmEvent = computed<EvmHistoryEvent | EvmSwapEvent | undefined>(() => {
-  if (isEvmSwapEvent(event) || isEvmEvent(event)) {
-    return event;
-  }
-
-  return undefined;
+const {
+  blockEvent,
+  canAddEvent,
+  canDeleteEvents,
+  confirmFixDuplicate,
+  confirmIgnoreDuplicate,
+  decodableEvmEvent,
+  deletableEventIds,
+  ethBlockEventsDecoding,
+  eventWithDecoding,
+  eventWithTxRef,
+  fixLoading,
+  ignoreLoading,
+  isAutoFixable,
+  isDuplicate,
+  openReportDialog,
+  toRedecodePayload,
+  txEventsDecoding,
+} = useHistoryEventActionMenu({
+  duplicateHandlingStatus: () => duplicateHandlingStatus,
+  event: () => event,
+  groupEvents: () => groupEvents,
+  onFixDuplicate: () => emit('fix-duplicate'),
+  onIgnoreDuplicate: () => emit('ignore-duplicate'),
 });
 
-const solanaEvent = computed<SolanaEvent | SolanaSwapEvent | undefined>(() => {
-  if (isSolanaSwapEvent(event) || isSolanaEvent(event)) {
-    return event;
-  }
-
-  return undefined;
-});
-
-const eventWithDecoding = computed<DecodableEventType | undefined>(() => {
-  const direct = get(evmEvent) || get(solanaEvent);
-  if (direct)
-    return direct;
-
-  if (!groupEvents)
-    return undefined;
-
-  for (const child of groupEvents) {
-    if (isEvmEvent(child) || isEvmSwapEvent(child) || isSolanaEvent(child) || isSolanaSwapEvent(child))
-      return child;
-  }
-
-  return undefined;
-});
-
-const decodableEvmEvent = computed<EvmHistoryEvent | EvmSwapEvent | undefined>(() => {
-  const decoded = get(eventWithDecoding);
-  if (decoded && (isEvmEvent(decoded) || isEvmSwapEvent(decoded)))
-    return decoded;
-
-  return undefined;
-});
-
-const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>(() => {
-  const evm = get(evmEvent);
-  const solana = get(solanaEvent);
-  if (evm) {
-    return {
-      location: evm.location,
-      txRef: evm.txRef,
-    };
-  }
-
-  if (solana) {
-    return {
-      location: solana.location,
-      txRef: solana.txRef,
-    };
-  }
-
-  if (isOnlineHistoryEvent(event) && 'txRef' in event && event.txRef) {
-    return {
-      location: event.location,
-      txRef: event.txRef,
-    };
-  }
-
-  return undefined;
-});
-
-const blockEvent = isEthBlockEventRef(() => event);
-
-const { t } = useI18n({ useScope: 'global' });
-
-function addEvent(event: HistoryEvent) {
-  if (isGroupEditableHistoryEvent(event)) {
+function addEvent(): void {
+  // `canAddEvent` already hides the action for a group-editable event; this narrows the
+  // row to the shape the event carries.
+  if (isGroupEditableHistoryEvent(event))
     return;
-  }
+
   emit('add-event', event);
 }
-const toggleIgnore = (event: HistoryEventEntry) => emit('toggle-ignore', event);
 
-function redecode(event: EthBlockEvent | DecodableEventType): void {
-  if (isEthBlockEvent(event)) {
-    emit('redecode', {
-      data: [event.blockNumber],
-      type: event.entryType,
-    });
-    return;
-  }
-
-  emit('redecode', {
-    data: toLocationAndTxRef(event),
-    type: event.entryType,
-  });
+function redecode(target: DecodableEventType): void {
+  emit('redecode', toRedecodePayload(target));
 }
 
-function redecodeWithOptions(event: DecodableEventType): void {
+function redecodeWithOptions(target: DecodableEventType): void {
   set(showMenu, false);
-  emit('redecode-with-options', {
-    data: toLocationAndTxRef(event),
-    type: event.entryType,
-  });
-}
-
-function deleteTxAndEvents(params: LocationAndTxRef): void {
-  emit('delete-tx', params);
-}
-
-function deleteEvents(): void {
-  const ids = groupEvents?.map(e => e.identifier) ?? [event.identifier];
-  emit('delete-events', ids);
-}
-
-const canDeleteEvents = computed<boolean>(() => !get(eventWithTxRef) && !get(blockEvent));
-
-function hideAddAction(item: HistoryEvent): boolean {
-  return isGroupEditableHistoryEvent(item);
-}
-
-const { show: showReportIssue } = useReportIssue();
-
-function openReportDialog(): void {
-  const txRef = get(eventWithTxRef)?.txRef;
-
-  const description = [
-    t('actions.history_events.report_issue.description_intro'),
-    txRef ? t('actions.history_events.report_issue.tx_hash', { hash: txRef }) : '',
-    t('actions.history_events.report_issue.location', { location: event.location }),
-    '',
-    t('actions.history_events.report_issue.more_detail'),
-    t('actions.history_events.report_issue.placeholder'),
-  ].filter(Boolean).join('\n');
-
-  showReportIssue({
-    description,
-    title: t('actions.history_events.report_issue.title'),
-  });
-}
-
-function confirmFixDuplicate(): void {
-  const groupIdentifier = event.groupIdentifier;
-  if (!groupIdentifier)
-    return;
-
-  confirmAndFixDuplicate([groupIdentifier], () => emit('fix-duplicate'));
-}
-
-function confirmIgnoreDuplicate(): void {
-  const groupIdentifier = event.groupIdentifier;
-  if (!groupIdentifier)
-    return;
-
-  confirmAndMarkNonDuplicated([groupIdentifier], () => emit('ignore-duplicate'));
+  emit('redecode-with-options', toRedecodePayload(target));
 }
 </script>
 
@@ -230,6 +92,7 @@ function confirmIgnoreDuplicate(): void {
       color="primary"
       class="mr-1"
       :loading="fixLoading"
+      data-testid="event-fix-duplicate"
       @click="confirmFixDuplicate()"
     >
       <template #prepend>
@@ -246,6 +109,7 @@ function confirmIgnoreDuplicate(): void {
       size="sm"
       class="mr-2"
       :loading="ignoreLoading"
+      data-testid="event-ignore-duplicate"
       @click="confirmIgnoreDuplicate()"
     >
       <template #prepend>
@@ -268,6 +132,7 @@ function confirmIgnoreDuplicate(): void {
           icon
           size="sm"
           class="!p-2"
+          data-testid="event-actions-menu"
           v-bind="attrs"
         >
           <RuiIcon
@@ -277,9 +142,10 @@ function confirmIgnoreDuplicate(): void {
         </RuiButton>
       </template>
       <RuiButton
-        v-if="!hideAddAction(event)"
+        v-if="canAddEvent"
         variant="list"
-        @click="addEvent(event)"
+        data-testid="event-add"
+        @click="addEvent()"
       >
         <template #prepend>
           <RuiIcon name="lu-plus" />
@@ -288,7 +154,8 @@ function confirmIgnoreDuplicate(): void {
       </RuiButton>
       <RuiButton
         variant="list"
-        @click="toggleIgnore(event)"
+        data-testid="event-toggle-ignore"
+        @click="emit('toggle-ignore', event)"
       >
         <template #prepend>
           <RuiIcon :name="event.ignoredInAccounting ? 'lu-eye' : 'lu-eye-off'" />
@@ -299,7 +166,8 @@ function confirmIgnoreDuplicate(): void {
         <RuiButton
           variant="list"
           :disabled="loading || redecoding || ethBlockEventsDecoding"
-          @click="redecode(blockEvent)"
+          data-testid="event-redecode-block"
+          @click="emit('redecode', toRedecodePayload(blockEvent))"
         >
           <template #prepend>
             <RuiIcon name="lu-rotate-ccw" />
@@ -320,7 +188,8 @@ function confirmIgnoreDuplicate(): void {
         variant="list"
         color="error"
         :disabled="loading"
-        @click="deleteTxAndEvents(eventWithTxRef)"
+        data-testid="event-delete-tx"
+        @click="emit('delete-tx', eventWithTxRef)"
       >
         <template #prepend>
           <RuiIcon name="lu-trash-2" />
@@ -332,7 +201,8 @@ function confirmIgnoreDuplicate(): void {
         variant="list"
         color="error"
         :disabled="loading"
-        @click="deleteEvents()"
+        data-testid="event-delete-events"
+        @click="emit('delete-events', deletableEventIds())"
       >
         <template #prepend>
           <RuiIcon name="lu-trash-2" />
@@ -342,6 +212,7 @@ function confirmIgnoreDuplicate(): void {
       <RuiDivider class="my-2" />
       <RuiButton
         variant="list"
+        data-testid="event-report-issue"
         @click="openReportDialog()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/history/events/HistoryEventsDialogContainer.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventsDialogContainer.spec.ts
@@ -1,0 +1,313 @@
+import type { DialogState } from '@/modules/history/events/dialog-manager/types';
+import type { UseHistoryEventsDialogContainerOptions } from '@/modules/history/events/use-history-events-dialog-container';
+import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
+import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as stubs from '@/modules/history/events/dialog-components';
+import { DIALOG_TYPES, type DialogEventHandlers } from '@/modules/history/events/dialog-types';
+import HistoryEventsDialogContainer from '@/modules/history/events/HistoryEventsDialogContainer.vue';
+
+/**
+ * The seam: which dialog the container renders for the open dialog type, and where each
+ * dialog's events go. The models behind them live in `use-history-events-dialog-container`,
+ * which has its own spec.
+ */
+
+// Every dialog is replaced by a stub that renders nothing, so the container's own wiring is
+// what the assertions see. `stubs` below is the mocked module itself, so a `findComponent`
+// is matching the exact component the container rendered.
+vi.mock('@/modules/history/events/dialog-components', async () => {
+  const { defineComponent, h } = await import('vue');
+
+  function stubDialog(name: string, emits: string[] = []): unknown {
+    return defineComponent({
+      emits: ['update:modelValue', ...emits],
+      name,
+      props: { modelValue: { default: undefined, type: [Boolean, Object] } },
+      setup: () => (): unknown => h('div', { 'data-testid': name }),
+    });
+  }
+
+  return {
+    AccountingRuleFormDialog: stubDialog('AccountingRuleFormDialog', ['refresh']),
+    BridgePotentialMatchesDialog: stubDialog('BridgePotentialMatchesDialog', ['matched', 'pinned']),
+    CustomizedEventDuplicatesDialog: stubDialog('CustomizedEventDuplicatesDialog'),
+    HistoryEventFormDialog: stubDialog('HistoryEventFormDialog', ['refresh']),
+    HistoryEventsDecodingStatusDialog: stubDialog('HistoryEventsDecodingStatusDialog', [
+      'redecode-all-events',
+      'reset-undecoded-transactions',
+    ]),
+    HistoryEventsProtocolCacheStatusDialog: stubDialog('HistoryEventsProtocolCacheStatusDialog'),
+    InternalTxConflictsDialog: stubDialog('InternalTxConflictsDialog'),
+    MatchAssetMovementsDialog: stubDialog('MatchAssetMovementsDialog', ['find-match', 'refresh']),
+    MatchBridgeTransactionsDialog: stubDialog('MatchBridgeTransactionsDialog', ['find-match']),
+    MissingRulesDialog: stubDialog('MissingRulesDialog', ['add', 'dismiss', 'edit-event', 'redecode']),
+    PotentialMatchesDialog: stubDialog('PotentialMatchesDialog', ['matched', 'pinned']),
+    RepullingTransactionFormDialog: stubDialog('RepullingTransactionFormDialog'),
+    TransactionFormDialog: stubDialog('TransactionFormDialog', ['reload']),
+  };
+});
+
+const movement = createMock<UnmatchedAssetMovement>({ groupIdentifier: 'group-a' });
+const transaction = createMock<UnmatchedBridgeTransaction>({ groupIdentifier: 'group-b' });
+
+const container = {
+  bridgeSubject: ref<UnmatchedBridgeTransaction | undefined>(),
+  closeDialog: vi.fn(),
+  currentDialog: ref<DialogState>({ type: 'closed' }),
+  decodingStatusPersistent: ref<boolean>(false),
+  modelAddTransaction: ref<unknown>(),
+  modelBridgeMatchesOpen: ref<boolean>(false),
+  modelDialogOpen: ref<boolean>(true),
+  modelFormData: ref<unknown>(),
+  modelMissingRule: ref<unknown>(),
+  modelMovementMatchesOpen: ref<boolean>(false),
+  movementSubject: ref<UnmatchedAssetMovement | undefined>(),
+  onBridgeMatched: vi.fn(),
+  onBridgePinned: vi.fn(),
+  onMovementMatched: vi.fn(),
+  onMovementPinned: vi.fn(),
+  openBridgeMatches: vi.fn(),
+  openMovementMatches: vi.fn(),
+  show: vi.fn().mockResolvedValue(undefined),
+};
+
+let options: UseHistoryEventsDialogContainerOptions;
+
+vi.mock('@/modules/history/events/use-history-events-dialog-container', () => ({
+  useHistoryEventsDialogContainer: (opts: UseHistoryEventsDialogContainerOptions): unknown => {
+    options = opts;
+    return container;
+  },
+}));
+
+describe('modules/history/events/HistoryEventsDialogContainer', () => {
+  type ContainerWrapper = VueWrapper<InstanceType<typeof HistoryEventsDialogContainer>>;
+
+  let wrapper: ContainerWrapper | undefined;
+
+  const eventHandlers: DialogEventHandlers = {
+    onHistoryEventSaved: vi.fn(),
+    onRedecodeAllEvents: vi.fn(),
+    onRedecodeTransaction: vi.fn(),
+    onResetUndecodedTransactions: vi.fn(),
+    onTransactionAdded: vi.fn(),
+  };
+
+  function mountContainer(props: Record<string, unknown> = {}): ContainerWrapper {
+    wrapper = mount(HistoryEventsDialogContainer, {
+      props: {
+        accountingRuleToEdit: undefined,
+        eventHandlers,
+        selectedEventIds: [1, 2],
+        ...props,
+      },
+    });
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(container.bridgeSubject, undefined);
+    set(container.currentDialog, { type: 'closed' });
+    set(container.decodingStatusPersistent, false);
+    set(container.modelBridgeMatchesOpen, false);
+    set(container.modelDialogOpen, true);
+    set(container.modelMovementMatchesOpen, false);
+    set(container.movementSubject, undefined);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should render only the accounting rule form while no dialog is open', () => {
+    const view = mountContainer();
+
+    // It is the one dialog with no `v-if`: it decides for itself from its own model.
+    expect(view.findComponent(stubs.AccountingRuleFormDialog).exists()).toBe(true);
+    expect(view.findComponent(stubs.HistoryEventFormDialog).exists()).toBe(false);
+    expect(view.findComponent(stubs.TransactionFormDialog).exists()).toBe(false);
+    expect(view.findComponent(stubs.MissingRulesDialog).exists()).toBe(false);
+  });
+
+  it.each([
+    [DIALOG_TYPES.EVENT_FORM, 'HistoryEventFormDialog'],
+    [DIALOG_TYPES.TRANSACTION_FORM, 'TransactionFormDialog'],
+    [DIALOG_TYPES.REPULLING_TRANSACTION, 'RepullingTransactionFormDialog'],
+    [DIALOG_TYPES.MISSING_RULES, 'MissingRulesDialog'],
+    [DIALOG_TYPES.DECODING_STATUS, 'HistoryEventsDecodingStatusDialog'],
+    [DIALOG_TYPES.PROTOCOL_CACHE, 'HistoryEventsProtocolCacheStatusDialog'],
+    [DIALOG_TYPES.CUSTOMIZED_EVENT_DUPLICATES, 'CustomizedEventDuplicatesDialog'],
+    [DIALOG_TYPES.INTERNAL_TX_CONFLICTS, 'InternalTxConflictsDialog'],
+    [DIALOG_TYPES.MATCH_ASSET_MOVEMENTS, 'MatchAssetMovementsDialog'],
+    [DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS, 'MatchBridgeTransactionsDialog'],
+  ] as const)('should render the %s dialog and nothing else', (type, expected) => {
+    set(container.currentDialog, createMock<DialogState>({ type }));
+    const view = mountContainer();
+
+    const rendered = Object.entries(stubs)
+      .filter(([, stub]) => view.findComponent(stub).exists())
+      .map(([name]) => name);
+
+    expect(rendered).toStrictEqual(expect.arrayContaining([expected]));
+    expect(rendered).toHaveLength(2); // the dialog itself, plus the accounting rule form
+  });
+
+  it('should give the decoding status dialog what the composable decided about persistence', () => {
+    set(container.currentDialog, createMock<DialogState>({ type: DIALOG_TYPES.DECODING_STATUS }));
+    set(container.decodingStatusPersistent, true);
+    const view = mountContainer({ refreshing: true });
+
+    const dialog = view.findComponent(stubs.HistoryEventsDecodingStatusDialog);
+    expect(dialog.attributes('persistent')).toBeDefined();
+    expect(dialog.attributes('refreshing')).toBeDefined();
+  });
+
+  describe('where each dialog reports to', () => {
+    it('should reload the events when one is saved', async () => {
+      set(container.currentDialog, createMock<DialogState>({ type: DIALOG_TYPES.EVENT_FORM }));
+      const view = mountContainer();
+
+      view.findComponent(stubs.HistoryEventFormDialog).vm.$emit('refresh');
+      await nextTick();
+
+      expect(eventHandlers.onHistoryEventSaved).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reload the events when a transaction is added', async () => {
+      set(container.currentDialog, createMock<DialogState>({ type: DIALOG_TYPES.TRANSACTION_FORM }));
+      const view = mountContainer();
+      const payload = { location: 'ethereum', txRef: '0xabc' };
+
+      view.findComponent(stubs.TransactionFormDialog).vm.$emit('reload', payload);
+      await nextTick();
+
+      expect(eventHandlers.onTransactionAdded).toHaveBeenCalledWith(payload);
+    });
+
+    it('should route the missing rules dialog through the manager', async () => {
+      set(container.currentDialog, createMock<DialogState>({ type: DIALOG_TYPES.MISSING_RULES }));
+      const view = mountContainer();
+      const dialog = view.findComponent(stubs.MissingRulesDialog);
+      const editData = createMock<Extract<DialogState, { type: 'eventForm' }>['data']>({});
+
+      dialog.vm.$emit('edit-event', editData);
+      dialog.vm.$emit('add', { eventSubtype: 'a', eventType: 'b' });
+      dialog.vm.$emit('redecode', { location: 'ethereum', txRef: '0xabc' });
+      dialog.vm.$emit('dismiss');
+      await nextTick();
+
+      expect(container.show).toHaveBeenCalledWith({ data: editData, type: DIALOG_TYPES.EVENT_FORM });
+      expect(container.show).toHaveBeenCalledWith({
+        data: { eventSubtype: 'a', eventType: 'b' },
+        type: DIALOG_TYPES.ADD_MISSING_RULE,
+      });
+      expect(eventHandlers.onRedecodeTransaction).toHaveBeenCalledWith({ location: 'ethereum', txRef: '0xabc' });
+      expect(container.closeDialog).toHaveBeenCalledTimes(1);
+    });
+
+    it('should route the decoding status actions to their handlers', async () => {
+      set(container.currentDialog, createMock<DialogState>({ type: DIALOG_TYPES.DECODING_STATUS }));
+      const view = mountContainer();
+      const dialog = view.findComponent(stubs.HistoryEventsDecodingStatusDialog);
+
+      dialog.vm.$emit('redecode-all-events');
+      dialog.vm.$emit('reset-undecoded-transactions');
+      await nextTick();
+
+      expect(eventHandlers.onRedecodeAllEvents).toHaveBeenCalledTimes(1);
+      expect(eventHandlers.onResetUndecodedTransactions).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report an accounting rule change to the page', async () => {
+      const view = mountContainer();
+
+      view.findComponent(stubs.AccountingRuleFormDialog).vm.$emit('refresh');
+      await nextTick();
+
+      expect(view.emitted('accounting-rule-refresh')).toHaveLength(1);
+    });
+
+    it('should report a match back to the page through the composable', () => {
+      const view = mountContainer();
+
+      options.onMovementMatched();
+      options.onBridgeMatched();
+
+      expect(view.emitted('movement-matched')).toHaveLength(1);
+      expect(view.emitted('bridge-matched')).toHaveLength(1);
+    });
+  });
+
+  describe('the potential matches dialogs', () => {
+    it('should open the movement one from the matching list', async () => {
+      set(container.currentDialog, createMock<DialogState>({ type: DIALOG_TYPES.MATCH_ASSET_MOVEMENTS }));
+      const view = mountContainer();
+
+      expect(view.findComponent(stubs.PotentialMatchesDialog).exists()).toBe(false);
+      view.findComponent(stubs.MatchAssetMovementsDialog).vm.$emit('find-match', movement);
+      await nextTick();
+
+      expect(container.openMovementMatches).toHaveBeenCalledWith(movement);
+    });
+
+    it('should show the movement the composable is holding', async () => {
+      set(container.movementSubject, movement);
+      set(container.modelMovementMatchesOpen, true);
+      const view = mountContainer();
+      const dialog = view.findComponent(stubs.PotentialMatchesDialog);
+
+      expect(dialog.exists()).toBe(true);
+      dialog.vm.$emit('matched');
+      dialog.vm.$emit('pinned');
+      await nextTick();
+
+      expect(container.onMovementMatched).toHaveBeenCalledTimes(1);
+      expect(container.onMovementPinned).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stay closed while the composable holds no movement', () => {
+      set(container.modelMovementMatchesOpen, true);
+      const view = mountContainer();
+
+      expect(view.findComponent(stubs.PotentialMatchesDialog).exists()).toBe(false);
+    });
+
+    it('should open the bridge one from the matching list', async () => {
+      set(container.currentDialog, createMock<DialogState>({ type: DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS }));
+      const view = mountContainer();
+
+      view.findComponent(stubs.MatchBridgeTransactionsDialog).vm.$emit('find-match', transaction);
+      await nextTick();
+
+      expect(container.openBridgeMatches).toHaveBeenCalledWith(transaction);
+    });
+
+    it('should show the transaction the composable is holding', async () => {
+      set(container.bridgeSubject, transaction);
+      set(container.modelBridgeMatchesOpen, true);
+      const view = mountContainer();
+      const dialog = view.findComponent(stubs.BridgePotentialMatchesDialog);
+
+      expect(dialog.exists()).toBe(true);
+      dialog.vm.$emit('matched');
+      dialog.vm.$emit('pinned');
+      await nextTick();
+
+      expect(container.onBridgeMatched).toHaveBeenCalledTimes(1);
+      expect(container.onBridgePinned).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should expose the manager and both potential-match openers', () => {
+    const view = mountContainer();
+
+    expect(view.vm.show).toBe(container.show);
+    expect(view.vm.showPotentialMatches).toBe(container.openMovementMatches);
+    expect(view.vm.showBridgePotentialMatches).toBe(container.openBridgeMatches);
+  });
+});

--- a/frontend/app/src/modules/history/events/HistoryEventsDialogContainer.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsDialogContainer.vue
@@ -1,11 +1,23 @@
 <script setup lang="ts">
-import type { AddTransactionHashPayload } from '@/modules/history/events/event-payloads';
-import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
-import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
+import type { DialogEventHandlers } from '@/modules/history/events/dialog-types';
 import type { AccountingRuleEntry } from '@/modules/settings/types/accounting';
-import { get } from '@vueuse/core';
-import { useHistoryEventsDialogManager } from '@/modules/history/events/dialog-manager/use-history-events-dialog-manager';
-import { DIALOG_TYPES, type DialogEventHandlers } from './dialog-types';
+import {
+  AccountingRuleFormDialog,
+  BridgePotentialMatchesDialog,
+  CustomizedEventDuplicatesDialog,
+  HistoryEventFormDialog,
+  HistoryEventsDecodingStatusDialog,
+  HistoryEventsProtocolCacheStatusDialog,
+  InternalTxConflictsDialog,
+  MatchAssetMovementsDialog,
+  MatchBridgeTransactionsDialog,
+  MissingRulesDialog,
+  PotentialMatchesDialog,
+  RepullingTransactionFormDialog,
+  TransactionFormDialog,
+} from '@/modules/history/events/dialog-components';
+import { useHistoryEventsDialogContainer } from '@/modules/history/events/use-history-events-dialog-container';
+import { DIALOG_TYPES } from './dialog-types';
 
 const accountingRuleToEdit = defineModel<AccountingRuleEntry | undefined>('accountingRuleToEdit', { required: true });
 
@@ -23,173 +35,34 @@ const emit = defineEmits<{
   'movement-matched': [];
 }>();
 
-// Shared loading component for lazy-loaded dialogs
-function DialogLoadingComponent() {
-  return h('div', { class: 'flex items-center justify-center p-4' }, h('RuiProgress', { circular: true, size: 40, variant: 'indeterminate' }));
-}
-
-// Lazy load heavy dialog components
-const MissingRulesDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/management/MissingRulesDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const HistoryEventFormDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/events/HistoryEventFormDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const HistoryEventsDecodingStatusDialog = defineAsyncComponent(() => import('@/modules/history/events/HistoryEventsDecodingStatusDialog.vue'));
-
-const HistoryEventsProtocolCacheStatusDialog = defineAsyncComponent(
-  () => import('@/modules/history/events/HistoryEventsProtocolCacheStatusDialog.vue'),
-);
-
-const RepullingTransactionFormDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/events/tx/RepullingTransactionFormDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const TransactionFormDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/events/tx/TransactionFormDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const AccountingRuleFormDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/settings/accounting/rule/AccountingRuleFormDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const CustomizedEventDuplicatesDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/events/CustomizedEventDuplicatesDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const InternalTxConflictsDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/internal-tx-conflicts/InternalTxConflictsDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const MatchAssetMovementsDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/events/MatchAssetMovementsDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const PotentialMatchesDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/events/PotentialMatchesDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const MatchBridgeTransactionsDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/events/MatchBridgeTransactionsDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
-const BridgePotentialMatchesDialog = defineAsyncComponent({
-  delay: 200,
-  loader: () => import('@/modules/history/events/BridgePotentialMatchesDialog.vue'),
-  loadingComponent: DialogLoadingComponent,
-});
-
 const {
+  bridgeSubject,
   closeDialog,
   currentDialog,
-  show: managerShow,
-} = useHistoryEventsDialogManager();
-
-// Type-specific computed properties for each dialog
-// Since dialogs only render when they match the type (v-if), we can safely use type assertions
-const formData = computed({
-  get: () => {
-    const dialog = get(currentDialog);
-    return dialog.type === DIALOG_TYPES.EVENT_FORM ? dialog.data : undefined;
-  },
-  set: () => closeDialog(), // Dialog components handle their own closing
+  decodingStatusPersistent,
+  modelAddTransaction,
+  modelBridgeMatchesOpen,
+  modelDialogOpen,
+  modelFormData,
+  modelMissingRule,
+  modelMovementMatchesOpen,
+  movementSubject,
+  onBridgeMatched,
+  onBridgePinned,
+  onMovementMatched,
+  onMovementPinned,
+  openBridgeMatches,
+  openMovementMatches,
+  show,
+} = useHistoryEventsDialogContainer({
+  onBridgeMatched: () => emit('bridge-matched'),
+  onMovementMatched: () => emit('movement-matched'),
 });
 
-const missingRuleData = computed({
-  get: () => {
-    const dialog = get(currentDialog);
-    return dialog.type === DIALOG_TYPES.MISSING_RULES ? dialog.data : undefined;
-  },
-  set: () => closeDialog(),
-});
-
-// Unified computed for dialogs that are always "open" when rendered
-const dialogIsOpen = computed({
-  get: () => true, // Always true when dialog is rendered (due to v-if)
-  set: () => closeDialog(),
-});
-
-const decodingStatusDialogPersistent = computed(() => {
-  const dialog = get(currentDialog);
-  return dialog.type === DIALOG_TYPES.DECODING_STATUS ? (dialog.data?.persistent || false) : false;
-});
-
-const addTransactionModelValue = computed({
-  get: () => {
-    const dialog = get(currentDialog);
-    return dialog.type === DIALOG_TYPES.TRANSACTION_FORM ? dialog.data : undefined;
-  },
-  set: (value: AddTransactionHashPayload | undefined) => {
-    if (value) {
-      managerShow({ data: value, type: DIALOG_TYPES.TRANSACTION_FORM });
-    }
-    else {
-      closeDialog();
-    }
-  },
-});
-
-const potentialMatchMovement = ref<UnmatchedAssetMovement>();
-const showPotentialMatchesDialog = ref<boolean>(false);
-
-function showPotentialMatches(movement: UnmatchedAssetMovement): void {
-  set(potentialMatchMovement, movement);
-  set(showPotentialMatchesDialog, true);
-}
-
-function onPotentialMatchMatched(): void {
-  set(potentialMatchMovement, undefined);
-  emit('movement-matched');
-}
-
-function onPotentialMatchPinned(): void {
-  set(potentialMatchMovement, undefined);
-  closeDialog();
-}
-
-const bridgePotentialMatchTransaction = ref<UnmatchedBridgeTransaction>();
-const showBridgePotentialMatchesDialog = ref<boolean>(false);
-
-function showBridgePotentialMatches(transaction: UnmatchedBridgeTransaction): void {
-  set(bridgePotentialMatchTransaction, transaction);
-  set(showBridgePotentialMatchesDialog, true);
-}
-
-function onBridgePotentialMatchMatched(): void {
-  set(bridgePotentialMatchTransaction, undefined);
-  emit('bridge-matched');
-}
-
-function onBridgePotentialMatchPinned(): void {
-  set(bridgePotentialMatchTransaction, undefined);
-  closeDialog();
-}
 defineExpose({
-  show: managerShow,
-  showBridgePotentialMatches,
-  showPotentialMatches,
+  show,
+  showBridgePotentialMatches: openBridgeMatches,
+  showPotentialMatches: openMovementMatches,
 });
 </script>
 
@@ -197,21 +70,21 @@ defineExpose({
   <div class="history-events-dialog-container">
     <HistoryEventFormDialog
       v-if="currentDialog.type === DIALOG_TYPES.EVENT_FORM"
-      v-model="formData"
+      v-model="modelFormData"
       :loading="loading"
       @refresh="eventHandlers.onHistoryEventSaved?.()"
     />
 
     <TransactionFormDialog
       v-if="currentDialog.type === DIALOG_TYPES.TRANSACTION_FORM"
-      v-model="addTransactionModelValue"
+      v-model="modelAddTransaction"
       :loading="sectionLoading"
       @reload="eventHandlers.onTransactionAdded?.($event)"
     />
 
     <RepullingTransactionFormDialog
       v-if="currentDialog.type === DIALOG_TYPES.REPULLING_TRANSACTION"
-      v-model="dialogIsOpen"
+      v-model="modelDialogOpen"
       :loading="sectionLoading"
       :repull-transactions="eventHandlers.onRepullTransactions"
       :repull-exchange-events="eventHandlers.onRepullExchangeEvents"
@@ -219,25 +92,25 @@ defineExpose({
 
     <MissingRulesDialog
       v-if="currentDialog.type === DIALOG_TYPES.MISSING_RULES"
-      v-model="missingRuleData"
-      @edit-event="managerShow({ data: $event, type: DIALOG_TYPES.EVENT_FORM })"
+      v-model="modelMissingRule"
+      @edit-event="show({ data: $event, type: DIALOG_TYPES.EVENT_FORM })"
       @redecode="eventHandlers.onRedecodeTransaction?.($event)"
-      @add="managerShow({ data: $event, type: DIALOG_TYPES.ADD_MISSING_RULE })"
+      @add="show({ data: $event, type: DIALOG_TYPES.ADD_MISSING_RULE })"
       @dismiss="closeDialog()"
     />
 
     <HistoryEventsDecodingStatusDialog
       v-if="currentDialog.type === DIALOG_TYPES.DECODING_STATUS"
-      v-model="dialogIsOpen"
+      v-model="modelDialogOpen"
       :refreshing="refreshing"
-      :persistent="decodingStatusDialogPersistent"
+      :persistent="decodingStatusPersistent"
       @redecode-all-events="eventHandlers.onRedecodeAllEvents?.()"
       @reset-undecoded-transactions="eventHandlers.onResetUndecodedTransactions?.()"
     />
 
     <HistoryEventsProtocolCacheStatusDialog
       v-if="currentDialog.type === DIALOG_TYPES.PROTOCOL_CACHE"
-      v-model="dialogIsOpen"
+      v-model="modelDialogOpen"
       :refreshing="refreshing"
     />
 
@@ -249,41 +122,41 @@ defineExpose({
 
     <CustomizedEventDuplicatesDialog
       v-if="currentDialog.type === DIALOG_TYPES.CUSTOMIZED_EVENT_DUPLICATES"
-      v-model="dialogIsOpen"
+      v-model="modelDialogOpen"
     />
 
     <InternalTxConflictsDialog
       v-if="currentDialog.type === DIALOG_TYPES.INTERNAL_TX_CONFLICTS"
-      v-model="dialogIsOpen"
+      v-model="modelDialogOpen"
     />
 
     <MatchAssetMovementsDialog
       v-if="currentDialog.type === DIALOG_TYPES.MATCH_ASSET_MOVEMENTS"
-      v-model="dialogIsOpen"
+      v-model="modelDialogOpen"
       @refresh="eventHandlers.onHistoryEventSaved?.()"
-      @find-match="showPotentialMatches($event)"
+      @find-match="openMovementMatches($event)"
     />
 
     <PotentialMatchesDialog
-      v-if="potentialMatchMovement && showPotentialMatchesDialog"
-      v-model="showPotentialMatchesDialog"
-      :movement="potentialMatchMovement"
-      @matched="onPotentialMatchMatched()"
-      @pinned="onPotentialMatchPinned()"
+      v-if="movementSubject && modelMovementMatchesOpen"
+      v-model="modelMovementMatchesOpen"
+      :movement="movementSubject"
+      @matched="onMovementMatched()"
+      @pinned="onMovementPinned()"
     />
 
     <MatchBridgeTransactionsDialog
       v-if="currentDialog.type === DIALOG_TYPES.MATCH_BRIDGE_TRANSACTIONS"
-      v-model="dialogIsOpen"
-      @find-match="showBridgePotentialMatches($event)"
+      v-model="modelDialogOpen"
+      @find-match="openBridgeMatches($event)"
     />
 
     <BridgePotentialMatchesDialog
-      v-if="bridgePotentialMatchTransaction && showBridgePotentialMatchesDialog"
-      v-model="showBridgePotentialMatchesDialog"
-      :transaction="bridgePotentialMatchTransaction"
-      @matched="onBridgePotentialMatchMatched()"
-      @pinned="onBridgePotentialMatchPinned()"
+      v-if="bridgeSubject && modelBridgeMatchesOpen"
+      v-model="modelBridgeMatchesOpen"
+      :transaction="bridgeSubject"
+      @matched="onBridgeMatched()"
+      @pinned="onBridgePinned()"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/history/events/HistoryEventsFiltersChips.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventsFiltersChips.spec.ts
@@ -1,0 +1,195 @@
+import type { UseHistoryEventsFiltersChipsOptions } from '@/modules/history/events/use-history-events-filters-chips';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import HistoryEventsFiltersChips from '@/modules/history/events/HistoryEventsFiltersChips.vue';
+
+/**
+ * The seam: which chip is rendered, what its close button calls, and that the fix and refresh
+ * actions on the duplicate chip appear only in the states that offer them. What each of those
+ * calls does to the URL belongs to `use-history-events-filters-chips`, which has its own spec.
+ */
+
+const chips = {
+  allDuplicatesResolved: ref<boolean>(false),
+  confirmFixDuplicate: vi.fn(),
+  duplicateChangesMessage: ref<string>(''),
+  duplicateChipText: ref<string>('Viewing auto fixable duplicates'),
+  fixLoading: ref<boolean>(false),
+  hasDuplicateChanges: ref<boolean>(false),
+  isAutoFixable: ref<boolean>(true),
+  refreshDuplicateView: vi.fn(),
+  removeAccountingEventParam: vi.fn(),
+  removeDuplicateEventsParam: vi.fn(),
+  removeMissingAcquisitionParam: vi.fn(),
+  removeNegativeBalanceParam: vi.fn(),
+  showAccountingEvent: ref<boolean>(false),
+  showDuplicates: ref<boolean>(false),
+  showMissingAcquisition: ref<boolean>(false),
+  showNegativeBalance: ref<boolean>(false),
+};
+
+let options: UseHistoryEventsFiltersChipsOptions;
+
+vi.mock('@/modules/history/events/use-history-events-filters-chips', () => ({
+  useHistoryEventsFiltersChips: (opts: UseHistoryEventsFiltersChipsOptions): unknown => {
+    options = opts;
+    return chips;
+  },
+}));
+
+describe('modules/history/events/HistoryEventsFiltersChips', () => {
+  let wrapper: VueWrapper | undefined;
+
+  function mountChips(props: Record<string, unknown> = {}): VueWrapper {
+    wrapper = mount(HistoryEventsFiltersChips, { props });
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(chips.allDuplicatesResolved, false);
+    set(chips.duplicateChangesMessage, '');
+    set(chips.duplicateChipText, 'Viewing auto fixable duplicates');
+    set(chips.fixLoading, false);
+    set(chips.hasDuplicateChanges, false);
+    set(chips.isAutoFixable, true);
+    set(chips.showAccountingEvent, false);
+    set(chips.showDuplicates, false);
+    set(chips.showMissingAcquisition, false);
+    set(chips.showNegativeBalance, false);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should forward its props and its refresh event to the composable', () => {
+    const view = mountChips({
+      duplicateHandlingStatus: DuplicateHandlingStatus.MANUAL_REVIEW,
+      groupIdentifiers: ['g1', 'g2'],
+    });
+
+    expect(options.groupIdentifiers()).toStrictEqual(['g1', 'g2']);
+    expect(options.duplicateHandlingStatus()).toBe(DuplicateHandlingStatus.MANUAL_REVIEW);
+
+    options.onRefresh();
+
+    expect(view.emitted('refresh')).toHaveLength(1);
+  });
+
+  it('should render no chip while nothing is filtered', () => {
+    const view = mountChips();
+
+    expect(view.find('[data-testid="missing-acquisition-chip"]').exists()).toBe(false);
+    expect(view.find('[data-testid="negative-balance-chip"]').exists()).toBe(false);
+    expect(view.find('[data-testid="accounting-divergence-chip"]').exists()).toBe(false);
+    expect(view.find('[data-testid="duplicate-events-chip"]').exists()).toBe(false);
+  });
+
+  it.each([
+    ['missing-acquisition-chip', 'showMissingAcquisition', 'removeMissingAcquisitionParam'],
+    ['negative-balance-chip', 'showNegativeBalance', 'removeNegativeBalanceParam'],
+    ['accounting-divergence-chip', 'showAccountingEvent', 'removeAccountingEventParam'],
+    ['duplicate-events-chip', 'showDuplicates', 'removeDuplicateEventsParam'],
+  ] as const)('should close the %s through the composable', async (testId, flag, remover) => {
+    set(chips[flag], true);
+    // The duplicate chip renders the fix action inside its own body, so it is turned
+    // off here to leave the close button as the only one under the chip.
+    set(chips.isAutoFixable, false);
+    const view = mountChips();
+
+    const chip = view.find(`[data-testid="${testId}"]`);
+    expect(chip.exists()).toBe(true);
+    await chip.find('button').trigger('click');
+
+    expect(chips[remover]).toHaveBeenCalledTimes(1);
+  });
+
+  it('should label the duplicate chip with what the composable says it is showing', () => {
+    set(chips.showDuplicates, true);
+    set(chips.duplicateChipText, 'Viewing duplicates for manual review');
+    const view = mountChips();
+
+    expect(view.find('[data-testid="duplicate-events-chip"]').text())
+      .toContain('Viewing duplicates for manual review');
+  });
+
+  describe('fixing every shown duplicate', () => {
+    beforeEach(() => {
+      set(chips.showDuplicates, true);
+    });
+
+    it('should offer the fix while the bucket is auto fixable and has not drifted', async () => {
+      const view = mountChips();
+
+      await view.find('[data-testid="duplicate-fix-all"]').trigger('click');
+
+      expect(chips.confirmFixDuplicate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not offer the fix for the manual review bucket', () => {
+      set(chips.isAutoFixable, false);
+      const view = mountChips();
+
+      expect(view.find('[data-testid="duplicate-fix-all"]').exists()).toBe(false);
+    });
+
+    it('should not offer the fix while the backend has drifted from the URL', () => {
+      set(chips.hasDuplicateChanges, true);
+      const view = mountChips();
+
+      expect(view.find('[data-testid="duplicate-fix-all"]').exists()).toBe(false);
+    });
+
+    it('should show the fix as loading while one is in flight', () => {
+      set(chips.fixLoading, true);
+      const view = mountChips();
+
+      const fix = view.findAllComponents({ name: 'RuiButton' })
+        .find(button => button.attributes('data-testid') === 'duplicate-fix-all');
+
+      expect(fix?.props('loading')).toBe(true);
+    });
+  });
+
+  describe('the drift notice', () => {
+    beforeEach(() => {
+      set(chips.showDuplicates, true);
+      set(chips.hasDuplicateChanges, true);
+      set(chips.duplicateChangesMessage, '2 resolved, 1 added');
+    });
+
+    it('should stay hidden while the URL and the backend agree', () => {
+      set(chips.hasDuplicateChanges, false);
+      const view = mountChips();
+
+      expect(view.find('[data-testid="duplicate-changes"]').exists()).toBe(false);
+    });
+
+    it('should show the message the composable produced', () => {
+      const view = mountChips();
+
+      expect(view.find('[data-testid="duplicate-changes"]').text()).toContain('2 resolved, 1 added');
+    });
+
+    it('should offer a refresh while some duplicates remain', async () => {
+      const view = mountChips();
+
+      const button = view.find('[data-testid="duplicate-refresh"]');
+      expect(button.text()).toBe('common.refresh');
+      await button.trigger('click');
+
+      expect(chips.refreshDuplicateView).toHaveBeenCalledTimes(1);
+    });
+
+    it('should offer to clear the filter once nothing is left to show', () => {
+      set(chips.allDuplicatesResolved, true);
+      const view = mountChips();
+
+      expect(view.find('[data-testid="duplicate-refresh"]').text())
+        .toBe('customized_event_duplicates.chips.clear_filter');
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/HistoryEventsFiltersChips.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsFiltersChips.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
-import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
-import { useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
+import type { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import { useHistoryEventsFiltersChips } from '@/modules/history/events/use-history-events-filters-chips';
 
 const { groupIdentifiers, duplicateHandlingStatus } = defineProps<{
   groupIdentifiers?: string[];
@@ -13,138 +12,35 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const router = useRouter();
-const route = useRoute();
-const { show } = useConfirmStore();
+
 const {
-  autoFixGroupIds,
-  fixDuplicates,
+  allDuplicatesResolved,
+  confirmFixDuplicate,
+  duplicateChangesMessage,
+  duplicateChipText,
   fixLoading,
-  manualReviewGroupIds,
-} = useCustomizedEventDuplicates();
-
-const isAutoFixable = computed<boolean>(() => duplicateHandlingStatus === DuplicateHandlingStatus.AUTO_FIX);
-
-const hasGroupIdentifiers = computed<boolean>(() => !!groupIdentifiers && groupIdentifiers.length > 0);
-
-const duplicateChipText = computed<string>(() => {
-  if (get(isAutoFixable))
-    return t('customized_event_duplicates.chips.viewing_auto_fixable');
-  return t('customized_event_duplicates.chips.viewing_manual_review');
+  hasDuplicateChanges,
+  isAutoFixable,
+  refreshDuplicateView,
+  removeAccountingEventParam,
+  removeDuplicateEventsParam,
+  removeMissingAcquisitionParam,
+  removeNegativeBalanceParam,
+  showAccountingEvent,
+  showDuplicates,
+  showMissingAcquisition,
+  showNegativeBalance,
+} = useHistoryEventsFiltersChips({
+  duplicateHandlingStatus: () => duplicateHandlingStatus,
+  groupIdentifiers: () => groupIdentifiers,
+  onRefresh: () => emit('refresh'),
 });
-
-// Track the current valid group IDs from the composable
-const currentValidGroupIds = computed<string[]>(() =>
-  get(isAutoFixable) ? get(autoFixGroupIds) : get(manualReviewGroupIds),
-);
-
-// Calculate the difference between URL params and current valid IDs
-const duplicateChanges = computed<{ resolved: number; added: number; remaining: string[] }>(() => {
-  const urlIds = groupIdentifiers ?? [];
-  const validIds = get(currentValidGroupIds);
-
-  if (urlIds.length === 0)
-    return { added: 0, remaining: [], resolved: 0 };
-
-  const remaining = urlIds.filter(id => validIds.includes(id));
-  const resolved = urlIds.length - remaining.length;
-  const added = validIds.filter(id => !urlIds.includes(id)).length;
-
-  return { added, remaining, resolved };
-});
-
-const hasDuplicateChanges = computed<boolean>(() => {
-  const { added, resolved } = get(duplicateChanges);
-  return resolved > 0 || added > 0;
-});
-
-const allDuplicatesResolved = computed<boolean>(() => {
-  const { remaining } = get(duplicateChanges);
-  return get(hasGroupIdentifiers) && remaining.length === 0;
-});
-
-const duplicateChangesMessage = computed<string>(() => {
-  const { added, resolved } = get(duplicateChanges);
-
-  if (get(allDuplicatesResolved))
-    return t('customized_event_duplicates.chips.all_resolved');
-
-  const messages: string[] = [];
-  if (resolved > 0)
-    messages.push(t('customized_event_duplicates.chips.resolved_count', { count: resolved }));
-
-  if (added > 0)
-    messages.push(t('customized_event_duplicates.chips.added_count', { count: added }));
-
-  return messages.join(' ');
-});
-
-function removeMissingAcquisitionParam(): void {
-  const query = { ...route.query };
-  delete query.missingAcquisitionIdentifier;
-  router.push({ query });
-}
-
-function removeNegativeBalanceParam(): void {
-  const query = { ...route.query };
-  delete query.highlightedNegativeBalanceEvent;
-  delete query.targetGroupIdentifier;
-  router.push({ query });
-}
-
-function removeAccountingEventParam(): void {
-  const query = { ...route.query };
-  delete query.highlightedAccountingEvent;
-  delete query.targetGroupIdentifier;
-  router.push({ query });
-}
-
-function removeDuplicateEventsParam(): void {
-  const query = { ...route.query };
-  delete query.groupIdentifiers;
-  delete query.duplicateHandlingStatus;
-  router.push({ query });
-}
-
-async function fixDuplicateEvent(): Promise<void> {
-  const ids = groupIdentifiers;
-  if (!ids || ids.length === 0)
-    return;
-
-  const result = await fixDuplicates(ids);
-  if (result.success) {
-    removeDuplicateEventsParam();
-    emit('refresh');
-  }
-}
-
-function confirmFixDuplicate(): void {
-  const count = groupIdentifiers?.length ?? 0;
-  show({
-    message: t('customized_event_duplicates.actions.fix_selected_confirm', { count }),
-    primaryAction: t('common.actions.confirm'),
-    title: t('customized_event_duplicates.actions.fix_selected'),
-  }, async () => fixDuplicateEvent());
-}
-
-function refreshDuplicateView(): void {
-  const validIds = get(currentValidGroupIds);
-
-  if (validIds.length === 0) {
-    removeDuplicateEventsParam();
-  }
-  else {
-    const query = { ...route.query, groupIdentifiers: validIds.join(',') };
-    router.replace({ query });
-  }
-  emit('refresh');
-}
 </script>
 
 <template>
   <div>
     <div
-      v-if="route.query.missingAcquisitionIdentifier"
+      v-if="showMissingAcquisition"
       class="pb-4"
     >
       <RuiChip
@@ -152,6 +48,7 @@ function refreshDuplicateView(): void {
         color="primary"
         size="sm"
         variant="outlined"
+        data-testid="missing-acquisition-chip"
         @click:close="removeMissingAcquisitionParam()"
       >
         {{ t('transactions.events.show_missing_acquisition') }}
@@ -159,7 +56,7 @@ function refreshDuplicateView(): void {
     </div>
 
     <RuiTooltip
-      v-if="route.query.highlightedNegativeBalanceEvent"
+      v-if="showNegativeBalance"
       class="pb-4"
       :popper="{ placement: 'bottom' }"
       :open-delay="400"
@@ -171,6 +68,7 @@ function refreshDuplicateView(): void {
           color="error"
           size="sm"
           variant="outlined"
+          data-testid="negative-balance-chip"
           @click:close="removeNegativeBalanceParam()"
         >
           {{ t('transactions.events.show_negative_balance') }}
@@ -180,7 +78,7 @@ function refreshDuplicateView(): void {
     </RuiTooltip>
 
     <RuiTooltip
-      v-if="route.query.highlightedAccountingEvent"
+      v-if="showAccountingEvent"
       class="pb-4"
       :popper="{ placement: 'bottom' }"
       :open-delay="400"
@@ -192,6 +90,7 @@ function refreshDuplicateView(): void {
           color="warning"
           size="sm"
           variant="outlined"
+          data-testid="accounting-divergence-chip"
           @click:close="removeAccountingEventParam()"
         >
           {{ t('transactions.events.show_accounting_divergence') }}
@@ -201,7 +100,7 @@ function refreshDuplicateView(): void {
     </RuiTooltip>
 
     <div
-      v-if="hasGroupIdentifiers"
+      v-if="showDuplicates"
       class="pb-4"
     >
       <RuiChip
@@ -209,6 +108,7 @@ function refreshDuplicateView(): void {
         color="warning"
         size="sm"
         variant="outlined"
+        data-testid="duplicate-events-chip"
         @click:close="removeDuplicateEventsParam()"
       >
         <div class="flex gap-1">
@@ -221,6 +121,7 @@ function refreshDuplicateView(): void {
             class="!py-0 underline !text-xs gap-1"
             color="primary"
             :loading="fixLoading"
+            data-testid="duplicate-fix-all"
             @click="confirmFixDuplicate()"
           >
             <template #prepend>
@@ -237,6 +138,7 @@ function refreshDuplicateView(): void {
       <div
         v-if="hasDuplicateChanges"
         class="mt-1 flex items-center gap-1 text-xs text-rui-secondary"
+        data-testid="duplicate-changes"
       >
         <RuiIcon
           name="lu-info"
@@ -248,6 +150,7 @@ function refreshDuplicateView(): void {
           variant="text"
           color="secondary"
           class="!py-0 underline"
+          data-testid="duplicate-refresh"
           @click="refreshDuplicateView()"
         >
           {{ allDuplicatesResolved ? t('customized_event_duplicates.chips.clear_filter') : t('common.refresh') }}

--- a/frontend/app/src/modules/history/events/HistoryEventsTableActions.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventsTableActions.spec.ts
@@ -1,0 +1,259 @@
+import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
+import type { UseHistoryEventsPillBarOptions } from '@/modules/history/events/use-history-events-pill-bar';
+import type { SelectionState } from '@/modules/history/events/use-selection-mode';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import HistoryEventsTableActions from '@/modules/history/events/HistoryEventsTableActions.vue';
+
+/**
+ * The seam: the selection toolbar - which action each button reports, and the states in which
+ * an action is refused. The bridge between the pill bar and the page's filter models lives in
+ * `use-history-events-pill-bar`, which has its own spec.
+ */
+
+const pillBar = {
+  applyView: vi.fn(),
+  modelPillParams: ref<Record<string, unknown>>({}),
+  pillLabels: ref({}),
+  pillState: ref({ matches: {}, params: {} }),
+  toggleMatchExact: vi.fn(),
+};
+
+let options: UseHistoryEventsPillBarOptions;
+
+vi.mock('@/modules/history/events/use-history-events-pill-bar', () => ({
+  useHistoryEventsPillBar: (opts: UseHistoryEventsPillBarOptions): unknown => {
+    options = opts;
+    return pillBar;
+  },
+}));
+
+function passthrough(name: string, slots: string[] = []): ReturnType<typeof defineComponent> {
+  return defineComponent({
+    name,
+    setup: (_props, context) => (): unknown => h('div', { 'data-testid': name }, [
+      context.slots.default?.(),
+      ...slots.map(slot => context.slots[slot]?.({ disabled: false })),
+    ]),
+  });
+}
+
+function leaf(name: string): ReturnType<typeof defineComponent> {
+  return defineComponent({
+    name,
+    setup: () => (): unknown => h('div', { 'data-testid': name }),
+  });
+}
+
+const HistoryTableActionsStub = passthrough('HistoryTableActions', ['filter']);
+const PillFilterBarStub = passthrough('PillFilterBar', ['modifiers', 'views']);
+const PillViewsMenuStub = leaf('PillViewsMenu');
+const HistoryEventsExportStub = leaf('HistoryEventsExport');
+const HistoryRedecodeButtonStub = defineComponent({
+  emits: ['redecode'],
+  name: 'HistoryRedecodeButton',
+  setup: () => (): unknown => h('div', { 'data-testid': 'HistoryRedecodeButton' }),
+});
+
+function selectionState(overrides: Partial<SelectionState> = {}): SelectionState {
+  return createMock<SelectionState>({
+    hasAvailableEvents: true,
+    isActive: true,
+    isAllSelected: false,
+    isPartiallySelected: false,
+    selectAllMatching: false,
+    selectedCount: 2,
+    totalMatchingCount: 40,
+    ...overrides,
+  });
+}
+
+describe('modules/history/events/HistoryEventsTableActions', () => {
+  let wrapper: VueWrapper | undefined;
+
+  function mountActions(props: Record<string, unknown> = {}): VueWrapper {
+    wrapper = mount(HistoryEventsTableActions, {
+      global: {
+        stubs: {
+          HistoryEventsExport: HistoryEventsExportStub,
+          HistoryRedecodeButton: HistoryRedecodeButtonStub,
+          HistoryTableActions: HistoryTableActionsStub,
+          PillFilterBar: PillFilterBarStub,
+          PillViewsMenu: PillViewsMenuStub,
+        },
+      },
+      props: {
+        action: undefined,
+        exportParams: createMock<HistoryEventRequestPayload>({}),
+        fields: [],
+        filters: {},
+        locationLabels: [],
+        selection: selectionState(),
+        toggles: { matchExactEvents: false, showIgnoredAssets: false, stateMarkers: [] },
+        ...props,
+      },
+    });
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should hand the page filter models to the pill bar bridge', () => {
+    mountActions({ action: 'deposit', locationLabels: ['kraken'] });
+
+    expect(get(options.action)).toBe('deposit');
+    expect(get(options.locationLabels)).toStrictEqual(['kraken']);
+    expect(get(options.toggles)).toStrictEqual({
+      matchExactEvents: false,
+      showIgnoredAssets: false,
+      stateMarkers: [],
+    });
+  });
+
+  it('should flip match exact through the bridge', async () => {
+    const view = mountActions();
+
+    await view.find('[data-testid="filter-match-exact"]').trigger('click');
+
+    expect(pillBar.toggleMatchExact).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show match exact as pressed when it is on', () => {
+    const view = mountActions({ toggles: { matchExactEvents: true, showIgnoredAssets: false, stateMarkers: [] } });
+
+    expect(view.find('[data-testid="filter-match-exact"]').attributes('aria-pressed')).toBe('true');
+  });
+
+  describe('the selection toolbar', () => {
+    it.each([
+      ['selection-delete', 'delete'],
+      ['selection-ignore', 'ignore'],
+      ['selection-unignore', 'unignore'],
+      ['selection-create-rule', 'create-rule'],
+      ['selection-exit', 'exit'],
+      ['selection-select-all-matching', 'toggle-select-all-matching'],
+    ] as const)('should report %s as a %s', async (testId, expected) => {
+      const view = mountActions({ ignoreStatus: { ignoredCount: 1, notIgnoredCount: 1 } });
+
+      await view.find(`[data-testid="${testId}"]`).trigger('click');
+
+      expect(view.emitted('selection:action')).toStrictEqual([[expected]]);
+    });
+
+    it('should report the page checkbox as a toggle-all', async () => {
+      const view = mountActions();
+
+      // The test id falls through to the checkbox wrapper, so the input is what to click.
+      await view.find('[data-testid="selection-select-all-page"] input').setValue(true);
+
+      expect(view.emitted('selection:action')).toStrictEqual([['toggle-all']]);
+    });
+
+    it('should count what is selected', () => {
+      const view = mountActions({ selection: selectionState({ selectedCount: 7 }) });
+
+      expect(view.find('[data-testid="selection-count"]').text())
+        .toBe('transactions.events.selection_mode.selected_count::7');
+    });
+
+    it.each([
+      'selection-delete',
+      'selection-ignore',
+      'selection-unignore',
+      'selection-create-rule',
+    ])('should disable %s while nothing is selected', (testId) => {
+      const view = mountActions({
+        ignoreStatus: { ignoredCount: 1, notIgnoredCount: 1 },
+        selection: selectionState({ selectedCount: 0 }),
+      });
+
+      expect(view.find(`[data-testid="${testId}"]`).attributes('disabled')).toBeDefined();
+    });
+
+    it('should refuse to ignore when nothing selected is still un-ignored', () => {
+      const view = mountActions({ ignoreStatus: { ignoredCount: 2, notIgnoredCount: 0 } });
+
+      expect(view.find('[data-testid="selection-ignore"]').attributes('disabled')).toBeDefined();
+      expect(view.find('[data-testid="selection-unignore"]').attributes('disabled')).toBeUndefined();
+    });
+
+    it('should refuse to unignore when nothing selected is ignored', () => {
+      const view = mountActions({ ignoreStatus: { ignoredCount: 0, notIgnoredCount: 2 } });
+
+      expect(view.find('[data-testid="selection-unignore"]').attributes('disabled')).toBeDefined();
+      expect(view.find('[data-testid="selection-ignore"]').attributes('disabled')).toBeUndefined();
+    });
+
+    it('should refuse both while the ignore counts are unknown', () => {
+      const view = mountActions();
+
+      expect(view.find('[data-testid="selection-ignore"]').attributes('disabled')).toBeDefined();
+      expect(view.find('[data-testid="selection-unignore"]').attributes('disabled')).toBeDefined();
+    });
+
+    it('should drop the per-page controls once everything matching is selected', () => {
+      const view = mountActions({
+        ignoreStatus: { ignoredCount: 1, notIgnoredCount: 1 },
+        selection: selectionState({ selectAllMatching: true }),
+      });
+
+      expect(view.find('[data-testid="selection-count"]').exists()).toBe(false);
+      expect(view.find('[data-testid="selection-select-all-matching"]').text())
+        .toContain('transactions.events.selection_mode.all_matching_selected::40');
+      expect(view.find('[data-testid="selection-ignore"]').attributes('disabled')).toBeDefined();
+      expect(view.find('[data-testid="selection-create-rule"]').attributes('disabled')).toBeDefined();
+      expect(view.find('[data-testid="selection-delete"]').attributes('disabled')).toBeUndefined();
+    });
+  });
+
+  describe('outside selection mode', () => {
+    it('should offer the toolbar in its place', () => {
+      const view = mountActions({ selection: selectionState({ isActive: false }) });
+
+      expect(view.find('[data-testid="selection-delete"]').exists()).toBe(false);
+      expect(view.findComponent(HistoryRedecodeButtonStub).exists()).toBe(true);
+      expect(view.findComponent(HistoryEventsExportStub).exists()).toBe(true);
+    });
+
+    it('should enter selection mode', async () => {
+      const view = mountActions({ selection: selectionState({ isActive: false }) });
+
+      await view.find('[data-testid="selection-toggle-mode"]').trigger('click');
+
+      expect(view.emitted('selection:action')).toStrictEqual([['toggle-mode']]);
+    });
+
+    it('should refuse to enter it with no events to select', () => {
+      const view = mountActions({ selection: selectionState({ hasAvailableEvents: false, isActive: false }) });
+
+      expect(view.find('[data-testid="selection-toggle-mode"]').attributes('disabled')).toBeDefined();
+    });
+
+    it('should hide the redecode button when the page asks it to', () => {
+      const view = mountActions({
+        hideRedecodeButtons: true,
+        selection: selectionState({ isActive: false }),
+      });
+
+      expect(view.findComponent(HistoryRedecodeButtonStub).exists()).toBe(false);
+    });
+
+    it('should pass a redecode on to the page', async () => {
+      const view = mountActions({ selection: selectionState({ isActive: false }) });
+
+      view.findComponent(HistoryRedecodeButtonStub).vm.$emit('redecode', 'all');
+      await nextTick();
+
+      expect(view.emitted('redecode')).toStrictEqual([['all']]);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/HistoryEventsTableActions.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsTableActions.vue
@@ -1,19 +1,15 @@
 <script lang="ts" setup>
-import type { SavedViewState } from '@/modules/core/table/pill/composables/use-saved-views';
-import type { SavedView } from '@/modules/core/table/pill/core/saved-view';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
 import type { DecodeScope } from '@/modules/history/events/event-payloads';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { IgnoreStatus } from '@/modules/history/events/use-history-events-selection-actions';
 import type { SelectionState } from '@/modules/history/events/use-selection-mode';
-import { arrayify } from '@/modules/core/common/data/array';
 import { type MatchedKeywordWithBehaviour, SavedFilterLocations } from '@/modules/core/table/filtering';
-import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import PillViewsMenu from '@/modules/core/table/pill/PillViewsMenu.vue';
 import HistoryEventsExport from '@/modules/history/events/HistoryEventsExport.vue';
-import { isValidHistoryEventState } from '@/modules/history/events/mapping/use-history-event-state-mapping';
+import { useHistoryEventsPillBar } from '@/modules/history/events/use-history-events-pill-bar';
 import HistoryTableActions from '@/modules/history/HistoryTableActions.vue';
 import HistoryRedecodeButton from '@/modules/history/redecode/HistoryRedecodeButton.vue';
 
@@ -41,63 +37,13 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-// Not a pill: it constrains how the other filters apply instead of filtering anything itself.
-function toggleMatchExact(): void {
-  set(toggles, { ...get(toggles), matchExactEvents: !get(toggles).matchExactEvents });
-}
-
-const pillLabels = usePillBarLabels();
-
-// The account, state and show-ignored filters are param-bound pills in the bar (paramKeys
-// `locationLabels`, `stateMarkers`, `showIgnoredAssets`). Bridge the bar's param bag to the models
-// that back them so the bar drives the same sources the standalone selector and dropdown used to.
-// An absent param clears its model — for the boolean that is the pill's whole state, since
-// removing it is how it is turned off.
-const pillParams = computed<Record<string, string | string[] | boolean>>({
-  get(): Record<string, string | string[] | boolean> {
-    const labels = get(locationLabels);
-    const { showIgnoredAssets, stateMarkers } = get(toggles);
-    const result: Record<string, string | string[] | boolean> = {};
-    const verb = get(action);
-    if (verb !== undefined)
-      result.action = verb;
-    if (labels.length > 0)
-      result.locationLabels = labels;
-    if (stateMarkers.length > 0)
-      result.stateMarkers = stateMarkers;
-    if (showIgnoredAssets)
-      result.showIgnoredAssets = true;
-    return result;
-  },
-  set(value: Record<string, string | string[] | boolean>): void {
-    const nextAction = value.action;
-    set(action, typeof nextAction === 'string' ? nextAction : undefined);
-
-    const nextLabels = value.locationLabels;
-    set(locationLabels, nextLabels === undefined || typeof nextLabels === 'boolean' ? [] : arrayify(nextLabels));
-
-    const nextMarkers = value.stateMarkers;
-    set(toggles, {
-      ...get(toggles),
-      showIgnoredAssets: value.showIgnoredAssets === true,
-      stateMarkers: nextMarkers === undefined || typeof nextMarkers === 'boolean'
-        ? []
-        : arrayify(nextMarkers).filter(isValidHistoryEventState),
-    });
-  },
-});
-
-// A saved view is the bar's two models under a name, so it both reads from and writes to the same
-// pair the bar is bound to.
-const pillState = computed<SavedViewState>(() => ({
-  matches: get(filters),
-  params: get(pillParams),
-}));
-
-function applyView(view: SavedView): void {
-  set(filters, view.matches);
-  set(pillParams, view.params);
-}
+const {
+  applyView,
+  modelPillParams,
+  pillLabels,
+  pillState,
+  toggleMatchExact,
+} = useHistoryEventsPillBar({ action, filters, locationLabels, toggles });
 
 const canIgnore = computed<boolean>(() => {
   const status = ignoreStatus;
@@ -147,7 +93,7 @@ function handleToggleSelectAllMatching(): void {
     <template #filter>
       <PillFilterBar
         v-model:matches="filters"
-        v-model:params="pillParams"
+        v-model:params="modelPillParams"
         class="flex-1 min-w-[12rem] md:min-w-[24rem]"
         :fields="fields"
         :labels="pillLabels"
@@ -219,6 +165,7 @@ function handleToggleSelectAllMatching(): void {
             color="primary"
             hide-details
             size="sm"
+            data-testid="selection-select-all-page"
             @update:model-value="handleToggleAll()"
           />
         </template>
@@ -227,6 +174,7 @@ function handleToggleSelectAllMatching(): void {
       <span
         v-if="!selection.selectAllMatching"
         class="text-sm text-rui-text-secondary -ml-1 mr-2 select-none"
+        data-testid="selection-count"
       >
         {{ t('transactions.events.selection_mode.selected_count', { count: selection.selectedCount }) }}
       </span>
@@ -241,6 +189,7 @@ function handleToggleSelectAllMatching(): void {
         size="sm"
         class="text-sm hover:underline cursor-pointer mr-2"
         :class="selection.selectAllMatching ? '-ml-3' : '-ml-1'"
+        data-testid="selection-select-all-matching"
         @click="handleToggleSelectAllMatching()"
       >
         {{ selection.selectAllMatching ? t('transactions.events.selection_mode.all_matching_selected', { count: selection.totalMatchingCount }) : t('transactions.events.selection_mode.select_all_matching') }}
@@ -261,6 +210,7 @@ function handleToggleSelectAllMatching(): void {
             variant="outlined"
             class="h-7 px-2.5"
             :disabled="selection.selectedCount === 0"
+            data-testid="selection-delete"
             @click="handleDelete()"
           >
             <RuiIcon
@@ -278,6 +228,7 @@ function handleToggleSelectAllMatching(): void {
               variant="outlined"
               class="h-7 px-2.5 !rounded-r-none"
               :disabled="selection.selectedCount === 0 || !canIgnore || selection.selectAllMatching"
+              data-testid="selection-ignore"
               @click="handleIgnore()"
             >
               <RuiIcon
@@ -294,6 +245,7 @@ function handleToggleSelectAllMatching(): void {
               variant="outlined"
               class="h-7 px-2.5 !rounded-l-none -ml-[1px]"
               :disabled="selection.selectedCount === 0 || !canUnignore || selection.selectAllMatching"
+              data-testid="selection-unignore"
               @click="handleUnignore()"
             >
               <RuiIcon
@@ -312,6 +264,7 @@ function handleToggleSelectAllMatching(): void {
             variant="outlined"
             class="h-7 px-2.5"
             :disabled="selection.selectedCount === 0 || selection.selectAllMatching"
+            data-testid="selection-create-rule"
             @click="handleCreateRule()"
           >
             <RuiIcon
@@ -325,6 +278,7 @@ function handleToggleSelectAllMatching(): void {
       <RuiButton
         variant="text"
         class="h-7 px-2.5"
+        data-testid="selection-exit"
         @click="handleExit()"
       >
         {{ t('common.actions.cancel') }}
@@ -337,6 +291,7 @@ function handleToggleSelectAllMatching(): void {
             variant="text"
             size="xl"
             :disabled="!selection.hasAvailableEvents"
+            data-testid="selection-toggle-mode"
             @click="handleToggleMode()"
           >
             <template #prepend>

--- a/frontend/app/src/modules/history/events/HistoryEventsView.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.spec.ts
@@ -1,0 +1,406 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import HistoryEventsView from '@/modules/history/events/HistoryEventsView.vue';
+
+/**
+ * The seam: what the page hands each of its four children, and where their events go. Every
+ * decision behind those values belongs to a composable with its own spec - the filters, the
+ * actions, the selection, and `use-history-events-view-actions` for the page's own handlers.
+ */
+
+const groups = ref<Collection<HistoryEventRow>>(
+  createMock<Collection<HistoryEventRow>>({ data: [], found: 0, limit: 10, total: 0 }),
+);
+const processing = ref<boolean>(false);
+const refreshing = ref<boolean>(false);
+const overlayAvailable = ref<boolean>(false);
+const duplicateHandlingStatus = ref<string | undefined>();
+const groupIdentifiers = ref<string[] | undefined>();
+const ignoreStatus = ref<{ ignoredCount: number; notIgnoredCount: number } | undefined>();
+const includes = ref({ evmEvents: true });
+
+const clearFilters = vi.fn();
+const onActionChanged = vi.fn();
+const onLocationLabelsChanged = vi.fn();
+const setPage = vi.fn();
+const handleSelectionAction = vi.fn();
+const handleAccountingRuleRefresh = vi.fn();
+const fetchDataAndLocations = vi.fn().mockResolvedValue(undefined);
+const redecodeBy = vi.fn();
+const redecodeBlocks = vi.fn();
+const refreshAll = vi.fn().mockResolvedValue(undefined);
+const dialogHandlers = { onHistoryEventSaved: vi.fn() };
+
+const handleRedecode = vi.fn();
+const handleUpdateEventIds = vi.fn();
+const handleMovementChanged = vi.fn();
+const handleBridgeChanged = vi.fn();
+
+vi.mock('@/modules/history/events/use-history-events-view-actions', () => ({
+  useHistoryEventsViewActions: (): unknown => ({
+    groupedEventsByTxRef: ref({}),
+    handleBridgeChanged,
+    handleMovementChanged,
+    handleRedecode,
+    handleUpdateEventIds,
+    originalGroups: ref([]),
+  }),
+}));
+
+vi.mock('@/modules/history/events/composables', () => ({
+  getDefaultToggles: (): unknown => ({ matchExactEvents: false, showIgnoredAssets: false, stateMarkers: [] }),
+  useHistoryEventFields: (): unknown => computed(() => []),
+  useHistoryEventNavigationConsumer: vi.fn(),
+  useHistoryEventsActions: (): unknown => ({
+    dialogHandlers,
+    fetch: { dataAndLocations: fetchDataAndLocations, dataAndRedecode: vi.fn() },
+    redecode: { blocks: redecodeBlocks, by: redecodeBy },
+    refresh: { all: refreshAll },
+  }),
+  useHistoryEventsDeletion: (): unknown => ({}),
+  useHistoryEventsDialogRouting: vi.fn(),
+  useHistoryEventsFilters: (): unknown => ({
+    action: ref(),
+    clearFilters,
+    duplicateHandlingStatus,
+    filters: ref({}),
+    groupIdentifiers,
+    groupLoading: ref(false),
+    groups,
+    hasActiveFilters: ref(false),
+    highlightedGroupIdentifier: ref(),
+    highlightedIdentifiers: ref(),
+    highlightTypes: ref(),
+    identifiers: ref(),
+    includes,
+    locationLabels: ref([]),
+    onActionChanged,
+    onLocationLabelsChanged,
+    pagination: ref({ limit: 10, page: 1 }),
+    refetch: vi.fn(),
+    requestPayload: computed(() => ({ limit: 10, offset: 0 })),
+    setPage,
+    sort: ref([]),
+  }),
+  useHistoryEventsOverlay: (): unknown => ({ available: overlayAvailable }),
+  useHistoryEventsSelectionActions: (): unknown => ({
+    handleAccountingRuleRefresh,
+    handleSelectionAction,
+    ignoreStatus,
+    modelAccountingRuleToEdit: ref(),
+    selectedEventIds: ref([1, 2]),
+  }),
+  useHistoryEventsSelectionMode: (): unknown => ({
+    setAvailableIds: vi.fn(),
+    setTotalMatchingCount: vi.fn(),
+    state: ref({ isActive: false }),
+  }),
+  useHistoryEventsStatus: (): unknown => ({
+    anyEventsDecoding: ref(false),
+    processing,
+    refreshing,
+    sectionLoading: ref(false),
+    shouldFetchEventsRegularly: ref(false),
+  }),
+  useHistoryEventsTableHeight: (): unknown => computed(() => 0),
+  useUnmatchedAssetMovements: (): unknown => ({
+    autoMatchLoading: ref(false),
+    autoMatchMovement: vi.fn(),
+    refreshUnmatchedAssetMovements: vi.fn(),
+  }),
+  useUnmatchedBridgeTransactions: (): unknown => ({
+    autoMatchLoading: ref(false),
+    refreshUnmatchedBridgeTransactions: vi.fn(),
+  }),
+}));
+
+function stub(name: string, emits: string[] = [], props: string[] = []): ReturnType<typeof defineComponent> {
+  return defineComponent({
+    emits,
+    name,
+    props: Object.fromEntries(props.map(prop => [prop, { default: undefined, required: false, type: null }])),
+    setup: (_props, { slots }) => (): unknown => h('div', { 'data-testid': name }, [
+      slots.buttons?.(),
+      slots.header?.(),
+      slots.default?.(),
+    ]),
+  });
+}
+
+const ViewButtonsStub = stub('HistoryEventsViewButtons', ['refresh', 'show:dialog'], ['includeEvmEvents', 'loading', 'processing']);
+const TableActionsStub = stub('HistoryEventsTableActions', ['redecode', 'selection:action', 'update:action', 'update:locationLabels'], ['fields', 'hideRedecodeButtons', 'ignoreStatus', 'processing', 'selection']);
+const FiltersChipsStub = stub('HistoryEventsFiltersChips', ['refresh'], ['duplicateHandlingStatus', 'groupIdentifiers']);
+const VirtualTableStub = stub('HistoryEventsVirtualTable', ['clear-filters', 'refresh', 'refresh:block-event', 'set-page', 'show:dialog', 'update-event-ids'], ['duplicateHandlingStatus', 'hasActiveFilters', 'highlight', 'processing', 'source']);
+const DialogContainerStub = stub('HistoryEventsDialogContainer', ['accounting-rule-refresh', 'bridge-matched', 'movement-matched'], ['eventHandlers', 'loading', 'refreshing', 'sectionLoading', 'selectedEventIds']);
+const TablePageLayoutStub = stub('TablePageLayout', [], ['child', 'hideHeader', 'title']);
+const OverlayToggleStub = stub('AccountingOverlayToggle');
+
+describe('modules/history/events/HistoryEventsView', () => {
+  let wrapper: VueWrapper | undefined;
+
+  function mountView(props: Record<string, unknown> = {}): VueWrapper {
+    wrapper = mount(HistoryEventsView, {
+      global: {
+        stubs: {
+          AccountingOverlayToggle: OverlayToggleStub,
+          BalanceDivergenceToggle: true,
+          HistoryEventsDialogContainer: DialogContainerStub,
+          HistoryEventsFiltersChips: FiltersChipsStub,
+          HistoryEventsTableActions: TableActionsStub,
+          HistoryEventsViewButtons: ViewButtonsStub,
+          HistoryEventsVirtualTable: VirtualTableStub,
+          RefreshButton: true,
+          SyncProgressPanel: true,
+          TablePageLayout: TablePageLayoutStub,
+        },
+      },
+      props,
+    });
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(processing, false);
+    set(refreshing, false);
+    set(overlayAvailable, false);
+    set(duplicateHandlingStatus, undefined);
+    set(groupIdentifiers, undefined);
+    set(ignoreStatus, undefined);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should title the page with the section it was given', () => {
+    const view = mountView({ mainPage: true, sectionTitle: 'Trades' });
+
+    expect(view.findComponent(TablePageLayoutStub).props('title'))
+      .toStrictEqual(['navigation_menu.history', 'Trades']);
+  });
+
+  it('should fall back to the generic title', () => {
+    const view = mountView({ mainPage: true });
+
+    expect(view.findComponent(TablePageLayoutStub).props('title'))
+      .toStrictEqual(['navigation_menu.history', 'transactions.title']);
+  });
+
+  it('should render as a child page, without the sync panel, when it is not the main page', () => {
+    const view = mountView();
+
+    const layout = view.findComponent(TablePageLayoutStub);
+    expect(layout.props('child')).toBe(true);
+    expect(layout.props('hideHeader')).toBe(true);
+    expect(view.find('sync-progress-panel-stub').exists()).toBe(false);
+  });
+
+  it('should keep the redecode buttons off a child page', () => {
+    const view = mountView();
+
+    expect(view.findComponent(TableActionsStub).props('hideRedecodeButtons')).toBe(true);
+  });
+
+  it('should offer them on the main page', () => {
+    const view = mountView({ mainPage: true });
+
+    expect(view.findComponent(TableActionsStub).props('hideRedecodeButtons')).toBe(false);
+  });
+
+  describe('what the table is asked to load', () => {
+    it('should hand it the source the projection built', () => {
+      const view = mountView();
+
+      const source = view.findComponent(VirtualTableStub).props('source');
+      expect(source).toStrictEqual({
+        excludeIgnored: true,
+        groupLoading: false,
+        groups: get(groups),
+        identifiers: undefined,
+        requestPayload: undefined,
+      });
+    });
+
+    it('should show it as processing while either a fetch or a refresh runs', async () => {
+      const view = mountView();
+      expect(view.findComponent(VirtualTableStub).props('processing')).toBe(false);
+
+      set(refreshing, true);
+      await nextTick();
+
+      expect(view.findComponent(VirtualTableStub).props('processing')).toBe(true);
+    });
+  });
+
+  describe('the accounting overlay toggles', () => {
+    it('should stay hidden while no overlay is available', () => {
+      const view = mountView();
+
+      expect(view.findComponent(OverlayToggleStub).exists()).toBe(false);
+    });
+
+    it('should appear once one is', async () => {
+      const view = mountView();
+
+      set(overlayAvailable, true);
+      await nextTick();
+
+      expect(view.findComponent(OverlayToggleStub).exists()).toBe(true);
+    });
+  });
+
+  describe('where the table sends its events', () => {
+    it('should clear the filters', async () => {
+      const view = mountView();
+
+      view.findComponent(VirtualTableStub).vm.$emit('clear-filters');
+      await nextTick();
+
+      expect(clearFilters).toHaveBeenCalledTimes(1);
+    });
+
+    it('should route a refresh through the page handler', async () => {
+      const view = mountView();
+      const payload = { transactions: [{ location: 'ethereum', txRef: '0xabc' }] };
+
+      view.findComponent(VirtualTableStub).vm.$emit('refresh', payload);
+      await nextTick();
+
+      expect(handleRedecode).toHaveBeenCalledWith(payload);
+    });
+
+    it('should redecode a block event through the actions', async () => {
+      const view = mountView();
+
+      view.findComponent(VirtualTableStub).vm.$emit('refresh:block-event', { blockNumbers: [1] });
+      await nextTick();
+
+      expect(redecodeBlocks).toHaveBeenCalledWith({ blockNumbers: [1] });
+    });
+
+    it('should page and report its rendered events', async () => {
+      const view = mountView();
+      const table = view.findComponent(VirtualTableStub);
+      const update = { eventIds: [1], groupedEvents: {} };
+
+      table.vm.$emit('set-page', 2);
+      table.vm.$emit('update-event-ids', update);
+      await nextTick();
+
+      expect(setPage).toHaveBeenCalledWith(2);
+      expect(handleUpdateEventIds).toHaveBeenCalledWith(update);
+    });
+  });
+
+  describe('where the toolbar sends its events', () => {
+    it('should report a selection action', async () => {
+      const view = mountView();
+
+      view.findComponent(TableActionsStub).vm.$emit('selection:action', 'delete');
+      await nextTick();
+
+      expect(handleSelectionAction).toHaveBeenCalledWith('delete');
+    });
+
+    it('should route a filter change through the filters composable', async () => {
+      const view = mountView();
+      const actions = view.findComponent(TableActionsStub);
+
+      actions.vm.$emit('update:action', 'deposit');
+      actions.vm.$emit('update:locationLabels', ['kraken']);
+      await nextTick();
+
+      expect(onActionChanged).toHaveBeenCalledWith('deposit');
+      expect(onLocationLabelsChanged).toHaveBeenCalledWith(['kraken']);
+    });
+
+    it('should redecode by the scope it was given', async () => {
+      const view = mountView();
+
+      view.findComponent(TableActionsStub).vm.$emit('redecode', 'all');
+      await nextTick();
+
+      expect(redecodeBy).toHaveBeenCalledWith('all');
+    });
+
+    it('should hand it the ignore counts the selection worked out', async () => {
+      const view = mountView();
+
+      set(ignoreStatus, { ignoredCount: 1, notIgnoredCount: 2 });
+      await nextTick();
+
+      expect(view.findComponent(TableActionsStub).props('ignoreStatus'))
+        .toStrictEqual({ ignoredCount: 1, notIgnoredCount: 2 });
+    });
+  });
+
+  describe('the filter chips', () => {
+    it('should be handed the duplicate filter the URL pins', async () => {
+      const view = mountView();
+
+      set(groupIdentifiers, ['g1']);
+      set(duplicateHandlingStatus, 'auto-fix');
+      await nextTick();
+
+      const chips = view.findComponent(FiltersChipsStub);
+      expect(chips.props('groupIdentifiers')).toStrictEqual(['g1']);
+      expect(chips.props('duplicateHandlingStatus')).toBe('auto-fix');
+    });
+
+    it('should reload the events when they ask for it', async () => {
+      const view = mountView();
+
+      view.findComponent(FiltersChipsStub).vm.$emit('refresh');
+      await nextTick();
+
+      expect(fetchDataAndLocations).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('the dialog container', () => {
+    it('should be handed the page handlers and the selected events', () => {
+      const view = mountView();
+
+      const container = view.findComponent(DialogContainerStub);
+      expect(container.props('eventHandlers')).toBe(dialogHandlers);
+      expect(container.props('selectedEventIds')).toStrictEqual([1, 2]);
+    });
+
+    it('should route each of its events to its own handler', async () => {
+      const view = mountView();
+      const container = view.findComponent(DialogContainerStub);
+
+      container.vm.$emit('accounting-rule-refresh');
+      container.vm.$emit('movement-matched');
+      container.vm.$emit('bridge-matched');
+      await nextTick();
+
+      expect(handleAccountingRuleRefresh).toHaveBeenCalledTimes(1);
+      expect(handleMovementChanged).toHaveBeenCalledTimes(1);
+      expect(handleBridgeChanged).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('the header buttons', () => {
+    it('should refresh everything', async () => {
+      const view = mountView({ mainPage: true });
+
+      view.findComponent(ViewButtonsStub).vm.$emit('refresh', true);
+      await nextTick();
+
+      expect(refreshAll).toHaveBeenCalledWith(true, true);
+    });
+
+    it('should be told whether evm events are included', () => {
+      const view = mountView({ mainPage: true });
+
+      expect(view.findComponent(ViewButtonsStub).props('includeEvmEvents')).toBe(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/HistoryEventsView.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
-import type { PullLocationTransactionPayload } from '@/modules/history/events/event-payloads';
 import type { HistoryEventsRestrictions } from '@/modules/history/events/history-events-restrictions';
-import type { HistoryEventRow } from '@/modules/history/events/schemas';
 import type { HistoryEventsTableHighlight, HistoryEventsTableSource } from '@/modules/history/events/types';
 import type { Filters } from '@/modules/history/events/use-events-filter';
 import { AccountingOverlayToggle, BalanceDivergenceToggle } from '@/modules/history/balances/components';
@@ -34,6 +32,8 @@ import {
   provideEventPriceUpdate,
 } from '@/modules/history/events/prices/use-event-price-update-trigger';
 import { provideHistoryEventsSelection } from '@/modules/history/events/use-history-events-selection-context';
+import { useHistoryEventsViewActions } from '@/modules/history/events/use-history-events-view-actions';
+import { toTableSource } from '@/modules/history/events/view-projections';
 import RefreshButton from '@/modules/shell/components/RefreshButton.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
@@ -49,7 +49,6 @@ const { mainPage = false, restrictions = {}, sectionTitle = '' } = defineProps<{
 const SyncProgressPanel = defineAsyncComponent(() => import('@/modules/shell/sync-progress/components/SyncProgressPanel.vue'));
 
 const { t } = useI18n({ useScope: 'global' });
-const route = useRoute();
 
 const toggles = ref<HistoryEventsToggles>(getDefaultToggles());
 // Synced through the router query by useHistoryEventsFilters' queryParamsOnly (see below).
@@ -125,12 +124,12 @@ const selectionMode = useHistoryEventsSelectionMode();
 // Read at the leaves (the row checkboxes) rather than threaded through the table and row switch.
 provideHistoryEventsSelection(selectionMode);
 
-const tableSource = computed<HistoryEventsTableSource>(() => ({
-  excludeIgnored: !get(toggles).showIgnoredAssets,
+const tableSource = computed<HistoryEventsTableSource>(() => toTableSource({
   groupLoading: get(groupLoading),
   groups: get(groups),
   identifiers: get(identifiers),
-  requestPayload: get(toggles).matchExactEvents ? get(requestPayload) : undefined,
+  requestPayload: get(requestPayload),
+  toggles: get(toggles),
 }));
 
 const tableHighlight = computed<HistoryEventsTableHighlight>(() => ({
@@ -139,10 +138,30 @@ const tableHighlight = computed<HistoryEventsTableHighlight>(() => ({
   types: get(highlightTypes),
 }));
 
-// Store grouped events for checking complete EVM transactions
-const groupedEventsByTxRef = ref<Record<string, HistoryEventRow[]>>({});
-// Store original groups data to preserve swap groups
-const originalGroups = ref<HistoryEventRow[]>([]);
+const debouncedProcessing = refDebounced(processing, 200);
+const { autoMatchLoading, autoMatchMovement, refreshUnmatchedAssetMovements } = useUnmatchedAssetMovements();
+const { autoMatchLoading: bridgeAutoMatchLoading, refreshUnmatchedBridgeTransactions } = useUnmatchedBridgeTransactions();
+const backgroundLoading = logicOr(debouncedProcessing, autoMatchLoading, bridgeAutoMatchLoading);
+
+const {
+  groupedEventsByTxRef,
+  handleBridgeChanged,
+  handleMovementChanged,
+  handleRedecode,
+  handleUpdateEventIds,
+  originalGroups,
+} = useHistoryEventsViewActions({
+  autoMatchMovement,
+  backgroundLoading,
+  fetchDataAndLocations: async () => actions.fetch.dataAndLocations(),
+  fetchDataAndRedecode: async event => actions.fetch.dataAndRedecode(event),
+  groups,
+  refreshAll: async () => actions.refresh.all(),
+  refreshUnmatchedAssetMovements,
+  refreshUnmatchedBridgeTransactions,
+  setAvailableIds: ids => selectionMode.setAvailableIds(ids),
+  setTotalMatchingCount: count => selectionMode.setTotalMatchingCount(count),
+});
 
 const deletion = useHistoryEventsDeletion(
   selectionMode,
@@ -165,40 +184,7 @@ const {
   selectionMode,
 });
 
-const debouncedProcessing = refDebounced(processing, 200);
-const { autoMatchLoading, autoMatchMovement, refreshUnmatchedAssetMovements } = useUnmatchedAssetMovements();
-const { autoMatchLoading: bridgeAutoMatchLoading, refreshUnmatchedBridgeTransactions } = useUnmatchedBridgeTransactions();
 useHistoryEventNavigationConsumer(pagination, requestPayload, groupLoading);
-const backgroundLoading = logicOr(debouncedProcessing, autoMatchLoading, bridgeAutoMatchLoading);
-
-// Handle updating available event IDs from the table
-function handleUpdateEventIds({ eventIds, groupedEvents, rawEvents }: { eventIds: number[]; groupedEvents: Record<string, HistoryEventRow[]>; rawEvents?: HistoryEventRow[] }): void {
-  selectionMode.setAvailableIds(eventIds);
-
-  // Store the grouped events for checking complete transactions
-  set(groupedEventsByTxRef, groupedEvents);
-  // Store the original groups data - prefer rawEvents if available, otherwise use groups.data
-  set(originalGroups, rawEvents || get(groups).data);
-}
-
-async function handleRedecode(event?: PullLocationTransactionPayload): Promise<void> {
-  await actions.fetch.dataAndRedecode(event);
-  if (event?.linkedMovement) {
-    const matched = await autoMatchMovement(event.linkedMovement);
-    if (matched)
-      await actions.fetch.dataAndLocations();
-  }
-}
-
-async function handleMovementChanged(): Promise<void> {
-  await refreshUnmatchedAssetMovements();
-  await actions.fetch.dataAndLocations();
-}
-
-async function handleBridgeChanged(): Promise<void> {
-  await refreshUnmatchedBridgeTransactions();
-  await actions.fetch.dataAndLocations();
-}
 
 provideEventPriceUpdate({
   open: (payload) => {
@@ -206,25 +192,7 @@ provideEventPriceUpdate({
   },
 });
 
-// Set total matching count from groups
-watchImmediate(groups, (newGroups) => {
-  selectionMode.setTotalMatchingCount(newGroups.found);
-});
-
 useHistoryEventsDialogRouting(dialogContainer);
-
-watch(backgroundLoading, async (isLoading, wasLoading) => {
-  if (!isLoading && wasLoading)
-    await actions.fetch.dataAndLocations();
-});
-
-// Wait until the route doesn't change anymore to give time for the persisted filter to be set.
-watchDebounced(route, async () => {
-  if (import.meta.env.VITE_NO_AUTO_FETCH === 'true')
-    await actions.fetch.dataAndLocations();
-  else
-    await actions.refresh.all();
-}, { debounce: 500, immediate: true, once: true });
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsPinned.spec.ts
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsPinned.spec.ts
@@ -1,0 +1,219 @@
+import type { UsePinnedMatchPanelOptions } from '@/modules/history/events/use-pinned-match-panel';
+import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import MatchAssetMovementsPinned from '@/modules/history/events/MatchAssetMovementsPinned.vue';
+import { PinnedNames } from '@/modules/session/types';
+
+/**
+ * The seam: every decision this panel used to make now lives in `usePinnedMatchPanel`, which has
+ * its own spec. What is left here is wiring - which rows the panel searches, how a row names its
+ * event, and that the content components are handed the panel's state and report their events back.
+ */
+
+const panel = {
+  activeGroupIdentifier: ref<string | undefined>(),
+  activePotentialMatchIdentifier: ref<number | undefined>(),
+  clearHighlight: vi.fn().mockResolvedValue(undefined),
+  closeDrawer: vi.fn().mockResolvedValue(undefined),
+  modelSheetOpen: ref<boolean>(false),
+  onMatched: vi.fn().mockResolvedValue(undefined),
+  select: vi.fn(),
+  showInHistoryEvents: vi.fn(),
+  showPotentialMatchInHistoryEvents: vi.fn(),
+  subject: ref<UnmatchedAssetMovement | undefined>(),
+  unpin: vi.fn().mockResolvedValue(undefined),
+};
+
+let options: UsePinnedMatchPanelOptions<UnmatchedAssetMovement>;
+
+vi.mock('@/modules/history/events/use-pinned-match-panel', () => ({
+  usePinnedMatchPanel: (opts: UsePinnedMatchPanelOptions<UnmatchedAssetMovement>): unknown => {
+    options = opts;
+    return panel;
+  },
+}));
+
+const unmatchedMovements = ref<UnmatchedAssetMovement[]>([]);
+const ignoredMovements = ref<UnmatchedAssetMovement[]>([]);
+
+vi.mock('@/modules/history/events/use-unmatched-asset-movements', () => ({
+  useUnmatchedAssetMovements: (): Record<string, unknown> => ({ ignoredMovements, unmatchedMovements }),
+}));
+
+const ContentStub = defineComponent({
+  emits: ['pin', 'select', 'show-in-events'],
+  name: 'MatchAssetMovementsContent',
+  props: {
+    highlightedGroupIdentifier: { default: undefined, type: String },
+    isPinned: { default: false, type: Boolean },
+    onActionComplete: { default: undefined, type: Function },
+  },
+  setup: () => (): unknown => h('div', { 'data-testid': 'content' }),
+});
+
+const PotentialStub = defineComponent({
+  emits: ['close', 'matched', 'show-in-events', 'show-unmatched-in-events'],
+  name: 'PotentialMatchesContent',
+  props: {
+    highlightedIdentifier: { default: undefined, type: Number },
+    isPinned: { default: false, type: Boolean },
+    movement: { default: undefined, type: Object },
+  },
+  setup: () => (): unknown => h('div', { 'data-testid': 'potential' }),
+});
+
+const SheetStub = defineComponent({
+  emits: ['update:modelValue'],
+  name: 'PinnedDetailSheet',
+  props: {
+    label: { default: undefined, type: String },
+    modelValue: { required: true, type: Boolean },
+  },
+  setup: (props, { slots }) => (): unknown => (props.modelValue
+    ? h('div', { 'data-testid': 'sheet' }, [slots.header?.(), slots.default?.()])
+    : null),
+});
+
+const movement = createMock<UnmatchedAssetMovement>({ groupIdentifier: 'group-a' });
+
+describe('modules/history/events/MatchAssetMovementsPinned', () => {
+  let wrapper: VueWrapper | undefined;
+
+  function mountPanel(props: Record<string, unknown> = {}): VueWrapper {
+    wrapper = mount(MatchAssetMovementsPinned, {
+      global: {
+        stubs: {
+          MatchAssetMovementsContent: ContentStub,
+          PinnedDetailSheet: SheetStub,
+          PotentialMatchesContent: PotentialStub,
+        },
+      },
+      props,
+    });
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(panel.activeGroupIdentifier, undefined);
+    set(panel.activePotentialMatchIdentifier, undefined);
+    set(panel.modelSheetOpen, false);
+    set(panel.subject, undefined);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should drive the panel from the asset movement collections', () => {
+    set(unmatchedMovements, [movement]);
+    set(ignoredMovements, []);
+    mountPanel();
+
+    expect(options.pinnedName).toBe(PinnedNames.MATCH_ASSET_MOVEMENTS);
+    expect(options.sources).toStrictEqual([unmatchedMovements, ignoredMovements]);
+  });
+
+  it('should forward its highlight props to the panel', () => {
+    mountPanel({
+      highlightedGroupIdentifier: 'group-a',
+      highlightedPotentialMatchIdentifier: 99,
+      potentialMatchGroupIdentifier: 'group-c',
+    });
+
+    expect(options.highlightedGroupIdentifier()).toBe('group-a');
+    expect(options.highlightedPotentialMatchIdentifier()).toBe(99);
+    expect(options.potentialMatchGroupIdentifier()).toBe('group-c');
+  });
+
+  it('should name a movement by the event inside its collection', () => {
+    mountPanel();
+
+    const identifier = options.getIdentifier(createMock<UnmatchedAssetMovement>({
+      events: [{ entry: { identifier: 77 } }],
+      groupIdentifier: 'group-a',
+    }));
+
+    expect(identifier).toBe(77);
+  });
+
+  it('should hand the content the highlighted group and the teardown', () => {
+    set(panel.activeGroupIdentifier, 'group-a');
+    const view = mountPanel();
+
+    const content = view.findComponent(ContentStub);
+    expect(content.props('highlightedGroupIdentifier')).toBe('group-a');
+    expect(content.props('isPinned')).toBe(true);
+    expect(content.props('onActionComplete')).toBe(panel.clearHighlight);
+  });
+
+  it('should report the content events to the panel', async () => {
+    const view = mountPanel();
+    const content = view.findComponent(ContentStub);
+
+    content.vm.$emit('select', movement);
+    content.vm.$emit('show-in-events', movement);
+    content.vm.$emit('pin');
+    await nextTick();
+
+    expect(panel.select).toHaveBeenCalledWith(movement);
+    expect(panel.showInHistoryEvents).toHaveBeenCalledWith(movement);
+    expect(panel.unpin).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep the sheet closed while no movement is selected', () => {
+    const view = mountPanel();
+
+    expect(view.find('[data-testid="sheet"]').exists()).toBe(false);
+    expect(view.findComponent(PotentialStub).exists()).toBe(false);
+  });
+
+  it('should show the selected movement once the sheet opens', async () => {
+    const view = mountPanel();
+
+    set(panel.modelSheetOpen, true);
+    set(panel.subject, movement);
+    set(panel.activePotentialMatchIdentifier, 99);
+    await nextTick();
+
+    const potential = view.findComponent(PotentialStub);
+    expect(potential.props('movement')).toBe(movement);
+    expect(potential.props('highlightedIdentifier')).toBe(99);
+    expect(potential.props('isPinned')).toBe(true);
+  });
+
+  it('should report the sheet events to the panel', async () => {
+    const view = mountPanel();
+    set(panel.modelSheetOpen, true);
+    set(panel.subject, movement);
+    await nextTick();
+    const potential = view.findComponent(PotentialStub);
+
+    potential.vm.$emit('close');
+    potential.vm.$emit('matched');
+    potential.vm.$emit('show-in-events', { groupIdentifier: 'group-c', identifier: 99 });
+    potential.vm.$emit('show-unmatched-in-events');
+    await nextTick();
+
+    expect(panel.closeDrawer).toHaveBeenCalledTimes(1);
+    expect(panel.onMatched).toHaveBeenCalledTimes(1);
+    expect(panel.showPotentialMatchInHistoryEvents)
+      .toHaveBeenCalledWith({ groupIdentifier: 'group-c', identifier: 99 });
+    expect(panel.showInHistoryEvents).toHaveBeenCalledWith(movement);
+  });
+
+  it('should close the drawer from the sheet header', async () => {
+    const view = mountPanel();
+    set(panel.modelSheetOpen, true);
+    set(panel.subject, movement);
+    await nextTick();
+
+    await view.find('[data-testid="sheet"] button').trigger('click');
+
+    expect(panel.closeDrawer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsPinned.vue
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsPinned.vue
@@ -1,17 +1,14 @@
 <script setup lang="ts">
-import { startPromise } from '@shared/utils';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import MatchAssetMovementsContent from '@/modules/history/events/MatchAssetMovementsContent.vue';
 import PotentialMatchesContent from '@/modules/history/events/PotentialMatchesContent.vue';
-import { HighlightTargetTypes, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
+import { usePinnedMatchPanel } from '@/modules/history/events/use-pinned-match-panel';
 import {
   type UnmatchedAssetMovement,
   useUnmatchedAssetMovements,
 } from '@/modules/history/events/use-unmatched-asset-movements';
 import { PinnedNames } from '@/modules/session/types';
 import PinnedDetailSheet from '@/modules/shell/pinned/PinnedDetailSheet.vue';
-import { usePinnedHighlightNavigation } from '@/modules/shell/pinned/use-pinned-highlight-navigation';
-import { usePinnedPanel } from '@/modules/shell/pinned/use-pinned-panel';
 
 const { highlightedGroupIdentifier, highlightedPotentialMatchIdentifier, potentialMatchGroupIdentifier } = defineProps<{
   highlightedGroupIdentifier?: string;
@@ -20,172 +17,28 @@ const { highlightedGroupIdentifier, highlightedPotentialMatchIdentifier, potenti
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const router = useRouter();
-const route = useRoute();
 
-const activeGroupIdentifier = ref<string | undefined>(highlightedGroupIdentifier);
-const activePotentialMatchIdentifier = ref<number | undefined>(highlightedPotentialMatchIdentifier);
-const potentialMatchMovement = ref<UnmatchedAssetMovement>();
-const showPotentialMatchesDrawer = ref<boolean>(false);
-
-const { isPinned, unpin: unpinPanel } = usePinnedPanel(PinnedNames.MATCH_ASSET_MOVEMENTS);
-const {
-  clearHighlightTarget,
-  requestNavigation,
-  setHighlightTarget,
-} = useHistoryEventNavigation();
-
-const { clearHighlight } = usePinnedHighlightNavigation(
-  ['highlightedAssetMovement', 'highlightedPotentialMatch'],
-  () => {
-    set(activeGroupIdentifier, undefined);
-    set(activePotentialMatchIdentifier, undefined);
-  },
-  () => get(isPinned),
-);
+const { ignoredMovements, unmatchedMovements } = useUnmatchedAssetMovements();
 
 const {
-  ignoredMovements,
-  unmatchedMovements,
-} = useUnmatchedAssetMovements();
-
-function selectMovement(movement: UnmatchedAssetMovement): void {
-  const identifier = getEventEntryFromCollection(movement.events).entry.identifier;
-
-  set(potentialMatchMovement, movement);
-  set(showPotentialMatchesDrawer, true);
-  set(activePotentialMatchIdentifier, undefined);
-  set(activeGroupIdentifier, movement.groupIdentifier);
-
-  clearHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH);
-  setHighlightTarget(HighlightTargetTypes.ASSET_MOVEMENT, { groupIdentifier: movement.groupIdentifier, identifier });
-
-  requestNavigation({
-    highlightedAssetMovement: identifier,
-    targetGroupIdentifier: movement.groupIdentifier,
-  });
-}
-
-async function closePotentialMatchesDrawer(): Promise<void> {
-  set(showPotentialMatchesDrawer, false);
-  set(potentialMatchMovement, undefined);
-  set(activePotentialMatchIdentifier, undefined);
-  clearHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH);
-
-  // Clear the green highlight from route while preserving the yellow highlight
-  const { highlightedPotentialMatch, ...remainingQuery } = get(route).query;
-  if (highlightedPotentialMatch) {
-    await router.replace({ query: remainingQuery });
-  }
-}
-
-// The sheet is only open once a movement is actually selected, so it never flashes empty while the
-// close animation drains the movement. Closing routes through the same cleanup as the header button.
-const potentialMatchesSheetOpen = computed<boolean>({
-  get: () => get(showPotentialMatchesDrawer) && !!get(potentialMatchMovement),
-  set: (value) => {
-    if (!value)
-      startPromise(closePotentialMatchesDrawer());
-  },
-});
-
-async function onPinnedMatched(): Promise<void> {
-  await closePotentialMatchesDrawer();
-  await clearHighlight();
-}
-
-async function unpin(): Promise<void> {
-  await clearHighlight();
-  unpinPanel();
-}
-
-function showInHistoryEvents(movement: UnmatchedAssetMovement): void {
-  const identifier = getEventEntryFromCollection(movement.events).entry.identifier;
-
-  set(activeGroupIdentifier, movement.groupIdentifier);
-  set(activePotentialMatchIdentifier, undefined);
-  clearHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH);
-  setHighlightTarget(HighlightTargetTypes.ASSET_MOVEMENT, { groupIdentifier: movement.groupIdentifier, identifier });
-
-  requestNavigation({
-    highlightedAssetMovement: identifier,
-    targetGroupIdentifier: movement.groupIdentifier,
-  });
-}
-
-function showPotentialMatchInHistoryEvents(
-  data: { identifier: number; groupIdentifier: string },
-  unmatchedIdentifier?: number,
-): void {
-  set(activePotentialMatchIdentifier, data.identifier);
-  setHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH, { groupIdentifier: data.groupIdentifier, identifier: data.identifier });
-
-  const yellowHighlight = unmatchedIdentifier
-    ?? (Number(get(route).query.highlightedAssetMovement) || undefined);
-
-  requestNavigation({
-    highlightedAssetMovement: yellowHighlight,
-    highlightedPotentialMatch: data.identifier,
-    targetGroupIdentifier: data.groupIdentifier,
-  });
-}
-
-const hasNavigatedToInitialHighlight = ref<boolean>(false);
-
-/**
- * Navigate to the highlighted movement if it exists.
- * Returns true if navigation was triggered, false otherwise.
- */
-function navigateToHighlightedMovement(targetGroupIdentifier: string): boolean {
-  const unmatched = get(unmatchedMovements);
-  const ignored = get(ignoredMovements);
-
-  const movement = unmatched.find(m => m.groupIdentifier === targetGroupIdentifier)
-    || ignored.find(m => m.groupIdentifier === targetGroupIdentifier);
-
-  if (movement) {
-    // If potential match identifier is also provided, open the drawer and navigate to potential match
-    if (highlightedPotentialMatchIdentifier && potentialMatchGroupIdentifier) {
-      const identifier = getEventEntryFromCollection(movement.events).entry.identifier;
-      set(potentialMatchMovement, movement);
-      set(showPotentialMatchesDrawer, true);
-      set(activeGroupIdentifier, movement.groupIdentifier);
-      showPotentialMatchInHistoryEvents(
-        {
-          groupIdentifier: potentialMatchGroupIdentifier,
-          identifier: highlightedPotentialMatchIdentifier,
-        },
-        identifier,
-      );
-    }
-    else {
-      showInHistoryEvents(movement);
-    }
-    return true;
-  }
-  return false;
-}
-
-// Watch for data to load and navigate to initial highlight if provided
-watch([unmatchedMovements, ignoredMovements], () => {
-  const initialHighlight = highlightedGroupIdentifier;
-  if (!initialHighlight || get(hasNavigatedToInitialHighlight))
-    return;
-
-  if (navigateToHighlightedMovement(initialHighlight)) {
-    set(hasNavigatedToInitialHighlight, true);
-  }
-});
-
-// Watch for prop changes to handle navigation when pinned section is already open
-watch(() => highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
-  // Only trigger if the highlight actually changed (not on initial mount)
-  if (!newHighlight || newHighlight === oldHighlight)
-    return;
-
-  // Update local ref and navigate to the new highlight
-  set(activeGroupIdentifier, newHighlight);
-  navigateToHighlightedMovement(newHighlight);
+  activeGroupIdentifier,
+  activePotentialMatchIdentifier,
+  clearHighlight,
+  closeDrawer,
+  modelSheetOpen,
+  onMatched,
+  select,
+  showInHistoryEvents,
+  showPotentialMatchInHistoryEvents,
+  subject: potentialMatchMovement,
+  unpin,
+} = usePinnedMatchPanel<UnmatchedAssetMovement>({
+  getIdentifier: movement => getEventEntryFromCollection(movement.events).entry.identifier,
+  highlightedGroupIdentifier: () => highlightedGroupIdentifier,
+  highlightedPotentialMatchIdentifier: () => highlightedPotentialMatchIdentifier,
+  pinnedName: PinnedNames.MATCH_ASSET_MOVEMENTS,
+  potentialMatchGroupIdentifier: () => potentialMatchGroupIdentifier,
+  sources: [unmatchedMovements, ignoredMovements],
 });
 </script>
 
@@ -197,12 +50,12 @@ watch(() => highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
         :on-action-complete="clearHighlight"
         is-pinned
         @pin="unpin()"
-        @select="selectMovement($event)"
+        @select="select($event)"
         @show-in-events="showInHistoryEvents($event)"
       />
 
       <PinnedDetailSheet
-        v-model="potentialMatchesSheetOpen"
+        v-model="modelSheetOpen"
         :label="t('asset_movement_matching.dialog.select_match_title')"
       >
         <template #header>
@@ -214,7 +67,7 @@ watch(() => highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
               variant="text"
               icon
               size="sm"
-              @click="closePotentialMatchesDrawer()"
+              @click="closeDrawer()"
             >
               <RuiIcon
                 name="lu-x"
@@ -231,8 +84,8 @@ watch(() => highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
             :movement="potentialMatchMovement"
             :highlighted-identifier="activePotentialMatchIdentifier"
             is-pinned
-            @close="closePotentialMatchesDrawer()"
-            @matched="onPinnedMatched()"
+            @close="closeDrawer()"
+            @matched="onMatched()"
             @show-in-events="showPotentialMatchInHistoryEvents($event)"
             @show-unmatched-in-events="showInHistoryEvents(potentialMatchMovement)"
           />

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsPinned.spec.ts
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsPinned.spec.ts
@@ -1,0 +1,246 @@
+import type { MatchingFlow } from '@/modules/history/events/matching/types';
+import type { UsePinnedMatchPanelOptions } from '@/modules/history/events/use-pinned-match-panel';
+import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import MatchBridgeTransactionsPinned from '@/modules/history/events/MatchBridgeTransactionsPinned.vue';
+import { PinnedNames } from '@/modules/session/types';
+
+/**
+ * The seam: the panel's behaviour lives in `usePinnedMatchPanel`, which has its own spec. What is
+ * left here is the wiring that makes this the bridge panel rather than the asset movement one -
+ * the bridge collections, the bridge flow, and the labels and explanation the drawer is given.
+ */
+
+const panel = {
+  activeGroupIdentifier: ref<string | undefined>(),
+  activePotentialMatchIdentifier: ref<number | undefined>(),
+  clearHighlight: vi.fn().mockResolvedValue(undefined),
+  closeDrawer: vi.fn().mockResolvedValue(undefined),
+  modelSheetOpen: ref<boolean>(false),
+  onMatched: vi.fn().mockResolvedValue(undefined),
+  select: vi.fn(),
+  showInHistoryEvents: vi.fn(),
+  showPotentialMatchInHistoryEvents: vi.fn(),
+  subject: ref<UnmatchedBridgeTransaction | undefined>(),
+  unpin: vi.fn().mockResolvedValue(undefined),
+};
+
+let options: UsePinnedMatchPanelOptions<UnmatchedBridgeTransaction>;
+
+vi.mock('@/modules/history/events/use-pinned-match-panel', () => ({
+  usePinnedMatchPanel: (opts: UsePinnedMatchPanelOptions<UnmatchedBridgeTransaction>): unknown => {
+    options = opts;
+    return panel;
+  },
+}));
+
+const unmatchedTransactions = ref<UnmatchedBridgeTransaction[]>([]);
+const ignoredTransactions = ref<UnmatchedBridgeTransaction[]>([]);
+const bridgeFlow = createMock<MatchingFlow>();
+const entryLabels = ref({ locationHeader: 'Chain', type: 'Bridge transaction' });
+const unmatchableExplanation = ref<string | undefined>('No counterpart is tracked.');
+
+const flowSubjects: unknown[] = [];
+
+vi.mock('@/modules/history/events/use-unmatched-bridge-transactions', () => ({
+  useBridgeEntryLabels: (subject: unknown): unknown => {
+    flowSubjects.push(subject);
+    return entryLabels;
+  },
+  useBridgeMatchingFlow: (): MatchingFlow => bridgeFlow,
+  useUnmatchedBridgeTransactions: (): Record<string, unknown> => ({ ignoredTransactions, unmatchedTransactions }),
+}));
+
+vi.mock('@/modules/history/events/use-untracked-bridge-counterpart', () => ({
+  useBridgeUnmatchableExplanation: (subject: unknown): Record<string, unknown> => {
+    flowSubjects.push(subject);
+    return { unmatchableExplanation };
+  },
+}));
+
+const ContentStub = defineComponent({
+  emits: ['pin', 'select', 'show-in-events'],
+  name: 'MatchBridgeTransactionsContent',
+  props: {
+    highlightedGroupIdentifier: { default: undefined, type: String },
+    isPinned: { default: false, type: Boolean },
+    onActionComplete: { default: undefined, type: Function },
+  },
+  setup: () => (): unknown => h('div', { 'data-testid': 'content' }),
+});
+
+const PotentialStub = defineComponent({
+  emits: ['close', 'matched', 'show-in-events', 'show-unmatched-in-events'],
+  name: 'PotentialMatchesContent',
+  props: {
+    emptyExplanation: { default: undefined, type: String },
+    entryLabels: { default: undefined, type: Object },
+    flow: { default: undefined, type: Object },
+    highlightedIdentifier: { default: undefined, type: Number },
+    isPinned: { default: false, type: Boolean },
+    movement: { default: undefined, type: Object },
+  },
+  setup: () => (): unknown => h('div', { 'data-testid': 'potential' }),
+});
+
+const SheetStub = defineComponent({
+  emits: ['update:modelValue'],
+  name: 'PinnedDetailSheet',
+  props: {
+    label: { default: undefined, type: String },
+    modelValue: { required: true, type: Boolean },
+  },
+  setup: (props, { slots }) => (): unknown => (props.modelValue
+    ? h('div', { 'data-testid': 'sheet' }, [slots.header?.(), slots.default?.()])
+    : null),
+});
+
+const transaction = createMock<UnmatchedBridgeTransaction>({ groupIdentifier: 'group-a', identifier: 11 });
+
+describe('modules/history/events/MatchBridgeTransactionsPinned', () => {
+  let wrapper: VueWrapper | undefined;
+
+  function mountPanel(props: Record<string, unknown> = {}): VueWrapper {
+    wrapper = mount(MatchBridgeTransactionsPinned, {
+      global: {
+        stubs: {
+          MatchBridgeTransactionsContent: ContentStub,
+          PinnedDetailSheet: SheetStub,
+          PotentialMatchesContent: PotentialStub,
+        },
+      },
+      props,
+    });
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    flowSubjects.length = 0;
+    set(panel.activeGroupIdentifier, undefined);
+    set(panel.activePotentialMatchIdentifier, undefined);
+    set(panel.modelSheetOpen, false);
+    set(panel.subject, undefined);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('should drive the panel from the bridge transaction collections', () => {
+    set(unmatchedTransactions, [transaction]);
+    mountPanel();
+
+    expect(options.pinnedName).toBe(PinnedNames.MATCH_BRIDGE_TRANSACTIONS);
+    expect(options.sources).toStrictEqual([unmatchedTransactions, ignoredTransactions]);
+  });
+
+  it('should forward its highlight props to the panel', () => {
+    mountPanel({
+      highlightedGroupIdentifier: 'group-a',
+      highlightedPotentialMatchIdentifier: 99,
+      potentialMatchGroupIdentifier: 'group-c',
+    });
+
+    expect(options.highlightedGroupIdentifier()).toBe('group-a');
+    expect(options.highlightedPotentialMatchIdentifier()).toBe(99);
+    expect(options.potentialMatchGroupIdentifier()).toBe('group-c');
+  });
+
+  it('should name a transaction by its own identifier', () => {
+    mountPanel();
+
+    expect(options.getIdentifier(transaction)).toBe(11);
+  });
+
+  it('should derive the labels and the explanation from the selected transaction', () => {
+    mountPanel();
+
+    expect(flowSubjects).toHaveLength(2);
+    for (const subject of flowSubjects)
+      expect(subject).toBe(panel.subject);
+  });
+
+  it('should hand the content the highlighted group and the teardown', () => {
+    set(panel.activeGroupIdentifier, 'group-a');
+    const view = mountPanel();
+
+    const content = view.findComponent(ContentStub);
+    expect(content.props('highlightedGroupIdentifier')).toBe('group-a');
+    expect(content.props('isPinned')).toBe(true);
+    expect(content.props('onActionComplete')).toBe(panel.clearHighlight);
+  });
+
+  it('should report the content events to the panel', async () => {
+    const view = mountPanel();
+    const content = view.findComponent(ContentStub);
+
+    content.vm.$emit('select', transaction);
+    content.vm.$emit('show-in-events', transaction);
+    content.vm.$emit('pin');
+    await nextTick();
+
+    expect(panel.select).toHaveBeenCalledWith(transaction);
+    expect(panel.showInHistoryEvents).toHaveBeenCalledWith(transaction);
+    expect(panel.unpin).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep the sheet closed while no transaction is selected', () => {
+    const view = mountPanel();
+
+    expect(view.find('[data-testid="sheet"]').exists()).toBe(false);
+    expect(view.findComponent(PotentialStub).exists()).toBe(false);
+  });
+
+  it('should give the drawer the bridge flow, labels and explanation', async () => {
+    const view = mountPanel();
+
+    set(panel.modelSheetOpen, true);
+    set(panel.subject, transaction);
+    set(panel.activePotentialMatchIdentifier, 99);
+    await nextTick();
+
+    const potential = view.findComponent(PotentialStub);
+    expect(potential.props('movement')).toBe(transaction);
+    expect(potential.props('flow')).toBe(bridgeFlow);
+    expect(potential.props('entryLabels')).toStrictEqual(get(entryLabels));
+    expect(potential.props('emptyExplanation')).toBe('No counterpart is tracked.');
+    expect(potential.props('highlightedIdentifier')).toBe(99);
+    expect(potential.props('isPinned')).toBe(true);
+  });
+
+  it('should report the sheet events to the panel', async () => {
+    const view = mountPanel();
+    set(panel.modelSheetOpen, true);
+    set(panel.subject, transaction);
+    await nextTick();
+    const potential = view.findComponent(PotentialStub);
+
+    potential.vm.$emit('close');
+    potential.vm.$emit('matched');
+    potential.vm.$emit('show-in-events', { groupIdentifier: 'group-c', identifier: 99 });
+    potential.vm.$emit('show-unmatched-in-events');
+    await nextTick();
+
+    expect(panel.closeDrawer).toHaveBeenCalledTimes(1);
+    expect(panel.onMatched).toHaveBeenCalledTimes(1);
+    expect(panel.showPotentialMatchInHistoryEvents)
+      .toHaveBeenCalledWith({ groupIdentifier: 'group-c', identifier: 99 });
+    expect(panel.showInHistoryEvents).toHaveBeenCalledWith(transaction);
+  });
+
+  it('should close the drawer from the sheet header', async () => {
+    const view = mountPanel();
+    set(panel.modelSheetOpen, true);
+    set(panel.subject, transaction);
+    await nextTick();
+
+    await view.find('[data-testid="sheet"] button').trigger('click');
+
+    expect(panel.closeDrawer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsPinned.vue
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsPinned.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import type { MatchingFlow } from '@/modules/history/events/matching/types';
-import { startPromise } from '@shared/utils';
 import MatchBridgeTransactionsContent from '@/modules/history/events/MatchBridgeTransactionsContent.vue';
 import PotentialMatchesContent from '@/modules/history/events/PotentialMatchesContent.vue';
-import { HighlightTargetTypes, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
+import { usePinnedMatchPanel } from '@/modules/history/events/use-pinned-match-panel';
 import {
   type UnmatchedBridgeTransaction,
   useBridgeEntryLabels,
@@ -13,8 +12,6 @@ import {
 import { useBridgeUnmatchableExplanation } from '@/modules/history/events/use-untracked-bridge-counterpart';
 import { PinnedNames } from '@/modules/session/types';
 import PinnedDetailSheet from '@/modules/shell/pinned/PinnedDetailSheet.vue';
-import { usePinnedHighlightNavigation } from '@/modules/shell/pinned/use-pinned-highlight-navigation';
-import { usePinnedPanel } from '@/modules/shell/pinned/use-pinned-panel';
 
 const { highlightedGroupIdentifier, highlightedPotentialMatchIdentifier, potentialMatchGroupIdentifier } = defineProps<{
   highlightedGroupIdentifier?: string;
@@ -23,177 +20,33 @@ const { highlightedGroupIdentifier, highlightedPotentialMatchIdentifier, potenti
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const router = useRouter();
-const route = useRoute();
 
-const activeGroupIdentifier = ref<string | undefined>(highlightedGroupIdentifier);
-const activePotentialMatchIdentifier = ref<number | undefined>(highlightedPotentialMatchIdentifier);
-const potentialMatchTransaction = ref<UnmatchedBridgeTransaction>();
-const showPotentialMatchesDrawer = ref<boolean>(false);
-
-const { isPinned, unpin: unpinPanel } = usePinnedPanel(PinnedNames.MATCH_BRIDGE_TRANSACTIONS);
-const {
-  clearHighlightTarget,
-  requestNavigation,
-  setHighlightTarget,
-} = useHistoryEventNavigation();
-
-const { clearHighlight } = usePinnedHighlightNavigation(
-  ['highlightedAssetMovement', 'highlightedPotentialMatch'],
-  () => {
-    set(activeGroupIdentifier, undefined);
-    set(activePotentialMatchIdentifier, undefined);
-  },
-  () => get(isPinned),
-);
+const { ignoredTransactions, unmatchedTransactions } = useUnmatchedBridgeTransactions();
 
 const {
-  ignoredTransactions,
-  unmatchedTransactions,
-} = useUnmatchedBridgeTransactions();
+  activeGroupIdentifier,
+  activePotentialMatchIdentifier,
+  clearHighlight,
+  closeDrawer,
+  modelSheetOpen,
+  onMatched,
+  select,
+  showInHistoryEvents,
+  showPotentialMatchInHistoryEvents,
+  subject: potentialMatchTransaction,
+  unpin,
+} = usePinnedMatchPanel<UnmatchedBridgeTransaction>({
+  getIdentifier: transaction => transaction.identifier,
+  highlightedGroupIdentifier: () => highlightedGroupIdentifier,
+  highlightedPotentialMatchIdentifier: () => highlightedPotentialMatchIdentifier,
+  pinnedName: PinnedNames.MATCH_BRIDGE_TRANSACTIONS,
+  potentialMatchGroupIdentifier: () => potentialMatchGroupIdentifier,
+  sources: [unmatchedTransactions, ignoredTransactions],
+});
 
 const flow: MatchingFlow = useBridgeMatchingFlow();
 const { unmatchableExplanation: emptyExplanation } = useBridgeUnmatchableExplanation(potentialMatchTransaction);
 const bridgeEntryLabels = useBridgeEntryLabels(potentialMatchTransaction);
-
-function selectTransaction(transaction: UnmatchedBridgeTransaction): void {
-  const identifier = transaction.identifier;
-
-  set(potentialMatchTransaction, transaction);
-  set(showPotentialMatchesDrawer, true);
-  set(activePotentialMatchIdentifier, undefined);
-  set(activeGroupIdentifier, transaction.groupIdentifier);
-
-  clearHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH);
-  setHighlightTarget(HighlightTargetTypes.ASSET_MOVEMENT, { groupIdentifier: transaction.groupIdentifier, identifier });
-
-  requestNavigation({
-    highlightedAssetMovement: identifier,
-    targetGroupIdentifier: transaction.groupIdentifier,
-  });
-}
-
-async function closePotentialMatchesDrawer(): Promise<void> {
-  set(showPotentialMatchesDrawer, false);
-  set(potentialMatchTransaction, undefined);
-  set(activePotentialMatchIdentifier, undefined);
-  clearHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH);
-
-  // Clear the green highlight from route while preserving the yellow highlight
-  const { highlightedPotentialMatch, ...remainingQuery } = get(route).query;
-  if (highlightedPotentialMatch) {
-    await router.replace({ query: remainingQuery });
-  }
-}
-
-// The sheet is only open once a transaction is actually selected, so it never flashes empty while
-// the close animation drains it. Closing routes through the same cleanup as the header button.
-const potentialMatchesSheetOpen = computed<boolean>({
-  get: () => get(showPotentialMatchesDrawer) && !!get(potentialMatchTransaction),
-  set: (value) => {
-    if (!value)
-      startPromise(closePotentialMatchesDrawer());
-  },
-});
-
-async function onPinnedMatched(): Promise<void> {
-  await closePotentialMatchesDrawer();
-  await clearHighlight();
-}
-
-async function unpin(): Promise<void> {
-  await clearHighlight();
-  unpinPanel();
-}
-
-function showInHistoryEvents(transaction: UnmatchedBridgeTransaction): void {
-  const identifier = transaction.identifier;
-
-  set(activeGroupIdentifier, transaction.groupIdentifier);
-  set(activePotentialMatchIdentifier, undefined);
-  clearHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH);
-  setHighlightTarget(HighlightTargetTypes.ASSET_MOVEMENT, { groupIdentifier: transaction.groupIdentifier, identifier });
-
-  requestNavigation({
-    highlightedAssetMovement: identifier,
-    targetGroupIdentifier: transaction.groupIdentifier,
-  });
-}
-
-function showPotentialMatchInHistoryEvents(
-  data: { identifier: number; groupIdentifier: string },
-  unmatchedIdentifier?: number,
-): void {
-  set(activePotentialMatchIdentifier, data.identifier);
-  setHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH, { groupIdentifier: data.groupIdentifier, identifier: data.identifier });
-
-  const yellowHighlight = unmatchedIdentifier
-    ?? (Number(get(route).query.highlightedAssetMovement) || undefined);
-
-  requestNavigation({
-    highlightedAssetMovement: yellowHighlight,
-    highlightedPotentialMatch: data.identifier,
-    targetGroupIdentifier: data.groupIdentifier,
-  });
-}
-
-const hasNavigatedToInitialHighlight = ref<boolean>(false);
-
-/**
- * Navigate to the highlighted transaction if it exists.
- * Returns true if navigation was triggered, false otherwise.
- */
-function navigateToHighlightedTransaction(targetGroupIdentifier: string): boolean {
-  const unmatched = get(unmatchedTransactions);
-  const ignored = get(ignoredTransactions);
-
-  const transaction = unmatched.find(tx => tx.groupIdentifier === targetGroupIdentifier)
-    || ignored.find(tx => tx.groupIdentifier === targetGroupIdentifier);
-
-  if (transaction) {
-    // If potential match identifier is also provided, open the drawer and navigate to potential match
-    if (highlightedPotentialMatchIdentifier && potentialMatchGroupIdentifier) {
-      const identifier = transaction.identifier;
-      set(potentialMatchTransaction, transaction);
-      set(showPotentialMatchesDrawer, true);
-      set(activeGroupIdentifier, transaction.groupIdentifier);
-      showPotentialMatchInHistoryEvents(
-        {
-          groupIdentifier: potentialMatchGroupIdentifier,
-          identifier: highlightedPotentialMatchIdentifier,
-        },
-        identifier,
-      );
-    }
-    else {
-      showInHistoryEvents(transaction);
-    }
-    return true;
-  }
-  return false;
-}
-
-// Watch for data to load and navigate to initial highlight if provided
-watch([unmatchedTransactions, ignoredTransactions], () => {
-  const initialHighlight = highlightedGroupIdentifier;
-  if (!initialHighlight || get(hasNavigatedToInitialHighlight))
-    return;
-
-  if (navigateToHighlightedTransaction(initialHighlight)) {
-    set(hasNavigatedToInitialHighlight, true);
-  }
-});
-
-// Watch for prop changes to handle navigation when pinned section is already open
-watch(() => highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
-  // Only trigger if the highlight actually changed (not on initial mount)
-  if (!newHighlight || newHighlight === oldHighlight)
-    return;
-
-  // Update local ref and navigate to the new highlight
-  set(activeGroupIdentifier, newHighlight);
-  navigateToHighlightedTransaction(newHighlight);
-});
 </script>
 
 <template>
@@ -204,12 +57,12 @@ watch(() => highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
         :on-action-complete="clearHighlight"
         is-pinned
         @pin="unpin()"
-        @select="selectTransaction($event)"
+        @select="select($event)"
         @show-in-events="showInHistoryEvents($event)"
       />
 
       <PinnedDetailSheet
-        v-model="potentialMatchesSheetOpen"
+        v-model="modelSheetOpen"
         :label="t('asset_movement_matching.dialog.select_match_title')"
       >
         <template #header>
@@ -221,7 +74,7 @@ watch(() => highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
               variant="text"
               icon
               size="sm"
-              @click="closePotentialMatchesDrawer()"
+              @click="closeDrawer()"
             >
               <RuiIcon
                 name="lu-x"
@@ -241,8 +94,8 @@ watch(() => highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
             :highlighted-identifier="activePotentialMatchIdentifier"
             :empty-explanation="emptyExplanation"
             is-pinned
-            @close="closePotentialMatchesDrawer()"
-            @matched="onPinnedMatched()"
+            @close="closeDrawer()"
+            @matched="onMatched()"
             @show-in-events="showPotentialMatchInHistoryEvents($event)"
             @show-unmatched-in-events="showInHistoryEvents(potentialMatchTransaction)"
           />

--- a/frontend/app/src/modules/history/events/dialog-components.ts
+++ b/frontend/app/src/modules/history/events/dialog-components.ts
@@ -1,0 +1,79 @@
+import type { Component } from 'vue';
+import { RuiProgress } from '@rotki/ui-library/components';
+
+/**
+ * The dialogs the events page can open, each loaded only once it is asked for. Named exports rather
+ * than inline async components in the container, because a spec can only stub what has a name.
+ */
+
+/**
+ * Shown in a dialog's place while its chunk is still loading.
+ *
+ * ⚠️ `RuiProgress` must be imported, not named: the Rui resolver only auto-imports into `.vue`, so
+ * `h('RuiProgress')` here builds a literal `<ruiprogress>` and the placeholder renders empty.
+ */
+function DialogLoadingComponent(): ReturnType<typeof h> {
+  return h('div', { class: 'flex items-center justify-center p-4' }, h(RuiProgress, { circular: true, size: 40, variant: 'indeterminate' }));
+}
+
+/** The delay before the loading placeholder appears, so a fast chunk never flashes one. */
+const LOADING_DELAY = 200;
+
+function lazyDialog(loader: () => Promise<{ default: Component }>): Component {
+  return defineAsyncComponent({
+    delay: LOADING_DELAY,
+    loader,
+    loadingComponent: DialogLoadingComponent,
+  });
+}
+
+export const MissingRulesDialog = lazyDialog(async () => import('@/modules/history/management/MissingRulesDialog.vue'));
+
+export const HistoryEventFormDialog = lazyDialog(
+  async () => import('@/modules/history/events/HistoryEventFormDialog.vue'),
+);
+
+// No placeholder: both status dialogs are small enough that one would only flash.
+export const HistoryEventsDecodingStatusDialog: Component = defineAsyncComponent(
+  async () => import('@/modules/history/events/HistoryEventsDecodingStatusDialog.vue'),
+);
+
+export const HistoryEventsProtocolCacheStatusDialog: Component = defineAsyncComponent(
+  async () => import('@/modules/history/events/HistoryEventsProtocolCacheStatusDialog.vue'),
+);
+
+export const RepullingTransactionFormDialog = lazyDialog(
+  async () => import('@/modules/history/events/tx/RepullingTransactionFormDialog.vue'),
+);
+
+export const TransactionFormDialog = lazyDialog(
+  async () => import('@/modules/history/events/tx/TransactionFormDialog.vue'),
+);
+
+export const AccountingRuleFormDialog = lazyDialog(
+  async () => import('@/modules/settings/accounting/rule/AccountingRuleFormDialog.vue'),
+);
+
+export const CustomizedEventDuplicatesDialog = lazyDialog(
+  async () => import('@/modules/history/events/CustomizedEventDuplicatesDialog.vue'),
+);
+
+export const InternalTxConflictsDialog = lazyDialog(
+  async () => import('@/modules/history/internal-tx-conflicts/InternalTxConflictsDialog.vue'),
+);
+
+export const MatchAssetMovementsDialog = lazyDialog(
+  async () => import('@/modules/history/events/MatchAssetMovementsDialog.vue'),
+);
+
+export const PotentialMatchesDialog = lazyDialog(
+  async () => import('@/modules/history/events/PotentialMatchesDialog.vue'),
+);
+
+export const MatchBridgeTransactionsDialog = lazyDialog(
+  async () => import('@/modules/history/events/MatchBridgeTransactionsDialog.vue'),
+);
+
+export const BridgePotentialMatchesDialog = lazyDialog(
+  async () => import('@/modules/history/events/BridgePotentialMatchesDialog.vue'),
+);

--- a/frontend/app/src/modules/history/events/use-history-event-action-menu.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-action-menu.spec.ts
@@ -1,0 +1,369 @@
+import type { EthBlockEvent, EvmHistoryEvent, HistoryEventEntry } from '@/modules/history/events/schemas';
+import { HistoryEventEntryType } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import {
+  useHistoryEventActionMenu,
+  type UseHistoryEventActionMenuReturn,
+} from '@/modules/history/events/use-history-event-action-menu';
+
+const ethBlockEventsDecoding = ref<boolean>(false);
+const txEventsDecoding = ref<boolean>(false);
+
+vi.mock('@/modules/history/events/use-history-events-status', () => ({
+  useHistoryEventsStatus: (): Record<string, unknown> => ({ ethBlockEventsDecoding, txEventsDecoding }),
+}));
+
+const confirmAndFixDuplicate = vi.fn();
+const confirmAndMarkNonDuplicated = vi.fn();
+const fixLoading = ref<boolean>(false);
+const ignoreLoading = ref<boolean>(false);
+
+vi.mock('@/modules/history/events/use-customized-event-duplicates', () => ({
+  useCustomizedEventDuplicates: (): Record<string, unknown> => ({
+    confirmAndFixDuplicate,
+    confirmAndMarkNonDuplicated,
+    fixLoading,
+    ignoreLoading,
+  }),
+}));
+
+const showReportIssue = vi.fn();
+
+vi.mock('@/modules/core/common/use-report-issue', () => ({
+  useReportIssue: (): Record<string, unknown> => ({ show: showReportIssue }),
+}));
+
+function createEvent(overrides: Partial<HistoryEventEntry>): HistoryEventEntry {
+  return createMock<HistoryEventEntry>({ identifier: 1, location: 'ethereum', ...overrides });
+}
+
+const evmEvent = createEvent({
+  entryType: HistoryEventEntryType.EVM_EVENT,
+  groupIdentifier: 'group-a',
+  txRef: '0xabc',
+});
+
+const solanaEvent = createEvent({
+  entryType: HistoryEventEntryType.SOLANA_EVENT,
+  location: 'solana',
+  txRef: 'sol-sig',
+});
+
+const blockEvent = createEvent({
+  blockNumber: 1234,
+  entryType: HistoryEventEntryType.ETH_BLOCK_EVENT,
+});
+
+/** The same two events, typed as what a re-decode payload is built from. */
+const decodableEvm = createMock<EvmHistoryEvent>({
+  entryType: HistoryEventEntryType.EVM_EVENT,
+  location: 'ethereum',
+  txRef: '0xabc',
+});
+
+const decodableBlock = createMock<EthBlockEvent>({
+  blockNumber: 1234,
+  entryType: HistoryEventEntryType.ETH_BLOCK_EVENT,
+});
+
+const onlineEvent = createEvent({
+  entryType: HistoryEventEntryType.HISTORY_EVENT,
+  location: 'kraken',
+});
+
+const event = ref<HistoryEventEntry>(evmEvent);
+const groupEvents = ref<HistoryEventEntry[] | undefined>();
+const duplicateHandlingStatus = ref<DuplicateHandlingStatus | undefined>();
+const onFixDuplicate = vi.fn();
+const onIgnoreDuplicate = vi.fn();
+
+interface Harness {
+  wrapper: VueWrapper;
+  menu: UseHistoryEventActionMenuReturn;
+}
+
+function mountMenu(): Harness {
+  let menu!: UseHistoryEventActionMenuReturn;
+  const Comp = defineComponent({
+    setup(): () => null {
+      menu = useHistoryEventActionMenu({
+        duplicateHandlingStatus: () => get(duplicateHandlingStatus),
+        event: () => get(event),
+        groupEvents: () => get(groupEvents),
+        onFixDuplicate,
+        onIgnoreDuplicate,
+      });
+      return (): null => null;
+    },
+  });
+  const wrapper = mount(Comp);
+  return { menu, wrapper };
+}
+
+describe('useHistoryEventActionMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(event, evmEvent);
+    set(groupEvents, undefined);
+    set(duplicateHandlingStatus, undefined);
+    set(ethBlockEventsDecoding, false);
+    set(txEventsDecoding, false);
+  });
+
+  describe('the duplicate actions', () => {
+    it('should offer neither action for a row that is not a duplicate', () => {
+      const { menu } = mountMenu();
+
+      expect(get(menu.isAutoFixable)).toBe(false);
+      expect(get(menu.isDuplicate)).toBe(false);
+    });
+
+    it('should offer both actions for an auto-fixable duplicate', () => {
+      set(duplicateHandlingStatus, DuplicateHandlingStatus.AUTO_FIX);
+      const { menu } = mountMenu();
+
+      expect(get(menu.isAutoFixable)).toBe(true);
+      expect(get(menu.isDuplicate)).toBe(true);
+    });
+
+    it('should offer only the dismissal for a duplicate needing review', () => {
+      set(duplicateHandlingStatus, DuplicateHandlingStatus.MANUAL_REVIEW);
+      const { menu } = mountMenu();
+
+      expect(get(menu.isAutoFixable)).toBe(false);
+      expect(get(menu.isDuplicate)).toBe(true);
+    });
+
+    it('should offer neither action for a duplicate already dismissed', () => {
+      set(duplicateHandlingStatus, DuplicateHandlingStatus.IGNORED);
+      const { menu } = mountMenu();
+
+      expect(get(menu.isAutoFixable)).toBe(false);
+      expect(get(menu.isDuplicate)).toBe(false);
+    });
+
+    it('should fix the row group and report it back', () => {
+      const { menu } = mountMenu();
+
+      menu.confirmFixDuplicate();
+
+      expect(confirmAndFixDuplicate).toHaveBeenCalledWith(['group-a'], expect.any(Function));
+      const [, onDone] = confirmAndFixDuplicate.mock.calls[0];
+      onDone();
+      expect(onFixDuplicate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should dismiss the row group and report it back', () => {
+      const { menu } = mountMenu();
+
+      menu.confirmIgnoreDuplicate();
+
+      expect(confirmAndMarkNonDuplicated).toHaveBeenCalledWith(['group-a'], expect.any(Function));
+      const [, onDone] = confirmAndMarkNonDuplicated.mock.calls[0];
+      onDone();
+      expect(onIgnoreDuplicate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should do nothing when the row belongs to no group', () => {
+      set(event, createEvent({ entryType: HistoryEventEntryType.EVM_EVENT, groupIdentifier: '' }));
+      const { menu } = mountMenu();
+
+      menu.confirmFixDuplicate();
+      menu.confirmIgnoreDuplicate();
+
+      expect(confirmAndFixDuplicate).not.toHaveBeenCalled();
+      expect(confirmAndMarkNonDuplicated).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('adding an event next to the row', () => {
+    it('should offer it for a row that stands for itself', () => {
+      const { menu } = mountMenu();
+
+      expect(get(menu.canAddEvent)).toBe(true);
+    });
+
+    it.each([
+      HistoryEventEntryType.ASSET_MOVEMENT_EVENT,
+      HistoryEventEntryType.SWAP_EVENT,
+    ])('should not offer it for a %s, which is edited as a group', (entryType) => {
+      set(event, createEvent({ entryType }));
+      const { menu } = mountMenu();
+
+      expect(get(menu.canAddEvent)).toBe(false);
+    });
+  });
+
+  describe('the transaction behind the row', () => {
+    it('should read it off an evm event', () => {
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithTxRef)).toStrictEqual({ location: 'ethereum', txRef: '0xabc' });
+    });
+
+    it('should read it off a solana event', () => {
+      set(event, solanaEvent);
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithTxRef)).toStrictEqual({ location: 'solana', txRef: 'sol-sig' });
+    });
+
+    it('should read it off an exchange event that carries one', () => {
+      set(event, createEvent({
+        entryType: HistoryEventEntryType.HISTORY_EVENT,
+        location: 'kraken',
+        txRef: 'withdrawal-ref',
+      }));
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithTxRef)).toStrictEqual({ location: 'kraken', txRef: 'withdrawal-ref' });
+    });
+
+    it('should find none on an exchange event without one', () => {
+      set(event, onlineEvent);
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithTxRef)).toBeUndefined();
+    });
+
+    it('should find none on a block event', () => {
+      set(event, blockEvent);
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithTxRef)).toBeUndefined();
+    });
+  });
+
+  describe('what a re-decode would run on', () => {
+    it('should use the row itself when the row can decode', () => {
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithDecoding)).toBe(evmEvent);
+      expect(get(menu.decodableEvmEvent)).toBe(evmEvent);
+    });
+
+    it('should fall back to the first child that can decode', () => {
+      set(event, onlineEvent);
+      set(groupEvents, [onlineEvent, solanaEvent, evmEvent]);
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithDecoding)).toBe(solanaEvent);
+    });
+
+    it('should offer no decode options for a solana event', () => {
+      set(event, solanaEvent);
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithDecoding)).toBe(solanaEvent);
+      expect(get(menu.decodableEvmEvent)).toBeUndefined();
+    });
+
+    it('should find nothing when neither the row nor its group can decode', () => {
+      set(event, onlineEvent);
+      set(groupEvents, [onlineEvent, blockEvent]);
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithDecoding)).toBeUndefined();
+      expect(get(menu.decodableEvmEvent)).toBeUndefined();
+    });
+
+    it('should find nothing when the row has no group to search', () => {
+      set(event, onlineEvent);
+      const { menu } = mountMenu();
+
+      expect(get(menu.eventWithDecoding)).toBeUndefined();
+    });
+
+    it('should name a block event re-decode by its block number', () => {
+      const { menu } = mountMenu();
+
+      expect(menu.toRedecodePayload(decodableBlock)).toStrictEqual({
+        data: [1234],
+        type: HistoryEventEntryType.ETH_BLOCK_EVENT,
+      });
+    });
+
+    it('should name every other re-decode by its location and transaction', () => {
+      const { menu } = mountMenu();
+
+      expect(menu.toRedecodePayload(decodableEvm)).toStrictEqual({
+        data: { location: 'ethereum', txRef: '0xabc' },
+        type: HistoryEventEntryType.EVM_EVENT,
+      });
+    });
+  });
+
+  describe('deleting the row', () => {
+    it('should offer the events delete only when there is no transaction and no block', () => {
+      set(event, onlineEvent);
+      const { menu } = mountMenu();
+
+      expect(get(menu.canDeleteEvents)).toBe(true);
+    });
+
+    it('should not offer it when the row belongs to a transaction', () => {
+      const { menu } = mountMenu();
+
+      expect(get(menu.canDeleteEvents)).toBe(false);
+    });
+
+    it('should not offer it for a block event', () => {
+      set(event, blockEvent);
+      const { menu } = mountMenu();
+
+      expect(get(menu.canDeleteEvents)).toBe(false);
+    });
+
+    it('should delete the whole group when the row stands for one', () => {
+      set(groupEvents, [createEvent({ identifier: 7 }), createEvent({ identifier: 9 })]);
+      const { menu } = mountMenu();
+
+      expect(menu.deletableEventIds()).toStrictEqual([7, 9]);
+    });
+
+    it('should delete only the row when it stands for itself', () => {
+      set(event, createEvent({ entryType: HistoryEventEntryType.HISTORY_EVENT, identifier: 42 }));
+      const { menu } = mountMenu();
+
+      expect(menu.deletableEventIds()).toStrictEqual([42]);
+    });
+  });
+
+  describe('reporting an issue', () => {
+    it('should name the transaction the row belongs to', () => {
+      const { menu } = mountMenu();
+
+      menu.openReportDialog();
+
+      const [{ description, title }] = showReportIssue.mock.calls[0];
+      expect(title).toBe('actions.history_events.report_issue.title');
+      expect(description).toContain('actions.history_events.report_issue.tx_hash::0xabc');
+      expect(description).toContain('actions.history_events.report_issue.location::ethereum');
+    });
+
+    it('should leave the transaction line out when the row has none', () => {
+      set(event, onlineEvent);
+      const { menu } = mountMenu();
+
+      menu.openReportDialog();
+
+      const [{ description }] = showReportIssue.mock.calls[0];
+      expect(description).not.toContain('actions.history_events.report_issue.tx_hash');
+      expect(description).toContain('actions.history_events.report_issue.location::kraken');
+    });
+  });
+
+  describe('the decode already in flight', () => {
+    it('should forward both decoding flags', () => {
+      set(ethBlockEventsDecoding, true);
+      const { menu } = mountMenu();
+
+      expect(get(menu.ethBlockEventsDecoding)).toBe(true);
+      expect(get(menu.txEventsDecoding)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-event-action-menu.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-action-menu.ts
@@ -1,0 +1,250 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { PullEventPayload } from '@/modules/history/events/event-payloads';
+import type {
+  EthBlockEvent,
+  EvmHistoryEvent,
+  EvmSwapEvent,
+  HistoryEventEntry,
+  SolanaEvent,
+  SolanaSwapEvent,
+} from '@/modules/history/events/schemas';
+import { useReportIssue } from '@/modules/core/common/use-report-issue';
+import {
+  isEthBlockEvent,
+  isEthBlockEventRef,
+  isEvmEvent,
+  isEvmSwapEvent,
+  isOnlineHistoryEvent,
+  isSolanaEvent,
+  isSolanaSwapEvent,
+  toLocationAndTxRef,
+} from '@/modules/history/event-utils';
+import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import { useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
+import { useHistoryEventsStatus } from '@/modules/history/events/use-history-events-status';
+import {
+  type DecodableEventType,
+  isGroupEditableHistoryEvent,
+} from '@/modules/history/management/forms/form-guards';
+
+interface TransactionRef {
+  location: string;
+  txRef: string;
+}
+
+export interface UseHistoryEventActionMenuOptions {
+  /** The row the menu belongs to. */
+  event: () => HistoryEventEntry;
+  /** The other events in the row's group, when the row stands for a group. */
+  groupEvents: () => HistoryEventEntry[] | undefined;
+  /** Which duplicate bucket the row is in, if any. */
+  duplicateHandlingStatus: () => DuplicateHandlingStatus | undefined;
+  /** Called once the row's duplicate has been fixed. */
+  onFixDuplicate: () => void;
+  /** Called once the row has been marked as not a duplicate. */
+  onIgnoreDuplicate: () => void;
+}
+
+export interface UseHistoryEventActionMenuReturn {
+  /** Whether the row's duplicate can be fixed without asking the user to choose. */
+  isAutoFixable: ComputedRef<boolean>;
+  /** Whether the row is a duplicate that has not been dismissed. */
+  isDuplicate: ComputedRef<boolean>;
+  /** Whether a fix is in flight. */
+  fixLoading: Ref<boolean>;
+  /** Whether a dismissal is in flight. */
+  ignoreLoading: Ref<boolean>;
+  /** Whether a decode of every block event is already running. */
+  ethBlockEventsDecoding: Ref<boolean>;
+  /** Whether a decode of every transaction is already running. */
+  txEventsDecoding: Ref<boolean>;
+  /** Whether an event can be added next to this row. */
+  canAddEvent: ComputedRef<boolean>;
+  /** The row as a block event, when it is one. */
+  blockEvent: ComputedRef<EthBlockEvent | undefined>;
+  /** The event a re-decode would run on: the row itself, or the first child that can decode. */
+  eventWithDecoding: ComputedRef<DecodableEventType | undefined>;
+  /** That same event when it is an EVM one, which is the only kind with decode options. */
+  decodableEvmEvent: ComputedRef<EvmHistoryEvent | EvmSwapEvent | undefined>;
+  /** The transaction the row belongs to, when it belongs to one. */
+  eventWithTxRef: ComputedRef<TransactionRef | undefined>;
+  /** Whether the row's events can be deleted on their own, without a transaction. */
+  canDeleteEvents: ComputedRef<boolean>;
+  /** The re-decode request for an event, which a block event names differently. */
+  toRedecodePayload: (event: EthBlockEvent | DecodableEventType) => PullEventPayload;
+  /** Every event a delete would remove: the whole group, or the row on its own. */
+  deletableEventIds: () => number[];
+  /** Open the issue reporter, pre-filled with what identifies this row. */
+  openReportDialog: () => void;
+  /** Ask before fixing the row's duplicate. */
+  confirmFixDuplicate: () => void;
+  /** Ask before marking the row as not a duplicate. */
+  confirmIgnoreDuplicate: () => void;
+}
+
+/**
+ * Everything the row's action menu has to work out about its event: which actions apply, what
+ * they act on, and what each request looks like.
+ *
+ * ⚠️ A row is not always the event an action runs on: a re-decode runs on the first decodable event
+ * in the group (possibly a child), a delete removes the whole group, and a block event names its
+ * re-decode by block number where everything else names it by location and transaction reference.
+ */
+export function useHistoryEventActionMenu(
+  options: UseHistoryEventActionMenuOptions,
+): UseHistoryEventActionMenuReturn {
+  const { duplicateHandlingStatus, event, groupEvents, onFixDuplicate, onIgnoreDuplicate } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { ethBlockEventsDecoding, txEventsDecoding } = useHistoryEventsStatus();
+  const { show: showReportIssue } = useReportIssue();
+  const {
+    confirmAndFixDuplicate,
+    confirmAndMarkNonDuplicated,
+    fixLoading,
+    ignoreLoading,
+  } = useCustomizedEventDuplicates();
+
+  const isAutoFixable = computed<boolean>(() => duplicateHandlingStatus() === DuplicateHandlingStatus.AUTO_FIX);
+
+  const isDuplicate = computed<boolean>(() => {
+    const status = duplicateHandlingStatus();
+    return !!status && status !== DuplicateHandlingStatus.IGNORED;
+  });
+
+  const canAddEvent = computed<boolean>(() => !isGroupEditableHistoryEvent(event()));
+
+  const evmEvent = computed<EvmHistoryEvent | EvmSwapEvent | undefined>(() => {
+    const row = event();
+    if (isEvmSwapEvent(row) || isEvmEvent(row))
+      return row;
+
+    return undefined;
+  });
+
+  const solanaEvent = computed<SolanaEvent | SolanaSwapEvent | undefined>(() => {
+    const row = event();
+    if (isSolanaSwapEvent(row) || isSolanaEvent(row))
+      return row;
+
+    return undefined;
+  });
+
+  const eventWithDecoding = computed<DecodableEventType | undefined>(() => {
+    const direct = get(evmEvent) ?? get(solanaEvent);
+    if (direct)
+      return direct;
+
+    const children = groupEvents();
+    if (!children)
+      return undefined;
+
+    for (const child of children) {
+      if (isEvmEvent(child) || isEvmSwapEvent(child) || isSolanaEvent(child) || isSolanaSwapEvent(child))
+        return child;
+    }
+
+    return undefined;
+  });
+
+  const decodableEvmEvent = computed<EvmHistoryEvent | EvmSwapEvent | undefined>(() => {
+    const decoded = get(eventWithDecoding);
+    if (decoded && (isEvmEvent(decoded) || isEvmSwapEvent(decoded)))
+      return decoded;
+
+    return undefined;
+  });
+
+  const eventWithTxRef = computed<TransactionRef | undefined>(() => {
+    const evm = get(evmEvent);
+    if (evm)
+      return { location: evm.location, txRef: evm.txRef };
+
+    const solana = get(solanaEvent);
+    if (solana)
+      return { location: solana.location, txRef: solana.txRef };
+
+    const row = event();
+    if (isOnlineHistoryEvent(row) && 'txRef' in row && row.txRef)
+      return { location: row.location, txRef: row.txRef };
+
+    return undefined;
+  });
+
+  const blockEvent = isEthBlockEventRef(() => event());
+
+  const canDeleteEvents = computed<boolean>(() => !get(eventWithTxRef) && !get(blockEvent));
+
+  function toRedecodePayload(target: EthBlockEvent | DecodableEventType): PullEventPayload {
+    if (isEthBlockEvent(target)) {
+      return {
+        data: [target.blockNumber],
+        type: target.entryType,
+      };
+    }
+
+    return {
+      data: toLocationAndTxRef(target),
+      type: target.entryType,
+    };
+  }
+
+  function deletableEventIds(): number[] {
+    return groupEvents()?.map(child => child.identifier) ?? [event().identifier];
+  }
+
+  function openReportDialog(): void {
+    const row = event();
+    const txRef = get(eventWithTxRef)?.txRef;
+
+    const description = [
+      t('actions.history_events.report_issue.description_intro'),
+      txRef ? t('actions.history_events.report_issue.tx_hash', { hash: txRef }) : '',
+      t('actions.history_events.report_issue.location', { location: row.location }),
+      '',
+      t('actions.history_events.report_issue.more_detail'),
+      t('actions.history_events.report_issue.placeholder'),
+    ].filter(Boolean).join('\n');
+
+    showReportIssue({
+      description,
+      title: t('actions.history_events.report_issue.title'),
+    });
+  }
+
+  function confirmFixDuplicate(): void {
+    const groupIdentifier = event().groupIdentifier;
+    if (!groupIdentifier)
+      return;
+
+    confirmAndFixDuplicate([groupIdentifier], onFixDuplicate);
+  }
+
+  function confirmIgnoreDuplicate(): void {
+    const groupIdentifier = event().groupIdentifier;
+    if (!groupIdentifier)
+      return;
+
+    confirmAndMarkNonDuplicated([groupIdentifier], onIgnoreDuplicate);
+  }
+
+  return {
+    blockEvent,
+    canAddEvent,
+    canDeleteEvents,
+    confirmFixDuplicate,
+    confirmIgnoreDuplicate,
+    decodableEvmEvent,
+    deletableEventIds,
+    ethBlockEventsDecoding,
+    eventWithDecoding,
+    eventWithTxRef,
+    fixLoading,
+    ignoreLoading,
+    isAutoFixable,
+    isDuplicate,
+    openReportDialog,
+    toRedecodePayload,
+    txEventsDecoding,
+  };
+}

--- a/frontend/app/src/modules/history/events/use-history-events-dialog-container.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-dialog-container.spec.ts
@@ -1,0 +1,242 @@
+import type { DialogState } from '@/modules/history/events/dialog-manager/types';
+import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
+import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { DIALOG_TYPES } from '@/modules/history/events/dialog-types';
+import {
+  useHistoryEventsDialogContainer,
+  type UseHistoryEventsDialogContainerReturn,
+} from '@/modules/history/events/use-history-events-dialog-container';
+
+const closeDialog = vi.fn();
+const show = vi.fn().mockResolvedValue(undefined);
+const currentDialog = ref<DialogState>({ type: 'closed' });
+
+vi.mock('@/modules/history/events/dialog-manager/use-history-events-dialog-manager', () => ({
+  useHistoryEventsDialogManager: (): Record<string, unknown> => ({ closeDialog, currentDialog, show }),
+}));
+
+const onMovementMatched = vi.fn();
+const onBridgeMatched = vi.fn();
+
+interface Harness {
+  wrapper: VueWrapper;
+  container: UseHistoryEventsDialogContainerReturn;
+}
+
+function mountContainer(): Harness {
+  let container!: UseHistoryEventsDialogContainerReturn;
+  const Comp = defineComponent({
+    setup(): () => null {
+      container = useHistoryEventsDialogContainer({ onBridgeMatched, onMovementMatched });
+      return (): null => null;
+    },
+  });
+  const wrapper = mount(Comp);
+  return { container, wrapper };
+}
+
+const movement = createMock<UnmatchedAssetMovement>({ groupIdentifier: 'group-a' });
+const transaction = createMock<UnmatchedBridgeTransaction>({ groupIdentifier: 'group-b' });
+
+describe('useHistoryEventsDialogContainer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(currentDialog, { type: 'closed' });
+    show.mockResolvedValue(undefined);
+  });
+
+  describe('reading a form back off the open dialog', () => {
+    it('should hand the event form the data the manager holds', () => {
+      const data = createMock<Extract<DialogState, { type: 'eventForm' }>['data']>({});
+      set(currentDialog, { data, type: DIALOG_TYPES.EVENT_FORM });
+      const { container } = mountContainer();
+
+      expect(get(container.modelFormData)).toBe(data);
+    });
+
+    it('should hand the event form nothing while another dialog is open', () => {
+      set(currentDialog, { data: undefined, type: DIALOG_TYPES.PROTOCOL_CACHE });
+      const { container } = mountContainer();
+
+      expect(get(container.modelFormData)).toBeUndefined();
+    });
+
+    it('should treat a write to the event form as a close', () => {
+      const { container } = mountContainer();
+
+      set(container.modelFormData, undefined);
+
+      expect(closeDialog).toHaveBeenCalledTimes(1);
+    });
+
+    it('should hand the missing rules dialog the data the manager holds', () => {
+      const data = createMock<Extract<DialogState, { type: 'missingRules' }>['data']>({});
+      set(currentDialog, { data, type: DIALOG_TYPES.MISSING_RULES });
+      const { container } = mountContainer();
+
+      expect(get(container.modelMissingRule)).toBe(data);
+    });
+
+    it('should treat a write to the missing rules dialog as a close', () => {
+      const { container } = mountContainer();
+
+      set(container.modelMissingRule, undefined);
+
+      expect(closeDialog).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('the dialogs that are open because they are rendered', () => {
+    it('should always read as open', () => {
+      const { container } = mountContainer();
+
+      expect(get(container.modelDialogOpen)).toBe(true);
+    });
+
+    it('should close the manager dialog when written to', () => {
+      const { container } = mountContainer();
+
+      set(container.modelDialogOpen, false);
+
+      expect(closeDialog).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('the decoding status dialog', () => {
+    it('should not be persistent by default', () => {
+      set(currentDialog, { data: { persistent: false }, type: DIALOG_TYPES.DECODING_STATUS });
+      const { container } = mountContainer();
+
+      expect(get(container.decodingStatusPersistent)).toBe(false);
+    });
+
+    it('should be persistent when the manager asked for it', () => {
+      set(currentDialog, { data: { persistent: true }, type: DIALOG_TYPES.DECODING_STATUS });
+      const { container } = mountContainer();
+
+      expect(get(container.decodingStatusPersistent)).toBe(true);
+    });
+
+    it('should not be persistent while a different dialog is open', () => {
+      set(currentDialog, { data: undefined, type: DIALOG_TYPES.PROTOCOL_CACHE });
+      const { container } = mountContainer();
+
+      expect(get(container.decodingStatusPersistent)).toBe(false);
+    });
+  });
+
+  describe('the add transaction form', () => {
+    it('should read the payload the manager holds', () => {
+      const data = { associatedAddress: '0x1', blockchain: 'eth', txRef: '0xabc' };
+      set(currentDialog, { data, type: DIALOG_TYPES.TRANSACTION_FORM });
+      const { container } = mountContainer();
+
+      expect(get(container.modelAddTransaction)).toStrictEqual(data);
+    });
+
+    it('should push an edited payload back through the manager', () => {
+      const { container } = mountContainer();
+      const data = { associatedAddress: '0x2', blockchain: 'eth', txRef: '0xdef' };
+
+      set(container.modelAddTransaction, data);
+
+      expect(show).toHaveBeenCalledWith({ data, type: DIALOG_TYPES.TRANSACTION_FORM });
+      expect(closeDialog).not.toHaveBeenCalled();
+    });
+
+    it('should close the dialog when the payload is cleared', () => {
+      const { container } = mountContainer();
+
+      set(container.modelAddTransaction, undefined);
+
+      expect(closeDialog).toHaveBeenCalledTimes(1);
+      expect(show).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the movement potential matches dialog', () => {
+    it('should stay closed until a movement is chosen', () => {
+      const { container } = mountContainer();
+
+      expect(get(container.movementSubject)).toBeUndefined();
+      expect(get(container.modelMovementMatchesOpen)).toBe(false);
+    });
+
+    it('should open on the movement it is given', () => {
+      const { container } = mountContainer();
+
+      container.openMovementMatches(movement);
+
+      expect(get(container.movementSubject)).toBe(movement);
+      expect(get(container.modelMovementMatchesOpen)).toBe(true);
+    });
+
+    it('should drop the movement and report the match', () => {
+      const { container } = mountContainer();
+      container.openMovementMatches(movement);
+
+      container.onMovementMatched();
+
+      expect(get(container.movementSubject)).toBeUndefined();
+      expect(onMovementMatched).toHaveBeenCalledTimes(1);
+      expect(closeDialog).not.toHaveBeenCalled();
+    });
+
+    it('should close the dialog behind it when the list is pinned', () => {
+      const { container } = mountContainer();
+      container.openMovementMatches(movement);
+
+      container.onMovementPinned();
+
+      expect(get(container.movementSubject)).toBeUndefined();
+      expect(closeDialog).toHaveBeenCalledTimes(1);
+      expect(onMovementMatched).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the bridge potential matches dialog', () => {
+    it('should open on the transaction it is given', () => {
+      const { container } = mountContainer();
+
+      container.openBridgeMatches(transaction);
+
+      expect(get(container.bridgeSubject)).toBe(transaction);
+      expect(get(container.modelBridgeMatchesOpen)).toBe(true);
+    });
+
+    it('should drop the transaction and report the match', () => {
+      const { container } = mountContainer();
+      container.openBridgeMatches(transaction);
+
+      container.onBridgeMatched();
+
+      expect(get(container.bridgeSubject)).toBeUndefined();
+      expect(onBridgeMatched).toHaveBeenCalledTimes(1);
+    });
+
+    it('should close the dialog behind it when the list is pinned', () => {
+      const { container } = mountContainer();
+      container.openBridgeMatches(transaction);
+
+      container.onBridgePinned();
+
+      expect(get(container.bridgeSubject)).toBeUndefined();
+      expect(closeDialog).toHaveBeenCalledTimes(1);
+      expect(onBridgeMatched).not.toHaveBeenCalled();
+    });
+
+    it('should keep the two dialogs apart', () => {
+      const { container } = mountContainer();
+
+      container.openMovementMatches(movement);
+      container.onBridgeMatched();
+
+      expect(get(container.movementSubject)).toBe(movement);
+      expect(get(container.modelMovementMatchesOpen)).toBe(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-dialog-container.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-dialog-container.ts
@@ -1,0 +1,174 @@
+import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import type { DialogState } from '@/modules/history/events/dialog-manager/types';
+import type { AddTransactionHashPayload } from '@/modules/history/events/event-payloads';
+import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
+import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
+import type {
+  GroupEventData,
+  HistoryEventEditData,
+  StandaloneEventData,
+} from '@/modules/history/management/forms/form-types';
+import { startPromise } from '@shared/utils';
+import { useHistoryEventsDialogManager } from '@/modules/history/events/dialog-manager/use-history-events-dialog-manager';
+import { DIALOG_TYPES, type DialogShowOptions } from '@/modules/history/events/dialog-types';
+
+interface PotentialMatchesState<T> {
+  subject: Readonly<Ref<T | undefined>>;
+  modelOpen: Ref<boolean>;
+  open: (subject: T) => void;
+  onMatched: () => void;
+  onPinned: () => void;
+}
+
+export interface UseHistoryEventsDialogContainerOptions {
+  /** Called once an asset movement has been matched. */
+  onMovementMatched: () => void;
+  /** Called once a bridge transaction has been matched. */
+  onBridgeMatched: () => void;
+}
+
+export interface UseHistoryEventsDialogContainerReturn {
+  /** Which dialog the manager currently has open. */
+  currentDialog: Readonly<Ref<DialogState>>;
+  /** Open a dialog through the manager. */
+  show: (options: DialogShowOptions) => Promise<void>;
+  /** Close whatever the manager has open. */
+  closeDialog: () => void;
+  /** `v-model` for the event form, which reads its data off the open dialog. */
+  modelFormData: WritableComputedRef<GroupEventData | StandaloneEventData | undefined>;
+  /** `v-model` for the missing rules dialog. */
+  modelMissingRule: WritableComputedRef<HistoryEventEditData | undefined>;
+  /** `v-model` for every dialog that is open purely because it is rendered. */
+  modelDialogOpen: WritableComputedRef<boolean>;
+  /** `v-model` for the add-transaction form, which the manager stores rather than the component. */
+  modelAddTransaction: WritableComputedRef<AddTransactionHashPayload | undefined>;
+  /** Whether the decoding status dialog refuses to close on a click outside. */
+  decodingStatusPersistent: ComputedRef<boolean>;
+  /** The movement whose potential matches are being shown, if any. */
+  movementSubject: Readonly<Ref<UnmatchedAssetMovement | undefined>>;
+  /** `v-model` for the movement potential-matches dialog. */
+  modelMovementMatchesOpen: Ref<boolean>;
+  /** Open the movement potential-matches dialog on a movement. */
+  openMovementMatches: (movement: UnmatchedAssetMovement) => void;
+  /** A movement was matched: drop it and tell the page to reload. */
+  onMovementMatched: () => void;
+  /** The movement list moved into the pinned rail: drop it and close the dialog behind it. */
+  onMovementPinned: () => void;
+  /** The bridge transaction whose potential matches are being shown, if any. */
+  bridgeSubject: Readonly<Ref<UnmatchedBridgeTransaction | undefined>>;
+  /** `v-model` for the bridge potential-matches dialog. */
+  modelBridgeMatchesOpen: Ref<boolean>;
+  /** Open the bridge potential-matches dialog on a transaction. */
+  openBridgeMatches: (transaction: UnmatchedBridgeTransaction) => void;
+  /** A bridge transaction was matched: drop it and tell the page to reload. */
+  onBridgeMatched: () => void;
+  /** The bridge list moved into the pinned rail: drop it and close the dialog behind it. */
+  onBridgePinned: () => void;
+}
+
+/**
+ * The models behind the dialog container.
+ *
+ * A manager-owned dialog is rendered by a `v-if` on the open dialog's type, so it is always "open"
+ * while it exists and its `v-model` only has to answer a close; the data it edits is read back off
+ * the manager's dialog state and narrowed here. The two potential-matches dialogs are opened by the
+ * dialog above them rather than by the manager, so the container holds their state itself.
+ */
+export function useHistoryEventsDialogContainer(
+  options: UseHistoryEventsDialogContainerOptions,
+): UseHistoryEventsDialogContainerReturn {
+  const { onBridgeMatched, onMovementMatched } = options;
+
+  const { closeDialog, currentDialog, show } = useHistoryEventsDialogManager();
+
+  // Dialogs only render when they match the type (v-if), so reading the data back off the
+  // open dialog is safe, and a write can only ever mean "close me".
+  const modelFormData = computed({
+    get: () => {
+      const dialog = get(currentDialog);
+      return dialog.type === DIALOG_TYPES.EVENT_FORM ? dialog.data : undefined;
+    },
+    set: () => closeDialog(), // Dialog components handle their own closing
+  });
+
+  const modelMissingRule = computed({
+    get: () => {
+      const dialog = get(currentDialog);
+      return dialog.type === DIALOG_TYPES.MISSING_RULES ? dialog.data : undefined;
+    },
+    set: () => closeDialog(),
+  });
+
+  const modelDialogOpen = computed({
+    get: () => true, // Always true when dialog is rendered (due to v-if)
+    set: () => closeDialog(),
+  });
+
+  const decodingStatusPersistent = computed<boolean>(() => {
+    const dialog = get(currentDialog);
+    return dialog.type === DIALOG_TYPES.DECODING_STATUS ? (dialog.data?.persistent ?? false) : false;
+  });
+
+  const modelAddTransaction = computed({
+    get: () => {
+      const dialog = get(currentDialog);
+      return dialog.type === DIALOG_TYPES.TRANSACTION_FORM ? dialog.data : undefined;
+    },
+    set: (value: AddTransactionHashPayload | undefined) => {
+      if (value) {
+        startPromise(show({ data: value, type: DIALOG_TYPES.TRANSACTION_FORM }));
+      }
+      else {
+        closeDialog();
+      }
+    },
+  });
+
+  function createPotentialMatches<T>(onMatched: () => void): PotentialMatchesState<T> {
+    const subject = shallowRef<T>();
+    const modelOpen = shallowRef<boolean>(false);
+
+    return {
+      modelOpen,
+      onMatched: (): void => {
+        set(subject, undefined);
+        onMatched();
+      },
+      onPinned: (): void => {
+        set(subject, undefined);
+        closeDialog();
+      },
+      open: (target: T): void => {
+        set(subject, target);
+        set(modelOpen, true);
+      },
+      subject: shallowReadonly(subject),
+    };
+  }
+
+  // Flattened rather than returned as two nested objects: a template only unwraps refs that
+  // are top-level setup bindings, so `matches.modelOpen` would reach `v-model` as the ref.
+  const movement = createPotentialMatches<UnmatchedAssetMovement>(onMovementMatched);
+  const bridge = createPotentialMatches<UnmatchedBridgeTransaction>(onBridgeMatched);
+
+  return {
+    bridgeSubject: bridge.subject,
+    closeDialog,
+    currentDialog,
+    decodingStatusPersistent,
+    modelAddTransaction,
+    modelBridgeMatchesOpen: bridge.modelOpen,
+    modelDialogOpen,
+    modelFormData,
+    modelMissingRule,
+    modelMovementMatchesOpen: movement.modelOpen,
+    movementSubject: movement.subject,
+    onBridgeMatched: bridge.onMatched,
+    onBridgePinned: bridge.onPinned,
+    onMovementMatched: movement.onMatched,
+    onMovementPinned: movement.onPinned,
+    openBridgeMatches: bridge.open,
+    openMovementMatches: movement.open,
+    show,
+  };
+}

--- a/frontend/app/src/modules/history/events/use-history-events-filters-chips.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-filters-chips.spec.ts
@@ -1,0 +1,360 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import {
+  useHistoryEventsFiltersChips,
+  type UseHistoryEventsFiltersChipsReturn,
+} from '@/modules/history/events/use-history-events-filters-chips';
+
+const routerPush = vi.fn().mockResolvedValue(undefined);
+const routerReplace = vi.fn().mockResolvedValue(undefined);
+const routeQuery = ref<Record<string, unknown>>({});
+
+const { useRouteMock, useRouterMock } = vi.hoisted(() => ({
+  useRouteMock: vi.fn(),
+  useRouterMock: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: useRouteMock,
+  useRouter: useRouterMock,
+}));
+
+const show = vi.fn();
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({ show }),
+}));
+
+const autoFixGroupIds = ref<string[]>([]);
+const manualReviewGroupIds = ref<string[]>([]);
+const fixLoading = ref<boolean>(false);
+const fixDuplicates = vi.fn().mockResolvedValue({ success: true });
+
+vi.mock('@/modules/history/events/use-customized-event-duplicates', () => ({
+  useCustomizedEventDuplicates: (): Record<string, unknown> => ({
+    autoFixGroupIds,
+    fixDuplicates,
+    fixLoading,
+    manualReviewGroupIds,
+  }),
+}));
+
+const groupIdentifiers = ref<string[] | undefined>();
+const duplicateHandlingStatus = ref<DuplicateHandlingStatus | undefined>();
+const onRefresh = vi.fn();
+
+interface Harness {
+  wrapper: VueWrapper;
+  chips: UseHistoryEventsFiltersChipsReturn;
+}
+
+function mountChips(): Harness {
+  let chips!: UseHistoryEventsFiltersChipsReturn;
+  const Comp = defineComponent({
+    setup(): () => null {
+      chips = useHistoryEventsFiltersChips({
+        duplicateHandlingStatus: () => get(duplicateHandlingStatus),
+        groupIdentifiers: () => get(groupIdentifiers),
+        onRefresh,
+      });
+      return (): null => null;
+    },
+  });
+  const wrapper = mount(Comp);
+  return { chips, wrapper };
+}
+
+describe('useHistoryEventsFiltersChips', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(routeQuery, {});
+    set(autoFixGroupIds, []);
+    set(manualReviewGroupIds, []);
+    set(fixLoading, false);
+    set(groupIdentifiers, undefined);
+    set(duplicateHandlingStatus, undefined);
+    fixDuplicates.mockResolvedValue({ success: true });
+    routerPush.mockResolvedValue(undefined);
+    routerReplace.mockResolvedValue(undefined);
+    useRouteMock.mockReturnValue(computed(() => ({ query: get(routeQuery) })));
+    useRouterMock.mockReturnValue({ push: routerPush, replace: routerReplace });
+  });
+
+  describe('which chips are shown', () => {
+    it('should show nothing for an empty query', () => {
+      const { chips } = mountChips();
+
+      expect(get(chips.showMissingAcquisition)).toBe(false);
+      expect(get(chips.showNegativeBalance)).toBe(false);
+      expect(get(chips.showAccountingEvent)).toBe(false);
+      expect(get(chips.showDuplicates)).toBe(false);
+    });
+
+    it('should show a chip for each filter the query carries', () => {
+      set(routeQuery, {
+        highlightedAccountingEvent: '3',
+        highlightedNegativeBalanceEvent: '2',
+        missingAcquisitionIdentifier: '1',
+      });
+      const { chips } = mountChips();
+
+      expect(get(chips.showMissingAcquisition)).toBe(true);
+      expect(get(chips.showNegativeBalance)).toBe(true);
+      expect(get(chips.showAccountingEvent)).toBe(true);
+    });
+
+    it('should not show the duplicate chip for an empty group list', () => {
+      set(groupIdentifiers, []);
+      const { chips } = mountChips();
+
+      expect(get(chips.showDuplicates)).toBe(false);
+    });
+
+    it('should show the duplicate chip once groups are pinned', () => {
+      set(groupIdentifiers, ['g1']);
+      const { chips } = mountChips();
+
+      expect(get(chips.showDuplicates)).toBe(true);
+    });
+
+    it('should name the bucket the pinned groups came from', () => {
+      set(groupIdentifiers, ['g1']);
+      set(duplicateHandlingStatus, DuplicateHandlingStatus.AUTO_FIX);
+      const { chips } = mountChips();
+
+      expect(get(chips.isAutoFixable)).toBe(true);
+      expect(get(chips.duplicateChipText)).toBe('customized_event_duplicates.chips.viewing_auto_fixable');
+
+      set(duplicateHandlingStatus, DuplicateHandlingStatus.MANUAL_REVIEW);
+
+      expect(get(chips.isAutoFixable)).toBe(false);
+      expect(get(chips.duplicateChipText)).toBe('customized_event_duplicates.chips.viewing_manual_review');
+    });
+  });
+
+  describe('closing a chip', () => {
+    beforeEach(() => {
+      set(routeQuery, {
+        duplicateHandlingStatus: 'auto_fix',
+        groupIdentifiers: 'g1',
+        highlightedAccountingEvent: '3',
+        highlightedNegativeBalanceEvent: '2',
+        missingAcquisitionIdentifier: '1',
+        targetGroupIdentifier: 'g1',
+      });
+    });
+
+    it('should drop only the missing acquisition key', () => {
+      const { chips } = mountChips();
+
+      chips.removeMissingAcquisitionParam();
+
+      expect(routerPush).toHaveBeenCalledWith({
+        query: {
+          duplicateHandlingStatus: 'auto_fix',
+          groupIdentifiers: 'g1',
+          highlightedAccountingEvent: '3',
+          highlightedNegativeBalanceEvent: '2',
+          targetGroupIdentifier: 'g1',
+        },
+      });
+    });
+
+    it('should drop the negative balance key and the group it targets', () => {
+      const { chips } = mountChips();
+
+      chips.removeNegativeBalanceParam();
+
+      const [{ query }] = routerPush.mock.calls[0];
+      expect(query).not.toHaveProperty('highlightedNegativeBalanceEvent');
+      expect(query).not.toHaveProperty('targetGroupIdentifier');
+      expect(query).toHaveProperty('highlightedAccountingEvent', '3');
+    });
+
+    it('should drop the accounting divergence key and the group it targets', () => {
+      const { chips } = mountChips();
+
+      chips.removeAccountingEventParam();
+
+      const [{ query }] = routerPush.mock.calls[0];
+      expect(query).not.toHaveProperty('highlightedAccountingEvent');
+      expect(query).not.toHaveProperty('targetGroupIdentifier');
+      expect(query).toHaveProperty('highlightedNegativeBalanceEvent', '2');
+    });
+
+    it('should drop both duplicate keys', () => {
+      const { chips } = mountChips();
+
+      chips.removeDuplicateEventsParam();
+
+      const [{ query }] = routerPush.mock.calls[0];
+      expect(query).not.toHaveProperty('groupIdentifiers');
+      expect(query).not.toHaveProperty('duplicateHandlingStatus');
+      expect(query).toHaveProperty('missingAcquisitionIdentifier', '1');
+    });
+  });
+
+  describe('drift between the URL and the backend', () => {
+    beforeEach(() => {
+      set(duplicateHandlingStatus, DuplicateHandlingStatus.AUTO_FIX);
+    });
+
+    it('should report no drift while the two agree', () => {
+      set(groupIdentifiers, ['g1', 'g2']);
+      set(autoFixGroupIds, ['g1', 'g2']);
+      const { chips } = mountChips();
+
+      expect(get(chips.hasDuplicateChanges)).toBe(false);
+      expect(get(chips.allDuplicatesResolved)).toBe(false);
+      expect(get(chips.duplicateChangesMessage)).toBe('');
+    });
+
+    it('should count the pinned groups that are no longer duplicates', () => {
+      set(groupIdentifiers, ['g1', 'g2']);
+      set(autoFixGroupIds, ['g1']);
+      const { chips } = mountChips();
+
+      expect(get(chips.hasDuplicateChanges)).toBe(true);
+      expect(get(chips.duplicateChangesMessage)).toBe('customized_event_duplicates.chips.resolved_count::1');
+    });
+
+    it('should count the duplicates that showed up after the URL was written', () => {
+      set(groupIdentifiers, ['g1']);
+      set(autoFixGroupIds, ['g1', 'g3']);
+      const { chips } = mountChips();
+
+      expect(get(chips.hasDuplicateChanges)).toBe(true);
+      expect(get(chips.duplicateChangesMessage)).toBe('customized_event_duplicates.chips.added_count::1');
+    });
+
+    it('should report both counts at once', () => {
+      set(groupIdentifiers, ['g1', 'g2']);
+      set(autoFixGroupIds, ['g1', 'g3']);
+      const { chips } = mountChips();
+
+      expect(get(chips.duplicateChangesMessage))
+        .toBe('customized_event_duplicates.chips.resolved_count::1 customized_event_duplicates.chips.added_count::1');
+    });
+
+    it('should say everything is resolved when nothing pinned is left', () => {
+      set(groupIdentifiers, ['g1', 'g2']);
+      set(autoFixGroupIds, []);
+      const { chips } = mountChips();
+
+      expect(get(chips.allDuplicatesResolved)).toBe(true);
+      expect(get(chips.duplicateChangesMessage)).toBe('customized_event_duplicates.chips.all_resolved');
+    });
+
+    it('should read the manual review bucket when that is the one shown', () => {
+      set(duplicateHandlingStatus, DuplicateHandlingStatus.MANUAL_REVIEW);
+      set(groupIdentifiers, ['g1']);
+      set(autoFixGroupIds, []);
+      set(manualReviewGroupIds, ['g1']);
+      const { chips } = mountChips();
+
+      expect(get(chips.hasDuplicateChanges)).toBe(false);
+      expect(get(chips.allDuplicatesResolved)).toBe(false);
+    });
+
+    it('should report no drift while nothing is pinned', () => {
+      set(autoFixGroupIds, ['g1']);
+      const { chips } = mountChips();
+
+      expect(get(chips.hasDuplicateChanges)).toBe(false);
+      expect(get(chips.allDuplicatesResolved)).toBe(false);
+    });
+  });
+
+  describe('re-pointing the URL at the current duplicates', () => {
+    beforeEach(() => {
+      set(routeQuery, { duplicateHandlingStatus: 'auto_fix', groupIdentifiers: 'g1,g2' });
+      set(duplicateHandlingStatus, DuplicateHandlingStatus.AUTO_FIX);
+      set(groupIdentifiers, ['g1', 'g2']);
+    });
+
+    it('should replace the pinned groups with what is still a duplicate', () => {
+      set(autoFixGroupIds, ['g1', 'g3']);
+      const { chips } = mountChips();
+
+      chips.refreshDuplicateView();
+
+      expect(routerReplace).toHaveBeenCalledWith({
+        query: { duplicateHandlingStatus: 'auto_fix', groupIdentifiers: 'g1,g3' },
+      });
+      expect(routerPush).not.toHaveBeenCalled();
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('should drop the filter entirely when nothing is a duplicate any more', () => {
+      set(autoFixGroupIds, []);
+      const { chips } = mountChips();
+
+      chips.refreshDuplicateView();
+
+      expect(routerReplace).not.toHaveBeenCalled();
+      const [{ query }] = routerPush.mock.calls[0];
+      expect(query).not.toHaveProperty('groupIdentifiers');
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('fixing the shown duplicates', () => {
+    beforeEach(() => {
+      set(routeQuery, { duplicateHandlingStatus: 'auto_fix', groupIdentifiers: 'g1,g2' });
+      set(duplicateHandlingStatus, DuplicateHandlingStatus.AUTO_FIX);
+      set(groupIdentifiers, ['g1', 'g2']);
+    });
+
+    async function confirmAndRun(chips: UseHistoryEventsFiltersChipsReturn): Promise<void> {
+      chips.confirmFixDuplicate();
+      const [, onConfirm] = show.mock.calls[0];
+      await onConfirm();
+    }
+
+    it('should ask before fixing anything', () => {
+      const { chips } = mountChips();
+
+      chips.confirmFixDuplicate();
+
+      const [message] = show.mock.calls[0];
+      expect(message).toStrictEqual({
+        message: 'customized_event_duplicates.actions.fix_selected_confirm::2',
+        primaryAction: 'common.actions.confirm',
+        title: 'customized_event_duplicates.actions.fix_selected',
+      });
+      expect(fixDuplicates).not.toHaveBeenCalled();
+    });
+
+    it('should clear the filter and reload once the fix succeeds', async () => {
+      const { chips } = mountChips();
+
+      await confirmAndRun(chips);
+
+      expect(fixDuplicates).toHaveBeenCalledWith(['g1', 'g2']);
+      expect(routerPush).toHaveBeenCalledTimes(1);
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('should leave the filter alone when the fix fails', async () => {
+      fixDuplicates.mockResolvedValue({ message: 'nope', success: false });
+      const { chips } = mountChips();
+
+      await confirmAndRun(chips);
+
+      expect(routerPush).not.toHaveBeenCalled();
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+
+    it('should not call the backend when nothing is pinned', async () => {
+      set(groupIdentifiers, []);
+      const { chips } = mountChips();
+
+      await confirmAndRun(chips);
+
+      expect(fixDuplicates).not.toHaveBeenCalled();
+      expect(onRefresh).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-filters-chips.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-filters-chips.ts
@@ -1,0 +1,215 @@
+import type { ComputedRef, Ref } from 'vue';
+import { startPromise } from '@shared/utils';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
+import { useCustomizedEventDuplicates } from '@/modules/history/events/use-customized-event-duplicates';
+
+export interface UseHistoryEventsFiltersChipsOptions {
+  /** The groups the URL asks the table to show, if any. */
+  groupIdentifiers: () => string[] | undefined;
+  /** Which duplicate bucket those groups came from. */
+  duplicateHandlingStatus: () => DuplicateHandlingStatus | undefined;
+  /** Called when the table has to reload, after a fix or a manual refresh. */
+  onRefresh: () => void;
+}
+
+export interface UseHistoryEventsFiltersChipsReturn {
+  /** Whether the missing-acquisition chip has a filter to show. */
+  showMissingAcquisition: ComputedRef<boolean>;
+  /** Whether the negative-balance chip has a filter to show. */
+  showNegativeBalance: ComputedRef<boolean>;
+  /** Whether the accounting-divergence chip has a filter to show. */
+  showAccountingEvent: ComputedRef<boolean>;
+  /** Whether the duplicate chip has groups to show. */
+  showDuplicates: ComputedRef<boolean>;
+  /** Whether the shown duplicates are the bucket that can be fixed automatically. */
+  isAutoFixable: ComputedRef<boolean>;
+  /** The duplicate chip's own label, which names the bucket. */
+  duplicateChipText: ComputedRef<string>;
+  /** Whether the backend's duplicates have moved on from what the URL asks for. */
+  hasDuplicateChanges: ComputedRef<boolean>;
+  /** Whether nothing the URL asks for is a duplicate any more. */
+  allDuplicatesResolved: ComputedRef<boolean>;
+  /** How the drift from the URL is described to the user. */
+  duplicateChangesMessage: ComputedRef<string>;
+  /** Whether a fix is in flight. */
+  fixLoading: Ref<boolean>;
+  /** Drop the missing-acquisition filter from the URL. */
+  removeMissingAcquisitionParam: () => void;
+  /** Drop the negative-balance filter, and the group it targets, from the URL. */
+  removeNegativeBalanceParam: () => void;
+  /** Drop the accounting-divergence filter, and the group it targets, from the URL. */
+  removeAccountingEventParam: () => void;
+  /** Drop the duplicate filter from the URL. */
+  removeDuplicateEventsParam: () => void;
+  /** Ask for confirmation, then fix every duplicate the chip is showing. */
+  confirmFixDuplicate: () => void;
+  /** Re-point the URL at what is still a duplicate, or drop the filter when nothing is. */
+  refreshDuplicateView: () => void;
+}
+
+/**
+ * The chips above the events table: what each one is showing, and what closing or
+ * acting on it does to the URL.
+ *
+ * Only the duplicate chip has depth: the URL pins a set of groups while the backend keeps
+ * re-deciding which groups are duplicates, so the chip describes the drift between the two and
+ * lets the user re-point the URL at the current answer.
+ */
+export function useHistoryEventsFiltersChips(
+  options: UseHistoryEventsFiltersChipsOptions,
+): UseHistoryEventsFiltersChipsReturn {
+  const { duplicateHandlingStatus, groupIdentifiers, onRefresh } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+  const router = useRouter();
+  const route = useRoute();
+  const { show } = useConfirmStore();
+  const {
+    autoFixGroupIds,
+    fixDuplicates,
+    fixLoading,
+    manualReviewGroupIds,
+  } = useCustomizedEventDuplicates();
+
+  const showMissingAcquisition = computed<boolean>(() => !!get(route).query.missingAcquisitionIdentifier);
+
+  const showNegativeBalance = computed<boolean>(() => !!get(route).query.highlightedNegativeBalanceEvent);
+
+  const showAccountingEvent = computed<boolean>(() => !!get(route).query.highlightedAccountingEvent);
+
+  const showDuplicates = computed<boolean>(() => {
+    const ids = groupIdentifiers();
+    return !!ids && ids.length > 0;
+  });
+
+  const isAutoFixable = computed<boolean>(() => duplicateHandlingStatus() === DuplicateHandlingStatus.AUTO_FIX);
+
+  const duplicateChipText = computed<string>(() => {
+    if (get(isAutoFixable))
+      return t('customized_event_duplicates.chips.viewing_auto_fixable');
+    return t('customized_event_duplicates.chips.viewing_manual_review');
+  });
+
+  // Track the current valid group IDs from the composable
+  const currentValidGroupIds = computed<string[]>(() =>
+    get(isAutoFixable) ? get(autoFixGroupIds) : get(manualReviewGroupIds),
+  );
+
+  // Calculate the difference between URL params and current valid IDs
+  const duplicateChanges = computed<{ resolved: number; added: number; remaining: string[] }>(() => {
+    const urlIds = groupIdentifiers() ?? [];
+    const validIds = get(currentValidGroupIds);
+
+    if (urlIds.length === 0)
+      return { added: 0, remaining: [], resolved: 0 };
+
+    const remaining = urlIds.filter(id => validIds.includes(id));
+    const resolved = urlIds.length - remaining.length;
+    const added = validIds.filter(id => !urlIds.includes(id)).length;
+
+    return { added, remaining, resolved };
+  });
+
+  const hasDuplicateChanges = computed<boolean>(() => {
+    const { added, resolved } = get(duplicateChanges);
+    return resolved > 0 || added > 0;
+  });
+
+  const allDuplicatesResolved = computed<boolean>(() => {
+    const { remaining } = get(duplicateChanges);
+    return get(showDuplicates) && remaining.length === 0;
+  });
+
+  const duplicateChangesMessage = computed<string>(() => {
+    const { added, resolved } = get(duplicateChanges);
+
+    if (get(allDuplicatesResolved))
+      return t('customized_event_duplicates.chips.all_resolved');
+
+    const messages: string[] = [];
+    if (resolved > 0)
+      messages.push(t('customized_event_duplicates.chips.resolved_count', { count: resolved }));
+
+    if (added > 0)
+      messages.push(t('customized_event_duplicates.chips.added_count', { count: added }));
+
+    return messages.join(' ');
+  });
+
+  function pushWithout(...keys: string[]): void {
+    const query = { ...get(route).query };
+    for (const key of keys)
+      delete query[key];
+    startPromise(router.push({ query }));
+  }
+
+  function removeMissingAcquisitionParam(): void {
+    pushWithout('missingAcquisitionIdentifier');
+  }
+
+  function removeNegativeBalanceParam(): void {
+    pushWithout('highlightedNegativeBalanceEvent', 'targetGroupIdentifier');
+  }
+
+  function removeAccountingEventParam(): void {
+    pushWithout('highlightedAccountingEvent', 'targetGroupIdentifier');
+  }
+
+  function removeDuplicateEventsParam(): void {
+    pushWithout('groupIdentifiers', 'duplicateHandlingStatus');
+  }
+
+  async function fixDuplicateEvent(): Promise<void> {
+    const ids = groupIdentifiers();
+    if (!ids || ids.length === 0)
+      return;
+
+    const result = await fixDuplicates(ids);
+    if (result.success) {
+      removeDuplicateEventsParam();
+      onRefresh();
+    }
+  }
+
+  function confirmFixDuplicate(): void {
+    const count = groupIdentifiers()?.length ?? 0;
+    show({
+      message: t('customized_event_duplicates.actions.fix_selected_confirm', { count }),
+      primaryAction: t('common.actions.confirm'),
+      title: t('customized_event_duplicates.actions.fix_selected'),
+    }, async () => fixDuplicateEvent());
+  }
+
+  function refreshDuplicateView(): void {
+    const validIds = get(currentValidGroupIds);
+
+    if (validIds.length === 0) {
+      removeDuplicateEventsParam();
+    }
+    else {
+      const query = { ...get(route).query, groupIdentifiers: validIds.join(',') };
+      startPromise(router.replace({ query }));
+    }
+    onRefresh();
+  }
+
+  return {
+    allDuplicatesResolved,
+    confirmFixDuplicate,
+    duplicateChangesMessage,
+    duplicateChipText,
+    fixLoading,
+    hasDuplicateChanges,
+    isAutoFixable,
+    refreshDuplicateView,
+    removeAccountingEventParam,
+    removeDuplicateEventsParam,
+    removeMissingAcquisitionParam,
+    removeNegativeBalanceParam,
+    showAccountingEvent,
+    showDuplicates,
+    showMissingAcquisition,
+    showNegativeBalance,
+  };
+}

--- a/frontend/app/src/modules/history/events/use-history-events-pill-bar.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-pill-bar.spec.ts
@@ -1,0 +1,214 @@
+import type { MatchedKeywordWithBehaviour } from '@/modules/core/table/filtering';
+import type { SavedView } from '@/modules/core/table/pill/core/saved-view';
+import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import {
+  useHistoryEventsPillBar,
+  type UseHistoryEventsPillBarReturn,
+} from '@/modules/history/events/use-history-events-pill-bar';
+
+const labels = { addFilter: 'Add filter' };
+
+vi.mock('@/modules/core/table/pill/composables/use-pill-bar-labels', () => ({
+  usePillBarLabels: (): unknown => computed(() => labels),
+}));
+
+function emptyToggles(): HistoryEventsToggles {
+  return { matchExactEvents: false, showIgnoredAssets: false, stateMarkers: [] };
+}
+
+const filters = ref<MatchedKeywordWithBehaviour<any>>({});
+const locationLabels = ref<string[]>([]);
+const action = ref<string | undefined>();
+const toggles = ref<HistoryEventsToggles>(emptyToggles());
+
+interface Harness {
+  wrapper: VueWrapper;
+  bar: UseHistoryEventsPillBarReturn;
+}
+
+function mountBar(): Harness {
+  let bar!: UseHistoryEventsPillBarReturn;
+  const Comp = defineComponent({
+    setup(): () => null {
+      bar = useHistoryEventsPillBar({ action, filters, locationLabels, toggles });
+      return (): null => null;
+    },
+  });
+  const wrapper = mount(Comp);
+  return { bar, wrapper };
+}
+
+describe('useHistoryEventsPillBar', () => {
+  beforeEach(() => {
+    set(filters, {});
+    set(locationLabels, []);
+    set(action, undefined);
+    set(toggles, emptyToggles());
+  });
+
+  describe('what the bar is handed', () => {
+    it('should send no params while nothing is filtered', () => {
+      const { bar } = mountBar();
+
+      expect(get(bar.modelPillParams)).toStrictEqual({});
+    });
+
+    it('should send a param for each filter that has a value', () => {
+      set(action, 'deposit');
+      set(locationLabels, ['kraken', 'coinbase']);
+      set(toggles, { matchExactEvents: false, showIgnoredAssets: true, stateMarkers: ['customized'] });
+      const { bar } = mountBar();
+
+      expect(get(bar.modelPillParams)).toStrictEqual({
+        action: 'deposit',
+        locationLabels: ['kraken', 'coinbase'],
+        showIgnoredAssets: true,
+        stateMarkers: ['customized'],
+      });
+    });
+
+    it('should leave the show-ignored param out rather than send it as false', () => {
+      set(toggles, { matchExactEvents: false, showIgnoredAssets: false, stateMarkers: [] });
+      const { bar } = mountBar();
+
+      expect(get(bar.modelPillParams)).not.toHaveProperty('showIgnoredAssets');
+    });
+
+    it('should send an empty action, since that is a value the pill can hold', () => {
+      set(action, '');
+      const { bar } = mountBar();
+
+      expect(get(bar.modelPillParams)).toStrictEqual({ action: '' });
+    });
+
+    it('should not send the match-exact toggle, which is not a pill', () => {
+      set(toggles, { matchExactEvents: true, showIgnoredAssets: false, stateMarkers: [] });
+      const { bar } = mountBar();
+
+      expect(get(bar.modelPillParams)).toStrictEqual({});
+    });
+  });
+
+  describe('what the bar writes back', () => {
+    it('should push each param into the model behind it', () => {
+      const { bar } = mountBar();
+
+      set(bar.modelPillParams, {
+        action: 'withdrawal',
+        locationLabels: ['kraken'],
+        showIgnoredAssets: true,
+        stateMarkers: ['customized'],
+      });
+
+      expect(get(action)).toBe('withdrawal');
+      expect(get(locationLabels)).toStrictEqual(['kraken']);
+      expect(get(toggles)).toStrictEqual({
+        matchExactEvents: false,
+        showIgnoredAssets: true,
+        stateMarkers: ['customized'],
+      });
+    });
+
+    it('should clear every model an absent param stands for', () => {
+      set(action, 'deposit');
+      set(locationLabels, ['kraken']);
+      set(toggles, { matchExactEvents: true, showIgnoredAssets: true, stateMarkers: ['customized'] });
+      const { bar } = mountBar();
+
+      set(bar.modelPillParams, {});
+
+      expect(get(action)).toBeUndefined();
+      expect(get(locationLabels)).toStrictEqual([]);
+      expect(get(toggles)).toStrictEqual({
+        matchExactEvents: true,
+        showIgnoredAssets: false,
+        stateMarkers: [],
+      });
+    });
+
+    it('should accept a single value where a list is expected', () => {
+      const { bar } = mountBar();
+
+      set(bar.modelPillParams, { locationLabels: 'kraken', stateMarkers: 'customized' });
+
+      expect(get(locationLabels)).toStrictEqual(['kraken']);
+      expect(get(toggles).stateMarkers).toStrictEqual(['customized']);
+    });
+
+    it('should drop a state marker the app does not know', () => {
+      const { bar } = mountBar();
+
+      set(bar.modelPillParams, { stateMarkers: ['customized', 'not-a-state'] });
+
+      expect(get(toggles).stateMarkers).toStrictEqual(['customized']);
+    });
+
+    it('should refuse a boolean where a string or list is expected', () => {
+      set(action, 'deposit');
+      set(locationLabels, ['kraken']);
+      const { bar } = mountBar();
+
+      set(bar.modelPillParams, { action: true, locationLabels: true, stateMarkers: true });
+
+      expect(get(action)).toBeUndefined();
+      expect(get(locationLabels)).toStrictEqual([]);
+      expect(get(toggles).stateMarkers).toStrictEqual([]);
+    });
+  });
+
+  describe('the match-exact toggle', () => {
+    it('should flip it without disturbing the other toggles', () => {
+      set(toggles, { matchExactEvents: false, showIgnoredAssets: true, stateMarkers: ['customized'] });
+      const { bar } = mountBar();
+
+      bar.toggleMatchExact();
+
+      expect(get(toggles)).toStrictEqual({
+        matchExactEvents: true,
+        showIgnoredAssets: true,
+        stateMarkers: ['customized'],
+      });
+
+      bar.toggleMatchExact();
+
+      expect(get(toggles).matchExactEvents).toBe(false);
+    });
+  });
+
+  describe('saved views', () => {
+    it('should store the matches and the params together', () => {
+      const matches = { asset: 'ETH' };
+      set(filters, matches);
+      set(action, 'deposit');
+      const { bar } = mountBar();
+
+      expect(get(bar.pillState)).toStrictEqual({ matches, params: { action: 'deposit' } });
+    });
+
+    it('should restore both from a view', () => {
+      set(action, 'deposit');
+      set(locationLabels, ['kraken']);
+      const { bar } = mountBar();
+      const view = createMock<SavedView>({
+        matches: { asset: 'BTC' },
+        params: { locationLabels: ['coinbase'] },
+      });
+
+      bar.applyView(view);
+
+      expect(get(filters)).toStrictEqual({ asset: 'BTC' });
+      expect(get(locationLabels)).toStrictEqual(['coinbase']);
+      expect(get(action)).toBeUndefined();
+    });
+  });
+
+  it('should hand the bar its own labels', () => {
+    const { bar } = mountBar();
+
+    expect(get(bar.pillLabels)).toStrictEqual(labels);
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-pill-bar.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-pill-bar.ts
@@ -1,0 +1,110 @@
+import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import type { MatchedKeywordWithBehaviour } from '@/modules/core/table/filtering';
+import type { SavedViewState } from '@/modules/core/table/pill/composables/use-saved-views';
+import type { SavedView } from '@/modules/core/table/pill/core/saved-view';
+import type { PillBarLabels } from '@/modules/core/table/pill/core/types';
+import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
+import { arrayify } from '@/modules/core/common/data/array';
+import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
+import { isValidHistoryEventState } from '@/modules/history/events/mapping/use-history-event-state-mapping';
+
+/** What the bar puts in, and reads out of, its param bag. */
+type PillParams = Record<string, string | string[] | boolean>;
+
+export interface UseHistoryEventsPillBarOptions {
+  /** The keyword matches the bar owns outright. */
+  filters: Ref<MatchedKeywordWithBehaviour<any>>;
+  /** The accounts pill, which the page also reads on its own. */
+  locationLabels: Ref<string[]>;
+  /** The action pill. */
+  action: Ref<string | undefined>;
+  /** The toggles behind the state and show-ignored pills, plus match-exact, which is not a pill. */
+  toggles: Ref<HistoryEventsToggles>;
+}
+
+export interface UseHistoryEventsPillBarReturn {
+  /** The bar's own labels. */
+  pillLabels: ComputedRef<PillBarLabels>;
+  /** `v-model:params` for the bar, bridged to the page's models. */
+  modelPillParams: WritableComputedRef<PillParams>;
+  /** What a saved view stores: the bar's two models under a name. */
+  pillState: ComputedRef<SavedViewState>;
+  /** Restore both models from a saved view. */
+  applyView: (view: SavedView) => void;
+  /** Constrain the active filters to the events themselves rather than their whole group. */
+  toggleMatchExact: () => void;
+}
+
+/**
+ * The bridge between the pill bar's param bag and the models the events page keeps.
+ *
+ * The account, state and show-ignored filters are param-bound pills (paramKeys `locationLabels`,
+ * `stateMarkers`, `showIgnoredAssets`). An absent param clears its model, which for the boolean is
+ * the pill's whole state: removing it is how it is turned off.
+ */
+export function useHistoryEventsPillBar(
+  options: UseHistoryEventsPillBarOptions,
+): UseHistoryEventsPillBarReturn {
+  const { action, filters, locationLabels, toggles } = options;
+
+  const pillLabels = usePillBarLabels();
+
+  // Not a pill: it constrains how the other filters apply instead of filtering anything itself.
+  function toggleMatchExact(): void {
+    set(toggles, { ...get(toggles), matchExactEvents: !get(toggles).matchExactEvents });
+  }
+
+  const modelPillParams = computed<PillParams>({
+    get(): PillParams {
+      const labels = get(locationLabels);
+      const { showIgnoredAssets, stateMarkers } = get(toggles);
+      const result: PillParams = {};
+      const verb = get(action);
+      if (verb !== undefined)
+        result.action = verb;
+      if (labels.length > 0)
+        result.locationLabels = labels;
+      if (stateMarkers.length > 0)
+        result.stateMarkers = stateMarkers;
+      if (showIgnoredAssets)
+        result.showIgnoredAssets = true;
+      return result;
+    },
+    set(value: PillParams): void {
+      const nextAction = value.action;
+      set(action, typeof nextAction === 'string' ? nextAction : undefined);
+
+      const nextLabels = value.locationLabels;
+      set(locationLabels, nextLabels === undefined || typeof nextLabels === 'boolean' ? [] : arrayify(nextLabels));
+
+      const nextMarkers = value.stateMarkers;
+      set(toggles, {
+        ...get(toggles),
+        showIgnoredAssets: value.showIgnoredAssets === true,
+        stateMarkers: nextMarkers === undefined || typeof nextMarkers === 'boolean'
+          ? []
+          : arrayify(nextMarkers).filter(isValidHistoryEventState),
+      });
+    },
+  });
+
+  // A saved view is the bar's two models under a name, so it both reads from and writes to the
+  // same pair the bar is bound to.
+  const pillState = computed<SavedViewState>(() => ({
+    matches: get(filters),
+    params: get(modelPillParams),
+  }));
+
+  function applyView(view: SavedView): void {
+    set(filters, view.matches);
+    set(modelPillParams, view.params);
+  }
+
+  return {
+    applyView,
+    modelPillParams,
+    pillLabels,
+    pillState,
+    toggleMatchExact,
+  };
+}

--- a/frontend/app/src/modules/history/events/use-history-events-selection-actions.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-selection-actions.ts
@@ -1,4 +1,4 @@
-import type { ComputedRef, Ref } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { UseHistoryEventsSelectionModeReturn } from './use-selection-mode';
 import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
 import type { AccountingRuleEntry } from '@/modules/settings/types/accounting';
@@ -11,8 +11,13 @@ interface UseHistoryEventsSelectionActionsOptions {
   deletion: {
     deleteSelected: () => Promise<void>;
   };
-  /** Unfiltered rows the selection ids are resolved against, so an action still finds an event that the displayed rows hide. */
-  originalGroups: Ref<HistoryEventRow[]>;
+  /**
+   * Unfiltered rows the selection ids are resolved against, so an action still finds an event that
+   * the displayed rows hide. The page passes a `shallowReadonly` ref, so a write here is a silent
+   * no-op. `MaybeRefOrGetter` rather than `Readonly<Ref<T>>` because readonly modifiers are ignored
+   * in assignability, so `set()` still compiles against the latter.
+   */
+  originalGroups: MaybeRefOrGetter<HistoryEventRow[]>;
   /** Invoked after an ignore or unignore succeeds, once selection mode has been exited, to reload the table. */
   refreshCallback: () => Promise<void>;
   /** Selection state and actions; `state.selectedIds` is read to resolve the targets and `actions.exit` is called once an action completes. */
@@ -55,7 +60,7 @@ export function useHistoryEventsSelectionActions(
 
   function getSelectedEvents(): HistoryEventEntry[] {
     const selectedIds = Array.from(get(selectionMode.state).selectedIds);
-    const allEvents = get(originalGroups).flat();
+    const allEvents = toValue(originalGroups).flat();
     return allEvents.filter(
       (event): event is HistoryEventEntry => !Array.isArray(event) && selectedIds.includes(event.identifier),
     );
@@ -88,7 +93,7 @@ export function useHistoryEventsSelectionActions(
    * and is rejected rather than silently using the first event's pair.
    */
   function startRuleCreation(selectedIds: number[]): void {
-    const selectedEvents = get(originalGroups).flat().filter(event =>
+    const selectedEvents = toValue(originalGroups).flat().filter(event =>
       !Array.isArray(event) && selectedIds.includes(event.identifier),
     );
 

--- a/frontend/app/src/modules/history/events/use-history-events-view-actions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-view-actions.spec.ts
@@ -1,0 +1,275 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { LinkedMovementMatch } from '@/modules/history/events/event-payloads';
+import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import {
+  useHistoryEventsViewActions,
+  type UseHistoryEventsViewActionsReturn,
+} from '@/modules/history/events/use-history-events-view-actions';
+
+const routeQuery = ref<Record<string, unknown>>({});
+
+const { useRouteMock } = vi.hoisted(() => ({ useRouteMock: vi.fn() }));
+
+vi.mock('vue-router', () => ({
+  useRoute: useRouteMock,
+}));
+
+const setAvailableIds = vi.fn();
+const setTotalMatchingCount = vi.fn();
+const fetchDataAndLocations = vi.fn().mockResolvedValue(undefined);
+const fetchDataAndRedecode = vi.fn().mockResolvedValue(undefined);
+const refreshAll = vi.fn().mockResolvedValue(undefined);
+const autoMatchMovement = vi.fn().mockResolvedValue(false);
+const refreshUnmatchedAssetMovements = vi.fn().mockResolvedValue(undefined);
+const refreshUnmatchedBridgeTransactions = vi.fn().mockResolvedValue(undefined);
+
+const rowA = createMock<HistoryEventRow>({ identifier: 1 });
+const rowB = createMock<HistoryEventRow>({ identifier: 2 });
+
+function collection(overrides: Partial<Collection<HistoryEventRow>> = {}): Collection<HistoryEventRow> {
+  return createMock<Collection<HistoryEventRow>>({ data: [rowA], found: 1, limit: 10, total: 1, ...overrides });
+}
+
+const groups = ref<Collection<HistoryEventRow>>(collection());
+const backgroundLoading = ref<boolean>(false);
+
+interface Harness {
+  wrapper: VueWrapper;
+  view: UseHistoryEventsViewActionsReturn;
+}
+
+// Every harness keeps its watchers alive, so an un-unmounted one from an earlier test would
+// answer this one's `backgroundLoading` too.
+const mounted: VueWrapper[] = [];
+
+function mountActions(): Harness {
+  let view!: UseHistoryEventsViewActionsReturn;
+  const Comp = defineComponent({
+    setup(): () => null {
+      view = useHistoryEventsViewActions({
+        autoMatchMovement,
+        backgroundLoading,
+        fetchDataAndLocations,
+        fetchDataAndRedecode,
+        groups,
+        refreshAll,
+        refreshUnmatchedAssetMovements,
+        refreshUnmatchedBridgeTransactions,
+        setAvailableIds,
+        setTotalMatchingCount,
+      });
+      return (): null => null;
+    },
+  });
+  const wrapper = mount(Comp);
+  mounted.push(wrapper);
+  return { view, wrapper };
+}
+
+const linkedMovement = createMock<LinkedMovementMatch>({ groupIdentifier: 'group-a', identifier: 9 });
+
+describe('useHistoryEventsViewActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    set(routeQuery, {});
+    set(groups, collection());
+    set(backgroundLoading, false);
+    autoMatchMovement.mockResolvedValue(false);
+    useRouteMock.mockReturnValue(computed(() => ({ query: get(routeQuery) })));
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  describe('what the table reports about its page', () => {
+    it('should hand the event ids to selection mode', () => {
+      const { view } = mountActions();
+
+      view.handleUpdateEventIds({ eventIds: [1, 2], groupedEvents: {} });
+
+      expect(setAvailableIds).toHaveBeenCalledWith([1, 2]);
+    });
+
+    it('should keep the grouped events a delete needs', () => {
+      const { view } = mountActions();
+      const groupedEvents = { '0xabc': [rowA, rowB] };
+
+      view.handleUpdateEventIds({ eventIds: [1, 2], groupedEvents });
+
+      expect(get(view.groupedEventsByTxRef)).toStrictEqual(groupedEvents);
+    });
+
+    it('should prefer the raw events the table produced', () => {
+      const { view } = mountActions();
+
+      view.handleUpdateEventIds({ eventIds: [1], groupedEvents: {}, rawEvents: [rowB] });
+
+      expect(get(view.originalGroups)).toStrictEqual([rowB]);
+    });
+
+    it('should fall back to the group page when the table produced none', () => {
+      set(groups, collection({ data: [rowA] }));
+      const { view } = mountActions();
+
+      view.handleUpdateEventIds({ eventIds: [1], groupedEvents: {} });
+
+      expect(get(view.originalGroups)).toStrictEqual([rowA]);
+    });
+
+    it('should treat an empty list of raw events as none', () => {
+      set(groups, collection({ data: [rowA] }));
+      const { view } = mountActions();
+
+      view.handleUpdateEventIds({ eventIds: [1], groupedEvents: {}, rawEvents: [] });
+
+      // `rawEvents: []` is still a list the table produced, so it wins over the group page.
+      expect(get(view.originalGroups)).toStrictEqual([]);
+    });
+  });
+
+  describe('re-decoding a transaction', () => {
+    it('should reload and stop there when nothing is linked to it', async () => {
+      const { view } = mountActions();
+      const payload = { transactions: [{ location: 'ethereum', txRef: '0xabc' }] };
+
+      await view.handleRedecode(payload);
+
+      expect(fetchDataAndRedecode).toHaveBeenCalledWith(payload);
+      expect(autoMatchMovement).not.toHaveBeenCalled();
+      expect(fetchDataAndLocations).not.toHaveBeenCalled();
+    });
+
+    it('should reload again once a linked movement is matched', async () => {
+      autoMatchMovement.mockResolvedValue(true);
+      const { view } = mountActions();
+
+      await view.handleRedecode({ linkedMovement, transactions: [{ location: 'ethereum', txRef: '0xabc' }] });
+
+      expect(autoMatchMovement).toHaveBeenCalledWith(linkedMovement);
+      expect(fetchDataAndLocations).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not reload again when the linked movement finds no match', async () => {
+      const { view } = mountActions();
+
+      await view.handleRedecode({ linkedMovement, transactions: [{ location: 'ethereum', txRef: '0xabc' }] });
+
+      expect(autoMatchMovement).toHaveBeenCalledTimes(1);
+      expect(fetchDataAndLocations).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reloading after a match', () => {
+    it('should re-read the unmatched movements before the events', async () => {
+      const { view } = mountActions();
+
+      await view.handleMovementChanged();
+
+      expect(refreshUnmatchedAssetMovements).toHaveBeenCalledTimes(1);
+      expect(fetchDataAndLocations).toHaveBeenCalledTimes(1);
+      expect(refreshUnmatchedAssetMovements.mock.invocationCallOrder[0])
+        .toBeLessThan(fetchDataAndLocations.mock.invocationCallOrder[0]);
+    });
+
+    it('should re-read the unmatched bridge transactions before the events', async () => {
+      const { view } = mountActions();
+
+      await view.handleBridgeChanged();
+
+      expect(refreshUnmatchedBridgeTransactions).toHaveBeenCalledTimes(1);
+      expect(fetchDataAndLocations).toHaveBeenCalledTimes(1);
+      expect(refreshUnmatchedBridgeTransactions.mock.invocationCallOrder[0])
+        .toBeLessThan(fetchDataAndLocations.mock.invocationCallOrder[0]);
+    });
+  });
+
+  describe('the total the filter matches', () => {
+    it('should report it as soon as the page mounts', () => {
+      set(groups, collection({ found: 42 }));
+      mountActions();
+
+      expect(setTotalMatchingCount).toHaveBeenCalledWith(42);
+    });
+
+    it('should report it again when the page changes', async () => {
+      mountActions();
+      setTotalMatchingCount.mockClear();
+
+      set(groups, collection({ found: 7 }));
+      await nextTick();
+
+      expect(setTotalMatchingCount).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe('background work finishing', () => {
+    it('should reload once it settles', async () => {
+      mountActions();
+      await vi.advanceTimersByTimeAsync(600);
+      fetchDataAndLocations.mockClear();
+
+      set(backgroundLoading, true);
+      await nextTick();
+      expect(fetchDataAndLocations).not.toHaveBeenCalled();
+
+      set(backgroundLoading, false);
+      await nextTick();
+
+      expect(fetchDataAndLocations).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not reload while it is still running', async () => {
+      mountActions();
+      await vi.advanceTimersByTimeAsync(600);
+      fetchDataAndLocations.mockClear();
+
+      set(backgroundLoading, true);
+      await nextTick();
+
+      expect(fetchDataAndLocations).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the first load', () => {
+    it('should wait for the route to settle before refreshing everything', async () => {
+      mountActions();
+
+      await nextTick();
+      expect(refreshAll).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(refreshAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh only once, however often the route changes', async () => {
+      mountActions();
+
+      set(routeQuery, { asset: 'ETH' });
+      await vi.advanceTimersByTimeAsync(600);
+      set(routeQuery, { asset: 'BTC' });
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(refreshAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should only reload the events when auto fetch is turned off', async () => {
+      vi.stubEnv('VITE_NO_AUTO_FETCH', 'true');
+      mountActions();
+
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(refreshAll).not.toHaveBeenCalled();
+      expect(fetchDataAndLocations).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-view-actions.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-view-actions.ts
@@ -1,0 +1,136 @@
+import type { Ref } from 'vue';
+import type { Collection } from '@/modules/core/common/collection';
+import type { LinkedMovementMatch, PullLocationTransactionPayload } from '@/modules/history/events/event-payloads';
+import type { HistoryEventRow } from '@/modules/history/events/schemas';
+
+/** The debounce on the first load, giving a persisted filter time to reach the route. */
+const INITIAL_LOAD_DEBOUNCE = 500;
+
+interface EventIdsUpdate {
+  eventIds: number[];
+  groupedEvents: Record<string, HistoryEventRow[]>;
+  rawEvents?: HistoryEventRow[];
+}
+
+export interface UseHistoryEventsViewActionsOptions {
+  /** The group collection the table is paging through. */
+  groups: Ref<Collection<HistoryEventRow>>;
+  /** Whether anything is loading in the background: a decode, or either auto-match. */
+  backgroundLoading: Ref<boolean>;
+  /** Tell selection mode which events are on the page. */
+  setAvailableIds: (ids: number[]) => void;
+  /** Tell selection mode how many events the current filter matches in total. */
+  setTotalMatchingCount: (count: number) => void;
+  /** Reload the events and the locations they came from. */
+  fetchDataAndLocations: () => Promise<void>;
+  /** Reload the events, re-decoding the transaction the table asked about. */
+  fetchDataAndRedecode: (event?: PullLocationTransactionPayload) => Promise<void>;
+  /** Refresh everything, which is what a first visit does. */
+  refreshAll: () => Promise<void>;
+  /** Try to match a movement to the transaction that was just decoded. */
+  autoMatchMovement: (movement: LinkedMovementMatch) => Promise<boolean>;
+  /** Re-read the unmatched asset movements. */
+  refreshUnmatchedAssetMovements: () => Promise<void>;
+  /** Re-read the unmatched bridge transactions. */
+  refreshUnmatchedBridgeTransactions: () => Promise<void>;
+}
+
+export interface UseHistoryEventsViewActionsReturn {
+  /** The page's events grouped by transaction, which a delete needs to spot a whole transaction. */
+  groupedEventsByTxRef: Readonly<Ref<Record<string, HistoryEventRow[]>>>;
+  /** The page's events before grouping, which a delete needs to keep swap groups intact. */
+  originalGroups: Readonly<Ref<HistoryEventRow[]>>;
+  /** Take what the table reports about the page it just rendered. */
+  handleUpdateEventIds: (update: EventIdsUpdate) => void;
+  /** Re-decode a transaction, and match the movement it belongs to if it names one. */
+  handleRedecode: (event?: PullLocationTransactionPayload) => Promise<void>;
+  /** Reload after an asset movement was matched. */
+  handleMovementChanged: () => Promise<void>;
+  /** Reload after a bridge transaction was matched. */
+  handleBridgeChanged: () => Promise<void>;
+}
+
+/**
+ * What the events page does in response to the table, the dialogs and its own loading.
+ *
+ * Three are reloads with a different first step. `handleUpdateEventIds` is the page copying what the
+ * table rendered, because a delete needs the events that made up a transaction and the grouped shape
+ * has already lost them.
+ */
+export function useHistoryEventsViewActions(
+  options: UseHistoryEventsViewActionsOptions,
+): UseHistoryEventsViewActionsReturn {
+  const {
+    autoMatchMovement,
+    backgroundLoading,
+    fetchDataAndLocations,
+    fetchDataAndRedecode,
+    groups,
+    refreshAll,
+    refreshUnmatchedAssetMovements,
+    refreshUnmatchedBridgeTransactions,
+    setAvailableIds,
+    setTotalMatchingCount,
+  } = options;
+
+  const route = useRoute();
+
+  // Grouped events for checking complete EVM transactions
+  const groupedEventsByTxRef = ref<Record<string, HistoryEventRow[]>>({});
+  // Original groups data, which preserves swap groups
+  const originalGroups = ref<HistoryEventRow[]>([]);
+
+  function handleUpdateEventIds({ eventIds, groupedEvents, rawEvents }: EventIdsUpdate): void {
+    setAvailableIds(eventIds);
+
+    set(groupedEventsByTxRef, groupedEvents);
+    // Prefer rawEvents if the table produced them, otherwise fall back to the group page
+    set(originalGroups, rawEvents ?? get(groups).data);
+  }
+
+  async function handleRedecode(event?: PullLocationTransactionPayload): Promise<void> {
+    await fetchDataAndRedecode(event);
+    if (event?.linkedMovement) {
+      const matched = await autoMatchMovement(event.linkedMovement);
+      if (matched)
+        await fetchDataAndLocations();
+    }
+  }
+
+  async function handleMovementChanged(): Promise<void> {
+    await refreshUnmatchedAssetMovements();
+    await fetchDataAndLocations();
+  }
+
+  async function handleBridgeChanged(): Promise<void> {
+    await refreshUnmatchedBridgeTransactions();
+    await fetchDataAndLocations();
+  }
+
+  watchImmediate(groups, (newGroups) => {
+    setTotalMatchingCount(newGroups.found);
+  });
+
+  // Something that ran in the background has finished, so what the table is showing is stale.
+  watch(backgroundLoading, async (isLoading, wasLoading) => {
+    if (!isLoading && wasLoading)
+      await fetchDataAndLocations();
+  });
+
+  // Wait until the route doesn't change anymore to give time for the persisted filter to be set.
+  watchDebounced(route, async () => {
+    if (import.meta.env.VITE_NO_AUTO_FETCH === 'true')
+      await fetchDataAndLocations();
+    else
+      await refreshAll();
+  }, { debounce: INITIAL_LOAD_DEBOUNCE, immediate: true, once: true });
+
+  return {
+    groupedEventsByTxRef: shallowReadonly(groupedEventsByTxRef),
+    handleBridgeChanged,
+    handleMovementChanged,
+    handleRedecode,
+    handleUpdateEventIds,
+    originalGroups: shallowReadonly(originalGroups),
+  };
+}

--- a/frontend/app/src/modules/history/events/use-pinned-match-panel.spec.ts
+++ b/frontend/app/src/modules/history/events/use-pinned-match-panel.spec.ts
@@ -1,0 +1,391 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { HighlightTargetTypes } from '@/modules/history/events/use-history-event-navigation';
+import { usePinnedMatchPanel, type UsePinnedMatchPanelReturn } from '@/modules/history/events/use-pinned-match-panel';
+import { PinnedNames } from '@/modules/session/types';
+
+interface TestRow {
+  groupIdentifier: string;
+  identifier: number;
+}
+
+const routerReplace = vi.fn().mockResolvedValue(undefined);
+const routeQuery = ref<Record<string, unknown>>({});
+
+const { useRouteMock, useRouterMock } = vi.hoisted(() => ({
+  useRouteMock: vi.fn(),
+  useRouterMock: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: useRouteMock,
+  useRouter: useRouterMock,
+}));
+
+const clearHighlightTarget = vi.fn();
+const requestNavigation = vi.fn();
+const setHighlightTarget = vi.fn();
+
+vi.mock('@/modules/history/events/use-history-event-navigation', async importOriginal => ({
+  ...(await importOriginal<object>()),
+  useHistoryEventNavigation: (): Record<string, unknown> => ({
+    clearHighlightTarget,
+    requestNavigation,
+    setHighlightTarget,
+  }),
+}));
+
+const clearHighlight = vi.fn().mockResolvedValue(undefined);
+const pinnedReset = vi.fn();
+
+vi.mock('@/modules/shell/pinned/use-pinned-highlight-navigation', () => ({
+  usePinnedHighlightNavigation: (_keys: string[], reset: () => void): Record<string, unknown> => {
+    pinnedReset.mockImplementation(reset);
+    return { clearHighlight };
+  },
+}));
+
+const unpinPanel = vi.fn();
+const isPinned = ref<boolean>(true);
+
+vi.mock('@/modules/shell/pinned/use-pinned-panel', () => ({
+  usePinnedPanel: (): Record<string, unknown> => ({ isPinned, unpin: unpinPanel }),
+}));
+
+const unmatched = ref<TestRow[]>([]);
+const ignored = ref<TestRow[]>([]);
+const groupProp = ref<string | undefined>();
+const matchProp = ref<number | undefined>();
+const matchGroupProp = ref<string | undefined>();
+
+interface Harness {
+  wrapper: VueWrapper;
+  panel: UsePinnedMatchPanelReturn<TestRow>;
+}
+
+// Every harness keeps its watchers alive, so an un-unmounted one from an earlier test would
+// answer this one's row collections and highlight props too.
+const mounted: VueWrapper[] = [];
+
+function mountPanel(): Harness {
+  let panel!: UsePinnedMatchPanelReturn<TestRow>;
+  const Comp = defineComponent({
+    setup(): () => null {
+      panel = usePinnedMatchPanel<TestRow>({
+        getIdentifier: row => row.identifier,
+        highlightedGroupIdentifier: () => get(groupProp),
+        highlightedPotentialMatchIdentifier: () => get(matchProp),
+        pinnedName: PinnedNames.MATCH_ASSET_MOVEMENTS,
+        potentialMatchGroupIdentifier: () => get(matchGroupProp),
+        sources: [unmatched, ignored],
+      });
+      return (): null => null;
+    },
+  });
+  const wrapper = mount(Comp);
+  mounted.push(wrapper);
+  return { panel, wrapper };
+}
+
+const rowA: TestRow = { groupIdentifier: 'group-a', identifier: 11 };
+const rowB: TestRow = { groupIdentifier: 'group-b', identifier: 22 };
+
+describe('usePinnedMatchPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(routeQuery, {});
+    set(unmatched, []);
+    set(ignored, []);
+    set(groupProp, undefined);
+    set(matchProp, undefined);
+    set(matchGroupProp, undefined);
+    set(isPinned, true);
+    useRouteMock.mockReturnValue(computed(() => ({ query: get(routeQuery) })));
+    useRouterMock.mockReturnValue({ replace: routerReplace });
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  describe('selecting a row', () => {
+    it('should open the drawer on the row and highlight it in the events table', () => {
+      const { panel } = mountPanel();
+
+      panel.select(rowA);
+
+      expect(get(panel.subject)).toStrictEqual(rowA);
+      expect(get(panel.modelSheetOpen)).toBe(true);
+      expect(get(panel.activeGroupIdentifier)).toBe('group-a');
+      expect(clearHighlightTarget).toHaveBeenCalledWith(HighlightTargetTypes.POTENTIAL_MATCH);
+      expect(setHighlightTarget).toHaveBeenCalledWith(HighlightTargetTypes.ASSET_MOVEMENT, {
+        groupIdentifier: 'group-a',
+        identifier: 11,
+      });
+      expect(requestNavigation).toHaveBeenCalledWith({
+        highlightedAssetMovement: 11,
+        targetGroupIdentifier: 'group-a',
+      });
+    });
+
+    it('should drop the green highlight of a previously selected row', () => {
+      const { panel } = mountPanel();
+      panel.showPotentialMatchInHistoryEvents({ groupIdentifier: 'group-a', identifier: 99 });
+      expect(get(panel.activePotentialMatchIdentifier)).toBe(99);
+
+      panel.select(rowA);
+
+      expect(get(panel.activePotentialMatchIdentifier)).toBeUndefined();
+    });
+
+    it('should not open the drawer when only highlighting in the events table', () => {
+      const { panel } = mountPanel();
+
+      panel.showInHistoryEvents(rowA);
+
+      expect(get(panel.subject)).toBeUndefined();
+      expect(get(panel.modelSheetOpen)).toBe(false);
+      expect(get(panel.activeGroupIdentifier)).toBe('group-a');
+      expect(requestNavigation).toHaveBeenCalledWith({
+        highlightedAssetMovement: 11,
+        targetGroupIdentifier: 'group-a',
+      });
+    });
+  });
+
+  describe('the detail sheet model', () => {
+    it('should stay closed until a row is actually selected', () => {
+      const { panel } = mountPanel();
+
+      expect(get(panel.modelSheetOpen)).toBe(false);
+    });
+
+    it('should close the drawer when written to false', async () => {
+      const { panel } = mountPanel();
+      panel.select(rowA);
+
+      set(panel.modelSheetOpen, false);
+      await nextTick();
+
+      expect(get(panel.subject)).toBeUndefined();
+      expect(get(panel.modelSheetOpen)).toBe(false);
+    });
+
+    it('should not close the drawer when written to true', async () => {
+      const { panel } = mountPanel();
+      panel.select(rowA);
+
+      set(panel.modelSheetOpen, true);
+      await nextTick();
+
+      expect(get(panel.subject)).toStrictEqual(rowA);
+      expect(get(panel.modelSheetOpen)).toBe(true);
+    });
+  });
+
+  describe('closing the drawer', () => {
+    it('should strip the green highlight from the route and keep the yellow one', async () => {
+      set(routeQuery, { highlightedAssetMovement: '11', highlightedPotentialMatch: '99', tab: 'events' });
+      const { panel } = mountPanel();
+      panel.select(rowA);
+
+      await panel.closeDrawer();
+
+      expect(clearHighlightTarget).toHaveBeenCalledWith(HighlightTargetTypes.POTENTIAL_MATCH);
+      expect(routerReplace).toHaveBeenCalledWith({
+        query: { highlightedAssetMovement: '11', tab: 'events' },
+      });
+    });
+
+    it('should leave the route alone when no green highlight is in it', async () => {
+      set(routeQuery, { highlightedAssetMovement: '11' });
+      const { panel } = mountPanel();
+      panel.select(rowA);
+
+      await panel.closeDrawer();
+
+      expect(routerReplace).not.toHaveBeenCalled();
+    });
+
+    it('should clear every highlight after a match was made', async () => {
+      const { panel } = mountPanel();
+      panel.select(rowA);
+
+      await panel.onMatched();
+
+      expect(get(panel.subject)).toBeUndefined();
+      expect(clearHighlight).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('unpinning', () => {
+    it('should clear the highlight before removing the tab', async () => {
+      const { panel } = mountPanel();
+
+      await panel.unpin();
+
+      expect(clearHighlight).toHaveBeenCalledTimes(1);
+      expect(unpinPanel).toHaveBeenCalledTimes(1);
+      expect(clearHighlight.mock.invocationCallOrder[0])
+        .toBeLessThan(unpinPanel.mock.invocationCallOrder[0]);
+    });
+
+    it('should reset the local highlight state when the shared teardown resets', () => {
+      const { panel } = mountPanel();
+      panel.select(rowA);
+
+      pinnedReset();
+
+      expect(get(panel.activeGroupIdentifier)).toBeUndefined();
+      expect(get(panel.activePotentialMatchIdentifier)).toBeUndefined();
+    });
+  });
+
+  describe('highlighting a potential match', () => {
+    it('should keep the row highlight it is given', () => {
+      const { panel } = mountPanel();
+
+      panel.showPotentialMatchInHistoryEvents({ groupIdentifier: 'group-a', identifier: 99 }, 11);
+
+      expect(get(panel.activePotentialMatchIdentifier)).toBe(99);
+      expect(setHighlightTarget).toHaveBeenCalledWith(HighlightTargetTypes.POTENTIAL_MATCH, {
+        groupIdentifier: 'group-a',
+        identifier: 99,
+      });
+      expect(requestNavigation).toHaveBeenCalledWith({
+        highlightedAssetMovement: 11,
+        highlightedPotentialMatch: 99,
+        targetGroupIdentifier: 'group-a',
+      });
+    });
+
+    it('should fall back to the row highlight in the route', () => {
+      set(routeQuery, { highlightedAssetMovement: '42' });
+      const { panel } = mountPanel();
+
+      panel.showPotentialMatchInHistoryEvents({ groupIdentifier: 'group-a', identifier: 99 });
+
+      expect(requestNavigation).toHaveBeenCalledWith({
+        highlightedAssetMovement: 42,
+        highlightedPotentialMatch: 99,
+        targetGroupIdentifier: 'group-a',
+      });
+    });
+
+    it('should send no row highlight when the route carries none', () => {
+      set(routeQuery, { highlightedAssetMovement: 'not-a-number' });
+      const { panel } = mountPanel();
+
+      panel.showPotentialMatchInHistoryEvents({ groupIdentifier: 'group-a', identifier: 99 });
+
+      expect(requestNavigation).toHaveBeenCalledWith({
+        highlightedAssetMovement: undefined,
+        highlightedPotentialMatch: 99,
+        targetGroupIdentifier: 'group-a',
+      });
+    });
+  });
+
+  describe('navigating to the requested highlight', () => {
+    it('should wait for the row to arrive before navigating', async () => {
+      set(groupProp, 'group-b');
+      mountPanel();
+
+      expect(requestNavigation).not.toHaveBeenCalled();
+
+      set(unmatched, [rowA, rowB]);
+      await nextTick();
+
+      expect(requestNavigation).toHaveBeenCalledWith({
+        highlightedAssetMovement: 22,
+        targetGroupIdentifier: 'group-b',
+      });
+    });
+
+    it('should navigate only once as more rows arrive', async () => {
+      set(groupProp, 'group-a');
+      mountPanel();
+
+      set(unmatched, [rowA]);
+      await nextTick();
+      set(unmatched, [rowA, rowB]);
+      await nextTick();
+
+      expect(requestNavigation).toHaveBeenCalledTimes(1);
+    });
+
+    it('should search the later sources when the first misses', async () => {
+      set(groupProp, 'group-b');
+      mountPanel();
+
+      set(unmatched, [rowA]);
+      set(ignored, [rowB]);
+      await nextTick();
+
+      expect(requestNavigation).toHaveBeenCalledWith({
+        highlightedAssetMovement: 22,
+        targetGroupIdentifier: 'group-b',
+      });
+    });
+
+    it('should not navigate when no highlight was requested', async () => {
+      mountPanel();
+
+      set(unmatched, [rowA, rowB]);
+      await nextTick();
+
+      expect(requestNavigation).not.toHaveBeenCalled();
+    });
+
+    it('should open the drawer on the row when a potential match is requested too', async () => {
+      set(groupProp, 'group-a');
+      set(matchProp, 99);
+      set(matchGroupProp, 'group-c');
+      const { panel } = mountPanel();
+
+      set(unmatched, [rowA]);
+      await nextTick();
+
+      expect(get(panel.subject)).toStrictEqual(rowA);
+      expect(get(panel.modelSheetOpen)).toBe(true);
+      expect(get(panel.activeGroupIdentifier)).toBe('group-a');
+      expect(requestNavigation).toHaveBeenCalledWith({
+        highlightedAssetMovement: 11,
+        highlightedPotentialMatch: 99,
+        targetGroupIdentifier: 'group-c',
+      });
+    });
+
+    it('should navigate again when the requested group changes', async () => {
+      set(groupProp, 'group-a');
+      set(unmatched, [rowA, rowB]);
+      const { panel } = mountPanel();
+      await nextTick();
+      requestNavigation.mockClear();
+
+      set(groupProp, 'group-b');
+      await nextTick();
+
+      expect(get(panel.activeGroupIdentifier)).toBe('group-b');
+      expect(requestNavigation).toHaveBeenCalledWith({
+        highlightedAssetMovement: 22,
+        targetGroupIdentifier: 'group-b',
+      });
+    });
+
+    it('should not navigate when the requested group is cleared', async () => {
+      set(groupProp, 'group-a');
+      set(unmatched, [rowA, rowB]);
+      mountPanel();
+      await nextTick();
+      requestNavigation.mockClear();
+
+      set(groupProp, undefined);
+      await nextTick();
+
+      expect(requestNavigation).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-pinned-match-panel.ts
+++ b/frontend/app/src/modules/history/events/use-pinned-match-panel.ts
@@ -1,0 +1,255 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { PinnedName } from '@/modules/session/types';
+import { startPromise } from '@shared/utils';
+import { HighlightTargetTypes, useHistoryEventNavigation } from '@/modules/history/events/use-history-event-navigation';
+import { usePinnedHighlightNavigation } from '@/modules/shell/pinned/use-pinned-highlight-navigation';
+import { usePinnedPanel } from '@/modules/shell/pinned/use-pinned-panel';
+
+/** The query keys the matching panels own; both the yellow and the green highlight. */
+const HIGHLIGHT_QUERY_KEYS = ['highlightedAssetMovement', 'highlightedPotentialMatch'];
+
+/** The least a row needs for the panel to navigate to it. */
+export interface PinnedMatchSubject {
+  groupIdentifier: string;
+}
+
+interface PotentialMatchLocation {
+  identifier: number;
+  groupIdentifier: string;
+}
+
+export interface UsePinnedMatchPanelOptions<T extends PinnedMatchSubject> {
+  /** Which pinned tab this panel occupies. */
+  pinnedName: PinnedName;
+  /** Row collections searched, in order, for the group the route asks to highlight. */
+  sources: MaybeRefOrGetter<T[]>[];
+  /** The event identifier a row highlights in the events table. */
+  getIdentifier: (subject: T) => number;
+  /** The group the route asks the panel to open on. */
+  highlightedGroupIdentifier: () => string | undefined;
+  /** The potential match the route asks the drawer to open on. */
+  highlightedPotentialMatchIdentifier: () => number | undefined;
+  /** The group that potential match belongs to. */
+  potentialMatchGroupIdentifier: () => string | undefined;
+}
+
+export interface UsePinnedMatchPanelReturn<T extends PinnedMatchSubject> {
+  /** The group currently highlighted in the panel's list. */
+  activeGroupIdentifier: Readonly<Ref<string | undefined>>;
+  /** The potential match currently highlighted in the drawer. */
+  activePotentialMatchIdentifier: Readonly<Ref<number | undefined>>;
+  /** The row whose potential matches the drawer is showing. */
+  subject: Readonly<Ref<T | undefined>>;
+  /** `v-model` for the detail sheet; closing routes through the same cleanup as the header button. */
+  modelSheetOpen: Ref<boolean>;
+  /** Reset local highlight state, clear the shared targets and strip the owned query keys. */
+  clearHighlight: () => Promise<void>;
+  /** Open the drawer on a row and highlight it in the events table. */
+  select: (subject: T) => void;
+  /** Close the drawer and drop the green highlight, keeping the yellow one. */
+  closeDrawer: () => Promise<void>;
+  /** Close the drawer and drop every highlight, after a match was made. */
+  onMatched: () => Promise<void>;
+  /** Drop every highlight, then remove the panel's tab. */
+  unpin: () => Promise<void>;
+  /** Highlight a row in the events table without opening the drawer. */
+  showInHistoryEvents: (subject: T) => void;
+  /** Highlight a potential match in the events table, keeping the row's own highlight. */
+  showPotentialMatchInHistoryEvents: (data: PotentialMatchLocation, unmatchedIdentifier?: number) => void;
+}
+
+/**
+ * The whole behaviour of a pinned matching panel: which row the drawer is on, which
+ * highlights the events table is showing, and the navigation that keeps the two in step.
+ *
+ * `MatchAssetMovementsPinned` and `MatchBridgeTransactionsPinned` are the same panel over different
+ * rows, and vary only in the collections they search, how a row names its event (an asset movement
+ * must be unwrapped from its collection, a bridge transaction carries the identifier directly) and
+ * the extra props their drawer content takes.
+ */
+export function usePinnedMatchPanel<T extends PinnedMatchSubject>(
+  options: UsePinnedMatchPanelOptions<T>,
+): UsePinnedMatchPanelReturn<T> {
+  const {
+    getIdentifier,
+    highlightedGroupIdentifier,
+    highlightedPotentialMatchIdentifier,
+    pinnedName,
+    potentialMatchGroupIdentifier,
+    sources,
+  } = options;
+
+  const router = useRouter();
+  const route = useRoute();
+
+  const activeGroupIdentifier = shallowRef<string | undefined>(highlightedGroupIdentifier());
+  const activePotentialMatchIdentifier = shallowRef<number | undefined>(highlightedPotentialMatchIdentifier());
+  const subject = shallowRef<T>();
+  const drawerOpen = shallowRef<boolean>(false);
+  const hasNavigatedToInitialHighlight = shallowRef<boolean>(false);
+
+  const { isPinned, unpin: unpinPanel } = usePinnedPanel(pinnedName);
+  const { clearHighlightTarget, requestNavigation, setHighlightTarget } = useHistoryEventNavigation();
+
+  const { clearHighlight } = usePinnedHighlightNavigation(
+    HIGHLIGHT_QUERY_KEYS,
+    () => {
+      set(activeGroupIdentifier, undefined);
+      set(activePotentialMatchIdentifier, undefined);
+    },
+    () => get(isPinned),
+  );
+
+  function highlightSubject(target: T): void {
+    const identifier = getIdentifier(target);
+
+    set(activeGroupIdentifier, target.groupIdentifier);
+    set(activePotentialMatchIdentifier, undefined);
+
+    clearHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH);
+    setHighlightTarget(HighlightTargetTypes.ASSET_MOVEMENT, {
+      groupIdentifier: target.groupIdentifier,
+      identifier,
+    });
+
+    requestNavigation({
+      highlightedAssetMovement: identifier,
+      targetGroupIdentifier: target.groupIdentifier,
+    });
+  }
+
+  function select(target: T): void {
+    set(subject, target);
+    set(drawerOpen, true);
+    highlightSubject(target);
+  }
+
+  function showInHistoryEvents(target: T): void {
+    highlightSubject(target);
+  }
+
+  async function closeDrawer(): Promise<void> {
+    set(drawerOpen, false);
+    set(subject, undefined);
+    set(activePotentialMatchIdentifier, undefined);
+    clearHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH);
+
+    // Clear the green highlight from route while preserving the yellow highlight
+    const { highlightedPotentialMatch, ...remainingQuery } = get(route).query;
+    if (highlightedPotentialMatch) {
+      await router.replace({ query: remainingQuery });
+    }
+  }
+
+  // The sheet is only open once a row is actually selected, so it never flashes empty while the
+  // close animation drains it. Closing routes through the same cleanup as the header button.
+  const modelSheetOpen = computed<boolean>({
+    get: () => get(drawerOpen) && !!get(subject),
+    set: (value) => {
+      if (!value)
+        startPromise(closeDrawer());
+    },
+  });
+
+  async function onMatched(): Promise<void> {
+    await closeDrawer();
+    await clearHighlight();
+  }
+
+  async function unpin(): Promise<void> {
+    await clearHighlight();
+    unpinPanel();
+  }
+
+  function showPotentialMatchInHistoryEvents(
+    data: PotentialMatchLocation,
+    unmatchedIdentifier?: number,
+  ): void {
+    set(activePotentialMatchIdentifier, data.identifier);
+    setHighlightTarget(HighlightTargetTypes.POTENTIAL_MATCH, {
+      groupIdentifier: data.groupIdentifier,
+      identifier: data.identifier,
+    });
+
+    const yellowHighlight = unmatchedIdentifier
+      ?? (Number(get(route).query.highlightedAssetMovement) || undefined);
+
+    requestNavigation({
+      highlightedAssetMovement: yellowHighlight,
+      highlightedPotentialMatch: data.identifier,
+      targetGroupIdentifier: data.groupIdentifier,
+    });
+  }
+
+  function findSubject(targetGroupIdentifier: string): T | undefined {
+    for (const source of sources) {
+      const match = toValue(source).find(item => item.groupIdentifier === targetGroupIdentifier);
+      if (match)
+        return match;
+    }
+    return undefined;
+  }
+
+  /**
+   * Navigate to the highlighted row if it has arrived.
+   * Returns true if navigation was triggered, false otherwise.
+   */
+  function navigateToHighlighted(targetGroupIdentifier: string): boolean {
+    const target = findSubject(targetGroupIdentifier);
+    if (!target)
+      return false;
+
+    const potentialMatch = highlightedPotentialMatchIdentifier();
+    const potentialMatchGroup = potentialMatchGroupIdentifier();
+
+    // If a potential match is also asked for, open the drawer and navigate to it
+    if (potentialMatch && potentialMatchGroup) {
+      set(subject, target);
+      set(drawerOpen, true);
+      set(activeGroupIdentifier, target.groupIdentifier);
+      showPotentialMatchInHistoryEvents(
+        { groupIdentifier: potentialMatchGroup, identifier: potentialMatch },
+        getIdentifier(target),
+      );
+    }
+    else {
+      showInHistoryEvents(target);
+    }
+    return true;
+  }
+
+  // Watch for data to load and navigate to the initial highlight if one was provided
+  watch(() => sources.map(source => toValue(source)), () => {
+    const initialHighlight = highlightedGroupIdentifier();
+    if (!initialHighlight || get(hasNavigatedToInitialHighlight))
+      return;
+
+    if (navigateToHighlighted(initialHighlight)) {
+      set(hasNavigatedToInitialHighlight, true);
+    }
+  });
+
+  // Watch for prop changes to handle navigation when the panel is already open
+  watch(highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
+    // Only trigger if the highlight actually changed (not on initial mount)
+    if (!newHighlight || newHighlight === oldHighlight)
+      return;
+
+    set(activeGroupIdentifier, newHighlight);
+    navigateToHighlighted(newHighlight);
+  });
+
+  return {
+    activeGroupIdentifier: readonly(activeGroupIdentifier),
+    activePotentialMatchIdentifier: readonly(activePotentialMatchIdentifier),
+    clearHighlight,
+    closeDrawer,
+    modelSheetOpen,
+    onMatched,
+    select,
+    showInHistoryEvents,
+    showPotentialMatchInHistoryEvents,
+    subject: shallowReadonly(subject),
+    unpin,
+  };
+}

--- a/frontend/app/src/modules/history/events/view-projections.spec.ts
+++ b/frontend/app/src/modules/history/events/view-projections.spec.ts
@@ -1,0 +1,65 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
+import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
+import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
+import { describe, expect, it } from 'vitest';
+import { toTableSource } from '@/modules/history/events/view-projections';
+
+const groups = createMock<Collection<HistoryEventRow>>({ data: [], found: 3, limit: 10, total: 3 });
+const requestPayload = createMock<HistoryEventRequestPayload>({ limit: 10, offset: 0 });
+
+function toggles(overrides: Partial<HistoryEventsToggles> = {}): HistoryEventsToggles {
+  return { matchExactEvents: false, showIgnoredAssets: false, stateMarkers: [], ...overrides };
+}
+
+describe('toTableSource', () => {
+  it('should exclude ignored assets unless the user asked to see them', () => {
+    expect(toTableSource({ groupLoading: false, groups, requestPayload, toggles: toggles() }).excludeIgnored)
+      .toBe(true);
+
+    expect(toTableSource({
+      groupLoading: false,
+      groups,
+      requestPayload,
+      toggles: toggles({ showIgnoredAssets: true }),
+    }).excludeIgnored).toBe(false);
+  });
+
+  it('should withhold the filter payload while match-exact is off', () => {
+    const source = toTableSource({ groupLoading: false, groups, requestPayload, toggles: toggles() });
+
+    expect(source.requestPayload).toBeUndefined();
+  });
+
+  it('should pass the filter payload down once match-exact is on', () => {
+    const source = toTableSource({
+      groupLoading: false,
+      groups,
+      requestPayload,
+      toggles: toggles({ matchExactEvents: true }),
+    });
+
+    expect(source.requestPayload).toBe(requestPayload);
+  });
+
+  it('should pass the group page and its loading state through unchanged', () => {
+    const source = toTableSource({
+      groupLoading: true,
+      groups,
+      identifiers: ['1', '2'],
+      requestPayload,
+      toggles: toggles(),
+    });
+
+    expect(source.groups).toBe(groups);
+    expect(source.groupLoading).toBe(true);
+    expect(source.identifiers).toStrictEqual(['1', '2']);
+  });
+
+  it('should load the whole page when no identifiers are given', () => {
+    const source = toTableSource({ groupLoading: false, groups, requestPayload, toggles: toggles() });
+
+    expect(source.identifiers).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/history/events/view-projections.ts
+++ b/frontend/app/src/modules/history/events/view-projections.ts
@@ -1,0 +1,32 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { HistoryEventsToggles } from '@/modules/history/events/dialog-types';
+import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
+import type { HistoryEventRow } from '@/modules/history/events/schemas';
+import type { HistoryEventsTableSource } from '@/modules/history/events/types';
+
+export interface TableSourceInput {
+  toggles: HistoryEventsToggles;
+  groupLoading: boolean;
+  groups: Collection<HistoryEventRow>;
+  identifiers?: string[];
+  requestPayload: HistoryEventRequestPayload;
+}
+
+/**
+ * What the events table is asked to load.
+ *
+ * `showIgnoredAssets` is the inverse of what the table takes. `matchExactEvents` decides whether the
+ * filter payload is passed down at all: without it the table loads every event in the selected
+ * groups, with it the same filter is applied again to the events inside them.
+ */
+export function toTableSource(input: TableSourceInput): HistoryEventsTableSource {
+  const { groupLoading, groups, identifiers, requestPayload, toggles } = input;
+
+  return {
+    excludeIgnored: !toggles.showIgnoredAssets,
+    groupLoading,
+    groups,
+    identifiers,
+    requestPayload: toggles.matchExactEvents ? requestPayload : undefined,
+  };
+}


### PR DESCRIPTION
Batch B of #12964, following #12989 (batch A, merged as #12991). Closes #12994.

Seven components in `modules/history/events/`, ~644 uncovered lines, none of which had a spec. Each one's logic moves to a sibling `use-*.ts` that a spec can drive directly, and the component spec covers only the wiring that remains.

## What changed

| Component | Extracted to |
|---|---|
| `MatchAssetMovementsPinned` + `MatchBridgeTransactionsPinned` | `use-pinned-match-panel.ts` — one composable, both panels |
| `HistoryEventsFiltersChips` | `use-history-events-filters-chips.ts` |
| `HistoryEventsAction` | `use-history-event-action-menu.ts` |
| `HistoryEventsDialogContainer` | `use-history-events-dialog-container.ts` + `dialog-components.ts` |
| `HistoryEventsTableActions` | `use-history-events-pill-bar.ts` |
| `HistoryEventsView` | `use-history-events-view-actions.ts` + `view-projections.ts` |

The issue asked whether the two `Match*Pinned` should share one composable. They should: they were the same panel over different rows, duplicated line for line — which row the drawer is on, which highlights the events table shows, and the navigation keeping the two in step. `usePinnedMatchPanel` is parameterised by the collections to search and how a row names its event; what is left in each component is the part that genuinely differs (the bridge flow, its entry labels, its unmatchable explanation).

One commit per file, extraction and its specs together.

## Coverage

The seven components go from 0% to 82.5% statements (250/303). The seven new `.ts` files are 96-100%.

`HistoryEventsDialogContainer` (62%) and `HistoryEventsView` (69%) are the two below the rest; the remainder in both is template that only renders when a child stub is swapped in, and raising it would mean mounting the real dialogs — the mount-only test the issue rules out. `dialog-components.ts` is 0% by design: it is lazy loaders, stubbed away in the container spec.

## Two things worth a reviewer's attention

**A pre-existing bug, fixed here.** `dialog-components.ts` inherited `h('RuiProgress', …)` from the old container — a *string*, so Vue built a literal `<ruiprogress>` element and the lazy-dialog loading placeholder was an empty box rather than a spinner. Rui components reach `.vue` files through the auto-import resolver, which does nothing for a raw string in `h()`, so a `.ts` file has to import the component. Verified both halves with a throwaway spec.

**`useHistoryEventsSelectionActions` now takes `originalGroups` as a `MaybeRefOrGetter`.** The page hands it a `shallowReadonly` ref, and it only ever reads. `Readonly<Ref<T>>` would not have expressed that: readonly modifiers are ignored in assignability, so `set()` still compiles against it and you get a silent no-op at runtime. This matches `useHistoryEventsDeletion`, which already took the same rows that way.

## Testing

~250 new specs. Every behavioural claim was negative-controlled — the guard was broken, the naming spec watched to go red, then restored.

Gates, all green on the rebased branch: `pnpm run test:unit` (9734 passing), `pnpm run lint`, `pnpm run typecheck`, `pnpm run lint:style`, `pnpm run knip`.
