### PR TITLE
test(frontend): pin scramble multiplier in display specs

### DIFF
--- a/frontend/app/src/modules/assets/amount-display/components/AssetAmountDisplay.spec.ts
+++ b/frontend/app/src/modules/assets/amount-display/components/AssetAmountDisplay.spec.ts
@@ -81,7 +81,7 @@ describe('modules/amount-display/components/AssetAmountDisplay', () => {
 
   describe('scramble data', () => {
     beforeEach(async () => {
-      useSettingsRepo().updateFrontend({ scrambleData: true });
+      useSettingsRepo().updateFrontend({ scrambleData: true, scrambleMultiplier: 1.02 });
     });
 
     it('should scramble the amount', async () => {
@@ -92,7 +92,7 @@ describe('modules/amount-display/components/AssetAmountDisplay', () => {
           asset: 'ETH',
         },
       });
-      expect(wrapper.find('[data-testid="display-amount"]').text()).not.toBe('1.50');
+      expect(wrapper.find('[data-testid="display-amount"]').text()).toBe('1.53');
     });
 
     it('should not scramble the amount when noScramble is true', async () => {

--- a/frontend/app/src/modules/assets/amount-display/components/AssetValueDisplay.spec.ts
+++ b/frontend/app/src/modules/assets/amount-display/components/AssetValueDisplay.spec.ts
@@ -90,7 +90,7 @@ describe('modules/amount-display/components/AssetValueDisplay', () => {
 
   describe('scramble data', () => {
     beforeEach(async () => {
-      useSettingsRepo().updateFrontend({ scrambleData: true });
+      useSettingsRepo().updateFrontend({ scrambleData: true, scrambleMultiplier: 1.02 });
     });
 
     it('should scramble the value', async () => {
@@ -101,7 +101,7 @@ describe('modules/amount-display/components/AssetValueDisplay', () => {
           asset: 'ETH',
         },
       });
-      expect(wrapper.find('[data-testid="display-amount"]').text()).not.toBe('4,000.00');
+      expect(wrapper.find('[data-testid="display-amount"]').text()).toBe('4,080.00');
     });
   });
 

--- a/frontend/app/src/modules/assets/amount-display/components/FiatDisplay.spec.ts
+++ b/frontend/app/src/modules/assets/amount-display/components/FiatDisplay.spec.ts
@@ -94,7 +94,7 @@ describe('modules/amount-display/components/FiatDisplay', () => {
 
   describe('scramble data', () => {
     beforeEach(async () => {
-      useSettingsRepo().updateFrontend({ scrambleData: true });
+      useSettingsRepo().updateFrontend({ scrambleData: true, scrambleMultiplier: 1.02 });
     });
 
     it('should scramble the value', async () => {
@@ -102,10 +102,10 @@ describe('modules/amount-display/components/FiatDisplay', () => {
         from: 'USD',
         value: bigNumberify(1.20440001),
       });
-      expect(wrapper.find('[data-testid="display-amount"]').text()).not.toBe('1.44');
+      expect(wrapper.find('[data-testid="display-amount"]').text()).toBe('1.47');
       await wrapper.find('[data-testid="display-amount"]').trigger('mouseover');
       await nextTick();
-      expect(wrapper.find('[data-testid="display-full-value"]').text()).not.toBe('1.445280012');
+      expect(wrapper.find('[data-testid="display-full-value"]').text()).toMatch('1.47418561224');
     });
 
     it('should not scramble the value when noScramble is true', async () => {

--- a/frontend/app/src/modules/assets/amount-display/components/ValueDisplay.spec.ts
+++ b/frontend/app/src/modules/assets/amount-display/components/ValueDisplay.spec.ts
@@ -86,7 +86,7 @@ describe('modules/amount-display/components/ValueDisplay', () => {
 
   describe('scramble data', () => {
     beforeEach(async () => {
-      useSettingsRepo().updateFrontend({ scrambleData: true });
+      useSettingsRepo().updateFrontend({ scrambleData: true, scrambleMultiplier: 1.02 });
     });
 
     it('should scramble the value', async () => {
@@ -94,7 +94,7 @@ describe('modules/amount-display/components/ValueDisplay', () => {
         global: { plugins: [pinia] },
         props: { value: bigNumberify(1.5) },
       });
-      expect(wrapper.find('[data-testid="display-amount"]').text()).not.toBe('1.50');
+      expect(wrapper.find('[data-testid="display-amount"]').text()).toBe('1.53');
     });
 
     it('should not scramble the value when noScramble is true', async () => {


### PR DESCRIPTION
## Problem

The four `scramble data` tests in the amount-display component specs enable scrambling but never set `scrambleMultiplier`, so they inherit the random default:

```ts
scrambleMultiplier: z.number().optional().default(generateRandomScrambleMultiplier())
```

`generateRandomScrambleMultiplier()` returns `Math.floor(500 + Math.random() * 9500) / 1000`, i.e. any of 9500 values in `0.500 … 9.999`, including `1.000`. Scrambling is a plain multiply, so a draw near 1.0 renders the scrambled amount identically to the input and the `not.toBe(...)` assertion fails. For `1.5` at `uiFloatingPrecision: 2` with `amountRoundingMode` = `ROUND_UP`, every multiplier in `0.994 … 1.000` prints `1.50` — 7 of 9500 draws. The zod default is evaluated once at module load, so a bad draw poisons the whole test process.

Observed as:

```
AssertionError: expected '1.50' not to be '1.50' // Object.is equality
 ❯ AssetAmountDisplay.spec.ts:95:73
```

## Fix

Pin `scrambleMultiplier: 1.02` in each `scramble data` block and assert the exact scrambled output instead of asserting it merely differs from the unscrambled one. `not.toBe('1.50')` would also pass if the component rendered garbage, so this strengthens the assertion as well as making it deterministic.

| spec | input | was | now |
|---|---|---|---|
| `AssetAmountDisplay` | 1.5 ETH | `not.toBe('1.50')` | `toBe('1.53')` |
| `ValueDisplay` | 1.5 | `not.toBe('1.50')` | `toBe('1.53')` |
| `AssetValueDisplay` | 2 ETH @ 2000 | `not.toBe('4,000.00')` | `toBe('4,080.00')` |
| `FiatDisplay` | 1.20440001 USD | `not.toBe('1.44')` / `not.toBe('1.445280012')` | `toBe('1.47')` / `toMatch('1.47418561224')` |

The `FiatDisplay` full-value node also carries the click-to-copy tooltip text, so that assertion stays `toMatch`, in line with its sibling test.

Tests only, no production code touched.

## Checks

- `pnpm run test:unit src/modules/assets/amount-display/` — 94 passed
- `pnpm run lint:file:check` on the four specs — clean
- `pnpm run typecheck` — clean