### PR TITLE
Frontend coverage batch C: the route pages

### DIFF
--- a/frontend/app/src/pages/airdrops/airdrop-rows.spec.ts
+++ b/frontend/app/src/pages/airdrops/airdrop-rows.spec.ts
@@ -1,0 +1,162 @@
+import type { Airdrops } from '@/modules/airdrops/airdrops';
+import { bigNumberify, Zero } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { flattenAirdrops, hasDetails, matchesStatus, toAirdropRows } from './airdrop-rows';
+
+const NOW = 1_700_000_000;
+const ADDRESS_A = '0xaaa';
+const ADDRESS_B = '0xbbb';
+
+function airdrops(): Airdrops {
+  return {
+    [ADDRESS_A]: {
+      poap: [
+        { assets: [1], claimed: false, event: 'devcon', link: 'https://poap', name: 'Devcon' },
+      ],
+      uniswap: { amount: bigNumberify(400), asset: 'UNI', claimed: true, hasDecoder: true, link: 'https://uni' },
+    },
+    [ADDRESS_B]: {
+      cow: { amount: bigNumberify(10), asset: 'COW', claimed: false, cutoffTime: NOW - 100, hasDecoder: true, link: 'https://cow' },
+    },
+  };
+}
+
+/** The fixture's poap entry, as the list it has to be for the poap branch to be exercised. */
+function poapSource(data: Airdrops): unknown[] {
+  const value = data[ADDRESS_A].poap;
+  if (!Array.isArray(value))
+    throw new TypeError('fixture changed: the poap source must stay a list');
+
+  return value;
+}
+
+describe('pages/airdrops/hasDetails', () => {
+  it('should identify a poap delivery by its list of details', () => {
+    expect(hasDetails([{ assets: [], event: 'e', link: 'l', name: 'n' }])).toBe(true);
+  });
+
+  it('should reject an absent or empty list', () => {
+    expect(hasDetails(undefined)).toBe(false);
+    expect(hasDetails([])).toBe(false);
+  });
+});
+
+describe('pages/airdrops/flattenAirdrops', () => {
+  it('should produce one row per address and source', () => {
+    const rows = flattenAirdrops(airdrops(), []);
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map(row => `${row.address}:${row.source}`)).toEqual([
+      `${ADDRESS_A}:poap`,
+      `${ADDRESS_A}:uniswap`,
+      `${ADDRESS_B}:cow`,
+    ]);
+  });
+
+  it('should treat an empty address list as every address', () => {
+    expect(flattenAirdrops(airdrops(), [])).toHaveLength(3);
+  });
+
+  it('should keep only the named addresses', () => {
+    const rows = flattenAirdrops(airdrops(), [ADDRESS_B]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].address).toBe(ADDRESS_B);
+  });
+
+  it('should carry a list-valued source through as poap details', () => {
+    const poap = flattenAirdrops(airdrops(), [ADDRESS_A]).find(row => row.source === 'poap');
+
+    expect(poap?.details).toHaveLength(1);
+    expect(poap?.details?.[0].event).toBe('devcon');
+  });
+
+  it('should copy the poap details rather than aliasing the response', () => {
+    const source = airdrops();
+    const poap = flattenAirdrops(source, [ADDRESS_A]).find(row => row.source === 'poap');
+
+    expect(poap?.details?.[0]).toEqual(expect.objectContaining({ event: 'devcon' }));
+    expect(poap?.details?.[0]).not.toBe(poapSource(source)[0]);
+  });
+
+  it('should spread a single-valued source onto the row', () => {
+    const uniswap = flattenAirdrops(airdrops(), [ADDRESS_A]).find(row => row.source === 'uniswap');
+
+    expect(uniswap?.asset).toBe('UNI');
+    expect(uniswap?.claimed).toBe(true);
+  });
+});
+
+describe('pages/airdrops/matchesStatus', () => {
+  const decoded = { address: ADDRESS_A, hasDecoder: true, source: 'uniswap' };
+
+  it('should match everything on an unrecognised status, which is what an absent pill means', () => {
+    expect(matchesStatus({ ...decoded, claimed: true }, '', NOW)).toBe(true);
+    expect(matchesStatus({ ...decoded, claimed: true }, 'nonsense', NOW)).toBe(true);
+  });
+
+  it('should read a row with no decoder as unknown', () => {
+    expect(matchesStatus({ address: ADDRESS_A, source: 'x' }, 'unknown', NOW)).toBe(true);
+    expect(matchesStatus(decoded, 'unknown', NOW)).toBe(false);
+  });
+
+  it('should read a decoded unclaimed row as unclaimed', () => {
+    expect(matchesStatus({ ...decoded, claimed: false }, 'unclaimed', NOW)).toBe(true);
+    expect(matchesStatus({ ...decoded, claimed: true }, 'unclaimed', NOW)).toBe(false);
+  });
+
+  it('should not read an undecoded row as unclaimed', () => {
+    expect(matchesStatus({ address: ADDRESS_A, claimed: false, source: 'x' }, 'unclaimed', NOW)).toBe(false);
+  });
+
+  describe('missed', () => {
+    it('should match an unclaimed row whose cutoff has passed', () => {
+      expect(matchesStatus({ ...decoded, claimed: false, cutoffTime: NOW - 1 }, 'missed', NOW)).toBe(true);
+    });
+
+    it('should not match while the cutoff is still ahead', () => {
+      expect(matchesStatus({ ...decoded, claimed: false, cutoffTime: NOW + 1 }, 'missed', NOW)).toBe(false);
+    });
+
+    it('should not match a row with no cutoff at all', () => {
+      expect(matchesStatus({ ...decoded, claimed: false }, 'missed', NOW)).toBe(false);
+    });
+
+    it('should not match a row that was claimed before the cutoff passed', () => {
+      expect(matchesStatus({ ...decoded, claimed: true, cutoffTime: NOW - 1 }, 'missed', NOW)).toBe(false);
+    });
+  });
+
+  it('should read a claimed row as claimed regardless of its decoder', () => {
+    expect(matchesStatus({ address: ADDRESS_A, claimed: true, source: 'x' }, 'claimed', NOW)).toBe(true);
+    expect(matchesStatus({ ...decoded, claimed: false }, 'claimed', NOW)).toBe(false);
+  });
+});
+
+describe('pages/airdrops/toAirdropRows', () => {
+  it('should index the rows from zero after filtering, not before', () => {
+    const rows = toAirdropRows(airdrops(), [], 'claimed', NOW);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].index).toBe(0);
+    expect(rows[0].source).toBe('uniswap');
+  });
+
+  it('should fill in a missing amount with zero', () => {
+    const poap = toAirdropRows(airdrops(), [ADDRESS_A], 'unknown', NOW)[0];
+
+    expect(poap.source).toBe('poap');
+    expect(poap.amount).toStrictEqual(Zero);
+  });
+
+  it('should keep an amount that is present', () => {
+    const rows = toAirdropRows(airdrops(), [ADDRESS_B], '', NOW);
+
+    expect(rows[0].amount.toNumber()).toBe(10);
+  });
+
+  it('should narrow by address and status together', () => {
+    expect(toAirdropRows(airdrops(), [ADDRESS_A], 'missed', NOW)).toHaveLength(0);
+    expect(toAirdropRows(airdrops(), [ADDRESS_B], 'missed', NOW)).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/pages/airdrops/airdrop-rows.ts
+++ b/frontend/app/src/pages/airdrops/airdrop-rows.ts
@@ -1,0 +1,89 @@
+import type { Airdrop, Airdrops, PoapDeliveryDetails } from '@/modules/airdrops/airdrops';
+import { type BigNumber, Zero } from '@rotki/common';
+
+/**
+ * A row as the table sees it: `index` is the table's `row-attr`, and `amount` is filled in so the
+ * cell never has to deal with an absent one.
+ */
+export type AirdropWithIndex = Omit<Airdrop, 'amount'> & { index: number; amount: BigNumber };
+
+/** POAP deliveries are the only airdrops stored as a list, so a list is what identifies them. */
+export function hasDetails(details?: PoapDeliveryDetails[]): details is PoapDeliveryDetails[] {
+  return !!details && details.length > 0;
+}
+
+/**
+ * Flattens the address-keyed, then source-keyed, response into one row per airdrop, keeping only
+ * the given addresses. An empty address list means every address, which is what the pill bar's
+ * absent account pill means.
+ */
+export function flattenAirdrops(data: Airdrops, addresses: string[]): Airdrop[] {
+  const result: Airdrop[] = [];
+  for (const address in data) {
+    if (addresses.length > 0 && !addresses.includes(address))
+      continue;
+
+    const airdrop = data[address];
+    for (const source in airdrop) {
+      const element = airdrop[source];
+      if (Array.isArray(element)) {
+        result.push({
+          address,
+          details: element.map(detail => ({ ...detail })),
+          source,
+        });
+      }
+      else {
+        result.push({
+          address,
+          source,
+          ...element,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Whether a row reads as the given status. An unrecognised status - including the empty one the
+ * page starts on - matches everything, so an absent pill is "all".
+ *
+ * `currentTimeSeconds` is a parameter rather than a `Date.now()` call so "missed" is testable.
+ */
+export function matchesStatus(airdrop: Airdrop, status: string, currentTimeSeconds: number): boolean {
+  switch (status) {
+    case 'unknown':
+      return !airdrop.hasDecoder;
+    case 'missed':
+      return (
+        !!airdrop.hasDecoder
+        && !airdrop.claimed
+        && typeof airdrop.cutoffTime !== 'undefined'
+        && airdrop.cutoffTime !== null
+        && airdrop.cutoffTime < currentTimeSeconds
+      );
+    case 'unclaimed':
+      return !!airdrop.hasDecoder && !airdrop.claimed;
+    case 'claimed':
+      return !!airdrop.claimed;
+    default:
+      return true;
+  }
+}
+
+/** The table's rows: flattened, narrowed to the chosen addresses and status, then indexed. */
+export function toAirdropRows(
+  data: Airdrops,
+  addresses: string[],
+  status: string,
+  currentTimeSeconds: number,
+): AirdropWithIndex[] {
+  return flattenAirdrops(data, addresses)
+    .filter(airdrop => matchesStatus(airdrop, status, currentTimeSeconds))
+    .map((value, index) => ({
+      ...value,
+      amount: value.amount ?? Zero,
+      index,
+    }));
+}

--- a/frontend/app/src/pages/airdrops/index.spec.ts
+++ b/frontend/app/src/pages/airdrops/index.spec.ts
@@ -1,0 +1,326 @@
+import type { AirdropWithIndex } from '@/pages/airdrops/airdrop-rows';
+import type { useAirdropsPage } from '@/pages/airdrops/use-airdrops-page';
+import { bigNumberify } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, nextTick, type Ref } from 'vue';
+import AirdropsPage from '@/pages/airdrops/index.vue';
+
+const fetchAirdrops = vi.fn(async (): Promise<void> => {});
+const expand = vi.fn();
+
+interface PageState {
+  hideUnknownAlert: boolean;
+  loading: boolean;
+  rows: AirdropWithIndex[];
+  status: string;
+  /** The alert's dismiss flag, published back so a test can watch the page write it. */
+  modelHideUnknownAlert?: Ref<boolean>;
+}
+
+const pageState = vi.hoisted((): PageState => ({
+  hideUnknownAlert: false,
+  loading: false,
+  rows: [],
+  status: '',
+}));
+
+vi.mock('@/pages/airdrops/use-airdrops-page', async () => {
+  const { computed, ref, shallowRef } = await import('vue');
+  return {
+    useAirdropsPage: (): ReturnType<typeof useAirdropsPage> => {
+      pageState.modelHideUnknownAlert = shallowRef(pageState.hideUnknownAlert);
+      return {
+        // The real four; a cell slot only renders for a column that is actually in `cols`.
+        cols: computed(() => [
+          { key: 'source', label: 'Source' },
+          { key: 'address', label: 'Address' },
+          { align: 'end', key: 'amount', label: 'Amount' },
+          { key: 'claimed', label: 'Status' },
+        ]),
+        expand,
+        fetchAirdrops,
+        fields: [],
+        loading: computed(() => pageState.loading),
+        modelExpanded: ref([]),
+        modelHideUnknownAlert: pageState.modelHideUnknownAlert,
+        modelPagination: ref(undefined),
+        modelPillParams: computed({ get: () => ({}), set: () => {} }),
+        modelSort: ref([]),
+        pillLabels: computed(() => ({
+          add: 'add',
+          clear: 'clear',
+          empty: 'empty',
+          narrow: 'narrow',
+          narrowEmpty: 'narrowEmpty',
+          remove: 'remove',
+          search: 'search',
+          syntax: 'syntax',
+        })),
+        refreshTooltip: computed(() => 'refresh the airdrops'),
+        rows: computed(() => pageState.rows),
+        status: computed(() => pageState.status),
+      };
+    },
+  };
+});
+
+/**
+ * Declared rather than written inline in `stubs` so its props are typed at the assertion site;
+ * `findComponent` by name alone yields a wrapper whose `props()` accepts nothing.
+ */
+const DataTableStub = defineComponent({
+  name: 'DataTableStub',
+  props: {
+    cols: { default: () => [], type: Array },
+    expanded: { default: () => [], type: Array },
+    loading: { default: false, type: Boolean },
+    pagination: { default: undefined, type: Object },
+    rows: { default: () => [], type: Array },
+    sort: { default: () => [], type: [Array, Object] },
+  },
+  template: '<div />',
+});
+
+/**
+ * The unknown-status alert. Stubbed so its `close` event can be emitted: without the Rui plugin
+ * installed `RuiAlert` does not resolve to a component here, and the point of the test is the
+ * page's `@close` binding rather than the alert's own dismiss control.
+ */
+const AlertStub = defineComponent({
+  emits: ['close'],
+  name: 'AlertStub',
+  props: { closeable: { default: false, type: Boolean }, type: { default: 'info', type: String } },
+  template: '<div><slot /></div>',
+});
+
+function row(index: number, source: string): AirdropWithIndex {
+  return { address: '0xaaa', amount: bigNumberify(index + 1), index, source };
+}
+
+describe('pages/airdrops/index', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AirdropsPage>>;
+
+  function mountPage(): VueWrapper<InstanceType<typeof AirdropsPage>> {
+    return mount(AirdropsPage, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          PillFilterBar: { props: ['params', 'fields', 'labels'], template: '<div data-testid="pill-bar-stub" />' },
+          RuiAlert: AlertStub,
+          RuiDataTable: DataTableStub,
+          TablePageLayout: { props: ['title'], template: '<div><slot name="buttons" /><slot /></div>' },
+        },
+      },
+    });
+  }
+
+  function hideAlertModel(): Ref<boolean> {
+    const model = pageState.modelHideUnknownAlert;
+    if (!model)
+      throw new Error('mount the page first');
+
+    return model;
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    pageState.hideUnknownAlert = false;
+    pageState.loading = false;
+    pageState.rows = [];
+    pageState.status = '';
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should hand the rows and columns to the table', () => {
+    pageState.rows = [row(0, 'uniswap'), row(1, 'cow')];
+
+    wrapper = mountPage();
+
+    const table = wrapper.findComponent(DataTableStub);
+    expect(table.props('rows')).toHaveLength(2);
+    expect(table.props('cols')).toHaveLength(4);
+  });
+
+  it('should pass the loading state to the table', () => {
+    pageState.loading = true;
+
+    wrapper = mountPage();
+
+    expect(wrapper.findComponent(DataTableStub).props('loading')).toBe(true);
+  });
+
+  it('should refetch from the refresh button', async () => {
+    wrapper = mountPage();
+
+    await wrapper.find('[data-testid=airdrop-refresh]').trigger('click');
+
+    expect(fetchAirdrops).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The status chip restates the claimed/missed/unclaimed decision that `matchesStatus` makes for
+   * the filter, so the two can drift. These mount the real data table, which is the only way its
+   * cell slots render at all.
+   */
+  describe('the status cell', () => {
+    function mountWithRealTable(): VueWrapper<InstanceType<typeof AirdropsPage>> {
+      return mount(AirdropsPage, {
+        global: {
+          plugins: [createPinia()],
+          provide: libraryDefaults,
+          stubs: {
+            AirdropDisplay: { props: ['source', 'iconUrl', 'icon'], template: '<div />' },
+            AssetAmountDisplay: { props: ['asset', 'amount'], template: '<div data-testid="asset-amount" />' },
+            ExternalLink: { props: ['url', 'custom'], template: '<div data-testid="external-link"><slot /></div>' },
+            HashLink: { props: ['text', 'location'], template: '<div />' },
+            PillFilterBar: { props: ['params', 'fields', 'labels'], template: '<div />' },
+            PoapDeliveryAirdrops: { props: ['items'], template: '<div data-testid="poap-details" />' },
+            TablePageLayout: { props: ['title'], template: '<div><slot name="buttons" /><slot /></div>' },
+            ValueDisplay: { props: ['value'], template: '<div data-testid="value-only" />' },
+          },
+        },
+      });
+    }
+
+    it('should read a claimed row as claimed', async () => {
+      pageState.rows = [{ ...row(0, 'uniswap'), asset: 'UNI', claimed: true, hasDecoder: true }];
+
+      wrapper = mountWithRealTable();
+      await nextTick();
+
+      expect(wrapper.text()).toContain('common.claimed');
+    });
+
+    it('should read an unclaimed row whose cutoff has passed as missed', async () => {
+      pageState.rows = [{
+        ...row(0, 'cow'),
+        asset: 'COW',
+        claimed: false,
+        cutoffTime: Math.floor(Date.now() / 1000) - 100,
+        hasDecoder: true,
+      }];
+
+      wrapper = mountWithRealTable();
+      await nextTick();
+
+      expect(wrapper.text()).toContain('common.missed');
+    });
+
+    it('should read an unclaimed row whose cutoff is ahead as unclaimed', async () => {
+      pageState.rows = [{
+        ...row(0, 'cow'),
+        asset: 'COW',
+        claimed: false,
+        cutoffTime: Math.floor(Date.now() / 1000) + 1000,
+        hasDecoder: true,
+      }];
+
+      wrapper = mountWithRealTable();
+      await nextTick();
+
+      expect(wrapper.text()).toContain('common.unclaimed');
+    });
+
+    it('should read a row with no decoder as unknown, whatever its claimed flag says', async () => {
+      pageState.rows = [{ ...row(0, 'mystery'), claimed: true }];
+
+      wrapper = mountWithRealTable();
+      await nextTick();
+
+      expect(wrapper.text()).toContain('common.unknown');
+      expect(wrapper.text()).not.toContain('common.claimed');
+    });
+
+    it('should show the amount against its asset when the row has one', async () => {
+      pageState.rows = [{ ...row(0, 'uniswap'), asset: 'UNI', hasDecoder: true }];
+
+      wrapper = mountWithRealTable();
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=asset-amount]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=value-only]').exists()).toBe(false);
+    });
+
+    it('should fall back to a bare value when the row names no asset', async () => {
+      pageState.rows = [{ ...row(0, 'uniswap'), hasDecoder: true }];
+
+      wrapper = mountWithRealTable();
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=value-only]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=asset-amount]').exists()).toBe(false);
+    });
+
+    it('should count the deliveries instead of an amount for a poap row', async () => {
+      pageState.rows = [{
+        ...row(0, 'poap'),
+        details: [
+          { assets: [], event: 'devcon', link: 'l', name: 'n' },
+          { assets: [], event: 'ethcc', link: 'l', name: 'n' },
+        ],
+      }];
+
+      wrapper = mountWithRealTable();
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=asset-amount]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid=value-only]').exists()).toBe(false);
+      expect(wrapper.text()).toContain('2');
+    });
+
+    it('should offer an external link for a row that is not a poap delivery', async () => {
+      pageState.rows = [{ ...row(0, 'uniswap'), asset: 'UNI', hasDecoder: true, link: 'https://uni' }];
+
+      wrapper = mountWithRealTable();
+      await nextTick();
+
+      expect(wrapper.find('[data-testid=external-link]').exists()).toBe(true);
+    });
+  });
+
+  describe('the unknown-status alert', () => {
+    it('should stay hidden while no status is chosen', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.find('[data-testid=airdrop-unknown-alert]').exists()).toBe(false);
+    });
+
+    it('should show once the unknown status is chosen', () => {
+      pageState.status = 'unknown';
+
+      wrapper = mountPage();
+
+      expect(wrapper.find('[data-testid=airdrop-unknown-alert]').exists()).toBe(true);
+    });
+
+    it('should stay hidden on the unknown status once it has been dismissed', () => {
+      pageState.status = 'unknown';
+      pageState.hideUnknownAlert = true;
+
+      wrapper = mountPage();
+
+      expect(wrapper.find('[data-testid=airdrop-unknown-alert]').exists()).toBe(false);
+    });
+
+    it('should record the dismissal when the alert is closed', async () => {
+      pageState.status = 'unknown';
+      wrapper = mountPage();
+
+      // Emitted from the alert itself, so this pins the `@close` binding. Writing the model
+      // directly would pass with that binding deleted.
+      wrapper.findComponent(AlertStub).vm.$emit('close');
+      await nextTick();
+
+      expect(get(hideAlertModel())).toBe(true);
+      expect(wrapper.find('[data-testid=airdrop-unknown-alert]').exists()).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/pages/airdrops/index.vue
+++ b/frontend/app/src/pages/airdrops/index.vue
@@ -1,23 +1,14 @@
 <script setup lang="ts">
-import type { DataTableColumn, DataTableSortData, TablePaginationData } from '@rotki/ui-library';
-import type {
-  Airdrop,
-  Airdrops,
-  PoapDeliveryDetails,
-} from '@/modules/airdrops/airdrops';
-import { type BigNumber, Zero } from '@rotki/common';
 import { msg } from '@/message-key';
 import AirdropDisplay from '@/modules/airdrops/AirdropDisplay.vue';
 import PoapDeliveryAirdrops from '@/modules/airdrops/PoapDeliveryAirdrops.vue';
-import { airdropParams, useAirdropFields } from '@/modules/airdrops/use-airdrop-fields';
-import { useAirdrops } from '@/modules/airdrops/use-airdrops';
 import { AssetAmountDisplay, ValueDisplay } from '@/modules/assets/amount-display/components';
-import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
-import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
+import { hasDetails } from '@/pages/airdrops/airdrop-rows';
+import { useAirdropsPage } from '@/pages/airdrops/use-airdrops-page';
 
 definePage({
   meta: {
@@ -25,135 +16,24 @@ definePage({
   },
 });
 
-type AirdropWithIndex = Omit<Airdrop, 'amount'> & { index: number; amount: BigNumber };
-
 const { t } = useI18n({ useScope: 'global' });
-const { airdrops, fetchAirdrops, loading } = useAirdrops();
-const hideUnknownAlert = useLocalStorage('rotki.airdrops.hide_unknown_alert', false);
 
-const sort = ref<DataTableSortData<AirdropWithIndex>>([]);
-
-const expanded = ref<AirdropWithIndex[]>([]);
-const status = ref<string>('');
-const pagination = ref<TablePaginationData>();
-const selectedAddresses = ref<string[]>([]);
-
-const refreshTooltip = computed<string>(() =>
-  t('helpers.refresh_header.tooltip', {
-    title: t('airdrops.title').toLocaleLowerCase(),
-  }),
-);
-
-const airdropAddresses = computed<string[]>(() => Object.keys(get(airdrops)));
-
-const fields = useAirdropFields(airdropAddresses);
-const pillLabels = usePillBarLabels();
-const pillParams = airdropParams(selectedAddresses, status);
-
-const rows = computed<AirdropWithIndex[]>(() => {
-  const data = filterByAddress(get(airdrops), get(selectedAddresses));
-  return data
-    .filter((airdrop) => {
-      const currentStatus = get(status);
-      const currentTime = Date.now() / 1000;
-      switch (currentStatus) {
-        case 'unknown':
-          return !airdrop.hasDecoder;
-        case 'missed':
-          return (
-            airdrop.hasDecoder
-            && !airdrop.claimed
-            && typeof airdrop.cutoffTime !== 'undefined'
-            && airdrop.cutoffTime !== null
-            && airdrop.cutoffTime < currentTime
-          );
-        case 'unclaimed':
-          return airdrop.hasDecoder && !airdrop.claimed;
-        case 'claimed':
-          return airdrop.claimed;
-        default:
-          return true;
-      }
-    })
-    .map((value, index) => ({
-      ...value,
-      amount: value.amount ?? Zero,
-      index,
-    }));
-});
-
-const cols = computed<DataTableColumn<AirdropWithIndex>[]>(() => [
-  {
-    key: 'source',
-    label: t('airdrops.headers.source'),
-    sortable: true,
-    width: '200px',
-  },
-  {
-    key: 'address',
-    label: t('common.address'),
-    sortable: true,
-  },
-  {
-    align: 'end',
-    key: 'amount',
-    label: t('common.amount'),
-    sortable: true,
-  },
-  {
-    key: 'claimed',
-    label: t('common.status'),
-  },
-]);
-
-useRememberTableSorting<AirdropWithIndex>(TableId.AIRDROP, sort, cols);
-
-function filterByAddress(data: Airdrops, addresses: string[]): Airdrop[] {
-  const result: Airdrop[] = [];
-  for (const address in data) {
-    if (addresses.length > 0 && !addresses.includes(address))
-      continue;
-
-    const airdrop = data[address];
-    for (const source in airdrop) {
-      const element = airdrop[source];
-      // Only poap deliveries are stored as an array, so this is also the poap branch.
-      if (Array.isArray(element)) {
-        result.push({
-          address,
-          details: element.map(detail => ({
-            ...detail,
-          })),
-          source,
-        });
-      }
-      else {
-        result.push({
-          address,
-          source,
-          ...element,
-        });
-      }
-    }
-  }
-  return result;
-}
-
-function hasDetails(details?: PoapDeliveryDetails[]): details is PoapDeliveryDetails[] {
-  return !!details && details.length > 0;
-}
-
-function expand(item: AirdropWithIndex) {
-  set(expanded, get(expanded).includes(item) ? [] : [item]);
-}
-
-onMounted(async () => {
-  await fetchAirdrops();
-});
-
-watch([status, selectedAddresses], () => {
-  set(pagination, { ...get(pagination), page: 1 });
-});
+const {
+  cols,
+  expand,
+  fetchAirdrops,
+  fields,
+  loading,
+  modelExpanded,
+  modelHideUnknownAlert,
+  modelPagination,
+  modelPillParams,
+  modelSort,
+  pillLabels,
+  refreshTooltip,
+  rows,
+  status,
+} = useAirdropsPage();
 </script>
 
 <template>
@@ -181,27 +61,27 @@ watch([status, selectedAddresses], () => {
 
     <RuiCard>
       <PillFilterBar
-        v-model:params="pillParams"
+        v-model:params="modelPillParams"
         class="mb-4"
         :fields="fields"
         :labels="pillLabels"
       />
 
       <RuiAlert
-        v-if="!hideUnknownAlert && status === 'unknown'"
+        v-if="!modelHideUnknownAlert && status === 'unknown'"
         type="info"
         class="mb-4"
         closeable
         data-testid="airdrop-unknown-alert"
-        @close="hideUnknownAlert = true"
+        @close="modelHideUnknownAlert = true"
       >
         {{ t('airdrops.unknown_info') }}
       </RuiAlert>
 
       <RuiDataTable
-        v-model:pagination="pagination"
-        v-model:expanded="expanded"
-        v-model:sort="sort"
+        v-model:pagination="modelPagination"
+        v-model:expanded="modelExpanded"
+        v-model:sort="modelSort"
         outlined
         data-testid="airdrop-table"
         :rows="rows"
@@ -286,7 +166,7 @@ watch([status, selectedAddresses], () => {
           </ExternalLink>
           <RuiTableRowExpander
             v-else
-            :expanded="expanded.includes(row)"
+            :expanded="modelExpanded.includes(row)"
             @click="expand(row)"
           />
         </template>

--- a/frontend/app/src/pages/airdrops/use-airdrops-page.spec.ts
+++ b/frontend/app/src/pages/airdrops/use-airdrops-page.spec.ts
@@ -1,0 +1,221 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { Airdrops } from '@/modules/airdrops/airdrops';
+import type { AirdropWithIndex } from '@/pages/airdrops/airdrop-rows';
+import { bigNumberify } from '@rotki/common';
+import { withSetup } from '@test/utils/with-setup';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type MaybeRefOrGetter, nextTick, type Ref } from 'vue';
+import { useAirdropsPage } from './use-airdrops-page';
+
+const ADDRESS_A = '0xaaa';
+const ADDRESS_B = '0xbbb';
+
+// Everything the mocks capture on mount. Filled in by the factories below, read back through the
+// accessors, which fail loudly rather than yielding undefined when the page was never mounted.
+const { airdropsRef, eligibleAddresses, fetchAirdrops, rememberSorting, selectedAddresses, status } = vi.hoisted(() => {
+  const airdropsRef: { current?: Ref<Airdrops> } = {};
+  /** What the page hands `useAirdropFields` as the addresses worth offering. */
+  const eligibleAddresses: { current?: MaybeRefOrGetter<string[]> } = {};
+  // The two params the pill bar writes. The real `airdropParams` wraps them in a params bag; here
+  // they are handed back directly so a test can drive them the way the bar would.
+  const selectedAddresses: { current?: Ref<string[]> } = {};
+  const status: { current?: Ref<string> } = {};
+
+  return {
+    airdropsRef,
+    eligibleAddresses,
+    fetchAirdrops: vi.fn(async (): Promise<void> => {}),
+    rememberSorting: vi.fn(),
+    selectedAddresses,
+    status,
+  };
+});
+
+function captured<T>(slot: { current?: T }, name: string): T {
+  if (slot.current === undefined)
+    throw new Error(`${name} was never captured - mount the page first`);
+
+  return slot.current;
+}
+
+vi.mock('@/modules/airdrops/use-airdrops', async () => {
+  const { ref: refFn, shallowRef: shallowRefFn } = await import('vue');
+  return {
+    useAirdrops: (): { airdrops: Ref<Airdrops>; fetchAirdrops: typeof fetchAirdrops; loading: Ref<boolean> } => {
+      airdropsRef.current = refFn<Airdrops>({});
+      return { airdrops: airdropsRef.current, fetchAirdrops, loading: shallowRefFn(false) };
+    },
+  };
+});
+
+vi.mock('@/modules/airdrops/use-airdrop-fields', () => ({
+  airdropParams: (addresses: Ref<string[]>, statusRef: Ref<string>): { value: unknown } => {
+    selectedAddresses.current = addresses;
+    status.current = statusRef;
+    return { value: {} };
+  },
+  useAirdropFields: (eligible: MaybeRefOrGetter<string[]>): [] => {
+    eligibleAddresses.current = eligible;
+    return [];
+  },
+}));
+
+vi.mock('@/modules/core/table/pill/composables/use-pill-bar-labels', () => ({
+  usePillBarLabels: (): Record<string, never> => ({}),
+}));
+
+vi.mock('@/modules/core/table/use-remember-table-sorting', () => ({
+  TableId: { AIRDROP: 'airdrop' },
+  useRememberTableSorting: rememberSorting,
+}));
+
+function row(index: number): AirdropWithIndex {
+  return { address: ADDRESS_A, amount: bigNumberify(1), index, source: `source-${index}` };
+}
+
+describe('pages/airdrops/useAirdropsPage', () => {
+  // The composable registers an onMounted hook and a watcher, so a harness left mounted would
+  // answer a later test.
+  const mounted: VueWrapper[] = [];
+
+  function setup(): ReturnType<typeof useAirdropsPage> {
+    const { result, wrapper } = withSetup(() => useAirdropsPage());
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  it('should fetch the airdrops on mount', async () => {
+    setup();
+    await flushPromises();
+
+    expect(fetchAirdrops).toHaveBeenCalledTimes(1);
+  });
+
+  it('should derive the rows from the fetched airdrops', async () => {
+    const { rows } = setup();
+    await flushPromises();
+
+    set(captured(airdropsRef, 'airdrops'), {
+      [ADDRESS_A]: { uniswap: { amount: bigNumberify(4), asset: 'UNI', claimed: true, hasDecoder: true, link: 'l' } },
+    });
+    await nextTick();
+
+    expect(get(rows)).toHaveLength(1);
+    expect(get(rows)[0].source).toBe('uniswap');
+  });
+
+  it('should offer only the addresses that actually hold an airdrop as filter options', async () => {
+    setup();
+    await flushPromises();
+
+    expect(toValue(captured(eligibleAddresses, 'eligible addresses'))).toEqual([]);
+
+    set(captured(airdropsRef, 'airdrops'), {
+      [ADDRESS_A]: { uniswap: { amount: bigNumberify(4), asset: 'UNI', claimed: true, link: 'l' } },
+      [ADDRESS_B]: { cow: { amount: bigNumberify(1), asset: 'COW', claimed: false, link: 'l' } },
+    });
+    await nextTick();
+
+    // Handed as a getter, so the list has to track a later fetch rather than being read once.
+    expect(toValue(captured(eligibleAddresses, 'eligible addresses'))).toEqual([ADDRESS_A, ADDRESS_B]);
+  });
+
+  describe('the pagination reset', () => {
+    it('should return to the first page when the status changes', async () => {
+      const { modelPagination } = setup();
+      await flushPromises();
+
+      set(modelPagination, { limit: 10, page: 4, total: 100 });
+      set(captured(status, 'status'), 'claimed');
+      await nextTick();
+
+      expect(get(modelPagination)?.page).toBe(1);
+    });
+
+    it('should return to the first page when the addresses change', async () => {
+      const { modelPagination } = setup();
+      await flushPromises();
+
+      set(modelPagination, { limit: 10, page: 4, total: 100 });
+      set(captured(selectedAddresses, 'selected addresses'), [ADDRESS_B]);
+      await nextTick();
+
+      expect(get(modelPagination)?.page).toBe(1);
+    });
+
+    it('should keep the rest of the pagination while resetting the page', async () => {
+      const { modelPagination } = setup();
+      await flushPromises();
+
+      set(modelPagination, { limit: 25, page: 4, total: 100 });
+      set(captured(status, 'status'), 'claimed');
+      await nextTick();
+
+      expect(get(modelPagination)?.limit).toBe(25);
+      expect(get(modelPagination)?.total).toBe(100);
+    });
+  });
+
+  describe('single expand', () => {
+    it('should open a row', async () => {
+      const { expand, modelExpanded } = setup();
+      await flushPromises();
+
+      const first = row(0);
+      expand(first);
+
+      expect(get(modelExpanded)).toEqual([first]);
+    });
+
+    it('should replace the open row rather than opening a second', async () => {
+      const { expand, modelExpanded } = setup();
+      await flushPromises();
+
+      const first = row(0);
+      const second = row(1);
+      expand(first);
+      expand(second);
+
+      expect(get(modelExpanded)).toEqual([second]);
+    });
+
+    it('should close the row when it is clicked again', async () => {
+      const { expand, modelExpanded } = setup();
+      await flushPromises();
+
+      const first = row(0);
+      expand(first);
+      expand(first);
+
+      expect(get(modelExpanded)).toEqual([]);
+    });
+  });
+
+  it('should register the table sorting under the airdrop table id', async () => {
+    setup();
+    await flushPromises();
+
+    expect(rememberSorting).toHaveBeenCalledWith('airdrop', expect.anything(), expect.anything());
+  });
+
+  it('should remember the dismissed unknown-status alert across mounts', async () => {
+    const { modelHideUnknownAlert } = setup();
+    await flushPromises();
+
+    set(modelHideUnknownAlert, true);
+    await nextTick();
+
+    expect(get(setup().modelHideUnknownAlert)).toBe(true);
+  });
+});

--- a/frontend/app/src/pages/airdrops/use-airdrops-page.ts
+++ b/frontend/app/src/pages/airdrops/use-airdrops-page.ts
@@ -1,0 +1,110 @@
+import type { DataTableColumn, DataTableSortData, TablePaginationData } from '@rotki/ui-library';
+import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import type { PillParams } from '@/modules/core/table/param-refs';
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
+import { airdropParams, useAirdropFields } from '@/modules/airdrops/use-airdrop-fields';
+import { useAirdrops } from '@/modules/airdrops/use-airdrops';
+import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
+import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
+import { type AirdropWithIndex, toAirdropRows } from '@/pages/airdrops/airdrop-rows';
+
+interface UseAirdropsPageReturn {
+  cols: ComputedRef<DataTableColumn<AirdropWithIndex>[]>;
+  expand: (item: AirdropWithIndex) => void;
+  fetchAirdrops: () => Promise<void>;
+  fields: FieldDef[];
+  loading: Readonly<Ref<boolean>>;
+  modelExpanded: Ref<AirdropWithIndex[]>;
+  modelHideUnknownAlert: Ref<boolean>;
+  modelPagination: Ref<TablePaginationData | undefined>;
+  modelPillParams: WritableComputedRef<PillParams>;
+  modelSort: Ref<DataTableSortData<AirdropWithIndex>>;
+  pillLabels: ReturnType<typeof usePillBarLabels>;
+  refreshTooltip: ComputedRef<string>;
+  rows: ComputedRef<AirdropWithIndex[]>;
+  status: Readonly<Ref<string>>;
+}
+
+export function useAirdropsPage(): UseAirdropsPageReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const { airdrops, fetchAirdrops, loading } = useAirdrops();
+
+  const modelHideUnknownAlert = useLocalStorage('rotki.airdrops.hide_unknown_alert', false);
+  const modelSort = ref<DataTableSortData<AirdropWithIndex>>([]);
+  const modelExpanded = ref<AirdropWithIndex[]>([]);
+  const modelPagination = ref<TablePaginationData>();
+  const status = shallowRef<string>('');
+  const selectedAddresses = ref<string[]>([]);
+
+  const refreshTooltip = computed<string>(() => t('helpers.refresh_header.tooltip', {
+    title: t('airdrops.title').toLocaleLowerCase(),
+  }));
+
+  const airdropAddresses = computed<string[]>(() => Object.keys(get(airdrops)));
+
+  const fields = useAirdropFields(airdropAddresses);
+  const pillLabels = usePillBarLabels();
+  const modelPillParams = airdropParams(selectedAddresses, status);
+
+  const rows = computed<AirdropWithIndex[]>(() =>
+    toAirdropRows(get(airdrops), get(selectedAddresses), get(status), Date.now() / 1000),
+  );
+
+  const cols = computed<DataTableColumn<AirdropWithIndex>[]>(() => [
+    {
+      key: 'source',
+      label: t('airdrops.headers.source'),
+      sortable: true,
+      width: '200px',
+    },
+    {
+      key: 'address',
+      label: t('common.address'),
+      sortable: true,
+    },
+    {
+      align: 'end',
+      key: 'amount',
+      label: t('common.amount'),
+      sortable: true,
+    },
+    {
+      key: 'claimed',
+      label: t('common.status'),
+    },
+  ]);
+
+  useRememberTableSorting<AirdropWithIndex>(TableId.AIRDROP, modelSort, cols);
+
+  /** Single-expand: expanding another row replaces the open one, and a repeat click closes it. */
+  function expand(item: AirdropWithIndex): void {
+    set(modelExpanded, get(modelExpanded).includes(item) ? [] : [item]);
+  }
+
+  onMounted(async () => {
+    await fetchAirdrops();
+  });
+
+  // Narrowing can leave the current page past the end of the shorter result, which reads as an
+  // empty table.
+  watch([status, selectedAddresses], () => {
+    set(modelPagination, { ...get(modelPagination), page: 1 });
+  });
+
+  return {
+    cols,
+    expand,
+    fetchAirdrops,
+    fields,
+    loading,
+    modelExpanded,
+    modelHideUnknownAlert,
+    modelPagination,
+    modelPillParams,
+    modelSort,
+    pillLabels,
+    refreshTooltip,
+    rows,
+    status: readonly(status),
+  };
+}

--- a/frontend/app/src/pages/assets/[identifier].spec.ts
+++ b/frontend/app/src/pages/assets/[identifier].spec.ts
@@ -1,0 +1,267 @@
+import type { useAssetDetail } from '@/pages/assets/use-asset-detail';
+import { type AssetBalanceWithPrice, bigNumberify } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import AssetLocations from '@/modules/assets/AssetLocations.vue';
+import AssetValueRow from '@/modules/assets/AssetValueRow.vue';
+import AssetDetailPage from '@/pages/assets/[identifier].vue';
+
+const IDENTIFIER = 'ETH';
+
+const goToEdit = vi.fn();
+const toggleIgnoreAsset = vi.fn(async (): Promise<void> => {});
+const toggleSpam = vi.fn(async (): Promise<void> => {});
+const toggleWhitelistAsset = vi.fn(async (): Promise<void> => {});
+
+interface DetailState {
+  collectionBalance: AssetBalanceWithPrice[];
+  collectionId: number | undefined;
+  isCollectionParent: boolean;
+  isCustomAsset: boolean;
+  premium: boolean;
+}
+
+const detailState = vi.hoisted((): DetailState => ({
+  collectionBalance: [],
+  collectionId: undefined,
+  isCollectionParent: false,
+  isCustomAsset: false,
+  premium: false,
+}));
+
+// `@/modules/premium/premium` reaches the real router through `main.ts`, which blows up under
+// vitest. The component itself is stubbed below; this only keeps the import graph out.
+vi.mock('@/modules/premium/premium', async () => {
+  const { defineComponent } = await import('vue');
+  return {
+    AssetAmountAndValueOverTime: defineComponent({
+      name: 'AssetAmountAndValueOverTime',
+      props: { asset: { default: '', type: String }, collectionId: { default: undefined, type: Number }, priceAsset: { default: undefined, type: String } },
+      template: '<div />',
+    }),
+  };
+});
+
+vi.mock('@/pages/assets/use-asset-detail', async () => {
+  const { computed, shallowRef } = await import('vue');
+  return {
+    useAssetDetail: (): ReturnType<typeof useAssetDetail> => ({
+      asset: computed(() => ({
+        assetType: 'evm token',
+        coingecko: 'ethereum',
+        cryptocompare: 'ETH',
+        customAssetType: 'a custom type',
+        isCustomAsset: detailState.isCustomAsset,
+        name: 'Ethereum',
+        resolved: true,
+        symbol: 'ETH',
+      })),
+      collectionAssetWithPrice: computed(() => IDENTIFIER),
+      collectionBalance: computed(() => detailState.collectionBalance),
+      collectionId: computed(() => detailState.collectionId),
+      contractInfo: computed(() => undefined),
+      goToEdit,
+      isCollectionParent: computed(() => detailState.isCollectionParent),
+      isCustomAsset: computed(() => detailState.isCustomAsset),
+      loadingIgnore: computed(() => false),
+      loadingSpam: computed(() => false),
+      loadingWhitelist: computed(() => false),
+      premium: shallowRef(detailState.premium),
+      toggleIgnoreAsset,
+      toggleSpam,
+      toggleWhitelistAsset,
+    }),
+  };
+});
+
+/**
+ * Declared rather than written inline in `stubs`: an inline stub has no component name, so it can
+ * be found neither by name nor with typed `props()`.
+ */
+const AssetIconStub = defineComponent({
+  name: 'AssetIconStub',
+  props: { identifier: { default: '', type: String }, showChain: { default: false, type: Boolean }, size: { default: '', type: String } },
+  template: '<div />',
+});
+
+const AssetBalancesStub = defineComponent({
+  name: 'AssetBalancesStub',
+  props: { balances: { default: () => [], type: Array }, breakdown: { default: undefined, type: Object } },
+  template: '<div data-testid="collection-balances" />',
+});
+
+const PremiumChartStub = defineComponent({
+  name: 'AssetAmountAndValueOverTime',
+  props: { asset: { default: '', type: String }, collectionId: { default: undefined, type: Number }, priceAsset: { default: undefined, type: String } },
+  template: '<div />',
+});
+
+const IgnoreSwitchStub = defineComponent({
+  emits: ['toggle-ignore', 'toggle-whitelist', 'toggle-spam'],
+  name: 'IgnoreSwitchStub',
+  props: { asset: { default: undefined, type: Object }, loading: { default: false, type: Boolean }, menuLoading: { default: false, type: Boolean } },
+  template: '<div data-testid="ignore-switch" />',
+});
+
+describe('pages/assets/[identifier]', () => {
+  let wrapper: VueWrapper<InstanceType<typeof AssetDetailPage>>;
+
+  function mountPage(): VueWrapper<InstanceType<typeof AssetDetailPage>> {
+    return mount(AssetDetailPage, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          AssetAmountAndValueOverTime: PremiumChartStub,
+          AssetAmountAndValuePlaceholder: { template: '<div data-testid="chart-placeholder" />' },
+          AssetBalances: AssetBalancesStub,
+          AssetExternalLinks: { props: ['coingecko', 'cryptocompare'], template: '<div />' },
+          AssetIcon: AssetIconStub,
+          AssetLocations: { props: ['identifier'], template: '<div data-testid="asset-locations" />' },
+          AssetValueRow: { props: ['isCollectionParent', 'identifier'], template: '<div />' },
+          HashLink: { props: ['location', 'type', 'text'], template: '<div />' },
+          ManagedAssetIgnoreSwitch: IgnoreSwitchStub,
+          TablePageLayout: { props: ['hideHeader'], template: '<div><slot /></div>' },
+        },
+      },
+      props: { identifier: IDENTIFIER },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    detailState.collectionBalance = [];
+    detailState.collectionId = undefined;
+    detailState.isCollectionParent = false;
+    detailState.isCustomAsset = false;
+    detailState.premium = false;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should show the symbol above the name for a regular asset', () => {
+    wrapper = mountPage();
+
+    expect(wrapper.text()).toContain('ETH');
+    expect(wrapper.text()).toContain('Ethereum');
+    expect(wrapper.text()).not.toContain('a custom type');
+  });
+
+  it('should show the name above the custom type for a custom asset', () => {
+    detailState.isCustomAsset = true;
+
+    wrapper = mountPage();
+
+    expect(wrapper.text()).toContain('a custom type');
+  });
+
+  it('should hide the ignore switch for a custom asset, which cannot be ignored', () => {
+    detailState.isCustomAsset = true;
+
+    wrapper = mountPage();
+
+    expect(wrapper.find('[data-testid=ignore-switch]').exists()).toBe(false);
+  });
+
+  it('should forward each switch event to its own action', async () => {
+    wrapper = mountPage();
+    const ignoreSwitch = wrapper.findComponent(IgnoreSwitchStub);
+
+    ignoreSwitch.vm.$emit('toggle-ignore');
+    ignoreSwitch.vm.$emit('toggle-whitelist');
+    ignoreSwitch.vm.$emit('toggle-spam');
+
+    expect(toggleIgnoreAsset).toHaveBeenCalledTimes(1);
+    expect(toggleWhitelistAsset).toHaveBeenCalledTimes(1);
+    expect(toggleSpam).toHaveBeenCalledTimes(1);
+  });
+
+  describe('a single asset', () => {
+    it('should offer the edit button and run it', async () => {
+      wrapper = mountPage();
+
+      await wrapper.find('[data-testid=edit-asset]').trigger('click');
+
+      expect(goToEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it('should show the per-location breakdown', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(AssetLocations).exists()).toBe(true);
+      expect(wrapper.find('[data-testid=collection-balances]').exists()).toBe(false);
+    });
+
+    it('should show the chain on the icon', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(AssetIconStub).props('showChain')).toBe(true);
+    });
+  });
+
+  describe('a collection parent', () => {
+    beforeEach(() => {
+      detailState.isCollectionParent = true;
+    });
+
+    it('should hide the edit button, which has no single asset to edit', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.find('[data-testid=edit-asset]').exists()).toBe(false);
+    });
+
+    it('should replace the location breakdown with the collection balances', () => {
+      detailState.collectionBalance = [{
+        amount: bigNumberify(1),
+        asset: 'eip155:1/erc20:0xabc',
+        price: bigNumberify(2),
+        value: bigNumberify(2),
+      }];
+
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(AssetLocations).exists()).toBe(false);
+      expect(wrapper.findComponent(AssetBalancesStub).props('balances')).toHaveLength(1);
+    });
+
+    it('should not show the chain on the icon', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(AssetIconStub).props('showChain')).toBe(false);
+    });
+
+    it('should tell the value row it is showing a collection', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(AssetValueRow).props('isCollectionParent')).toBe(true);
+    });
+  });
+
+  describe('the value-over-time chart', () => {
+    it('should show the placeholder without premium', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.find('[data-testid=chart-placeholder]').exists()).toBe(true);
+      expect(wrapper.findComponent(PremiumChartStub).exists()).toBe(false);
+    });
+
+    it('should show the real chart with premium, carrying the priced asset and collection', () => {
+      detailState.premium = true;
+      detailState.collectionId = 5;
+
+      wrapper = mountPage();
+
+      const chart = wrapper.findComponent(PremiumChartStub);
+      expect(chart.exists()).toBe(true);
+      expect(chart.props('asset')).toBe(IDENTIFIER);
+      expect(chart.props('priceAsset')).toBe(IDENTIFIER);
+      expect(chart.props('collectionId')).toBe(5);
+    });
+  });
+});

--- a/frontend/app/src/pages/assets/[identifier].vue
+++ b/frontend/app/src/pages/assets/[identifier].vue
@@ -1,21 +1,17 @@
 <script setup lang="ts">
-import type { AssetBalanceWithPrice } from '@rotki/common';
 import { msg } from '@/message-key';
 import ManagedAssetIgnoreSwitch from '@/modules/assets/admin/managed/ManagedAssetIgnoreSwitch.vue';
 import AssetExternalLinks from '@/modules/assets/AssetExternalLinks.vue';
 import AssetLocations from '@/modules/assets/AssetLocations.vue';
 import AssetValueRow from '@/modules/assets/AssetValueRow.vue';
-import { type AssetResolutionOptions, useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import AssetBalances from '@/modules/balances/AssetBalances.vue';
-import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
 import { NoteLocation } from '@/modules/core/common/notes';
 import { AssetAmountAndValueOverTime } from '@/modules/premium/premium';
-import { usePremium } from '@/modules/premium/use-premium';
 import AssetIcon from '@/modules/shell/components/AssetIcon.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 import AssetAmountAndValuePlaceholder from '@/modules/statistics/AssetAmountAndValuePlaceholder.vue';
-import { useAssetPageActions } from '@/pages/assets/use-asset-page-actions';
+import { useAssetDetail } from '@/pages/assets/use-asset-detail';
 
 definePage({
   meta: {
@@ -36,85 +32,24 @@ const { identifier } = defineProps<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const router = useRouter();
-const route = useRoute();
-
-const { refetchAssetInfo, useAssetContractInfo, useAssetInfo } = useAssetInfoRetrieval();
-const premium = usePremium();
-const { useBalances } = useAggregatedBalances();
-
-const aggregatedBalances = useBalances();
-
-const isCollectionParent = computed<boolean>(() => {
-  const currentRoute = get(route);
-  const collectionParent = currentRoute.query.collectionParent;
-
-  return !!collectionParent;
-});
-
-const assetRetrievalOption = computed<AssetResolutionOptions>(() => ({
-  collectionParent: get(isCollectionParent),
-}));
-
-const asset = useAssetInfo(() => identifier, assetRetrievalOption);
-const contractInfo = useAssetContractInfo(() => identifier, assetRetrievalOption);
 
 const {
+  asset,
+  collectionAssetWithPrice,
+  collectionBalance,
+  collectionId,
+  contractInfo,
+  goToEdit,
+  isCollectionParent,
+  isCustomAsset,
   loadingIgnore,
   loadingSpam,
   loadingWhitelist,
+  premium,
   toggleIgnoreAsset,
   toggleSpam,
   toggleWhitelistAsset,
-} = useAssetPageActions({
-  asset,
-  identifier: computed<string>(() => identifier),
-  refetchAssetInfo,
-});
-
-const isCustomAsset = computed(() => get(asset)?.isCustomAsset);
-
-const collectionId = computed<number | undefined>(() => {
-  if (!get(isCollectionParent))
-    return undefined;
-
-  const collectionId = get(asset)?.collectionId;
-  return (collectionId && parseInt(collectionId)) || undefined;
-});
-
-const editRoute = computed(() => ({
-  path: get(isCustomAsset) ? '/asset-manager/custom' : '/asset-manager/managed',
-  query: {
-    id: identifier,
-  },
-}));
-
-const collectionBalance = computed<AssetBalanceWithPrice[]>(() => {
-  if (!get(isCollectionParent))
-    return [];
-
-  return get(aggregatedBalances).find(data => data.asset === identifier)?.breakdown || [];
-});
-
-const collectionAssetWithPrice = computed<string | undefined>(() => {
-  const collectionBalanceVal = get(collectionBalance);
-
-  const id = identifier;
-
-  if (collectionBalanceVal.length === 0) {
-    return id;
-  }
-
-  if (collectionBalanceVal.some(item => item.asset === id)) {
-    return id;
-  }
-
-  return collectionBalanceVal[0].asset;
-});
-
-function goToEdit(): void {
-  router.push(get(editRoute));
-}
+} = useAssetDetail(() => identifier);
 </script>
 
 <template>
@@ -174,6 +109,7 @@ function goToEdit(): void {
           v-if="!isCollectionParent"
           icon
           variant="text"
+          data-testid="edit-asset"
           @click="goToEdit()"
         >
           <RuiIcon name="lu-pencil" />

--- a/frontend/app/src/pages/assets/use-asset-detail.spec.ts
+++ b/frontend/app/src/pages/assets/use-asset-detail.spec.ts
@@ -1,0 +1,254 @@
+import type { VueWrapper } from '@vue/test-utils';
+import { type AssetBalanceWithPrice, bigNumberify } from '@rotki/common';
+import { withSetup } from '@test/utils/with-setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, type ComputedRef, type Ref } from 'vue';
+import { useAssetDetail } from './use-asset-detail';
+
+const PARENT = 'ETH';
+const MEMBER = 'eip155:1/erc20:0xabc';
+
+interface AssetInfoShape {
+  collectionId?: string;
+  isCustomAsset?: boolean;
+  name?: string;
+  symbol?: string;
+}
+
+const { assetInfo, balances, pushMock, retrievalOptions, routeQuery } = vi.hoisted(() => {
+  const assetInfo: { current: AssetInfoShape | null } = { current: null };
+  const balances: { current: AssetBalanceWithPrice[] } = { current: [] };
+  /** The resolution options the page hands the retrieval composables on each call. */
+  const retrievalOptions: { current?: ComputedRef<{ collectionParent: boolean }> } = {};
+  const routeQuery: { current: Record<string, string> } = { current: {} };
+
+  return { assetInfo, balances, pushMock: vi.fn(async (): Promise<void> => {}), retrievalOptions, routeQuery };
+});
+
+vi.mock('vue-router', () => ({
+  useRoute: (): ComputedRef<{ query: Record<string, string> }> => computed(() => ({ query: routeQuery.current })),
+  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', async () => {
+  const { computed: computedFn } = await import('vue');
+  return {
+    useAssetInfoRetrieval: (): Record<string, unknown> => ({
+      refetchAssetInfo: vi.fn(),
+      useAssetContractInfo: (): ComputedRef<null> => computedFn(() => null),
+      useAssetInfo: (_id: unknown, options: ComputedRef<{ collectionParent: boolean }>): ComputedRef<AssetInfoShape | null> => {
+        retrievalOptions.current = options;
+        return computedFn(() => assetInfo.current);
+      },
+    }),
+  };
+});
+
+vi.mock('@/modules/balances/use-aggregated-balances', async () => {
+  const { computed: computedFn } = await import('vue');
+  return {
+    useAggregatedBalances: (): { useBalances: () => ComputedRef<AssetBalanceWithPrice[]> } => ({
+      useBalances: (): ComputedRef<AssetBalanceWithPrice[]> => computedFn(() => balances.current),
+    }),
+  };
+});
+
+vi.mock('@/modules/premium/use-premium', async () => {
+  const { shallowRef } = await import('vue');
+  return { usePremium: (): Ref<boolean> => shallowRef(false) };
+});
+
+vi.mock('@/pages/assets/use-asset-page-actions', async () => {
+  const { shallowRef } = await import('vue');
+  return {
+    useAssetPageActions: (): Record<string, unknown> => ({
+      loadingIgnore: shallowRef(false),
+      loadingSpam: shallowRef(false),
+      loadingWhitelist: shallowRef(false),
+      toggleIgnoreAsset: vi.fn(),
+      toggleSpam: vi.fn(),
+      toggleWhitelistAsset: vi.fn(),
+    }),
+  };
+});
+
+function balance(asset: string): AssetBalanceWithPrice {
+  return {
+    amount: bigNumberify(1),
+    asset,
+    price: bigNumberify(2),
+    value: bigNumberify(2),
+  };
+}
+
+describe('pages/assets/useAssetDetail', () => {
+  const mounted: VueWrapper[] = [];
+
+  function setup(identifier = PARENT): ReturnType<typeof useAssetDetail> {
+    const { result, wrapper } = withSetup(() => useAssetDetail(() => identifier));
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    assetInfo.current = null;
+    balances.current = [];
+    routeQuery.current = {};
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  describe('the collectionParent query', () => {
+    it('should read as a single asset when the query is absent', () => {
+      const { isCollectionParent } = setup();
+
+      expect(get(isCollectionParent)).toBe(false);
+    });
+
+    it('should read as a collection parent whatever value the query carries', () => {
+      routeQuery.current = { collectionParent: 'false' };
+
+      const { isCollectionParent } = setup();
+
+      // Only the presence of the param is read; a literal "false" still means collection parent.
+      expect(get(isCollectionParent)).toBe(true);
+    });
+
+    it('should pass the flag through to the asset resolution', () => {
+      routeQuery.current = { collectionParent: 'true' };
+
+      setup();
+
+      expect(retrievalOptions.current?.value).toEqual({ collectionParent: true });
+    });
+  });
+
+  describe('collectionId', () => {
+    it('should be undefined for a single asset even when the asset names a collection', () => {
+      assetInfo.current = { collectionId: '5' };
+
+      const { collectionId } = setup();
+
+      expect(get(collectionId)).toBeUndefined();
+    });
+
+    it('should parse the collection id for a parent', () => {
+      routeQuery.current = { collectionParent: 'true' };
+      assetInfo.current = { collectionId: '5' };
+
+      const { collectionId } = setup();
+
+      expect(get(collectionId)).toBe(5);
+    });
+
+    it('should be undefined when the parent names no collection', () => {
+      routeQuery.current = { collectionParent: 'true' };
+      assetInfo.current = {};
+
+      const { collectionId } = setup();
+
+      expect(get(collectionId)).toBeUndefined();
+    });
+
+    it('should treat a zero collection id as absent', () => {
+      routeQuery.current = { collectionParent: 'true' };
+      assetInfo.current = { collectionId: '0' };
+
+      const { collectionId } = setup();
+
+      expect(get(collectionId)).toBeUndefined();
+    });
+  });
+
+  describe('collectionBalance', () => {
+    it('should be empty for a single asset, whatever the balances hold', () => {
+      balances.current = [{ ...balance(PARENT), breakdown: [balance(MEMBER)] }];
+
+      const { collectionBalance } = setup();
+
+      expect(get(collectionBalance)).toEqual([]);
+    });
+
+    it('should be the parent breakdown for a collection parent', () => {
+      routeQuery.current = { collectionParent: 'true' };
+      balances.current = [{ ...balance(PARENT), breakdown: [balance(MEMBER)] }];
+
+      const { collectionBalance } = setup();
+
+      expect(get(collectionBalance)).toHaveLength(1);
+      expect(get(collectionBalance)[0].asset).toBe(MEMBER);
+    });
+
+    it('should be empty when the parent has no entry in the balances', () => {
+      routeQuery.current = { collectionParent: 'true' };
+      balances.current = [balance('BTC')];
+
+      const { collectionBalance } = setup();
+
+      expect(get(collectionBalance)).toEqual([]);
+    });
+
+    it('should be empty when the parent entry carries no breakdown', () => {
+      routeQuery.current = { collectionParent: 'true' };
+      balances.current = [balance(PARENT)];
+
+      const { collectionBalance } = setup();
+
+      expect(get(collectionBalance)).toEqual([]);
+    });
+  });
+
+  describe('which asset the price chart follows', () => {
+    it('should follow the asset itself when there is no collection', () => {
+      const { collectionAssetWithPrice } = setup();
+
+      expect(get(collectionAssetWithPrice)).toBe(PARENT);
+    });
+
+    it('should follow the parent when the parent is itself priced', () => {
+      routeQuery.current = { collectionParent: 'true' };
+      balances.current = [{ ...balance(PARENT), breakdown: [balance(MEMBER), balance(PARENT)] }];
+
+      const { collectionAssetWithPrice } = setup();
+
+      expect(get(collectionAssetWithPrice)).toBe(PARENT);
+    });
+
+    it('should fall back to the first member when the parent is not priced', () => {
+      routeQuery.current = { collectionParent: 'true' };
+      balances.current = [{ ...balance(PARENT), breakdown: [balance(MEMBER), balance('OTHER')] }];
+
+      const { collectionAssetWithPrice } = setup();
+
+      expect(get(collectionAssetWithPrice)).toBe(MEMBER);
+    });
+  });
+
+  describe('the edit route', () => {
+    it('should go to the managed asset manager for a regular asset', () => {
+      assetInfo.current = { isCustomAsset: false };
+
+      setup().goToEdit();
+
+      expect(pushMock).toHaveBeenCalledWith({ path: '/asset-manager/managed', query: { id: PARENT } });
+    });
+
+    it('should go to the custom asset manager for a custom asset', () => {
+      assetInfo.current = { isCustomAsset: true };
+
+      setup().goToEdit();
+
+      expect(pushMock).toHaveBeenCalledWith({ path: '/asset-manager/custom', query: { id: PARENT } });
+    });
+  });
+
+  it('should report whether the asset is a custom one', () => {
+    assetInfo.current = { isCustomAsset: true };
+
+    expect(get(setup().isCustomAsset)).toBe(true);
+  });
+});

--- a/frontend/app/src/pages/assets/use-asset-detail.ts
+++ b/frontend/app/src/pages/assets/use-asset-detail.ts
@@ -1,0 +1,133 @@
+import type { AssetBalanceWithPrice } from '@rotki/common';
+import type { ComputedRef, DeepReadonly, MaybeRefOrGetter, Ref } from 'vue';
+import { startPromise } from '@shared/utils';
+import { type AssetResolutionOptions, useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
+import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
+import { usePremium } from '@/modules/premium/use-premium';
+import { useAssetPageActions } from '@/pages/assets/use-asset-page-actions';
+
+/**
+ * Present on the route when the page is showing a collection's parent rather than one asset. Its
+ * value is never read - only whether it is there at all.
+ */
+const COLLECTION_PARENT_QUERY = 'collectionParent';
+
+type AssetInfo = ReturnType<ReturnType<typeof useAssetInfoRetrieval>['useAssetInfo']>;
+
+type ContractInfo = ReturnType<ReturnType<typeof useAssetInfoRetrieval>['useAssetContractInfo']>;
+
+interface UseAssetDetailReturn {
+  asset: AssetInfo;
+  collectionAssetWithPrice: ComputedRef<string | undefined>;
+  collectionBalance: ComputedRef<AssetBalanceWithPrice[]>;
+  collectionId: ComputedRef<number | undefined>;
+  contractInfo: ContractInfo;
+  goToEdit: () => void;
+  isCollectionParent: ComputedRef<boolean>;
+  isCustomAsset: ComputedRef<boolean | undefined>;
+  loadingIgnore: DeepReadonly<Ref<boolean>>;
+  loadingSpam: DeepReadonly<Ref<boolean>>;
+  loadingWhitelist: DeepReadonly<Ref<boolean>>;
+  premium: Ref<boolean>;
+  toggleIgnoreAsset: () => Promise<void>;
+  toggleSpam: () => Promise<void>;
+  toggleWhitelistAsset: () => Promise<void>;
+}
+
+export function useAssetDetail(identifier: MaybeRefOrGetter<string>): UseAssetDetailReturn {
+  const router = useRouter();
+  const route = useRoute();
+
+  const { refetchAssetInfo, useAssetContractInfo, useAssetInfo } = useAssetInfoRetrieval();
+  const premium = usePremium();
+  const { useBalances } = useAggregatedBalances();
+
+  const aggregatedBalances = useBalances();
+
+  const isCollectionParent = computed<boolean>(() => !!get(route).query[COLLECTION_PARENT_QUERY]);
+
+  const assetRetrievalOption = computed<AssetResolutionOptions>(() => ({
+    collectionParent: get(isCollectionParent),
+  }));
+
+  const asset = useAssetInfo(() => toValue(identifier), assetRetrievalOption);
+  const contractInfo = useAssetContractInfo(() => toValue(identifier), assetRetrievalOption);
+
+  const {
+    loadingIgnore,
+    loadingSpam,
+    loadingWhitelist,
+    toggleIgnoreAsset,
+    toggleSpam,
+    toggleWhitelistAsset,
+  } = useAssetPageActions({
+    asset,
+    identifier: computed<string>(() => toValue(identifier)),
+    refetchAssetInfo,
+  });
+
+  const isCustomAsset = computed<boolean | undefined>(() => get(asset)?.isCustomAsset);
+
+  const collectionId = computed<number | undefined>(() => {
+    if (!get(isCollectionParent))
+      return undefined;
+
+    // A zero or unparsable id reads as absent, the same as no id at all.
+    const raw = get(asset)?.collectionId;
+    const parsed = raw ? Number.parseInt(raw) : Number.NaN;
+    return Number.isNaN(parsed) || parsed === 0 ? undefined : parsed;
+  });
+
+  const editRoute = computed(() => ({
+    path: get(isCustomAsset) ? '/asset-manager/custom' : '/asset-manager/managed',
+    query: {
+      id: toValue(identifier),
+    },
+  }));
+
+  const collectionBalance = computed<AssetBalanceWithPrice[]>(() => {
+    if (!get(isCollectionParent))
+      return [];
+
+    return get(aggregatedBalances).find(data => data.asset === toValue(identifier))?.breakdown ?? [];
+  });
+
+  /**
+   * Which asset the price chart should follow. The parent itself when it is priced or when there
+   * is nothing to go on, otherwise the first member of the collection that is.
+   */
+  const collectionAssetWithPrice = computed<string | undefined>(() => {
+    const balances = get(collectionBalance);
+    const id = toValue(identifier);
+
+    if (balances.length === 0)
+      return id;
+
+    if (balances.some(item => item.asset === id))
+      return id;
+
+    return balances[0].asset;
+  });
+
+  function goToEdit(): void {
+    startPromise(router.push(get(editRoute)));
+  }
+
+  return {
+    asset,
+    collectionAssetWithPrice,
+    collectionBalance,
+    collectionId,
+    contractInfo,
+    goToEdit,
+    isCollectionParent,
+    isCustomAsset,
+    loadingIgnore,
+    loadingSpam,
+    loadingWhitelist,
+    premium,
+    toggleIgnoreAsset,
+    toggleSpam,
+    toggleWhitelistAsset,
+  };
+}

--- a/frontend/app/src/pages/assets/use-asset-page-actions.spec.ts
+++ b/frontend/app/src/pages/assets/use-asset-page-actions.spec.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, type ComputedRef, type Ref, shallowRef } from 'vue';
+import { useAssetPageActions } from './use-asset-page-actions';
+
+const IDENTIFIER = 'eip155:1/erc20:0xabc';
+
+const {
+  ignoreAssetWithConfirmation,
+  ignoredState,
+  markAssetsAsSpam,
+  removeAssetFromSpamList,
+  unWhitelistAsset,
+  unignoreAsset,
+  whitelistAsset,
+} = vi.hoisted(() => ({
+  ignoreAssetWithConfirmation: vi.fn(async (): Promise<void> => {}),
+  ignoredState: { ignored: false, whitelisted: false },
+  markAssetsAsSpam: vi.fn(async (): Promise<void> => {}),
+  removeAssetFromSpamList: vi.fn(async (): Promise<void> => {}),
+  unWhitelistAsset: vi.fn(async (): Promise<void> => {}),
+  unignoreAsset: vi.fn(async (): Promise<void> => {}),
+  whitelistAsset: vi.fn(async (): Promise<void> => {}),
+}));
+
+vi.mock('@/modules/assets/use-ignored-asset-confirmation', () => ({
+  useIgnoredAssetConfirmation: (): { ignoreAssetWithConfirmation: typeof ignoreAssetWithConfirmation } => ({
+    ignoreAssetWithConfirmation,
+  }),
+}));
+
+vi.mock('@/modules/assets/use-ignored-asset-operations', () => ({
+  useIgnoredAssetOperations: (): { unignoreAsset: typeof unignoreAsset } => ({ unignoreAsset }),
+}));
+
+vi.mock('@/modules/assets/use-assets-store', async () => {
+  const { computed: computedFn } = await import('vue');
+  return {
+    useAssetsStore: (): {
+      useIsAssetIgnored: () => ComputedRef<boolean>;
+      useIsAssetWhitelisted: () => ComputedRef<boolean>;
+    } => ({
+      useIsAssetIgnored: (): ComputedRef<boolean> => computedFn(() => ignoredState.ignored),
+      useIsAssetWhitelisted: (): ComputedRef<boolean> => computedFn(() => ignoredState.whitelisted),
+    }),
+  };
+});
+
+vi.mock('@/modules/assets/use-whitelisted-asset-operations', () => ({
+  useWhitelistedAssetOperations: (): {
+    unWhitelistAsset: typeof unWhitelistAsset;
+    whitelistAsset: typeof whitelistAsset;
+  } => ({ unWhitelistAsset, whitelistAsset }),
+}));
+
+vi.mock('@/modules/assets/use-spam-asset', () => ({
+  useSpamAsset: (): { markAssetsAsSpam: typeof markAssetsAsSpam; removeAssetFromSpamList: typeof removeAssetFromSpamList } => ({
+    markAssetsAsSpam,
+    removeAssetFromSpamList,
+  }),
+}));
+
+describe('pages/assets/useAssetPageActions', () => {
+  const refetchAssetInfo = vi.fn();
+  let asset: Ref<{ isSpam?: boolean; name?: string | null; symbol?: string | null } | null>;
+
+  function setup(): ReturnType<typeof useAssetPageActions> {
+    return useAssetPageActions({
+      asset: computed(() => get(asset)),
+      identifier: shallowRef(IDENTIFIER),
+      refetchAssetInfo,
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ignoredState.ignored = false;
+    ignoredState.whitelisted = false;
+    asset = shallowRef({ isSpam: false, symbol: 'ABC' });
+  });
+
+  describe('spam', () => {
+    it('should mark an asset as spam and refresh its info', async () => {
+      await setup().toggleSpam();
+
+      expect(markAssetsAsSpam).toHaveBeenCalledWith([IDENTIFIER]);
+      expect(removeAssetFromSpamList).not.toHaveBeenCalled();
+      expect(refetchAssetInfo).toHaveBeenCalledWith(IDENTIFIER);
+    });
+
+    it('should take an asset back off the spam list', async () => {
+      set(asset, { isSpam: true });
+
+      await setup().toggleSpam();
+
+      expect(removeAssetFromSpamList).toHaveBeenCalledWith(IDENTIFIER);
+      expect(markAssetsAsSpam).not.toHaveBeenCalled();
+    });
+
+    it('should read an asset with no spam flag as not spam', async () => {
+      set(asset, { symbol: 'ABC' });
+
+      const { isSpam, toggleSpam } = setup();
+      expect(get(isSpam)).toBe(false);
+
+      await toggleSpam();
+
+      expect(markAssetsAsSpam).toHaveBeenCalled();
+    });
+
+    it('should lower the loading flag even when the call fails', async () => {
+      markAssetsAsSpam.mockRejectedValueOnce(new Error('nope'));
+
+      const { loadingSpam, toggleSpam } = setup();
+
+      await expect(toggleSpam()).rejects.toThrow('nope');
+      expect(get(loadingSpam)).toBe(false);
+    });
+  });
+
+  describe('ignore', () => {
+    it('should ask for confirmation when ignoring, preferring the symbol over the name', async () => {
+      // Both are set, so this fails if the fallback order is reversed. With only one of them
+      // present either order produces the same string and the test proves nothing.
+      set(asset, { name: 'Some Token', symbol: 'ABC' });
+
+      await setup().toggleIgnoreAsset();
+
+      expect(ignoreAssetWithConfirmation).toHaveBeenCalledWith(IDENTIFIER, 'ABC');
+      expect(unignoreAsset).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the name when the asset has no symbol', async () => {
+      set(asset, { name: 'Some Token', symbol: null });
+
+      await setup().toggleIgnoreAsset();
+
+      expect(ignoreAssetWithConfirmation).toHaveBeenCalledWith(IDENTIFIER, 'Some Token');
+    });
+
+    it('should unignore without a confirmation when the asset is already ignored', async () => {
+      ignoredState.ignored = true;
+
+      await setup().toggleIgnoreAsset();
+
+      expect(unignoreAsset).toHaveBeenCalledWith(IDENTIFIER);
+      expect(ignoreAssetWithConfirmation).not.toHaveBeenCalled();
+    });
+
+    it('should not refresh the asset info, which the ignore flow owns', async () => {
+      await setup().toggleIgnoreAsset();
+
+      expect(refetchAssetInfo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('whitelist', () => {
+    it('should whitelist an asset that is not on the list', async () => {
+      await setup().toggleWhitelistAsset();
+
+      expect(whitelistAsset).toHaveBeenCalledWith(IDENTIFIER);
+      expect(unWhitelistAsset).not.toHaveBeenCalled();
+      expect(refetchAssetInfo).toHaveBeenCalledWith(IDENTIFIER);
+    });
+
+    it('should remove an asset that is already whitelisted', async () => {
+      ignoredState.whitelisted = true;
+
+      await setup().toggleWhitelistAsset();
+
+      expect(unWhitelistAsset).toHaveBeenCalledWith(IDENTIFIER);
+      expect(whitelistAsset).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should report the ignored state it was given', () => {
+    ignoredState.ignored = true;
+
+    expect(get(setup().isIgnored)).toBe(true);
+  });
+});

--- a/frontend/app/src/pages/balances/exchange/[[exchange]].spec.ts
+++ b/frontend/app/src/pages/balances/exchange/[[exchange]].spec.ts
@@ -1,0 +1,167 @@
+import type { useExchangeBalancesPage } from '@/pages/balances/exchange/use-exchange-balances-page';
+import { type AssetBalanceWithPrice, bigNumberify } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import ExchangeBalancesPage from '@/pages/balances/exchange/[[exchange]].vue';
+
+const navigateToExchangeSetup = vi.fn();
+const openExchangeDetails = vi.fn();
+const refreshExchangeBalances = vi.fn(async (): Promise<void> => {});
+const refreshSelectedExchangeBalances = vi.fn(async (): Promise<void> => {});
+
+interface PageState {
+  balances: AssetBalanceWithPrice[];
+  detailTab: number;
+  loading: boolean;
+  used: string[];
+}
+
+const pageState = vi.hoisted((): PageState => ({
+  balances: [],
+  detailTab: 0,
+  loading: false,
+  used: [],
+}));
+
+const DetailPanelStub = defineComponent({
+  emits: ['refresh', 'update:modelValue'],
+  name: 'ExchangeDetailPanelStub',
+  props: {
+    balances: { default: () => [], type: Array },
+    exchange: { default: '', type: String },
+    loading: { default: false, type: Boolean },
+    modelValue: { default: 0, type: Number },
+  },
+  template: '<div data-testid="detail-panel" />',
+});
+
+vi.mock('@/pages/balances/exchange/use-exchange-balances-page', async () => {
+  const { computed, shallowRef } = await import('vue');
+  return {
+    isBinance: (id?: string): boolean => id === 'binance',
+    useExchangeBalancesPage: (): ReturnType<typeof useExchangeBalancesPage> => ({
+      balances: computed(() => pageState.balances),
+      exchangeBalance: () => bigNumberify(100),
+      isExchangeLoading: computed(() => pageState.loading),
+      modelExchangeDetailTabs: shallowRef(pageState.detailTab),
+      modelSelectedExchange: shallowRef(''),
+      modelSelectedTab: shallowRef(undefined),
+      navigateToExchangeSetup,
+      openExchangeDetails,
+      refreshExchangeBalances,
+      refreshSelectedExchangeBalances,
+      sortedExchanges: computed(() => pageState.used),
+      usedExchanges: computed(() => pageState.used),
+    }),
+  };
+});
+
+describe('pages/balances/exchange/[[exchange]]', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ExchangeBalancesPage>>;
+
+  function mountPage(exchange?: string): VueWrapper<InstanceType<typeof ExchangeBalancesPage>> {
+    return mount(ExchangeBalancesPage, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          ExchangeAmountRow: { props: ['balance', 'exchange'], template: '<div />' },
+          ExchangeDetailPanel: DetailPanelStub,
+          FiatDisplay: { props: ['value'], template: '<div />' },
+          HideSmallBalances: { props: ['source'], template: '<div />' },
+          InternalLink: { props: ['to'], template: '<a><slot /></a>' },
+          LocationDisplay: { props: ['identifier', 'openDetails', 'size'], template: '<div data-testid="exchange-tab" />' },
+          RuiMenuSelect: { props: ['modelValue', 'options', 'label'], template: '<div data-testid="exchange-picker" />' },
+          TablePageLayout: { props: ['title'], template: '<div><slot name="buttons" /><slot /></div>' },
+        },
+      },
+      props: { exchange },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    pageState.balances = [];
+    pageState.detailTab = 0;
+    pageState.loading = false;
+    pageState.used = [];
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  describe('with no exchange connected', () => {
+    it('should offer the setup shortcut instead of the picker', async () => {
+      wrapper = mountPage();
+
+      expect(wrapper.find('[data-testid=exchange-picker]').exists()).toBe(false);
+      await wrapper.find('[data-testid=add-exchange]').trigger('click');
+
+      expect(navigateToExchangeSetup).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('with exchanges connected', () => {
+    beforeEach(() => {
+      pageState.used = ['kraken', 'binance'];
+    });
+
+    it('should show a tab per exchange', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findAll('[data-testid=exchange-tab]')).toHaveLength(2);
+    });
+
+    it('should show the hint rather than a panel until one is chosen', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(DetailPanelStub).exists()).toBe(false);
+      expect(wrapper.text()).toContain('exchange_balances.select_hint');
+    });
+
+    it('should show the panel for the exchange in the route, with its balances', () => {
+      pageState.balances = [{
+        amount: bigNumberify(1),
+        asset: 'ETH',
+        price: bigNumberify(2),
+        value: bigNumberify(2),
+      }];
+
+      wrapper = mountPage('kraken');
+
+      const panel = wrapper.findComponent(DetailPanelStub);
+      expect(panel.exists()).toBe(true);
+      expect(panel.props('exchange')).toBe('kraken');
+      expect(panel.props('balances')).toHaveLength(1);
+    });
+
+    it('should refresh a single exchange from the panel', () => {
+      wrapper = mountPage('kraken');
+
+      wrapper.findComponent(DetailPanelStub).vm.$emit('refresh', 'kraken');
+
+      expect(refreshSelectedExchangeBalances).toHaveBeenCalledWith('kraken');
+    });
+
+    it('should refresh every exchange from the toolbar button', async () => {
+      wrapper = mountPage('kraken');
+
+      await wrapper.find('[data-testid=refresh-exchange-balances]').trigger('click');
+
+      expect(refreshExchangeBalances).toHaveBeenCalledTimes(1);
+    });
+
+    it('should block the toolbar refresh while a detail tab other than the first is open', () => {
+      pageState.detailTab = 1;
+
+      wrapper = mountPage('kraken');
+
+      expect(wrapper.find('[data-testid=refresh-exchange-balances]').attributes('disabled')).toBeDefined();
+    });
+  });
+});

--- a/frontend/app/src/pages/balances/exchange/[[exchange]].vue
+++ b/frontend/app/src/pages/balances/exchange/[[exchange]].vue
@@ -1,22 +1,15 @@
 <script setup lang="ts">
-import { type AssetBalanceWithPrice, type BigNumber, Zero } from '@rotki/common';
 import { msg } from '@/message-key';
 import ExchangeAmountRow from '@/modules/accounts/exchanges/ExchangeAmountRow.vue';
 import { FiatDisplay } from '@/modules/assets/amount-display/components';
 import ExchangeDetailPanel from '@/modules/balances/exchanges/ExchangeDetailPanel.vue';
-import { useBinanceSavings } from '@/modules/balances/exchanges/use-binance-savings';
-import { useConnectedExchangesStore } from '@/modules/balances/exchanges/use-connected-exchanges-store';
-import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
-import { useBalanceRefresh } from '@/modules/balances/use-balance-refresh';
-import { uniqueStrings } from '@/modules/core/common/data/data';
 import { NoteLocation } from '@/modules/core/common/notes';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import HideSmallBalances from '@/modules/settings/HideSmallBalances.vue';
 import { BalanceSource } from '@/modules/settings/types/frontend-settings';
 import InternalLink from '@/modules/shell/components/InternalLink.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
-import { ActivityKind } from '@/modules/task-center/core/types';
-import { useTaskCenter } from '@/modules/task-center/use-task-center';
+import { useExchangeBalancesPage } from '@/pages/balances/exchange/use-exchange-balances-page';
 
 definePage({
   meta: {
@@ -29,96 +22,21 @@ definePage({
 const { exchange } = defineProps<{ exchange?: string }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const selectedTab = ref<string | undefined>(exchange ?? undefined);
-const { useIsActive } = useTaskCenter();
-const { getExchangeBalances } = useAggregatedBalances();
-const { refreshExchangeSavings } = useBinanceSavings();
-const { connectedExchanges } = storeToRefs(useConnectedExchangesStore());
 
-const { refreshBalance, refreshExchangeBalance } = useBalanceRefresh();
-
-async function refreshExchangeBalances() {
-  await Promise.all([refreshBalance('exchange'), refreshExchangeSavings(true)]);
-}
-
-async function refreshSelectedExchangeBalances(exchangeLocation: string) {
-  if (isBinance(exchangeLocation))
-    await Promise.all([refreshExchangeBalance(exchangeLocation), refreshExchangeSavings(true)]);
-  else
-    await refreshExchangeBalance(exchangeLocation);
-}
-const selectedExchange = ref<string>('');
-const usedExchanges = computed<string[]>(() =>
-  get(connectedExchanges)
-    .map(({ location }) => location)
-    .filter(uniqueStrings),
-);
-
-const isExchangeLoading = useIsActive(ActivityKind.EXCHANGE_BALANCES);
-
-const router = useRouter();
-const route = useRoute();
-
-function setSelectedExchange() {
-  set(selectedExchange, get(route).query.location);
-}
-
-onMounted(() => {
-  setSelectedExchange();
-});
-
-watch(route, () => {
-  setSelectedExchange();
-});
-
-function exchangeBalance(exchange: string): BigNumber {
-  const balances = getExchangeBalances(exchange);
-  return balances.reduce((sum, asset: AssetBalanceWithPrice) => sum.plus(asset.value), Zero);
-}
-
-const sortedExchanges = computed(() =>
-  get(usedExchanges).sort((a, b) => exchangeBalance(b).minus(exchangeBalance(a)).toNumber()),
-);
-
-function openExchangeDetails() {
-  router.push({
-    name: '/balances/exchange/[[exchange]]',
-    params: {
-      exchange: get(selectedExchange),
-    },
-  });
-}
-
-const balances = computed(() => {
-  const currentExchange = exchange;
-  if (!currentExchange)
-    return [];
-
-  return getExchangeBalances(currentExchange);
-});
-
-const vueRouter = useRouter();
-
-function navigate() {
-  vueRouter.push({
-    path: '/api-keys/exchanges',
-    query: { add: 'true' },
-  });
-}
-
-const exchangeDetailTabs = ref<number>(0);
-
-watch(() => exchange, () => {
-  set(exchangeDetailTabs, 0);
-});
-
-onMounted(() => {
-  refreshExchangeSavings();
-});
-
-function isBinance(exchange?: string): exchange is 'binance' | 'binanceus' {
-  return !!exchange && ['binance', 'binanceus'].includes(exchange);
-}
+const {
+  balances,
+  exchangeBalance,
+  isExchangeLoading,
+  modelExchangeDetailTabs,
+  modelSelectedExchange,
+  modelSelectedTab,
+  navigateToExchangeSetup,
+  openExchangeDetails,
+  refreshExchangeBalances,
+  refreshSelectedExchangeBalances,
+  sortedExchanges,
+  usedExchanges,
+} = useExchangeBalancesPage(() => exchange);
 </script>
 
 <template>
@@ -130,8 +48,9 @@ function isBinance(exchange?: string): exchange is 'binance' | 'binanceus' {
             color="primary"
             variant="outlined"
             size="lg"
-            :disabled="exchangeDetailTabs !== 0"
+            :disabled="modelExchangeDetailTabs !== 0"
             :loading="isExchangeLoading"
+            data-testid="refresh-exchange-balances"
             @click="refreshExchangeBalances()"
           >
             <template #prepend>
@@ -145,7 +64,8 @@ function isBinance(exchange?: string): exchange is 'binance' | 'binanceus' {
       <RuiButton
         color="primary"
         size="lg"
-        @click="navigate()"
+        data-testid="add-exchange"
+        @click="navigateToExchangeSetup()"
       >
         <template #prepend>
           <RuiIcon name="lu-plus" />
@@ -161,7 +81,7 @@ function isBinance(exchange?: string): exchange is 'binance' | 'binanceus' {
       >
         <div class="md:hidden mb-4">
           <RuiMenuSelect
-            v-model="selectedExchange"
+            v-model="modelSelectedExchange"
             :options="usedExchanges"
             :label="t('exchange_balances.select_exchange')"
             hide-details
@@ -185,7 +105,7 @@ function isBinance(exchange?: string): exchange is 'binance' | 'binanceus' {
         </div>
         <div class="hidden md:block w-40 shrink-0 border-r border-default">
           <RuiTabs
-            v-model="selectedTab"
+            v-model="modelSelectedTab"
             vertical
             align="end"
             color="primary"
@@ -221,7 +141,7 @@ function isBinance(exchange?: string): exchange is 'binance' | 'binanceus' {
         <div class="flex-1">
           <ExchangeDetailPanel
             v-if="exchange"
-            v-model="exchangeDetailTabs"
+            v-model="modelExchangeDetailTabs"
             :exchange="exchange"
             :loading="isExchangeLoading"
             :balances="balances"

--- a/frontend/app/src/pages/balances/exchange/use-exchange-balances-page.spec.ts
+++ b/frontend/app/src/pages/balances/exchange/use-exchange-balances-page.spec.ts
@@ -1,0 +1,303 @@
+import type { VueWrapper } from '@vue/test-utils';
+import { type AssetBalanceWithPrice, bigNumberify } from '@rotki/common';
+import { withSetup } from '@test/utils/with-setup';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComputedRef, ref, type Ref } from 'vue';
+import { isBinance, useExchangeBalancesPage } from './use-exchange-balances-page';
+
+const {
+  connected,
+  exchangeBalances,
+  pushMock,
+  refreshBalance,
+  refreshExchangeBalance,
+  refreshExchangeSavings,
+  routeRef,
+} = vi.hoisted(() => {
+  const connected: { current: { location: string }[] } = { current: [] };
+  const exchangeBalances: { current: Record<string, AssetBalanceWithPrice[]> } = { current: {} };
+  const routeRef: { current?: Ref<{ query: Record<string, string> }> } = {};
+
+  return {
+    connected,
+    exchangeBalances,
+    pushMock: vi.fn(async (): Promise<void> => {}),
+    refreshBalance: vi.fn(async (): Promise<void> => {}),
+    refreshExchangeBalance: vi.fn(async (): Promise<void> => {}),
+    refreshExchangeSavings: vi.fn(async (): Promise<void> => {}),
+    routeRef,
+  };
+});
+
+vi.mock('vue-router', async () => {
+  const { ref: refFn } = await import('vue');
+  return {
+    useRoute: (): Ref<{ query: Record<string, string> }> => {
+      routeRef.current ??= refFn({ query: {} });
+      return routeRef.current;
+    },
+    useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+  };
+});
+
+vi.mock('@/modules/balances/use-aggregated-balances', () => ({
+  useAggregatedBalances: (): { getExchangeBalances: (id: string) => AssetBalanceWithPrice[] } => ({
+    getExchangeBalances: (id: string): AssetBalanceWithPrice[] => exchangeBalances.current[id] ?? [],
+  }),
+}));
+
+vi.mock('@/modules/balances/exchanges/use-binance-savings', () => ({
+  useBinanceSavings: (): { refreshExchangeSavings: typeof refreshExchangeSavings } => ({ refreshExchangeSavings }),
+}));
+
+vi.mock('@/modules/balances/exchanges/use-connected-exchanges-store', async () => {
+  const { computed: computedFn } = await import('vue');
+  return {
+    useConnectedExchangesStore: (): { connectedExchanges: ComputedRef<{ location: string }[]> } => ({
+      connectedExchanges: computedFn(() => connected.current),
+    }),
+  };
+});
+
+vi.mock('@/modules/balances/use-balance-refresh', () => ({
+  useBalanceRefresh: (): { refreshBalance: typeof refreshBalance; refreshExchangeBalance: typeof refreshExchangeBalance } => ({
+    refreshBalance,
+    refreshExchangeBalance,
+  }),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', async () => {
+  const { computed: computedFn } = await import('vue');
+  return {
+    useTaskCenter: (): { useIsActive: () => ComputedRef<boolean> } => ({
+      useIsActive: (): ComputedRef<boolean> => computedFn(() => false),
+    }),
+  };
+});
+
+vi.mock('pinia', async importOriginal => ({
+  ...(await importOriginal<typeof import('pinia')>()),
+  storeToRefs: (store: Record<string, unknown>): Record<string, unknown> => store,
+}));
+
+function balance(asset: string, value: number): AssetBalanceWithPrice {
+  return {
+    amount: bigNumberify(value),
+    asset,
+    price: bigNumberify(1),
+    value: bigNumberify(value),
+  };
+}
+
+describe('pages/balances/exchange/isBinance', () => {
+  it('should recognise both binance exchanges', () => {
+    expect(isBinance('binance')).toBe(true);
+    expect(isBinance('binanceus')).toBe(true);
+  });
+
+  it('should reject anything else, including nothing at all', () => {
+    expect(isBinance('kraken')).toBe(false);
+    expect(isBinance('')).toBe(false);
+    expect(isBinance(undefined)).toBe(false);
+  });
+});
+
+describe('pages/balances/exchange/useExchangeBalancesPage', () => {
+  // Each harness watches the shared route ref, so a leftover one would answer a later test.
+  const mounted: VueWrapper[] = [];
+
+  function setup(exchange?: string): ReturnType<typeof useExchangeBalancesPage> {
+    const { result, wrapper } = withSetup(() => useExchangeBalancesPage(() => exchange));
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connected.current = [];
+    exchangeBalances.current = {};
+    routeRef.current = ref({ query: {} });
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  it('should refresh the savings balances on mount', async () => {
+    setup();
+    await flushPromises();
+
+    expect(refreshExchangeSavings).toHaveBeenCalledTimes(1);
+  });
+
+  describe('the connected exchanges', () => {
+    it('should list each exchange once, however many keys it has', async () => {
+      connected.current = [{ location: 'kraken' }, { location: 'binance' }, { location: 'kraken' }];
+
+      const { usedExchanges } = setup();
+      await flushPromises();
+
+      expect(get(usedExchanges)).toEqual(['kraken', 'binance']);
+    });
+
+    it('should sort them by balance, largest first', async () => {
+      connected.current = [{ location: 'kraken' }, { location: 'binance' }, { location: 'coinbase' }];
+      exchangeBalances.current = {
+        binance: [balance('BTC', 500)],
+        coinbase: [balance('SOL', 50)],
+        kraken: [balance('ETH', 100)],
+      };
+
+      const { sortedExchanges } = setup();
+      await flushPromises();
+
+      expect(get(sortedExchanges)).toEqual(['binance', 'kraken', 'coinbase']);
+    });
+
+    it('should not reorder the unsorted list when the sorted one is read', async () => {
+      // The mobile picker binds `usedExchanges` and the desktop tabs bind `sortedExchanges`.
+      // Sorting in place would silently reorder the picker as soon as the tabs render.
+      connected.current = [{ location: 'kraken' }, { location: 'binance' }];
+      exchangeBalances.current = { binance: [balance('BTC', 500)], kraken: [balance('ETH', 100)] };
+
+      const { sortedExchanges, usedExchanges } = setup();
+      await flushPromises();
+
+      expect(get(sortedExchanges)).toEqual(['binance', 'kraken']);
+      expect(get(usedExchanges)).toEqual(['kraken', 'binance']);
+    });
+
+    it('should total every asset an exchange holds', async () => {
+      exchangeBalances.current = { kraken: [balance('ETH', 100), balance('BTC', 25)] };
+
+      const { exchangeBalance } = setup();
+      await flushPromises();
+
+      expect(exchangeBalance('kraken').toNumber()).toBe(125);
+    });
+
+    it('should total an exchange with no balances as zero', async () => {
+      const { exchangeBalance } = setup();
+      await flushPromises();
+
+      expect(exchangeBalance('kraken').toNumber()).toBe(0);
+    });
+  });
+
+  describe('with no exchange in the route', () => {
+    it('should expose no balances, so the page shows its hint', async () => {
+      exchangeBalances.current = { kraken: [balance('ETH', 100)] };
+
+      const { balances } = setup();
+      await flushPromises();
+
+      expect(get(balances)).toEqual([]);
+    });
+
+    it('should start with no tab highlighted', async () => {
+      const { modelSelectedTab } = setup();
+      await flushPromises();
+
+      expect(get(modelSelectedTab)).toBeUndefined();
+    });
+  });
+
+  describe('with an exchange in the route', () => {
+    it('should expose that exchange balances', async () => {
+      exchangeBalances.current = { kraken: [balance('ETH', 100)] };
+
+      const { balances } = setup('kraken');
+      await flushPromises();
+
+      expect(get(balances)).toHaveLength(1);
+      expect(get(balances)[0].asset).toBe('ETH');
+    });
+
+    it('should highlight its tab', async () => {
+      const { modelSelectedTab } = setup('kraken');
+      await flushPromises();
+
+      expect(get(modelSelectedTab)).toBe('kraken');
+    });
+  });
+
+  describe('the location query the mobile picker reads', () => {
+    it('should be picked up on mount', async () => {
+      routeRef.current = ref({ query: { location: 'kraken' } });
+
+      const { modelSelectedExchange } = setup();
+      await flushPromises();
+
+      expect(get(modelSelectedExchange)).toBe('kraken');
+    });
+
+    it('should follow a later route change', async () => {
+      const { modelSelectedExchange } = setup();
+      await flushPromises();
+
+      set(routeRef.current!, { query: { location: 'binance' } });
+      await flushPromises();
+
+      expect(get(modelSelectedExchange)).toBe('binance');
+    });
+
+    it('should open the details for whatever the picker holds', async () => {
+      routeRef.current = ref({ query: { location: 'kraken' } });
+
+      const { openExchangeDetails } = setup();
+      await flushPromises();
+      openExchangeDetails();
+
+      expect(pushMock).toHaveBeenCalledWith({
+        name: '/balances/exchange/[[exchange]]',
+        params: { exchange: 'kraken' },
+      });
+    });
+  });
+
+  describe('refreshing', () => {
+    it('should refresh every exchange and the savings together', async () => {
+      const { refreshExchangeBalances } = setup();
+      await flushPromises();
+      refreshExchangeSavings.mockClear();
+
+      await refreshExchangeBalances();
+
+      expect(refreshBalance).toHaveBeenCalledWith('exchange');
+      expect(refreshExchangeSavings).toHaveBeenCalledWith(true);
+    });
+
+    it('should refresh the savings alongside a binance refresh', async () => {
+      const { refreshSelectedExchangeBalances } = setup();
+      await flushPromises();
+      refreshExchangeSavings.mockClear();
+
+      await refreshSelectedExchangeBalances('binance');
+
+      expect(refreshExchangeBalance).toHaveBeenCalledWith('binance');
+      expect(refreshExchangeSavings).toHaveBeenCalledWith(true);
+    });
+
+    it('should not touch the savings for any other exchange', async () => {
+      const { refreshSelectedExchangeBalances } = setup();
+      await flushPromises();
+      refreshExchangeSavings.mockClear();
+
+      await refreshSelectedExchangeBalances('kraken');
+
+      expect(refreshExchangeBalance).toHaveBeenCalledWith('kraken');
+      expect(refreshExchangeSavings).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should send the user to the exchange setup with the add dialog open', async () => {
+    const { navigateToExchangeSetup } = setup();
+    await flushPromises();
+
+    navigateToExchangeSetup();
+
+    expect(pushMock).toHaveBeenCalledWith({ path: '/api-keys/exchanges', query: { add: 'true' } });
+  });
+});

--- a/frontend/app/src/pages/balances/exchange/use-exchange-balances-page.ts
+++ b/frontend/app/src/pages/balances/exchange/use-exchange-balances-page.ts
@@ -1,0 +1,137 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { type AssetBalanceWithPrice, type BigNumber, Zero } from '@rotki/common';
+import { startPromise } from '@shared/utils';
+import { useBinanceSavings } from '@/modules/balances/exchanges/use-binance-savings';
+import { useConnectedExchangesStore } from '@/modules/balances/exchanges/use-connected-exchanges-store';
+import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balances';
+import { useBalanceRefresh } from '@/modules/balances/use-balance-refresh';
+import { uniqueStrings } from '@/modules/core/common/data/data';
+import { ActivityKind } from '@/modules/task-center/core/types';
+import { useTaskCenter } from '@/modules/task-center/use-task-center';
+
+/** The two exchanges that also hold savings balances, which refresh alongside the main ones. */
+const BINANCE_EXCHANGES = ['binance', 'binanceus'];
+
+export function isBinance(exchange?: string): exchange is 'binance' | 'binanceus' {
+  return !!exchange && BINANCE_EXCHANGES.includes(exchange);
+}
+
+interface UseExchangeBalancesPageReturn {
+  balances: ComputedRef<AssetBalanceWithPrice[]>;
+  exchangeBalance: (exchange: string) => BigNumber;
+  isExchangeLoading: ComputedRef<boolean>;
+  modelExchangeDetailTabs: Ref<number>;
+  modelSelectedExchange: Ref<string>;
+  modelSelectedTab: Ref<string | undefined>;
+  navigateToExchangeSetup: () => void;
+  openExchangeDetails: () => void;
+  refreshExchangeBalances: () => Promise<void>;
+  refreshSelectedExchangeBalances: (exchangeLocation: string) => Promise<void>;
+  sortedExchanges: ComputedRef<string[]>;
+  usedExchanges: ComputedRef<string[]>;
+}
+
+export function useExchangeBalancesPage(exchange: MaybeRefOrGetter<string | undefined>): UseExchangeBalancesPageReturn {
+  const router = useRouter();
+  const route = useRoute();
+
+  const { useIsActive } = useTaskCenter();
+  const { getExchangeBalances } = useAggregatedBalances();
+  const { refreshExchangeSavings } = useBinanceSavings();
+  const { connectedExchanges } = storeToRefs(useConnectedExchangesStore());
+  const { refreshBalance, refreshExchangeBalance } = useBalanceRefresh();
+
+  // Seeded from the route once. The tabs themselves are links, so the router drives the page and
+  // this only sets the initially highlighted one.
+  const modelSelectedTab = shallowRef<string | undefined>(toValue(exchange) ?? undefined);
+  const modelSelectedExchange = shallowRef<string>('');
+  const modelExchangeDetailTabs = shallowRef<number>(0);
+
+  const isExchangeLoading = useIsActive(ActivityKind.EXCHANGE_BALANCES);
+
+  const usedExchanges = computed<string[]>(() =>
+    get(connectedExchanges)
+      .map(({ location }) => location)
+      .filter(uniqueStrings),
+  );
+
+  function exchangeBalance(exchange: string): BigNumber {
+    return getExchangeBalances(exchange).reduce(
+      (sum, asset: AssetBalanceWithPrice) => sum.plus(asset.value),
+      Zero,
+    );
+  }
+
+  // Sorts a copy: `sort` in place would reorder the array `usedExchanges` has cached, so rendering
+  // the desktop tabs would silently reorder the mobile picker bound to it.
+  const sortedExchanges = computed<string[]>(() =>
+    [...get(usedExchanges)].sort((a, b) => exchangeBalance(b).minus(exchangeBalance(a)).toNumber()),
+  );
+
+  const balances = computed<AssetBalanceWithPrice[]>(() => {
+    const current = toValue(exchange);
+    if (!current)
+      return [];
+
+    return getExchangeBalances(current);
+  });
+
+  async function refreshExchangeBalances(): Promise<void> {
+    await Promise.all([refreshBalance('exchange'), refreshExchangeSavings(true)]);
+  }
+
+  /** Binance also has savings balances, which the generic refresh does not cover. */
+  async function refreshSelectedExchangeBalances(exchangeLocation: string): Promise<void> {
+    if (isBinance(exchangeLocation))
+      await Promise.all([refreshExchangeBalance(exchangeLocation), refreshExchangeSavings(true)]);
+    else
+      await refreshExchangeBalance(exchangeLocation);
+  }
+
+  function openExchangeDetails(): void {
+    startPromise(router.push({
+      name: '/balances/exchange/[[exchange]]',
+      params: { exchange: get(modelSelectedExchange) },
+    }));
+  }
+
+  function navigateToExchangeSetup(): void {
+    startPromise(router.push({
+      path: '/api-keys/exchanges',
+      query: { add: 'true' },
+    }));
+  }
+
+  function setSelectedExchange(): void {
+    set(modelSelectedExchange, get(route).query.location);
+  }
+
+  onMounted(() => {
+    setSelectedExchange();
+    startPromise(refreshExchangeSavings());
+  });
+
+  watch(route, () => {
+    setSelectedExchange();
+  });
+
+  // A different exchange starts on its own first tab rather than inheriting the previous one's.
+  watch(() => toValue(exchange), () => {
+    set(modelExchangeDetailTabs, 0);
+  });
+
+  return {
+    balances,
+    exchangeBalance,
+    isExchangeLoading,
+    modelExchangeDetailTabs,
+    modelSelectedExchange,
+    modelSelectedTab,
+    navigateToExchangeSetup,
+    openExchangeDetails,
+    refreshExchangeBalances,
+    refreshSelectedExchangeBalances,
+    sortedExchanges,
+    usedExchanges,
+  };
+}

--- a/frontend/app/src/pages/reports/[id].spec.ts
+++ b/frontend/app/src/pages/reports/[id].spec.ts
@@ -1,0 +1,151 @@
+import type { useReportDetail } from '@/pages/reports/use-report-detail';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { createAccountingSettings, createReport, LATEST_REPORT_ID } from '@test/utils/reports-test-data';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import AccountingSettingsDisplay from '@/modules/reports/AccountingSettingsDisplay.vue';
+import ExportReportCsv from '@/modules/reports/ExportReportCsv.vue';
+import ProfitLossOverview from '@/modules/reports/ProfitLossOverview.vue';
+import ReportActionable from '@/modules/reports/ReportActionable.vue';
+import ReportHeader from '@/modules/reports/ReportHeader.vue';
+import ReportDetailPage from '@/pages/reports/[id].vue';
+
+type ReportDetail = ReturnType<typeof useReportDetail>;
+
+const regenerateReport = vi.fn(async (): Promise<void> => {});
+
+/**
+ * The page is a seam: it owns no logic beyond handing the composable's output to its children, so
+ * the composable is mocked and the assertions are about what reaches each child.
+ */
+const detailState = vi.hoisted(() => ({
+  eventsSkipped: 0,
+  latest: true,
+  loading: false,
+  missingAcquisitions: 0,
+  missingPrices: 0,
+  showCompletenessWarning: false,
+  showStaleDetails: false,
+}));
+
+vi.mock('@/pages/reports/use-report-detail', () => ({
+  useReportDetail: (): ReportDetail => ({
+    eventsSkippedCount: computed(() => detailState.eventsSkipped),
+    hasActionableIssues: computed(() => detailState.missingAcquisitions > 0 || detailState.missingPrices > 0),
+    initialOpenReportActionable: computed(() => true),
+    latest: computed(() => detailState.latest),
+    loading: computed(() => detailState.loading),
+    missingAcquisitionsCount: computed(() => detailState.missingAcquisitions),
+    missingPricesCount: computed(() => detailState.missingPrices),
+    modelReportEvents: ref({ data: [], found: 0, limit: 0, total: 0 }),
+    refreshing: computed(() => false),
+    regenerateReport,
+    reportId: LATEST_REPORT_ID,
+    selectedReport: computed(() => createReport({ endTs: 456, startTs: 123 })),
+    settings: computed(() => createReport().settings),
+    showCompletenessWarning: computed(() => detailState.showCompletenessWarning),
+    showStaleDetails: computed(() => detailState.showStaleDetails),
+  }),
+}));
+
+describe('pages/reports/[id]', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ReportDetailPage>>;
+
+  function mountPage(): VueWrapper<InstanceType<typeof ReportDetailPage>> {
+    return mount(ReportDetailPage, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          AccountingSettingsDisplay: { props: ['accountingSettings'], template: '<div data-testid="settings-stub" />' },
+          ExportReportCsv: { props: ['reportId'], template: '<div data-testid="export-stub" />' },
+          ProfitLossEvents: { props: ['report', 'refreshing', 'reportEvents'], template: '<div data-testid="events-stub" />' },
+          ProfitLossOverview: { props: ['report', 'symbol', 'loading'], template: '<div data-testid="overview-stub" />' },
+          ProgressScreen: { template: '<div data-testid="progress-stub"><slot /></div>' },
+          ReportActionable: { emits: ['regenerate'], props: ['report', 'initialOpen'], template: '<div data-testid="actionable-stub" />' },
+          ReportHeader: { props: ['period'], template: '<div data-testid="header-stub" />' },
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    detailState.eventsSkipped = 0;
+    detailState.latest = true;
+    detailState.loading = false;
+    detailState.missingAcquisitions = 0;
+    detailState.missingPrices = 0;
+    detailState.showCompletenessWarning = false;
+    detailState.showStaleDetails = false;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should show only the progress screen while loading', () => {
+    detailState.loading = true;
+
+    wrapper = mountPage();
+
+    expect(wrapper.find('[data-testid=progress-stub]').exists()).toBe(true);
+    expect(wrapper.findComponent(ReportHeader).exists()).toBe(false);
+  });
+
+  it('should hand the report period to the header and the id to the csv export', () => {
+    wrapper = mountPage();
+
+    expect(wrapper.findComponent(ReportHeader).props('period')).toEqual({ end: 456, start: 123 });
+    expect(wrapper.findComponent(ExportReportCsv).props('reportId')).toBe(LATEST_REPORT_ID);
+  });
+
+  it('should hand the accounting settings down and the report to the overview', () => {
+    wrapper = mountPage();
+
+    expect(wrapper.findComponent(AccountingSettingsDisplay).props('accountingSettings')).toEqual(createAccountingSettings());
+    expect(wrapper.findComponent(ProfitLossOverview).props('report').identifier).toBe(LATEST_REPORT_ID);
+  });
+
+  it('should offer the actionable panel only for the latest report', () => {
+    wrapper = mountPage();
+    expect(wrapper.findComponent(ReportActionable).exists()).toBe(true);
+    wrapper.unmount();
+
+    detailState.latest = false;
+    wrapper = mountPage();
+
+    expect(wrapper.findComponent(ReportActionable).exists()).toBe(false);
+  });
+
+  it('should regenerate from the button and from the actionable panel alike', async () => {
+    wrapper = mountPage();
+
+    await wrapper.find('[data-testid=regenerate-report]').trigger('click');
+    expect(regenerateReport).toHaveBeenCalledTimes(1);
+
+    wrapper.findComponent(ReportActionable).vm.$emit('regenerate');
+    expect(regenerateReport).toHaveBeenCalledTimes(2);
+  });
+
+  it('should show the completeness warning and never the stale notice alongside it', () => {
+    detailState.showCompletenessWarning = true;
+    detailState.showStaleDetails = true;
+
+    wrapper = mountPage();
+
+    expect(wrapper.find('[data-testid=completeness-warning]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=stale-details]').exists()).toBe(false);
+  });
+
+  it('should fall back to the stale notice when there is no completeness warning', () => {
+    detailState.showStaleDetails = true;
+
+    wrapper = mountPage();
+
+    expect(wrapper.find('[data-testid=stale-details]').exists()).toBe(true);
+  });
+});

--- a/frontend/app/src/pages/reports/[id].vue
+++ b/frontend/app/src/pages/reports/[id].vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Report } from '@/modules/reports/report-types';
 import { msg } from '@/message-key';
 import { NoteLocation } from '@/modules/core/common/notes';
 import AccountingSettingsDisplay from '@/modules/reports/AccountingSettingsDisplay.vue';
@@ -8,9 +7,8 @@ import ProfitLossEvents from '@/modules/reports/ProfitLossEvents.vue';
 import ProfitLossOverview from '@/modules/reports/ProfitLossOverview.vue';
 import ReportActionable from '@/modules/reports/ReportActionable.vue';
 import ReportHeader from '@/modules/reports/ReportHeader.vue';
-import { useReportOperations } from '@/modules/reports/use-report-operations';
-import { defaultReportEvents, useReportsStore } from '@/modules/reports/use-reports-store';
 import ProgressScreen from '@/modules/shell/components/ProgressScreen.vue';
+import { useReportDetail } from '@/pages/reports/use-report-detail';
 
 definePage({
   meta: {
@@ -27,69 +25,23 @@ defineOptions({
 
 const { t } = useI18n({ useScope: 'global' });
 
-const loading = ref(true);
-const refreshing = ref(false);
-const initialOpenReportActionable = ref<boolean>(false);
-
-const reportsStore = useReportsStore();
-const { actionableItems, reports } = storeToRefs(reportsStore);
-const { isLatestReport } = reportsStore;
-const { fetchReports, getActionableItems } = useReportOperations();
-
-const router = useRouter();
-const route = useRoute<'/reports/[id]'>();
-const currentRoute = get(route);
-const reportId = Number(String(currentRoute.params.id));
-const latest = isLatestReport(reportId);
-
-const selectedReport = computed<Report>(() => get(reports).entries.find(item => item.identifier === reportId)!);
-const settings = computed(() => get(selectedReport).settings);
-
-const missingAcquisitionsCount = computed<number>(() => get(actionableItems)?.missingAcquisitions.length ?? 0);
-const missingPricesCount = computed<number>(() => get(actionableItems)?.missingPrices.length ?? 0);
-const eventsSkippedCount = computed<number>(() => get(actionableItems)?.eventsSkippedNoRule ?? 0);
-const hasActionableIssues = computed<boolean>(() => get(latest) && (get(missingAcquisitionsCount) > 0 || get(missingPricesCount) > 0));
-const showCompletenessWarning = computed<boolean>(() => get(hasActionableIssues) || (get(latest) && get(eventsSkippedCount) > 0));
-
-// Detailed issues are only kept for the latest report. For older reports we can
-// still tell whether they had incomplete processing, and only then is it worth
-// explaining why the details are unavailable.
-const reportHadIssues = computed<boolean>(() => {
-  const report = get(reports).entries.find(item => item.identifier === reportId);
-  return !!report && report.processedActions < report.totalActions;
-});
-const showStaleDetails = computed<boolean>(() => !get(latest) && get(reportHadIssues));
-
-const reportEvents = ref(defaultReportEvents());
-
-onMounted(async () => {
-  set(loading, true);
-  if (get(reports).entries.length === 0)
-    await fetchReports();
-
-  if (get(latest)) {
-    await getActionableItems();
-  }
-
-  if (get(route).query.openReportActionable) {
-    set(initialOpenReportActionable, true);
-    await router.replace({ query: {} });
-  }
-
-  set(loading, false);
-});
-
-async function regenerateReport() {
-  const { endTs, startTs } = get(selectedReport);
-  await router.push({
-    path: '/reports',
-    query: {
-      end: endTs.toString(),
-      regenerate: 'true',
-      start: startTs.toString(),
-    },
-  });
-}
+const {
+  eventsSkippedCount,
+  hasActionableIssues,
+  initialOpenReportActionable,
+  latest,
+  loading,
+  missingAcquisitionsCount,
+  missingPricesCount,
+  modelReportEvents,
+  refreshing,
+  regenerateReport,
+  reportId,
+  selectedReport,
+  settings,
+  showCompletenessWarning,
+  showStaleDetails,
+} = useReportDetail();
 </script>
 
 <template>
@@ -115,6 +67,7 @@ async function regenerateReport() {
         <RuiButton
           color="primary"
           variant="outlined"
+          data-testid="regenerate-report"
           @click="regenerateReport()"
         >
           <template #prepend>
@@ -129,6 +82,7 @@ async function regenerateReport() {
       <RuiAlert
         v-if="showCompletenessWarning"
         type="warning"
+        data-testid="completeness-warning"
       >
         <div v-if="hasActionableIssues">
           <div class="font-medium">
@@ -151,16 +105,16 @@ async function regenerateReport() {
       <RuiAlert
         v-else-if="showStaleDetails"
         type="info"
+        data-testid="stale-details"
       >
         {{ t('profit_loss_report.actionable.stale_details') }}
       </RuiAlert>
       <ProfitLossOverview
         :report="selectedReport"
-        :symbol="settings.profitCurrency"
         :loading="loading"
       />
       <ProfitLossEvents
-        v-model:report-events="reportEvents"
+        v-model:report-events="modelReportEvents"
         :report="selectedReport"
         :refreshing="refreshing"
       />

--- a/frontend/app/src/pages/reports/index.spec.ts
+++ b/frontend/app/src/pages/reports/index.spec.ts
@@ -1,0 +1,222 @@
+import type { useReportsPage } from '@/pages/reports/use-reports-page';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, type Ref, shallowRef } from 'vue';
+import ReportGenerator from '@/modules/reports/ReportGenerator.vue';
+import ErrorScreen from '@/modules/shell/components/error/ErrorScreen.vue';
+import ProgressScreen from '@/modules/shell/components/ProgressScreen.vue';
+import ReportsIndexPage from '@/pages/reports/index.vue';
+
+interface PageState {
+  isRunning: boolean;
+  /** Filled in by the mocked composable on every mount; see the mock below. */
+  modelReportDebugData?: Ref<File | undefined>;
+}
+
+const { clearError, exportData, generate, handleImportComplete, pageState, storeState } = vi.hoisted(() => {
+  const pageState: PageState = { isRunning: false };
+  return {
+    clearError: vi.fn(),
+    exportData: vi.fn(async (): Promise<void> => {}),
+    generate: vi.fn(async (): Promise<void> => {}),
+    handleImportComplete: vi.fn(async (): Promise<void> => {}),
+    pageState,
+    storeState: { error: '', message: '', processingState: '', progress: '' },
+  };
+});
+
+/**
+ * The page is a seam over `useReportsPage`, so the composable is mocked and the assertions are
+ * about which screen shows and what each child is handed.
+ */
+vi.mock('@/pages/reports/use-reports-page', async () => {
+  const { computed: computedFn, shallowRef: shallowRefFn } = await import('vue');
+  return {
+    useReportsPage: (): ReturnType<typeof useReportsPage> => {
+      // Published back to the test so it can put a file in the uploader; the import button stays
+      // disabled without one, and a click on a disabled button is silently dropped.
+      pageState.modelReportDebugData = shallowRefFn<File | undefined>(undefined);
+      return {
+        exportData,
+        generate,
+        handleImportComplete,
+        importDataLoading: computedFn(() => false),
+        isRunning: computedFn(() => pageState.isRunning),
+        modelImportDataDialog: shallowRefFn(false),
+        modelReportDebugData: pageState.modelReportDebugData,
+        navigateToReport: vi.fn(),
+      };
+    },
+  };
+});
+
+vi.mock('@/modules/reports/use-reports-store', () => ({
+  useReportsStore: (): {
+    clearError: typeof clearError;
+    processingState: string;
+    progress: string;
+    reportError: ReturnType<typeof shallowRef<{ error: string; message: string }>>;
+  } => ({
+    clearError,
+    processingState: storeState.processingState,
+    progress: storeState.progress,
+    reportError: shallowRef({ error: storeState.error, message: storeState.message }),
+  }),
+}));
+
+vi.mock('pinia', async importOriginal => ({
+  ...(await importOriginal<typeof import('pinia')>()),
+  storeToRefs: (store: Record<string, unknown>): Record<string, unknown> => store,
+}));
+
+describe('pages/reports/index', () => {
+  let wrapper: VueWrapper<InstanceType<typeof ReportsIndexPage>>;
+
+  /**
+   * The generator and the table are toggled with `v-show`, so they stay in the tree and only the
+   * inline style changes. VTU's `isVisible()` reports true for both states on a wrapper that was
+   * never attached to the document, so the style is read directly.
+   */
+  /** The debug-data model the mocked composable published on the last mount. */
+  function debugDataModel(): Ref<File | undefined> {
+    const model = pageState.modelReportDebugData;
+    if (!model)
+      throw new Error('mount the page before reaching for its debug-data model');
+
+    return model;
+  }
+
+  function isHidden(testId: string): boolean {
+    return wrapper.find(`[data-testid=${testId}]`).attributes('style')?.includes('display: none') ?? false;
+  }
+
+  function mountPage(): VueWrapper<InstanceType<typeof ReportsIndexPage>> {
+    return mount(ReportsIndexPage, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          ErrorScreen: { props: ['message', 'error', 'title', 'subtitle'], template: '<div data-testid="error-stub"><slot name="bottom" /></div>' },
+          FileUpload: { props: ['modelValue', 'source', 'fileFilter'], template: '<div data-testid="upload-stub" />' },
+          ProgressScreen: { props: ['progress'], template: '<div data-testid="progress-stub"><slot name="message" /><slot /></div>' },
+          ReportGenerator: { emits: ['generate', 'export-data', 'import-data'], template: '<div data-testid="generator-stub" />' },
+          ReportsTable: { template: '<div data-testid="table-stub" />' },
+          // RuiDialog teleports its contents; a pass-through keeps them in the tree.
+          RuiDialog: { props: ['modelValue', 'maxWidth'], template: '<div><slot /></div>' },
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    pageState.isRunning = false;
+    storeState.error = '';
+    storeState.message = '';
+    storeState.processingState = '';
+    storeState.progress = '';
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should show the generator and the table while idle', () => {
+    wrapper = mountPage();
+
+    expect(isHidden('generator-stub')).toBe(false);
+    expect(isHidden('table-stub')).toBe(false);
+    expect(wrapper.find('[data-testid=progress-stub]').exists()).toBe(false);
+  });
+
+  it('should replace them with the progress screen while a report is running', () => {
+    pageState.isRunning = true;
+    storeState.progress = '40';
+    storeState.processingState = 'crunching';
+
+    wrapper = mountPage();
+
+    expect(wrapper.find('[data-testid=progress-stub]').exists()).toBe(true);
+    expect(isHidden('generator-stub')).toBe(true);
+    expect(isHidden('table-stub')).toBe(true);
+  });
+
+  it('should hand the progress and the processing state to the progress screen', () => {
+    pageState.isRunning = true;
+    storeState.progress = '40';
+    storeState.processingState = 'crunching';
+
+    wrapper = mountPage();
+
+    expect(wrapper.findComponent(ProgressScreen).props('progress')).toBe('40');
+    expect(wrapper.find('[data-testid=progress-stub]').text()).toContain('crunching');
+  });
+
+  describe('when the last report errored', () => {
+    beforeEach(() => {
+      storeState.message = 'it broke';
+      storeState.error = 'stack';
+    });
+
+    it('should show the error screen instead of the generator', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(ErrorScreen).props('message')).toBe('it broke');
+      expect(wrapper.findComponent(ErrorScreen).props('error')).toBe('stack');
+      expect(isHidden('generator-stub')).toBe(true);
+    });
+
+    it('should clear the error from the close button', async () => {
+      wrapper = mountPage();
+
+      await wrapper.find('[data-testid=clear-error]').trigger('click');
+
+      expect(clearError).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stay on the progress screen when a run is in flight, error or not', () => {
+      pageState.isRunning = true;
+
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(ErrorScreen).exists()).toBe(false);
+      expect(wrapper.find('[data-testid=progress-stub]').exists()).toBe(true);
+    });
+  });
+
+  it('should forward the generator events with their payloads', () => {
+    wrapper = mountPage();
+    const generator = wrapper.findComponent(ReportGenerator);
+
+    generator.vm.$emit('generate', { end: 2, start: 1 });
+    expect(generate).toHaveBeenCalledWith({ end: 2, start: 1 });
+
+    generator.vm.$emit('export-data', { end: 2, start: 1 });
+    expect(exportData).toHaveBeenCalledWith({ end: 2, start: 1 });
+  });
+
+  it('should keep the import disabled until a file is chosen', async () => {
+    wrapper = mountPage();
+
+    const confirm = wrapper.find('[data-testid=confirm-import]');
+    expect(confirm.attributes('disabled')).toBeDefined();
+
+    set(debugDataModel(), new File(['{}'], 'debug.json'));
+    await nextTick();
+
+    expect(confirm.attributes('disabled')).toBeUndefined();
+  });
+
+  it('should run the import from the dialog confirm button', async () => {
+    wrapper = mountPage();
+    set(debugDataModel(), new File(['{}'], 'debug.json'));
+    await nextTick();
+
+    await wrapper.find('[data-testid=confirm-import]').trigger('click');
+
+    expect(handleImportComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/src/pages/reports/index.vue
+++ b/frontend/app/src/pages/reports/index.vue
@@ -1,17 +1,13 @@
 <script setup lang="ts">
 import { msg } from '@/message-key';
 import { NoteLocation } from '@/modules/core/common/notes';
-import { firstQueryValue } from '@/modules/core/table/route';
 import ReportGenerator from '@/modules/reports/ReportGenerator.vue';
 import ReportsTable from '@/modules/reports/ReportsTable.vue';
 import { useReportsStore } from '@/modules/reports/use-reports-store';
-import { useInterop } from '@/modules/shell/app/use-electron-interop';
 import ErrorScreen from '@/modules/shell/components/error/ErrorScreen.vue';
 import ProgressScreen from '@/modules/shell/components/ProgressScreen.vue';
-import { ActivityKind } from '@/modules/task-center/core/types';
-import { useTaskCenter } from '@/modules/task-center/use-task-center';
 import FileUpload from '@/modules/user-data/FileUpload.vue';
-import { useReportsPageActions } from '@/pages/reports/use-reports-page-actions';
+import { useReportsPage } from '@/pages/reports/use-reports-page';
 
 definePage({
   meta: {
@@ -20,66 +16,25 @@ definePage({
   },
 });
 
-const { useIsActive } = useTaskCenter();
+const { t } = useI18n({ useScope: 'global' });
+
 const reportsStore = useReportsStore();
 const { reportError } = storeToRefs(reportsStore);
 const { clearError } = reportsStore;
-const isRunning = useIsActive(ActivityKind.PNL_REPORT);
-const importDataDialog = ref<boolean>(false);
-const reportDebugData = ref<File>();
+
 const reportDebugDataUploader = useTemplateRef<InstanceType<typeof FileUpload>>('reportDebugDataUploader');
 
-const router = useRouter();
-const route = useRoute();
-
-const { t } = useI18n({ useScope: 'global' });
-const { getPath } = useInterop();
-
-function navigateToReport(reportId: number): void {
-  if (route.name === '/reports/') {
-    router.push({
-      name: '/reports/[id]',
-      params: {
-        id: reportId.toString(),
-      },
-      query: {
-        openReportActionable: 'true',
-      },
-    });
-  }
-}
-
-const { exportData, generate, importData, importDataLoading } = useReportsPageActions({
-  getPath,
-  onNavigateToReport: navigateToReport,
-  reportDebugData,
+const {
+  exportData,
+  generate,
+  handleImportComplete,
+  importDataLoading,
+  isRunning,
+  modelImportDataDialog,
+  modelReportDebugData,
+} = useReportsPage({
+  onResetUploader: () => get(reportDebugDataUploader)?.removeFile(),
 });
-
-onMounted(async () => {
-  const query = get(route).query;
-  if (!query.regenerate) {
-    return;
-  }
-
-  const start = firstQueryValue(query.start);
-  const end = firstQueryValue(query.end);
-  if (!(start && end)) {
-    return;
-  }
-  const period = {
-    end: Number.parseInt(end),
-    start: Number.parseInt(start),
-  };
-  await router.replace({ query: {} });
-  await generate(period);
-});
-
-async function handleImportComplete(): Promise<void> {
-  await importData();
-  set(importDataDialog, false);
-  get(reportDebugDataUploader)?.removeFile();
-  set(reportDebugData, undefined);
-}
 
 const processingState = computed(() => reportsStore.processingState);
 const progress = computed(() => reportsStore.progress);
@@ -91,7 +46,7 @@ const progress = computed(() => reportsStore.progress);
       v-show="!isRunning && !reportError.message"
       @generate="generate($event)"
       @export-data="exportData($event)"
-      @import-data="importDataDialog = true"
+      @import-data="modelImportDataDialog = true"
     />
     <ErrorScreen
       v-if="!isRunning && reportError.message"
@@ -105,6 +60,7 @@ const progress = computed(() => reportsStore.progress);
         <RuiButton
           variant="text"
           class="mt-2"
+          data-testid="clear-error"
           @click="clearError()"
         >
           {{ t('common.actions.close') }}
@@ -131,7 +87,7 @@ const progress = computed(() => reportsStore.progress);
       {{ t('profit_loss_report.loading_hint') }}
     </ProgressScreen>
     <RuiDialog
-      v-model="importDataDialog"
+      v-model="modelImportDataDialog"
       max-width="600"
     >
       <RuiCard>
@@ -140,7 +96,7 @@ const progress = computed(() => reportsStore.progress);
         </template>
         <FileUpload
           ref="reportDebugDataUploader"
-          v-model="reportDebugData"
+          v-model="modelReportDebugData"
           source="json"
           file-filter=".json"
         />
@@ -149,13 +105,14 @@ const progress = computed(() => reportsStore.progress);
           <RuiButton
             variant="text"
             color="primary"
-            @click="importDataDialog = false"
+            @click="modelImportDataDialog = false"
           >
             {{ t('common.actions.cancel') }}
           </RuiButton>
           <RuiButton
             color="primary"
-            :disabled="!reportDebugData"
+            data-testid="confirm-import"
+            :disabled="!modelReportDebugData"
             :loading="importDataLoading"
             @click="handleImportComplete()"
           >

--- a/frontend/app/src/pages/reports/use-report-detail.spec.ts
+++ b/frontend/app/src/pages/reports/use-report-detail.spec.ts
@@ -1,0 +1,283 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { Collection } from '@/modules/core/common/collection';
+import type { ProfitLossEvent, ReportActionableItem, Reports } from '@/modules/reports/report-types';
+import {
+  createActionableItems,
+  createMissingAcquisitions,
+  createMissingPrices,
+  createReport,
+  createReports,
+  LATEST_REPORT_ID,
+  OLDER_REPORT_ID,
+} from '@test/utils/reports-test-data';
+import { withSetup } from '@test/utils/with-setup';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, type ComputedRef, type Ref } from 'vue';
+import { useReportDetail } from './use-report-detail';
+
+interface RouteState {
+  params: { id: string };
+  query: Record<string, string>;
+}
+
+interface StoreState {
+  actionableItems: ReportActionableItem;
+  lastGenerated: number | null;
+  reports: Reports;
+}
+
+// `vi.hoisted` runs before the imports above, so nothing here may call a fixture. These are inert
+// starting values; `beforeEach` gives every field the one the test needs.
+const { fetchReports, getActionableItems, pushMock, replaceMock, routeState, storeState } = vi.hoisted(() => {
+  const routeState: RouteState = { params: { id: '' }, query: {} };
+  const storeState: StoreState = {
+    actionableItems: { eventsSkippedNoRule: 0, missingAcquisitions: [], missingPrices: [] },
+    lastGenerated: null,
+    reports: { entries: [], entriesFound: 0, entriesLimit: 0 },
+  };
+  return {
+    fetchReports: vi.fn(async (): Promise<void> => {}),
+    getActionableItems: vi.fn(async (): Promise<void> => {}),
+    pushMock: vi.fn(async (): Promise<void> => {}),
+    replaceMock: vi.fn(async (): Promise<void> => {}),
+    routeState,
+    storeState,
+  };
+});
+
+vi.mock('vue-router', () => ({
+  useRoute: (): ComputedRef<RouteState> => computed(() => ({ params: routeState.params, query: routeState.query })),
+  useRouter: (): { push: typeof pushMock; replace: typeof replaceMock } => ({ push: pushMock, replace: replaceMock }),
+}));
+
+vi.mock('@/modules/reports/use-report-operations', () => ({
+  useReportOperations: (): { fetchReports: typeof fetchReports; getActionableItems: typeof getActionableItems } => ({
+    fetchReports,
+    getActionableItems,
+  }),
+}));
+
+vi.mock('@/modules/reports/use-reports-store', async () => {
+  const { computed: computedFn, ref: refFn } = await import('vue');
+  return {
+    defaultReportEvents: (): Collection<ProfitLossEvent> => ({ data: [], found: 0, limit: 0, total: 0 }),
+    useReportsStore: (): {
+      actionableItems: Ref<ReportActionableItem>;
+      isLatestReport: (id: number) => ComputedRef<boolean>;
+      reports: Ref<Reports>;
+    } => ({
+      actionableItems: refFn<ReportActionableItem>(storeState.actionableItems),
+      isLatestReport: (id: number): ComputedRef<boolean> => computedFn(() => storeState.lastGenerated === id),
+      reports: refFn<Reports>(storeState.reports),
+    }),
+  };
+});
+
+// `storeToRefs` is auto-imported from pinia; the mocked store above already hands back refs, so it
+// only has to pass them through.
+vi.mock('pinia', async importOriginal => ({
+  ...(await importOriginal<typeof import('pinia')>()),
+  storeToRefs: (store: Record<string, unknown>): Record<string, unknown> => store,
+}));
+
+describe('pages/reports/useReportDetail', () => {
+  // Each harness registers an onMounted hook. One left mounted would keep answering later tests, so
+  // every wrapper is tracked and torn down.
+  const mounted: VueWrapper[] = [];
+
+  function setup(): ReturnType<typeof useReportDetail> {
+    const { result, wrapper } = withSetup(() => useReportDetail());
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeState.params = { id: String(LATEST_REPORT_ID) };
+    routeState.query = {};
+    storeState.actionableItems = createActionableItems();
+    storeState.lastGenerated = LATEST_REPORT_ID;
+    storeState.reports = createReports([createReport()]);
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  it('should resolve the report named by the route param', async () => {
+    storeState.reports = createReports([
+      createReport({ identifier: OLDER_REPORT_ID, startTs: 1 }),
+      createReport({ identifier: LATEST_REPORT_ID, startTs: 2 }),
+    ]);
+
+    const { reportId, selectedReport } = setup();
+    await flushPromises();
+
+    expect(reportId).toBe(LATEST_REPORT_ID);
+    expect(get(selectedReport).identifier).toBe(LATEST_REPORT_ID);
+    expect(get(selectedReport).startTs).toBe(2);
+  });
+
+  it('should fetch the reports on mount only when the store is empty', async () => {
+    storeState.reports = createReports([]);
+
+    setup();
+    await flushPromises();
+
+    expect(fetchReports).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not refetch the reports when the store already holds them', async () => {
+    setup();
+    await flushPromises();
+
+    expect(fetchReports).not.toHaveBeenCalled();
+  });
+
+  it('should load the actionable items only for the latest report', async () => {
+    setup();
+    await flushPromises();
+
+    expect(getActionableItems).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip the actionable items for an older report', async () => {
+    // The store still names LATEST_REPORT_ID as the last generated one, so this route is not it.
+    routeState.params = { id: String(OLDER_REPORT_ID) };
+    storeState.reports = createReports([createReport({ identifier: OLDER_REPORT_ID })]);
+
+    setup();
+    await flushPromises();
+
+    expect(getActionableItems).not.toHaveBeenCalled();
+  });
+
+  it('should clear the loading flag once the mount work settles', async () => {
+    const { loading } = setup();
+    expect(get(loading)).toBe(true);
+
+    await flushPromises();
+
+    expect(get(loading)).toBe(false);
+  });
+
+  describe('the openReportActionable query written by reports/index', () => {
+    it('should open the panel and clear the query when the param is present', async () => {
+      routeState.query = { openReportActionable: 'true' };
+
+      const { initialOpenReportActionable } = setup();
+      await flushPromises();
+
+      expect(get(initialOpenReportActionable)).toBe(true);
+      expect(replaceMock).toHaveBeenCalledWith({ query: {} });
+    });
+
+    it('should leave the panel shut and navigate nowhere without the param', async () => {
+      const { initialOpenReportActionable } = setup();
+      await flushPromises();
+
+      expect(get(initialOpenReportActionable)).toBe(false);
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the regenerate query it writes back to reports/index', () => {
+    it('should carry the selected report period as strings', async () => {
+      storeState.reports = createReports([createReport({ endTs: 456, identifier: LATEST_REPORT_ID, startTs: 123 })]);
+
+      const { regenerateReport } = setup();
+      await flushPromises();
+      await regenerateReport();
+
+      expect(pushMock).toHaveBeenCalledWith({
+        path: '/reports',
+        query: { end: '456', regenerate: 'true', start: '123' },
+      });
+    });
+  });
+
+  describe('the completeness warning', () => {
+    it('should show for the latest report with missing acquisitions', async () => {
+      storeState.actionableItems = createActionableItems({ missingAcquisitions: createMissingAcquisitions(2) });
+
+      const { hasActionableIssues, missingAcquisitionsCount, showCompletenessWarning } = setup();
+      await flushPromises();
+
+      expect(get(missingAcquisitionsCount)).toBe(2);
+      expect(get(hasActionableIssues)).toBe(true);
+      expect(get(showCompletenessWarning)).toBe(true);
+    });
+
+    it('should show for the latest report with missing prices', async () => {
+      storeState.actionableItems = createActionableItems({ missingPrices: createMissingPrices(3) });
+
+      const { hasActionableIssues, missingPricesCount } = setup();
+      await flushPromises();
+
+      expect(get(missingPricesCount)).toBe(3);
+      expect(get(hasActionableIssues)).toBe(true);
+    });
+
+    it('should show for the latest report with skipped events but flag no actionable issues', async () => {
+      storeState.actionableItems = createActionableItems({ eventsSkippedNoRule: 3 });
+
+      const { eventsSkippedCount, hasActionableIssues, showCompletenessWarning } = setup();
+      await flushPromises();
+
+      expect(get(eventsSkippedCount)).toBe(3);
+      expect(get(hasActionableIssues)).toBe(false);
+      expect(get(showCompletenessWarning)).toBe(true);
+    });
+
+    it('should stay hidden for an older report even when issues are present', async () => {
+      storeState.lastGenerated = LATEST_REPORT_ID;
+      routeState.params = { id: String(OLDER_REPORT_ID) };
+      storeState.reports = createReports([createReport({ identifier: OLDER_REPORT_ID })]);
+      storeState.actionableItems = createActionableItems({ eventsSkippedNoRule: 3 });
+
+      const { showCompletenessWarning } = setup();
+      await flushPromises();
+
+      expect(get(showCompletenessWarning)).toBe(false);
+    });
+  });
+
+  describe('the stale-details notice', () => {
+    it('should show for an older report that processed fewer actions than it held', async () => {
+      routeState.params = { id: String(OLDER_REPORT_ID) };
+      storeState.reports = createReports([
+        createReport({ identifier: OLDER_REPORT_ID, processedActions: 4, totalActions: 10 }),
+      ]);
+
+      const { showStaleDetails } = setup();
+      await flushPromises();
+
+      expect(get(showStaleDetails)).toBe(true);
+    });
+
+    it('should stay hidden for an older report that processed everything', async () => {
+      routeState.params = { id: String(OLDER_REPORT_ID) };
+      storeState.reports = createReports([
+        createReport({ identifier: OLDER_REPORT_ID, processedActions: 10, totalActions: 10 }),
+      ]);
+
+      const { showStaleDetails } = setup();
+      await flushPromises();
+
+      expect(get(showStaleDetails)).toBe(false);
+    });
+
+    it('should stay hidden for the latest report, which shows the detailed warning instead', async () => {
+      storeState.reports = createReports([
+        createReport({ identifier: LATEST_REPORT_ID, processedActions: 4, totalActions: 10 }),
+      ]);
+
+      const { showStaleDetails } = setup();
+      await flushPromises();
+
+      expect(get(showStaleDetails)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/pages/reports/use-report-detail.ts
+++ b/frontend/app/src/pages/reports/use-report-detail.ts
@@ -1,0 +1,114 @@
+import type { ComputedRef, DeepReadonly, Ref } from 'vue';
+import type { Collection } from '@/modules/core/common/collection';
+import type { ProfitLossEvent, Report } from '@/modules/reports/report-types';
+import { useReportOperations } from '@/modules/reports/use-report-operations';
+import { defaultReportEvents, useReportsStore } from '@/modules/reports/use-reports-store';
+
+/**
+ * The query param `reports/index` sets when it sends the user here after generating a report.
+ * Consumed once on mount and then cleared, so a reload does not reopen the panel.
+ */
+const OPEN_REPORT_ACTIONABLE_QUERY = 'openReportActionable';
+
+interface UseReportDetailReturn {
+  eventsSkippedCount: ComputedRef<number>;
+  hasActionableIssues: ComputedRef<boolean>;
+  initialOpenReportActionable: DeepReadonly<Ref<boolean>>;
+  latest: ComputedRef<boolean>;
+  loading: DeepReadonly<Ref<boolean>>;
+  missingAcquisitionsCount: ComputedRef<number>;
+  missingPricesCount: ComputedRef<number>;
+  modelReportEvents: Ref<Collection<ProfitLossEvent>>;
+  refreshing: DeepReadonly<Ref<boolean>>;
+  regenerateReport: () => Promise<void>;
+  reportId: number;
+  selectedReport: ComputedRef<Report>;
+  settings: ComputedRef<Report['settings']>;
+  showCompletenessWarning: ComputedRef<boolean>;
+  showStaleDetails: ComputedRef<boolean>;
+}
+
+export function useReportDetail(): UseReportDetailReturn {
+  const reportsStore = useReportsStore();
+  const { actionableItems, reports } = storeToRefs(reportsStore);
+  const { isLatestReport } = reportsStore;
+  const { fetchReports, getActionableItems } = useReportOperations();
+
+  const router = useRouter();
+  const route = useRoute<'/reports/[id]'>();
+  const reportId = Number(String(get(route).params.id));
+  const latest = isLatestReport(reportId);
+
+  const loading = shallowRef<boolean>(true);
+  const refreshing = shallowRef<boolean>(false);
+  const initialOpenReportActionable = shallowRef<boolean>(false);
+  const modelReportEvents = ref<Collection<ProfitLossEvent>>(defaultReportEvents());
+
+  function findReport(): Report | undefined {
+    return get(reports).entries.find(item => item.identifier === reportId);
+  }
+
+  const selectedReport = computed<Report>(() => findReport()!);
+  const settings = computed<Report['settings']>(() => get(selectedReport).settings);
+
+  const missingAcquisitionsCount = computed<number>(() => get(actionableItems)?.missingAcquisitions.length ?? 0);
+  const missingPricesCount = computed<number>(() => get(actionableItems)?.missingPrices.length ?? 0);
+  const eventsSkippedCount = computed<number>(() => get(actionableItems)?.eventsSkippedNoRule ?? 0);
+  const hasActionableIssues = computed<boolean>(() => get(latest) && (get(missingAcquisitionsCount) > 0 || get(missingPricesCount) > 0));
+  const showCompletenessWarning = computed<boolean>(() => get(hasActionableIssues) || (get(latest) && get(eventsSkippedCount) > 0));
+
+  // Detailed issues are only kept for the latest report. For older reports we can still tell
+  // whether they had incomplete processing, and only then is it worth explaining why the details
+  // are unavailable.
+  const reportHadIssues = computed<boolean>(() => {
+    const report = findReport();
+    return !!report && report.processedActions < report.totalActions;
+  });
+  const showStaleDetails = computed<boolean>(() => !get(latest) && get(reportHadIssues));
+
+  onMounted(async () => {
+    set(loading, true);
+    if (get(reports).entries.length === 0)
+      await fetchReports();
+
+    if (get(latest))
+      await getActionableItems();
+
+    if (get(route).query[OPEN_REPORT_ACTIONABLE_QUERY]) {
+      set(initialOpenReportActionable, true);
+      await router.replace({ query: {} });
+    }
+
+    set(loading, false);
+  });
+
+  async function regenerateReport(): Promise<void> {
+    const { endTs, startTs } = get(selectedReport);
+    await router.push({
+      path: '/reports',
+      query: {
+        end: endTs.toString(),
+        regenerate: 'true',
+        start: startTs.toString(),
+      },
+    });
+  }
+
+  return {
+    eventsSkippedCount,
+    hasActionableIssues,
+    initialOpenReportActionable: readonly(initialOpenReportActionable),
+    latest,
+    loading: readonly(loading),
+    missingAcquisitionsCount,
+    missingPricesCount,
+    modelReportEvents,
+    refreshing: readonly(refreshing),
+    regenerateReport,
+    reportId,
+    selectedReport,
+    settings,
+    showCompletenessWarning,
+    showStaleDetails,
+  };
+}

--- a/frontend/app/src/pages/reports/use-reports-page-actions.spec.ts
+++ b/frontend/app/src/pages/reports/use-reports-page-actions.spec.ts
@@ -1,0 +1,282 @@
+import { err, ok } from 'plainfp/result';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, shallowRef } from 'vue';
+import { Cancelled, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { useReportsPageActions } from './use-reports-page-actions';
+
+const PERIOD = { end: 1_600_100_000, start: 1_600_000_000 };
+
+const {
+  downloadFileByTextContent,
+  exportReportData,
+  fetchReports,
+  generateReport,
+  importReportData,
+  interopState,
+  notify,
+  openDirectory,
+  showErrorMessage,
+  showSuccessMessage,
+  submitTask,
+  unpin,
+  uploadReportData,
+} = vi.hoisted(() => ({
+  downloadFileByTextContent: vi.fn(),
+  exportReportData: vi.fn(async (): Promise<unknown> => ({ events: [] })),
+  fetchReports: vi.fn(async (): Promise<void> => {}),
+  generateReport: vi.fn(async (): Promise<number> => 1),
+  importReportData: vi.fn(async (): Promise<boolean> => true),
+  interopState: { appSession: false },
+  notify: vi.fn(),
+  openDirectory: vi.fn(async (): Promise<string | undefined> => '/tmp/out'),
+  showErrorMessage: vi.fn(),
+  showSuccessMessage: vi.fn(),
+  submitTask: vi.fn(),
+  unpin: vi.fn(),
+  uploadReportData: vi.fn(async (): Promise<boolean> => true),
+}));
+
+vi.mock('@/modules/reports/use-report-generation', () => ({
+  useReportGeneration: (): { exportReportData: typeof exportReportData; generateReport: typeof generateReport } => ({
+    exportReportData,
+    generateReport,
+  }),
+}));
+
+vi.mock('@/modules/reports/use-report-operations', () => ({
+  useReportOperations: (): { fetchReports: typeof fetchReports } => ({ fetchReports }),
+}));
+
+vi.mock('@/modules/reports/use-reports-api', () => ({
+  useReportsApi: (): { importReportData: typeof importReportData; uploadReportData: typeof uploadReportData } => ({
+    importReportData,
+    uploadReportData,
+  }),
+}));
+
+vi.mock('@/modules/shell/pinned/use-pinned-panel', () => ({
+  usePinnedPanel: (): { unpin: typeof unpin } => ({ unpin }),
+}));
+
+vi.mock('@/modules/task-center/use-native-task', () => ({
+  useNativeTask: (): { submitTask: typeof submitTask } => ({ submitTask }),
+}));
+
+vi.mock('@/modules/core/common/file/download', () => ({
+  downloadFileByTextContent,
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  getErrorMessage: (error: unknown): string => error instanceof Error ? error.message : String(error),
+  useNotifications: (): {
+    notify: typeof notify;
+    showErrorMessage: typeof showErrorMessage;
+    showSuccessMessage: typeof showSuccessMessage;
+  } => ({ notify, showErrorMessage, showSuccessMessage }),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (): Ref<string> => shallowRef('DD/MM/YYYY'),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): { appSession: boolean; openDirectory: typeof openDirectory } => ({
+    appSession: interopState.appSession,
+    openDirectory,
+  }),
+}));
+
+describe('pages/reports/useReportsPageActions', () => {
+  const onNavigateToReport = vi.fn();
+  const getPath = vi.fn((): string | undefined => undefined);
+  let reportDebugData: Ref<File | undefined>;
+
+  function setup(): ReturnType<typeof useReportsPageActions> {
+    return useReportsPageActions({ getPath, onNavigateToReport, reportDebugData });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    interopState.appSession = false;
+    reportDebugData = shallowRef<File | undefined>();
+    generateReport.mockResolvedValue(1);
+    exportReportData.mockResolvedValue({ events: [] });
+    openDirectory.mockResolvedValue('/tmp/out');
+    getPath.mockReturnValue(undefined);
+    submitTask.mockResolvedValue(ok(true));
+  });
+
+  describe('generate', () => {
+    it('should clear the pinned report card before generating', async () => {
+      await setup().generate(PERIOD);
+
+      expect(unpin).toHaveBeenCalledTimes(1);
+      expect(unpin.mock.invocationCallOrder[0]).toBeLessThan(generateReport.mock.invocationCallOrder[0]);
+    });
+
+    it('should navigate to the new report and notify with a re-navigating action', async () => {
+      generateReport.mockResolvedValue(77);
+
+      await setup().generate(PERIOD);
+
+      expect(onNavigateToReport).toHaveBeenCalledWith(77);
+      expect(notify).toHaveBeenCalledTimes(1);
+
+      // The notification's action must land on the same report, not merely on the reports list.
+      onNavigateToReport.mockClear();
+      notify.mock.calls[0][0].action.action();
+      expect(onNavigateToReport).toHaveBeenCalledWith(77);
+    });
+
+    it('should neither navigate nor notify when no report was produced', async () => {
+      generateReport.mockResolvedValue(0);
+
+      await setup().generate(PERIOD);
+
+      expect(onNavigateToReport).not.toHaveBeenCalled();
+      expect(notify).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exportData on the desktop app', () => {
+    beforeEach(() => {
+      interopState.appSession = true;
+    });
+
+    it('should abort without exporting when no directory is chosen', async () => {
+      openDirectory.mockResolvedValue(undefined);
+
+      await setup().exportData(PERIOD);
+
+      expect(exportReportData).not.toHaveBeenCalled();
+    });
+
+    it('should pass the chosen directory and report success', async () => {
+      await setup().exportData(PERIOD);
+
+      expect(exportReportData).toHaveBeenCalledWith({
+        directoryPath: '/tmp/out',
+        fromTimestamp: PERIOD.start,
+        toTimestamp: PERIOD.end,
+      });
+      expect(showSuccessMessage).toHaveBeenCalled();
+      expect(downloadFileByTextContent).not.toHaveBeenCalled();
+    });
+
+    it('should report a failure when the backend declines the export', async () => {
+      exportReportData.mockResolvedValue(false);
+
+      await setup().exportData(PERIOD);
+
+      expect(showErrorMessage).toHaveBeenCalled();
+      expect(showSuccessMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exportData on the web', () => {
+    it('should download the payload instead of asking for a directory', async () => {
+      await setup().exportData(PERIOD);
+
+      expect(openDirectory).not.toHaveBeenCalled();
+      expect(exportReportData).toHaveBeenCalledWith({ fromTimestamp: PERIOD.start, toTimestamp: PERIOD.end });
+      expect(downloadFileByTextContent).toHaveBeenCalledWith(
+        JSON.stringify({ events: [] }, null, 2),
+        'pnl_debug.json',
+        'application/json',
+      );
+    });
+
+    it('should surface a thrown error as a message rather than rejecting', async () => {
+      exportReportData.mockRejectedValue(new Error('boom'));
+
+      await expect(setup().exportData(PERIOD)).resolves.toBeUndefined();
+
+      expect(showErrorMessage).toHaveBeenCalledWith(expect.anything(), 'boom');
+    });
+  });
+
+  describe('importData', () => {
+    const file = new File(['{}'], 'debug.json');
+
+    it('should do nothing when no file is held', async () => {
+      await setup().importData();
+
+      expect(submitTask).not.toHaveBeenCalled();
+    });
+
+    it('should upload the file itself when there is no local path', async () => {
+      set(reportDebugData, file);
+
+      await setup().importData();
+
+      const { run } = submitTask.mock.calls[0][0];
+      await run({ runTask: async (fn: () => Promise<boolean>) => ok(await fn()) });
+
+      expect(uploadReportData).toHaveBeenCalledWith(file);
+      expect(importReportData).not.toHaveBeenCalled();
+    });
+
+    it('should import by path when the desktop app resolves one', async () => {
+      set(reportDebugData, file);
+      getPath.mockReturnValue('/home/user/debug.json');
+
+      await setup().importData();
+
+      const { run } = submitTask.mock.calls[0][0];
+      await run({ runTask: async (fn: () => Promise<boolean>) => ok(await fn()) });
+
+      expect(importReportData).toHaveBeenCalledWith('/home/user/debug.json');
+      expect(uploadReportData).not.toHaveBeenCalled();
+    });
+
+    it('should refresh the reports on success', async () => {
+      set(reportDebugData, file);
+
+      await setup().importData();
+
+      expect(showSuccessMessage).toHaveBeenCalled();
+      expect(fetchReports).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report a failure and not refresh when the import returns false', async () => {
+      set(reportDebugData, file);
+      submitTask.mockResolvedValue(ok(false));
+
+      await setup().importData();
+
+      expect(showErrorMessage).toHaveBeenCalled();
+      expect(fetchReports).not.toHaveBeenCalled();
+    });
+
+    it('should refresh quietly on a cancellation, with no error shown', async () => {
+      set(reportDebugData, file);
+      submitTask.mockResolvedValue(err<TaskError>(Cancelled({ message: 'stopped' })));
+
+      await setup().importData();
+
+      expect(fetchReports).toHaveBeenCalledTimes(1);
+      expect(showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it('should surface an actionable failure with its message', async () => {
+      set(reportDebugData, file);
+      submitTask.mockResolvedValue(err<TaskError>(TaskFailed({ message: 'bad json' })));
+
+      await setup().importData();
+
+      expect(showErrorMessage).toHaveBeenCalledWith(expect.anything(), expect.stringContaining('bad json'));
+      expect(fetchReports).not.toHaveBeenCalled();
+    });
+
+    it('should lower the loading flag again once the import settles', async () => {
+      set(reportDebugData, file);
+      const { importData, importDataLoading } = setup();
+
+      const pending = importData();
+      expect(get(importDataLoading)).toBe(true);
+
+      await pending;
+      expect(get(importDataLoading)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/pages/reports/use-reports-page.spec.ts
+++ b/frontend/app/src/pages/reports/use-reports-page.spec.ts
@@ -1,0 +1,174 @@
+import type { VueWrapper } from '@vue/test-utils';
+import { withSetup } from '@test/utils/with-setup';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, type ComputedRef } from 'vue';
+import { useReportsPage } from './use-reports-page';
+
+interface RouteState {
+  name: string;
+  query: Record<string, string>;
+}
+
+const { exportData, generate, importData, onResetUploader, pushMock, replaceMock, routeState } = vi.hoisted(() => {
+  const routeState: RouteState = { name: '/reports/', query: {} };
+  return {
+    exportData: vi.fn(async (): Promise<void> => {}),
+    generate: vi.fn(async (): Promise<void> => {}),
+    importData: vi.fn(async (): Promise<void> => {}),
+    onResetUploader: vi.fn(),
+    // `router.push` resolves; a mock returning undefined would break the `startPromise` wrapper.
+    pushMock: vi.fn(async (): Promise<void> => {}),
+    replaceMock: vi.fn(async (): Promise<void> => {}),
+    routeState,
+  };
+});
+
+vi.mock('vue-router', () => ({
+  useRoute: (): ComputedRef<RouteState> => computed(() => ({ name: routeState.name, query: routeState.query })),
+  useRouter: (): { push: typeof pushMock; replace: typeof replaceMock } => ({ push: pushMock, replace: replaceMock }),
+}));
+
+vi.mock('@/pages/reports/use-reports-page-actions', async () => {
+  const { shallowRef } = await import('vue');
+  return {
+    useReportsPageActions: (): {
+      exportData: typeof exportData;
+      generate: typeof generate;
+      importData: typeof importData;
+      importDataLoading: ReturnType<typeof shallowRef<boolean>>;
+    } => ({ exportData, generate, importData, importDataLoading: shallowRef(false) }),
+  };
+});
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): { getPath: () => undefined } => ({ getPath: () => undefined }),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', async () => {
+  const { computed: computedFn } = await import('vue');
+  return {
+    useTaskCenter: (): { useIsActive: () => ComputedRef<boolean> } => ({
+      useIsActive: (): ComputedRef<boolean> => computedFn(() => false),
+    }),
+  };
+});
+
+describe('pages/reports/useReportsPage', () => {
+  // The composable registers an onMounted hook, so a harness left mounted would answer a later test.
+  const mounted: VueWrapper[] = [];
+
+  function setup(): ReturnType<typeof useReportsPage> {
+    const { result, wrapper } = withSetup(() => useReportsPage({ onResetUploader }));
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeState.name = '/reports/';
+    routeState.query = {};
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  describe('the regenerate query written by reports/[id]', () => {
+    it('should clear the query before generating, so a reload does not run twice', async () => {
+      routeState.query = { end: '456', regenerate: 'true', start: '123' };
+
+      setup();
+      await flushPromises();
+
+      expect(replaceMock).toHaveBeenCalledWith({ query: {} });
+      expect(generate).toHaveBeenCalledWith({ end: 456, start: 123 });
+      expect(replaceMock.mock.invocationCallOrder[0]).toBeLessThan(generate.mock.invocationCallOrder[0]);
+    });
+
+    it('should do nothing without the regenerate flag, even with a period present', async () => {
+      routeState.query = { end: '456', start: '123' };
+
+      setup();
+      await flushPromises();
+
+      expect(generate).not.toHaveBeenCalled();
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when the period is incomplete', async () => {
+      routeState.query = { regenerate: 'true', start: '123' };
+
+      setup();
+      await flushPromises();
+
+      expect(generate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigating to a generated report', () => {
+    it('should ask reports/[id] to open the actionable panel', async () => {
+      const { navigateToReport } = setup();
+      await flushPromises();
+
+      navigateToReport(42);
+
+      expect(pushMock).toHaveBeenCalledWith({
+        name: '/reports/[id]',
+        params: { id: '42' },
+        query: { openReportActionable: 'true' },
+      });
+    });
+
+    it('should not navigate once the user has left the reports list', async () => {
+      routeState.name = '/settings/general';
+
+      const { navigateToReport } = setup();
+      await flushPromises();
+
+      navigateToReport(42);
+
+      expect(pushMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('completing a debug-data import', () => {
+    it('should shut the dialog and drop the held file', async () => {
+      const { handleImportComplete, modelImportDataDialog, modelReportDebugData } = setup();
+      await flushPromises();
+
+      set(modelImportDataDialog, true);
+      set(modelReportDebugData, new File(['{}'], 'debug.json'));
+
+      await handleImportComplete();
+
+      expect(importData).toHaveBeenCalledTimes(1);
+      expect(get(modelImportDataDialog)).toBe(false);
+      expect(get(modelReportDebugData)).toBeUndefined();
+      expect(onResetUploader).toHaveBeenCalledTimes(1);
+    });
+
+    it('should import before clearing, so the file is still there when it is read', async () => {
+      const { handleImportComplete, modelReportDebugData } = setup();
+      await flushPromises();
+
+      set(modelReportDebugData, new File(['{}'], 'debug.json'));
+      importData.mockImplementationOnce(async () => {
+        expect(get(modelReportDebugData)).toBeDefined();
+      });
+
+      await handleImportComplete();
+
+      expect(importData).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should expose the generation actions untouched', async () => {
+    const { exportData: exposedExport, generate: exposedGenerate } = setup();
+    await flushPromises();
+
+    expect(exposedExport).toBe(exportData);
+    expect(exposedGenerate).toBe(generate);
+  });
+});

--- a/frontend/app/src/pages/reports/use-reports-page.ts
+++ b/frontend/app/src/pages/reports/use-reports-page.ts
@@ -1,0 +1,99 @@
+import type { ComputedRef, DeepReadonly, Ref } from 'vue';
+import type { ProfitLossReportPeriod } from '@/modules/reports/report-types';
+import { startPromise } from '@shared/utils';
+import { firstQueryValue } from '@/modules/core/table/route';
+import { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { ActivityKind } from '@/modules/task-center/core/types';
+import { useTaskCenter } from '@/modules/task-center/use-task-center';
+import { useReportsPageActions } from '@/pages/reports/use-reports-page-actions';
+
+/**
+ * The query params `reports/[id]` sets when it sends the user back here to regenerate a report.
+ * All three must be present, and they are cleared before the run starts so a reload does not
+ * regenerate a second time.
+ */
+const REGENERATE_QUERY = 'regenerate';
+
+interface UseReportsPageOptions {
+  /** Clears the file the debug-data uploader is holding; owned by the page, which owns the ref. */
+  onResetUploader: () => void;
+}
+
+interface UseReportsPageReturn {
+  exportData: (period: ProfitLossReportPeriod) => Promise<void>;
+  generate: (period: ProfitLossReportPeriod) => Promise<void>;
+  handleImportComplete: () => Promise<void>;
+  importDataLoading: DeepReadonly<Ref<boolean>>;
+  isRunning: ComputedRef<boolean>;
+  modelImportDataDialog: Ref<boolean>;
+  modelReportDebugData: Ref<File | undefined>;
+  navigateToReport: (reportId: number) => void;
+}
+
+export function useReportsPage(options: UseReportsPageOptions): UseReportsPageReturn {
+  const { onResetUploader } = options;
+
+  const { useIsActive } = useTaskCenter();
+  const { getPath } = useInterop();
+
+  const isRunning = useIsActive(ActivityKind.PNL_REPORT);
+  const modelImportDataDialog = shallowRef<boolean>(false);
+  const modelReportDebugData = shallowRef<File | undefined>();
+
+  const router = useRouter();
+  const route = useRoute();
+
+  function navigateToReport(reportId: number): void {
+    // Guard against a late generation landing after the user has already navigated away.
+    if (get(route).name !== '/reports/')
+      return;
+
+    startPromise(router.push({
+      name: '/reports/[id]',
+      params: { id: reportId.toString() },
+      query: { openReportActionable: 'true' },
+    }));
+  }
+
+  const { exportData, generate, importData, importDataLoading } = useReportsPageActions({
+    getPath,
+    onNavigateToReport: navigateToReport,
+    reportDebugData: modelReportDebugData,
+  });
+
+  onMounted(async () => {
+    const query = get(route).query;
+    if (!query[REGENERATE_QUERY])
+      return;
+
+    const start = firstQueryValue(query.start);
+    const end = firstQueryValue(query.end);
+    if (!(start && end))
+      return;
+
+    const period = {
+      end: Number.parseInt(end),
+      start: Number.parseInt(start),
+    };
+    await router.replace({ query: {} });
+    await generate(period);
+  });
+
+  async function handleImportComplete(): Promise<void> {
+    await importData();
+    set(modelImportDataDialog, false);
+    onResetUploader();
+    set(modelReportDebugData, undefined);
+  }
+
+  return {
+    exportData,
+    generate,
+    handleImportComplete,
+    importDataLoading,
+    isRunning,
+    modelImportDataDialog,
+    modelReportDebugData,
+    navigateToReport,
+  };
+}

--- a/frontend/app/src/pages/staking/[[location]].spec.ts
+++ b/frontend/app/src/pages/staking/[[location]].spec.ts
@@ -1,0 +1,118 @@
+import type { RouteLocationRaw } from 'vue-router';
+import type { StakingInfo, useStakingPage } from '@/pages/staking/use-staking-page';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import StakingPage from '@/pages/staking/[[location]].vue';
+
+const getRedirectLink = vi.fn((location: string): RouteLocationRaw => ({
+  name: '/staking/[[location]]',
+  params: { location },
+}));
+
+const STAKING: StakingInfo[] = [
+  { id: 'eth2', image: '/images/protocols/ethereum.svg', name: 'Eth2' },
+  { id: 'liquity', image: '/images/protocols/liquity.png', name: 'Liquity' },
+  { id: 'kraken', image: '/images/protocols/kraken.svg', name: 'Kraken' },
+  { id: 'lido-csm', image: '/images/protocols/lido_csm.svg', name: 'Lido CSM' },
+];
+
+const pageState = vi.hoisted((): { hasPage: boolean } => ({ hasPage: false }));
+
+vi.mock('@/pages/staking/use-staking-page', async () => {
+  const { computed, defineComponent: defineComponentFn } = await import('vue');
+  const selected = defineComponentFn({
+    name: 'SelectedStakingPage',
+    template: '<div data-testid="selected-staking-page" />',
+  });
+  return {
+    useStakingPage: (): ReturnType<typeof useStakingPage> => ({
+      getRedirectLink,
+      modelLocation: computed({ get: () => undefined, set: () => {} }),
+      page: computed(() => pageState.hasPage ? selected : null),
+      staking: computed(() => STAKING),
+    }),
+  };
+});
+
+describe('pages/staking/[[location]]', () => {
+  let wrapper: VueWrapper<InstanceType<typeof StakingPage>>;
+
+  function mountPage(location: '' | 'kraken' = ''): VueWrapper<InstanceType<typeof StakingPage>> {
+    return mount(StakingPage, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          AppImage: { props: ['src', 'size', 'fit'], template: '<div data-testid="protocol-image" />' },
+          FullSizeContent: { template: '<div data-testid="empty-state"><slot /></div>' },
+          InternalLink: { props: ['to'], template: '<a data-testid="protocol-link"><slot /></a>' },
+          RuiMenuSelect: { props: ['modelValue', 'options', 'label', 'keyAttr', 'textAttr'], template: '<div data-testid="location-select" />' },
+        },
+      },
+      props: { location },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    pageState.hasPage = false;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should offer every staking location in the dropdown', () => {
+    wrapper = mountPage();
+
+    expect(wrapper.find('[data-testid=location-select]').exists()).toBe(true);
+  });
+
+  describe('with no location chosen', () => {
+    it('should show the empty state rather than a staking page', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.find('[data-testid=staking-picker]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=staking-page]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid=empty-state]').exists()).toBe(true);
+    });
+
+    it('should offer a shortcut into each location', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findAll('[data-testid=protocol-link]')).toHaveLength(STAKING.length);
+      expect(getRedirectLink).toHaveBeenCalledWith('eth2');
+      expect(getRedirectLink).toHaveBeenCalledWith('lido-csm');
+    });
+
+    it('should show an image for each location', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findAll('[data-testid=protocol-image]').length).toBeGreaterThanOrEqual(STAKING.length);
+    });
+  });
+
+  describe('with a location chosen', () => {
+    beforeEach(() => {
+      pageState.hasPage = true;
+    });
+
+    it('should render that page and drop the empty state', () => {
+      wrapper = mountPage('kraken');
+
+      expect(wrapper.find('[data-testid=staking-page]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=selected-staking-page]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=staking-picker]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid=empty-state]').exists()).toBe(false);
+    });
+
+    it('should keep the dropdown available so another location can be chosen', () => {
+      wrapper = mountPage('kraken');
+
+      expect(wrapper.find('[data-testid=location-select]').exists()).toBe(true);
+    });
+  });
+});

--- a/frontend/app/src/pages/staking/[[location]].vue
+++ b/frontend/app/src/pages/staking/[[location]].vue
@@ -1,20 +1,11 @@
 <script setup lang="ts">
-import type { RouteLocationRaw } from 'vue-router';
-import { startPromise } from '@shared/utils';
+import type { StakingLocation } from '@/pages/staking/staking-pages';
 import { msg } from '@/message-key';
-import { getPublicProtocolImagePath } from '@/modules/core/common/file/file';
 import { NoteLocation } from '@/modules/core/common/notes';
 import AppImage from '@/modules/shell/components/AppImage.vue';
 import FullSizeContent from '@/modules/shell/components/FullSizeContent.vue';
 import InternalLink from '@/modules/shell/components/InternalLink.vue';
-
-type NavType = 'eth2' | 'liquity' | 'kraken' | 'lido-csm';
-
-interface StakingInfo {
-  id: NavType;
-  image: string;
-  name: string;
-}
+import { useStakingPage } from '@/pages/staking/use-staking-page';
 
 definePage({
   meta: {
@@ -25,88 +16,16 @@ definePage({
 });
 
 const { location: locationProp } = defineProps<{
-  location: NavType | '';
+  location: StakingLocation | '';
 }>();
 
 const imageSize = '64px';
 
-const pages = {
-  'eth2': defineAsyncComponent(() => import('@/modules/staking/eth/EthStakingPage.vue')),
-  'kraken': defineAsyncComponent(() => import('@/modules/staking/kraken/KrakenPage.vue')),
-  'lido-csm': defineAsyncComponent(() => import('@/modules/staking/lido-csm/LidoCsmPage.vue')),
-  'liquity': defineAsyncComponent(() => import('@/modules/staking/liquity/LiquityPage.vue')),
-};
-
 const { t } = useI18n({ useScope: 'global' });
 
-const lastLocation = useLocalStorage('rotki.staking.last_location', '');
-
-const location = computed({
-  get() {
-    return locationProp || undefined;
-  },
-  set(value?: NavType) {
-    set(lastLocation, value);
-    if (value)
-      startPromise(redirect(value));
-  },
-});
-
-const staking = computed<StakingInfo[]>(() => [
-  {
-    id: 'eth2',
-    image: getPublicProtocolImagePath('ethereum.svg'),
-    name: t('staking.eth2'),
-  },
-  {
-    id: 'liquity',
-    image: getPublicProtocolImagePath('liquity.png'),
-    name: t('staking.liquity'),
-  },
-  {
-    id: 'kraken',
-    image: getPublicProtocolImagePath('kraken.svg'),
-    name: t('staking.kraken'),
-  },
-  {
-    id: 'lido-csm',
-    image: getPublicProtocolImagePath('lido_csm.svg'),
-    name: t('staking.lido_csm'),
-  },
-]);
-
-const router = useRouter();
 const [DefineIcon, ReuseIcon] = createReusableTemplate<{ image: string }>();
 
-function getRedirectLink(location: string): RouteLocationRaw {
-  return {
-    name: '/staking/[[location]]',
-    params: { location },
-  };
-}
-
-async function redirect(location: string) {
-  await nextTick(() => {
-    router.push(getRedirectLink(location));
-  });
-}
-
-const page = computed(() => {
-  const selectedLocation = get(location);
-  return selectedLocation ? pages[selectedLocation] : null;
-});
-
-onMounted(async () => {
-  if (locationProp) {
-    set(location, locationProp);
-    return;
-  }
-  const lastLocationVal = get(lastLocation);
-  if (!lastLocationVal)
-    return;
-
-  await redirect(lastLocationVal);
-});
+const { getRedirectLink, modelLocation, page, staking } = useStakingPage(() => locationProp);
 </script>
 
 <template>
@@ -121,7 +40,7 @@ onMounted(async () => {
         />
       </DefineIcon>
       <RuiMenuSelect
-        v-model="location"
+        v-model="modelLocation"
         :options="staking"
         :label="t('staking_page.dropdown_label')"
         key-attr="id"
@@ -145,10 +64,14 @@ onMounted(async () => {
     <div
       v-if="page"
       class="pt-8"
+      data-testid="staking-page"
     >
       <Component :is="page" />
     </div>
-    <div v-else>
+    <div
+      v-else
+      data-testid="staking-picker"
+    >
       <div class="flex items-center justify-center md:justify-end mt-2 md:mr-6 text-rui-text-secondary gap-2">
         <RuiIcon
           class="shrink-0"

--- a/frontend/app/src/pages/staking/staking-pages.ts
+++ b/frontend/app/src/pages/staking/staking-pages.ts
@@ -1,0 +1,14 @@
+import type { Component } from 'vue';
+
+export type StakingLocation = 'eth2' | 'liquity' | 'kraken' | 'lido-csm';
+
+/**
+ * The staking page each location resolves to, loaded on demand. Kept apart from the composable so
+ * a spec can replace the whole map without pulling four page components into the module graph.
+ */
+export const stakingPages: Record<StakingLocation, Component> = {
+  'eth2': defineAsyncComponent(async () => import('@/modules/staking/eth/EthStakingPage.vue')),
+  'kraken': defineAsyncComponent(async () => import('@/modules/staking/kraken/KrakenPage.vue')),
+  'lido-csm': defineAsyncComponent(async () => import('@/modules/staking/lido-csm/LidoCsmPage.vue')),
+  'liquity': defineAsyncComponent(async () => import('@/modules/staking/liquity/LiquityPage.vue')),
+};

--- a/frontend/app/src/pages/staking/use-staking-page.spec.ts
+++ b/frontend/app/src/pages/staking/use-staking-page.spec.ts
@@ -1,0 +1,171 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { StakingLocation } from '@/pages/staking/staking-pages';
+import { withSetup } from '@test/utils/with-setup';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStakingPage } from './use-staking-page';
+
+const LAST_LOCATION_KEY = 'rotki.staking.last_location';
+
+const pushMock = vi.hoisted(() => vi.fn(async (): Promise<void> => {}));
+
+vi.mock('vue-router', () => ({
+  useRouter: (): { push: typeof pushMock } => ({ push: pushMock }),
+}));
+
+// The real map pulls in four staking pages; only the identity of each entry matters here.
+vi.mock('@/pages/staking/staking-pages', () => ({
+  stakingPages: {
+    'eth2': { name: 'Eth2Page' },
+    'kraken': { name: 'KrakenPage' },
+    'lido-csm': { name: 'LidoCsmPage' },
+    'liquity': { name: 'LiquityPage' },
+  },
+}));
+
+vi.mock('@/modules/core/common/file/file', () => ({
+  getPublicProtocolImagePath: (file: string): string => `/images/protocols/${file}`,
+}));
+
+describe('pages/staking/useStakingPage', () => {
+  // The composable registers an onMounted hook that can navigate, so a leftover harness would
+  // push during a later test.
+  const mounted: VueWrapper[] = [];
+
+  function setup(location: StakingLocation | ''): ReturnType<typeof useStakingPage> {
+    const { result, wrapper } = withSetup(() => useStakingPage(() => location));
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  describe('with a location in the route', () => {
+    it('should resolve the page for that location', async () => {
+      const { page } = setup('kraken');
+      await flushPromises();
+
+      expect(get(page)).toEqual({ name: 'KrakenPage' });
+    });
+
+    it('should remember it as the last location', async () => {
+      setup('liquity');
+      await flushPromises();
+
+      expect(localStorage.getItem(LAST_LOCATION_KEY)).toContain('liquity');
+    });
+
+    it('should overwrite a different remembered location', async () => {
+      localStorage.setItem(LAST_LOCATION_KEY, 'kraken');
+
+      setup('eth2');
+      await flushPromises();
+
+      expect(localStorage.getItem(LAST_LOCATION_KEY)).toContain('eth2');
+    });
+  });
+
+  describe('with no location in the route', () => {
+    it('should resolve no page, so the picker shows', async () => {
+      const { page } = setup('');
+      await flushPromises();
+
+      expect(get(page)).toBeNull();
+    });
+
+    it('should stay put when nothing was remembered', async () => {
+      const { page } = setup('');
+      await flushPromises();
+
+      expect(pushMock).not.toHaveBeenCalled();
+      expect(get(page)).toBeNull();
+    });
+
+    it('should reopen the remembered location', async () => {
+      localStorage.setItem(LAST_LOCATION_KEY, 'lido-csm');
+
+      setup('');
+      await flushPromises();
+
+      expect(pushMock).toHaveBeenCalledWith({
+        name: '/staking/[[location]]',
+        params: { location: 'lido-csm' },
+      });
+    });
+
+    it('should not record anything new while redirecting', async () => {
+      localStorage.setItem(LAST_LOCATION_KEY, 'kraken');
+
+      setup('');
+      await flushPromises();
+
+      expect(localStorage.getItem(LAST_LOCATION_KEY)).toContain('kraken');
+    });
+  });
+
+  describe('choosing a location from the dropdown', () => {
+    it('should navigate to the chosen one and remember it', async () => {
+      const { modelLocation } = setup('');
+      await flushPromises();
+
+      set(modelLocation, 'liquity');
+      await flushPromises();
+
+      expect(pushMock).toHaveBeenCalledWith({
+        name: '/staking/[[location]]',
+        params: { location: 'liquity' },
+      });
+      expect(localStorage.getItem(LAST_LOCATION_KEY)).toContain('liquity');
+    });
+
+    it('should clear the remembered location and navigate nowhere when the choice is cleared', async () => {
+      localStorage.setItem(LAST_LOCATION_KEY, 'kraken');
+      const { modelLocation } = setup('kraken');
+      await flushPromises();
+      pushMock.mockClear();
+
+      set(modelLocation, undefined);
+      await flushPromises();
+
+      expect(pushMock).not.toHaveBeenCalled();
+    });
+
+    it('should read the route param back out, not what was written', async () => {
+      const { modelLocation } = setup('kraken');
+      await flushPromises();
+
+      set(modelLocation, 'eth2');
+      await flushPromises();
+
+      // The prop is the source of truth; the write only navigates, and the real route change is
+      // what swaps the page.
+      expect(get(modelLocation)).toBe('kraken');
+    });
+  });
+
+  it('should offer the four staking locations with their images', async () => {
+    const { staking } = setup('');
+    await flushPromises();
+
+    expect(get(staking).map(item => item.id)).toEqual(['eth2', 'liquity', 'kraken', 'lido-csm']);
+    expect(get(staking)[0].image).toBe('/images/protocols/ethereum.svg');
+  });
+
+  it('should build a redirect link for a location', async () => {
+    const { getRedirectLink } = setup('');
+    await flushPromises();
+
+    expect(getRedirectLink('kraken')).toEqual({
+      name: '/staking/[[location]]',
+      params: { location: 'kraken' },
+    });
+  });
+});

--- a/frontend/app/src/pages/staking/use-staking-page.ts
+++ b/frontend/app/src/pages/staking/use-staking-page.ts
@@ -1,0 +1,86 @@
+import type { Component, ComputedRef, MaybeRefOrGetter, Ref, WritableComputedRef } from 'vue';
+import type { RouteLocationRaw } from 'vue-router';
+import { startPromise } from '@shared/utils';
+import { getPublicProtocolImagePath } from '@/modules/core/common/file/file';
+import { type StakingLocation, stakingPages } from '@/pages/staking/staking-pages';
+
+export interface StakingInfo {
+  id: StakingLocation;
+  image: string;
+  name: string;
+}
+
+/** Where the last visited location is remembered, so a bare `/staking` reopens it. */
+const LAST_LOCATION_KEY = 'rotki.staking.last_location';
+
+interface UseStakingPageReturn {
+  getRedirectLink: (location: string) => RouteLocationRaw;
+  modelLocation: WritableComputedRef<StakingLocation | undefined>;
+  page: ComputedRef<Component | null>;
+  staking: ComputedRef<StakingInfo[]>;
+}
+
+export function useStakingPage(locationProp: MaybeRefOrGetter<StakingLocation | ''>): UseStakingPageReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const router = useRouter();
+
+  const lastLocation: Ref<string> = useLocalStorage(LAST_LOCATION_KEY, '');
+
+  function getRedirectLink(location: string): RouteLocationRaw {
+    return {
+      name: '/staking/[[location]]',
+      params: { location },
+    };
+  }
+
+  async function redirect(location: string): Promise<void> {
+    await nextTick(() => {
+      startPromise(router.push(getRedirectLink(location)));
+    });
+  }
+
+  const modelLocation = computed<StakingLocation | undefined>({
+    get() {
+      return toValue(locationProp) || undefined;
+    },
+    set(value?: StakingLocation) {
+      set(lastLocation, value);
+      if (value)
+        startPromise(redirect(value));
+    },
+  });
+
+  const staking = computed<StakingInfo[]>(() => [
+    { id: 'eth2', image: getPublicProtocolImagePath('ethereum.svg'), name: t('staking.eth2') },
+    { id: 'liquity', image: getPublicProtocolImagePath('liquity.png'), name: t('staking.liquity') },
+    { id: 'kraken', image: getPublicProtocolImagePath('kraken.svg'), name: t('staking.kraken') },
+    { id: 'lido-csm', image: getPublicProtocolImagePath('lido_csm.svg'), name: t('staking.lido_csm') },
+  ]);
+
+  const page = computed<Component | null>(() => {
+    const selected = get(modelLocation);
+    return selected ? stakingPages[selected] : null;
+  });
+
+  onMounted(async () => {
+    const current = toValue(locationProp);
+    if (current) {
+      // Writing it back is what records it as the remembered location.
+      set(modelLocation, current);
+      return;
+    }
+
+    const remembered = get(lastLocation);
+    if (!remembered)
+      return;
+
+    await redirect(remembered);
+  });
+
+  return {
+    getRedirectLink,
+    modelLocation,
+    page,
+    staking,
+  };
+}

--- a/frontend/app/src/pages/statistics/snapshots/index.spec.ts
+++ b/frontend/app/src/pages/statistics/snapshots/index.spec.ts
@@ -1,0 +1,159 @@
+import type { SnapshotListRow } from '@/modules/dashboard/snapshots/composables/use-snapshot-list';
+import type { useSnapshotsPage } from '@/pages/statistics/snapshots/use-snapshots-page';
+import { bigNumberify } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import SnapshotsPage from '@/pages/statistics/snapshots/index.vue';
+
+const confirmDelete = vi.fn();
+const confirmTakeSnapshot = vi.fn();
+const importSnapshot = vi.fn();
+const open = vi.fn();
+const openExport = vi.fn();
+const refresh = vi.fn(async (): Promise<void> => {});
+
+interface PageState {
+  rows: SnapshotListRow[];
+  selectedTimestamp: number;
+}
+
+const pageState = vi.hoisted((): PageState => ({ rows: [], selectedTimestamp: 0 }));
+
+const ListTableStub = defineComponent({
+  emits: ['open', 'export', 'delete', 'update:pagination'],
+  name: 'SnapshotListTableStub',
+  props: {
+    emptyDescription: { default: '', type: String },
+    loading: { default: false, type: Boolean },
+    pagination: { default: undefined, type: Object },
+    rows: { default: () => [], type: Array },
+  },
+  template: '<div data-testid="snapshot-list" />',
+});
+
+const ExportDialogStub = defineComponent({
+  name: 'ExportSnapshotDialogStub',
+  props: {
+    balance: { default: undefined, type: Object },
+    modelValue: { default: false, type: Boolean },
+    timestamp: { default: 0, type: Number },
+  },
+  template: '<div data-testid="export-dialog" />',
+});
+
+vi.mock('@/pages/statistics/snapshots/use-snapshots-page', async () => {
+  const { computed, ref, shallowRef } = await import('vue');
+  return {
+    useSnapshotsPage: (): ReturnType<typeof useSnapshotsPage> => ({
+      confirmDelete,
+      confirmTakeSnapshot,
+      emptyDescription: computed(() => 'nothing here'),
+      forceSaving: shallowRef(false),
+      importSnapshot,
+      importing: shallowRef(false),
+      loading: shallowRef(false),
+      modelBalanceFile: shallowRef(undefined),
+      modelExportDialog: shallowRef(false),
+      modelFilters: ref({}),
+      modelImportDialog: shallowRef(false),
+      modelLocationFile: shallowRef(undefined),
+      modelPagination: ref({ limit: 10, page: 1, total: 0 }),
+      open,
+      openExport,
+      refresh,
+      rows: computed(() => pageState.rows),
+      selectedBalance: computed(() => bigNumberify(500)),
+      selectedTimestamp: computed(() => pageState.selectedTimestamp),
+    }),
+  };
+});
+
+describe('pages/statistics/snapshots/index', () => {
+  let wrapper: VueWrapper<InstanceType<typeof SnapshotsPage>>;
+
+  function mountPage(): VueWrapper<InstanceType<typeof SnapshotsPage>> {
+    return mount(SnapshotsPage, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          ExportSnapshotDialog: ExportDialogStub,
+          SnapshotImportDialog: { props: ['modelValue', 'balanceFile', 'locationFile', 'loading'], template: '<div data-testid="import-dialog" />' },
+          SnapshotListFilter: { props: ['modelValue'], template: '<div data-testid="list-filter" />' },
+          SnapshotListTable: ListTableStub,
+          TablePageLayout: { props: ['title'], template: '<div><slot name="buttons" /><slot /></div>' },
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    pageState.rows = [];
+    pageState.selectedTimestamp = 0;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should hand the rows and the empty message to the table', () => {
+    pageState.rows = [{ timestamp: 100, usdValue: bigNumberify(500) }];
+
+    wrapper = mountPage();
+
+    const table = wrapper.findComponent(ListTableStub);
+    expect(table.props('rows')).toHaveLength(1);
+    expect(table.props('emptyDescription')).toBe('nothing here');
+  });
+
+  it('should refresh from the toolbar button', async () => {
+    wrapper = mountPage();
+
+    await wrapper.find('[data-testid=refresh-snapshots]').trigger('click');
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('should ask before taking a snapshot rather than taking one', async () => {
+    wrapper = mountPage();
+
+    await wrapper.find('[data-testid=take-snapshot]').trigger('click');
+
+    expect(confirmTakeSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('should route each table event to its own handler, with the timestamp', () => {
+    wrapper = mountPage();
+    const table = wrapper.findComponent(ListTableStub);
+
+    table.vm.$emit('open', 100);
+    table.vm.$emit('export', 200);
+    table.vm.$emit('delete', 300);
+
+    expect(open).toHaveBeenCalledWith(100);
+    expect(openExport).toHaveBeenCalledWith(200);
+    expect(confirmDelete).toHaveBeenCalledWith(300);
+  });
+
+  it('should hand the selected snapshot and its value to the export dialog', () => {
+    pageState.selectedTimestamp = 200;
+
+    wrapper = mountPage();
+
+    const dialog = wrapper.findComponent(ExportDialogStub);
+    expect(dialog.props('timestamp')).toBe(200);
+    expect(dialog.props('balance')).toStrictEqual(bigNumberify(500));
+  });
+
+  it('should show the filter and the import dialog', () => {
+    wrapper = mountPage();
+
+    expect(wrapper.find('[data-testid=list-filter]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=import-dialog]').exists()).toBe(true);
+  });
+});

--- a/frontend/app/src/pages/statistics/snapshots/index.vue
+++ b/frontend/app/src/pages/statistics/snapshots/index.vue
@@ -1,24 +1,12 @@
 <script setup lang="ts">
-import type { TablePaginationData } from '@rotki/ui-library';
-import type { LocationQueryRaw } from 'vue-router';
-import type { LocationQuery } from '@/modules/core/table/route';
-import { type BigNumber, type Message, Zero } from '@rotki/common';
-import { startPromise } from '@shared/utils';
 import { msg } from '@/message-key';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { NoteLocation } from '@/modules/core/common/notes';
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
-import { applyPaginationDefaults, parseQueryPagination } from '@/modules/core/table/pagination-filter-utils';
 import ExportSnapshotDialog from '@/modules/dashboard/ExportSnapshotDialog.vue';
 import SnapshotImportDialog from '@/modules/dashboard/SnapshotImportDialog.vue';
 import SnapshotListFilter from '@/modules/dashboard/snapshots/components/SnapshotListFilter.vue';
 import SnapshotListTable from '@/modules/dashboard/snapshots/components/SnapshotListTable.vue';
-import { useSnapshotActions } from '@/modules/dashboard/snapshots/composables/use-snapshot-actions';
-import { type SnapshotListFilters, type SnapshotListRow, useSnapshotList } from '@/modules/dashboard/snapshots/composables/use-snapshot-list';
-import { useItemsPerPage } from '@/modules/session/use-items-per-page';
-import { useSnapshotApi } from '@/modules/settings/api/use-snapshot-api';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
+import { useSnapshotsPage } from '@/pages/statistics/snapshots/use-snapshots-page';
 
 definePage({
   meta: {
@@ -28,125 +16,28 @@ definePage({
 });
 
 const { t } = useI18n({ useScope: 'global' });
-const router = useRouter();
-const route = useRoute();
-const itemsPerPage = useItemsPerPage();
 
-const exportDialog = ref<boolean>(false);
-const importDialog = ref<boolean>(false);
-const selectedTimestamp = ref<number>(0);
-
-// View-state lives in the URL query, so it survives reload and is restored by the
-// browser's back/forward when returning from a snapshot's detail page.
-const filters = ref<SnapshotListFilters>({});
-const pagination = ref<TablePaginationData>(applyPaginationDefaults(get(itemsPerPage)));
-
-const { hasSnapshots, loading, refresh, rows } = useSnapshotList(filters);
-const { deleteSnapshot } = useSnapshotApi();
-const { setMessage } = useMessageStore();
-const { show } = useConfirmStore();
-const { forceSave, forceSaving, importing, importSnapshot, modelBalanceFile, modelLocationFile } = useSnapshotActions();
-
-/** Reads the date range + page from the URL query into the view-state. */
-function readQuery(query: LocationQuery): void {
-  const from = Number(query.from);
-  const to = Number(query.to);
-  set(filters, {
-    fromTimestamp: query.from && Number.isFinite(from) ? from : undefined,
-    toTimestamp: query.to && Number.isFinite(to) ? to : undefined,
-  });
-  set(pagination, parseQueryPagination(query, get(pagination)));
-}
-
-/** Mirrors the view-state back into the URL query (replace: no history spam). */
-function writeQuery(): void {
-  const { fromTimestamp, toTimestamp } = get(filters);
-  const { limit, page } = get(pagination);
-  const query: LocationQueryRaw = {
-    ...(fromTimestamp !== undefined ? { from: fromTimestamp } : {}),
-    ...(toTimestamp !== undefined ? { to: toTimestamp } : {}),
-    ...(page > 1 ? { page } : {}),
-    ...(limit !== get(itemsPerPage) ? { limit } : {}),
-  };
-  startPromise(router.replace({ query }));
-}
-
-readQuery(get(route).query);
-
-watch([
-  (): number | undefined => get(filters).fromTimestamp,
-  (): number | undefined => get(filters).toTimestamp,
-  (): number => get(pagination).page,
-  (): number => get(pagination).limit,
-], writeQuery);
-
-// When the list is empty, tell apart a genuinely empty account from a range
-// filter that excludes everything.
-const emptyDescription = computed<string>(() =>
-  get(hasSnapshots)
-    ? t('dashboard.snapshot.list.empty_filtered')
-    : t('dashboard.snapshot.list.empty'));
-
-function open(timestamp: number): void {
-  startPromise(router.push(`/statistics/snapshots/${timestamp}`));
-}
-
-// The export dialog shows the selected snapshot's stored USD net worth; the dialog
-// converts it at the snapshot's historic rate itself (#12277), lazily, so opening
-// it never triggers a whole-series conversion.
-const selectedRow = computed<SnapshotListRow | undefined>(() =>
-  get(rows).find(item => item.timestamp === get(selectedTimestamp)));
-const selectedBalance = computed<BigNumber>(() => get(selectedRow)?.usdValue ?? Zero);
-
-function openExport(timestamp: number): void {
-  set(selectedTimestamp, timestamp);
-  set(exportDialog, true);
-}
-
-async function performDelete(timestamp: number): Promise<void> {
-  let message: Message;
-  try {
-    const success = await deleteSnapshot({ timestamp });
-    message = {
-      description: success
-        ? t('dashboard.snapshot.delete.message.success')
-        : t('dashboard.snapshot.delete.message.failure'),
-      success,
-      title: t('dashboard.snapshot.delete.message.title'),
-    };
-    if (success)
-      await refresh();
-  }
-  catch (error: unknown) {
-    message = {
-      description: getErrorMessage(error),
-      success: false,
-      title: t('dashboard.snapshot.delete.message.title'),
-    };
-  }
-  setMessage(message);
-}
-
-function confirmDelete(timestamp: number): void {
-  show(
-    {
-      message: t('dashboard.snapshot.delete.dialog.message'),
-      title: t('dashboard.snapshot.delete.dialog.title'),
-    },
-    () => performDelete(timestamp),
-  );
-}
-
-// Force-save refetches every balance (slow, rate-limit prone), so confirm first.
-function confirmTakeSnapshot(): void {
-  show(
-    {
-      message: t('dashboard.snapshot.list.take_snapshot_confirm.message'),
-      title: t('dashboard.snapshot.list.take_snapshot_confirm.title'),
-    },
-    () => forceSave(),
-  );
-}
+const {
+  confirmDelete,
+  confirmTakeSnapshot,
+  emptyDescription,
+  forceSaving,
+  importing,
+  importSnapshot,
+  loading,
+  modelBalanceFile,
+  modelExportDialog,
+  modelFilters,
+  modelImportDialog,
+  modelLocationFile,
+  modelPagination,
+  open,
+  openExport,
+  refresh,
+  rows,
+  selectedBalance,
+  selectedTimestamp,
+} = useSnapshotsPage();
 </script>
 
 <template>
@@ -156,6 +47,7 @@ function confirmTakeSnapshot(): void {
         variant="outlined"
         color="primary"
         :loading="loading"
+        data-testid="refresh-snapshots"
         @click="refresh()"
       >
         <template #prepend>
@@ -165,7 +57,7 @@ function confirmTakeSnapshot(): void {
       </RuiButton>
 
       <SnapshotImportDialog
-        v-model="importDialog"
+        v-model="modelImportDialog"
         v-model:balance-file="modelBalanceFile"
         v-model:location-file="modelLocationFile"
         :loading="importing"
@@ -180,6 +72,7 @@ function confirmTakeSnapshot(): void {
           <RuiButton
             color="primary"
             :loading="forceSaving"
+            data-testid="take-snapshot"
             @click="confirmTakeSnapshot()"
           >
             <template #prepend>
@@ -194,12 +87,12 @@ function confirmTakeSnapshot(): void {
 
     <RuiCard>
       <SnapshotListFilter
-        v-model="filters"
+        v-model="modelFilters"
         class="mb-4"
       />
 
       <SnapshotListTable
-        v-model:pagination="pagination"
+        v-model:pagination="modelPagination"
         :rows="rows"
         :loading="loading"
         :empty-description="emptyDescription"
@@ -210,7 +103,7 @@ function confirmTakeSnapshot(): void {
     </RuiCard>
 
     <ExportSnapshotDialog
-      v-model="exportDialog"
+      v-model="modelExportDialog"
       :timestamp="selectedTimestamp"
       :balance="selectedBalance"
     />

--- a/frontend/app/src/pages/statistics/snapshots/snapshot-query.spec.ts
+++ b/frontend/app/src/pages/statistics/snapshots/snapshot-query.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { parseSnapshotFilters, toSnapshotQuery } from './snapshot-query';
+
+const DEFAULT_LIMIT = 10;
+
+describe('pages/statistics/snapshots/parseSnapshotFilters', () => {
+  it('should read both bounds as numbers', () => {
+    expect(parseSnapshotFilters({ from: '100', to: '200' })).toEqual({
+      fromTimestamp: 100,
+      toTimestamp: 200,
+    });
+  });
+
+  it('should read an absent bound as no bound', () => {
+    expect(parseSnapshotFilters({})).toEqual({
+      fromTimestamp: undefined,
+      toTimestamp: undefined,
+    });
+  });
+
+  it('should read one bound without the other', () => {
+    expect(parseSnapshotFilters({ from: '100' })).toEqual({
+      fromTimestamp: 100,
+      toTimestamp: undefined,
+    });
+  });
+
+  it('should reject a bound that is not a number rather than passing NaN on', () => {
+    // NaN would compare false against every timestamp and read as an empty account.
+    expect(parseSnapshotFilters({ from: 'yesterday' })).toEqual({
+      fromTimestamp: undefined,
+      toTimestamp: undefined,
+    });
+  });
+
+  it('should reject an empty bound, which Number() would otherwise read as zero', () => {
+    expect(parseSnapshotFilters({ from: '' }).fromTimestamp).toBeUndefined();
+  });
+
+  it('should keep a zero bound that was actually asked for', () => {
+    expect(parseSnapshotFilters({ from: '0' }).fromTimestamp).toBe(0);
+  });
+});
+
+describe('pages/statistics/snapshots/toSnapshotQuery', () => {
+  const firstPage = { limit: DEFAULT_LIMIT, page: 1, total: 100 };
+
+  it('should be empty when nothing differs from the defaults', () => {
+    expect(toSnapshotQuery({}, firstPage, DEFAULT_LIMIT)).toEqual({});
+  });
+
+  it('should carry both bounds when they are set', () => {
+    expect(toSnapshotQuery({ fromTimestamp: 100, toTimestamp: 200 }, firstPage, DEFAULT_LIMIT)).toEqual({
+      from: 100,
+      to: 200,
+    });
+  });
+
+  it('should carry a zero bound, which is a real bound', () => {
+    expect(toSnapshotQuery({ fromTimestamp: 0 }, firstPage, DEFAULT_LIMIT)).toEqual({ from: 0 });
+  });
+
+  it('should leave the first page out', () => {
+    expect(toSnapshotQuery({}, { ...firstPage, page: 1 }, DEFAULT_LIMIT)).toEqual({});
+  });
+
+  it('should carry any later page', () => {
+    expect(toSnapshotQuery({}, { ...firstPage, page: 3 }, DEFAULT_LIMIT)).toEqual({ page: 3 });
+  });
+
+  it('should leave the default page size out', () => {
+    expect(toSnapshotQuery({}, { ...firstPage, limit: DEFAULT_LIMIT }, DEFAULT_LIMIT)).toEqual({});
+  });
+
+  it('should carry a page size that differs from the default', () => {
+    expect(toSnapshotQuery({}, { ...firstPage, limit: 25 }, DEFAULT_LIMIT)).toEqual({ limit: 25 });
+  });
+
+  it('should carry everything at once', () => {
+    expect(toSnapshotQuery(
+      { fromTimestamp: 100, toTimestamp: 200 },
+      { limit: 25, page: 3, total: 100 },
+      DEFAULT_LIMIT,
+    )).toEqual({ from: 100, limit: 25, page: 3, to: 200 });
+  });
+
+  it('should round-trip a query back through the filter parser', () => {
+    const filters = { fromTimestamp: 100, toTimestamp: 200 };
+
+    const query = toSnapshotQuery(filters, firstPage, DEFAULT_LIMIT);
+
+    expect(parseSnapshotFilters({ from: String(query.from), to: String(query.to) })).toEqual(filters);
+  });
+});

--- a/frontend/app/src/pages/statistics/snapshots/snapshot-query.ts
+++ b/frontend/app/src/pages/statistics/snapshots/snapshot-query.ts
@@ -1,0 +1,36 @@
+import type { TablePaginationData } from '@rotki/ui-library';
+import type { LocationQueryRaw } from 'vue-router';
+import type { LocationQuery } from '@/modules/core/table/route';
+import type { SnapshotListFilters } from '@/modules/dashboard/snapshots/composables/use-snapshot-list';
+
+/**
+ * The date range carried by the URL query. A param that is absent, empty or not a finite number
+ * reads as no bound at all rather than as `NaN`, which would filter every row away.
+ */
+export function parseSnapshotFilters(query: LocationQuery): SnapshotListFilters {
+  const from = Number(query.from);
+  const to = Number(query.to);
+  return {
+    fromTimestamp: query.from && Number.isFinite(from) ? from : undefined,
+    toTimestamp: query.to && Number.isFinite(to) ? to : undefined,
+  };
+}
+
+/**
+ * The view-state as a URL query. Anything at its default is left out, so the common case is a bare
+ * `/statistics/snapshots` rather than a URL restating every default.
+ */
+export function toSnapshotQuery(
+  filters: SnapshotListFilters,
+  pagination: TablePaginationData,
+  defaultLimit: number,
+): LocationQueryRaw {
+  const { fromTimestamp, toTimestamp } = filters;
+  const { limit, page } = pagination;
+  return {
+    ...(fromTimestamp !== undefined ? { from: fromTimestamp } : {}),
+    ...(toTimestamp !== undefined ? { to: toTimestamp } : {}),
+    ...(page > 1 ? { page } : {}),
+    ...(limit !== defaultLimit ? { limit } : {}),
+  };
+}

--- a/frontend/app/src/pages/statistics/snapshots/use-snapshots-page.spec.ts
+++ b/frontend/app/src/pages/statistics/snapshots/use-snapshots-page.spec.ts
@@ -1,0 +1,302 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComputedRef, Ref } from 'vue';
+import type { SnapshotListRow } from '@/modules/dashboard/snapshots/composables/use-snapshot-list';
+import { bigNumberify } from '@rotki/common';
+import { withSetup } from '@test/utils/with-setup';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSnapshotsPage } from './use-snapshots-page';
+
+const ITEMS_PER_PAGE = 10;
+
+const {
+  confirmCallbacks,
+  deleteSnapshot,
+  forceSave,
+  hasSnapshotsState,
+  pushMock,
+  refresh,
+  replaceMock,
+  routeQuery,
+  rowsState,
+  setMessage,
+  show,
+} = vi.hoisted(() => {
+  const confirmCallbacks: (() => Promise<void> | void)[] = [];
+  const hasSnapshotsState = { current: true };
+  const routeQuery: { current: Record<string, string> } = { current: {} };
+  const rowsState: { current: SnapshotListRow[] } = { current: [] };
+
+  return {
+    confirmCallbacks,
+    deleteSnapshot: vi.fn(async (): Promise<boolean> => true),
+    forceSave: vi.fn(async (): Promise<void> => {}),
+    hasSnapshotsState,
+    pushMock: vi.fn(async (): Promise<void> => {}),
+    refresh: vi.fn(async (): Promise<void> => {}),
+    replaceMock: vi.fn(async (): Promise<void> => {}),
+    routeQuery,
+    rowsState,
+    setMessage: vi.fn(),
+    show: vi.fn((_options: unknown, onConfirm: () => Promise<void> | void) => {
+      confirmCallbacks.push(onConfirm);
+    }),
+  };
+});
+
+vi.mock('vue-router', async () => {
+  const { computed } = await import('vue');
+  return {
+    useRoute: (): ComputedRef<{ query: Record<string, string> }> => computed(() => ({ query: routeQuery.current })),
+    useRouter: (): { push: typeof pushMock; replace: typeof replaceMock } => ({ push: pushMock, replace: replaceMock }),
+  };
+});
+
+vi.mock('@/modules/session/use-items-per-page', async () => {
+  const { shallowRef } = await import('vue');
+  return { useItemsPerPage: (): Ref<number> => shallowRef(ITEMS_PER_PAGE) };
+});
+
+vi.mock('@/modules/dashboard/snapshots/composables/use-snapshot-list', async () => {
+  const { computed, shallowRef } = await import('vue');
+  return {
+    useSnapshotList: (): Record<string, unknown> => ({
+      hasSnapshots: computed(() => hasSnapshotsState.current),
+      loading: shallowRef(false),
+      refresh,
+      rows: computed(() => rowsState.current),
+    }),
+  };
+});
+
+vi.mock('@/modules/dashboard/snapshots/composables/use-snapshot-actions', async () => {
+  const { shallowRef } = await import('vue');
+  return {
+    useSnapshotActions: (): Record<string, unknown> => ({
+      forceSave,
+      forceSaving: shallowRef(false),
+      importSnapshot: vi.fn(),
+      importing: shallowRef(false),
+      modelBalanceFile: shallowRef(undefined),
+      modelLocationFile: shallowRef(undefined),
+    }),
+  };
+});
+
+vi.mock('@/modules/settings/api/use-snapshot-api', () => ({
+  useSnapshotApi: (): { deleteSnapshot: typeof deleteSnapshot } => ({ deleteSnapshot }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): { setMessage: typeof setMessage } => ({ setMessage }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): { show: typeof show } => ({ show }),
+}));
+
+function row(timestamp: number, usdValue: number): SnapshotListRow {
+  return { timestamp, usdValue: bigNumberify(usdValue) };
+}
+
+describe('pages/statistics/snapshots/useSnapshotsPage', () => {
+  // The composable installs a watcher that writes the URL, so a leftover harness would keep
+  // replacing the query during a later test.
+  const mounted: VueWrapper[] = [];
+
+  function setup(): ReturnType<typeof useSnapshotsPage> {
+    const { result, wrapper } = withSetup(() => useSnapshotsPage());
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    confirmCallbacks.length = 0;
+    hasSnapshotsState.current = true;
+    routeQuery.current = {};
+    rowsState.current = [];
+    deleteSnapshot.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  describe('restoring the view-state from the URL', () => {
+    it('should read the date range out of the query', async () => {
+      routeQuery.current = { from: '100', to: '200' };
+
+      const { modelFilters } = setup();
+      await flushPromises();
+
+      expect(get(modelFilters)).toEqual({ fromTimestamp: 100, toTimestamp: 200 });
+    });
+
+    it('should start unfiltered when the query is bare', async () => {
+      const { modelFilters } = setup();
+      await flushPromises();
+
+      expect(get(modelFilters)).toEqual({ fromTimestamp: undefined, toTimestamp: undefined });
+    });
+  });
+
+  describe('mirroring the view-state back into the URL', () => {
+    it('should replace rather than push, so the range does not fill the history', async () => {
+      const { modelFilters } = setup();
+      await flushPromises();
+
+      set(modelFilters, { fromTimestamp: 100, toTimestamp: 200 });
+      await flushPromises();
+
+      expect(replaceMock).toHaveBeenCalledWith({ query: { from: 100, to: 200 } });
+      expect(pushMock).not.toHaveBeenCalled();
+    });
+
+    it('should follow a page change', async () => {
+      const { modelPagination } = setup();
+      await flushPromises();
+
+      set(modelPagination, { ...get(modelPagination), page: 3 });
+      await flushPromises();
+
+      expect(replaceMock).toHaveBeenCalledWith({ query: { page: 3 } });
+    });
+
+    it('should not write anything on mount alone', async () => {
+      setup();
+      await flushPromises();
+
+      expect(replaceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the empty message', () => {
+    it('should blame the filter when the account does have snapshots', async () => {
+      hasSnapshotsState.current = true;
+
+      const { emptyDescription } = setup();
+      await flushPromises();
+
+      expect(get(emptyDescription)).toBe('dashboard.snapshot.list.empty_filtered');
+    });
+
+    it('should say the account is empty when it has none at all', async () => {
+      hasSnapshotsState.current = false;
+
+      const { emptyDescription } = setup();
+      await flushPromises();
+
+      expect(get(emptyDescription)).toBe('dashboard.snapshot.list.empty');
+    });
+  });
+
+  describe('the export dialog', () => {
+    it('should open on the chosen snapshot and carry its stored value', async () => {
+      rowsState.current = [row(100, 500), row(200, 900)];
+
+      const { modelExportDialog, openExport, selectedBalance, selectedTimestamp } = setup();
+      await flushPromises();
+
+      openExport(200);
+
+      expect(get(modelExportDialog)).toBe(true);
+      expect(get(selectedTimestamp)).toBe(200);
+      expect(get(selectedBalance).toNumber()).toBe(900);
+    });
+
+    it('should fall back to zero when the chosen snapshot is not in the current page', async () => {
+      rowsState.current = [row(100, 500)];
+
+      const { openExport, selectedBalance } = setup();
+      await flushPromises();
+
+      openExport(999);
+
+      expect(get(selectedBalance).toNumber()).toBe(0);
+    });
+  });
+
+  it('should open a snapshot detail page', async () => {
+    const { open } = setup();
+    await flushPromises();
+
+    open(1234);
+
+    expect(pushMock).toHaveBeenCalledWith('/statistics/snapshots/1234');
+  });
+
+  describe('deleting a snapshot', () => {
+    it('should ask first and delete nothing until it is confirmed', async () => {
+      const { confirmDelete } = setup();
+      await flushPromises();
+
+      confirmDelete(100);
+
+      expect(show).toHaveBeenCalledTimes(1);
+      expect(deleteSnapshot).not.toHaveBeenCalled();
+    });
+
+    it('should delete, refresh and report success once confirmed', async () => {
+      const { confirmDelete } = setup();
+      await flushPromises();
+
+      confirmDelete(100);
+      await confirmCallbacks[0]();
+
+      expect(deleteSnapshot).toHaveBeenCalledWith({ timestamp: 100 });
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    });
+
+    it('should report a refused delete without refreshing', async () => {
+      deleteSnapshot.mockResolvedValue(false);
+      const { confirmDelete } = setup();
+      await flushPromises();
+
+      confirmDelete(100);
+      await confirmCallbacks[0]();
+
+      expect(refresh).not.toHaveBeenCalled();
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    });
+
+    it('should report a thrown error as a message rather than rejecting', async () => {
+      deleteSnapshot.mockRejectedValue(new Error('backend said no'));
+      const { confirmDelete } = setup();
+      await flushPromises();
+
+      confirmDelete(100);
+      await expect(confirmCallbacks[0]()).resolves.toBeUndefined();
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({
+        description: 'backend said no',
+        success: false,
+      }));
+      expect(refresh).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('taking a snapshot', () => {
+    it('should ask first, because a force-save refetches every balance', async () => {
+      const { confirmTakeSnapshot } = setup();
+      await flushPromises();
+
+      confirmTakeSnapshot();
+
+      expect(show).toHaveBeenCalledTimes(1);
+      expect(forceSave).not.toHaveBeenCalled();
+    });
+
+    it('should force-save once confirmed', async () => {
+      const { confirmTakeSnapshot } = setup();
+      await flushPromises();
+
+      confirmTakeSnapshot();
+      await confirmCallbacks[0]();
+
+      expect(forceSave).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/app/src/pages/statistics/snapshots/use-snapshots-page.ts
+++ b/frontend/app/src/pages/statistics/snapshots/use-snapshots-page.ts
@@ -1,0 +1,168 @@
+import type { TablePaginationData } from '@rotki/ui-library';
+import type { ComputedRef, Ref } from 'vue';
+import type { LocationQuery } from '@/modules/core/table/route';
+import { type BigNumber, type Message, Zero } from '@rotki/common';
+import { startPromise } from '@shared/utils';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { applyPaginationDefaults, parseQueryPagination } from '@/modules/core/table/pagination-filter-utils';
+import { useSnapshotActions } from '@/modules/dashboard/snapshots/composables/use-snapshot-actions';
+import { type SnapshotListFilters, type SnapshotListRow, useSnapshotList } from '@/modules/dashboard/snapshots/composables/use-snapshot-list';
+import { useItemsPerPage } from '@/modules/session/use-items-per-page';
+import { useSnapshotApi } from '@/modules/settings/api/use-snapshot-api';
+import { parseSnapshotFilters, toSnapshotQuery } from '@/pages/statistics/snapshots/snapshot-query';
+
+type SnapshotActions = ReturnType<typeof useSnapshotActions>;
+
+interface UseSnapshotsPageReturn {
+  confirmDelete: (timestamp: number) => void;
+  confirmTakeSnapshot: () => void;
+  emptyDescription: ComputedRef<string>;
+  forceSaving: SnapshotActions['forceSaving'];
+  importSnapshot: SnapshotActions['importSnapshot'];
+  importing: SnapshotActions['importing'];
+  loading: Readonly<Ref<boolean>>;
+  modelBalanceFile: SnapshotActions['modelBalanceFile'];
+  modelExportDialog: Ref<boolean>;
+  modelFilters: Ref<SnapshotListFilters>;
+  modelImportDialog: Ref<boolean>;
+  modelLocationFile: SnapshotActions['modelLocationFile'];
+  modelPagination: Ref<TablePaginationData>;
+  open: (timestamp: number) => void;
+  openExport: (timestamp: number) => void;
+  refresh: () => Promise<void>;
+  rows: Readonly<Ref<SnapshotListRow[]>>;
+  selectedBalance: ComputedRef<BigNumber>;
+  selectedTimestamp: Readonly<Ref<number>>;
+}
+
+export function useSnapshotsPage(): UseSnapshotsPageReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const router = useRouter();
+  const route = useRoute();
+  const itemsPerPage = useItemsPerPage();
+
+  const modelExportDialog = shallowRef<boolean>(false);
+  const modelImportDialog = shallowRef<boolean>(false);
+  const selectedTimestamp = shallowRef<number>(0);
+
+  // View-state lives in the URL query, so it survives reload and is restored by the browser's
+  // back/forward when returning from a snapshot's detail page.
+  const modelFilters = ref<SnapshotListFilters>({});
+  const modelPagination = ref<TablePaginationData>(applyPaginationDefaults(get(itemsPerPage)));
+
+  const { hasSnapshots, loading, refresh, rows } = useSnapshotList(modelFilters);
+  const { deleteSnapshot } = useSnapshotApi();
+  const { setMessage } = useMessageStore();
+  const { show } = useConfirmStore();
+  const { forceSave, forceSaving, importing, importSnapshot, modelBalanceFile, modelLocationFile } = useSnapshotActions();
+
+  function readQuery(query: LocationQuery): void {
+    set(modelFilters, parseSnapshotFilters(query));
+    set(modelPagination, parseQueryPagination(query, get(modelPagination)));
+  }
+
+  /** Mirrors the view-state back into the URL query (replace: no history spam). */
+  function writeQuery(): void {
+    startPromise(router.replace({ query: toSnapshotQuery(get(modelFilters), get(modelPagination), get(itemsPerPage)) }));
+  }
+
+  readQuery(get(route).query);
+
+  watch([
+    (): number | undefined => get(modelFilters).fromTimestamp,
+    (): number | undefined => get(modelFilters).toTimestamp,
+    (): number => get(modelPagination).page,
+    (): number => get(modelPagination).limit,
+  ], writeQuery);
+
+  // When the list is empty, tell apart a genuinely empty account from a range filter that
+  // excludes everything.
+  const emptyDescription = computed<string>(() => get(hasSnapshots)
+    ? t('dashboard.snapshot.list.empty_filtered')
+    : t('dashboard.snapshot.list.empty'));
+
+  function open(timestamp: number): void {
+    startPromise(router.push(`/statistics/snapshots/${timestamp}`));
+  }
+
+  // The export dialog shows the selected snapshot's stored USD net worth; the dialog converts it
+  // at the snapshot's historic rate itself (#12277), lazily, so opening it never triggers a
+  // whole-series conversion.
+  const selectedRow = computed<SnapshotListRow | undefined>(() =>
+    get(rows).find(item => item.timestamp === get(selectedTimestamp)));
+  const selectedBalance = computed<BigNumber>(() => get(selectedRow)?.usdValue ?? Zero);
+
+  function openExport(timestamp: number): void {
+    set(selectedTimestamp, timestamp);
+    set(modelExportDialog, true);
+  }
+
+  async function performDelete(timestamp: number): Promise<void> {
+    let message: Message;
+    try {
+      const success = await deleteSnapshot({ timestamp });
+      message = {
+        description: success
+          ? t('dashboard.snapshot.delete.message.success')
+          : t('dashboard.snapshot.delete.message.failure'),
+        success,
+        title: t('dashboard.snapshot.delete.message.title'),
+      };
+      if (success)
+        await refresh();
+    }
+    catch (error: unknown) {
+      message = {
+        description: getErrorMessage(error),
+        success: false,
+        title: t('dashboard.snapshot.delete.message.title'),
+      };
+    }
+    setMessage(message);
+  }
+
+  function confirmDelete(timestamp: number): void {
+    show(
+      {
+        message: t('dashboard.snapshot.delete.dialog.message'),
+        title: t('dashboard.snapshot.delete.dialog.title'),
+      },
+      async () => performDelete(timestamp),
+    );
+  }
+
+  // Force-save refetches every balance (slow, rate-limit prone), so confirm first.
+  function confirmTakeSnapshot(): void {
+    show(
+      {
+        message: t('dashboard.snapshot.list.take_snapshot_confirm.message'),
+        title: t('dashboard.snapshot.list.take_snapshot_confirm.title'),
+      },
+      async () => forceSave(),
+    );
+  }
+
+  return {
+    confirmDelete,
+    confirmTakeSnapshot,
+    emptyDescription,
+    forceSaving,
+    importing,
+    importSnapshot,
+    loading,
+    modelBalanceFile,
+    modelExportDialog,
+    modelFilters,
+    modelImportDialog,
+    modelLocationFile,
+    modelPagination,
+    open,
+    openExport,
+    refresh,
+    rows,
+    selectedBalance,
+    selectedTimestamp: readonly(selectedTimestamp),
+  };
+}

--- a/frontend/app/tests/unit/utils/reports-test-data.ts
+++ b/frontend/app/tests/unit/utils/reports-test-data.ts
@@ -1,0 +1,73 @@
+import type { MissingAcquisition, MissingPrice, Report, ReportActionableItem, Reports } from '@/modules/reports/report-types';
+import type { BaseAccountingSettings } from '@/modules/settings/types/user-settings';
+import { createMock } from '@test/utils/create-mock';
+
+/**
+ * Fixtures shared by the two `pages/reports/` specs. They sit together because the pair shares a
+ * store and a navigation contract, not because the pages share logic.
+ */
+
+export const LATEST_REPORT_ID = 42;
+
+export const OLDER_REPORT_ID = 7;
+
+const PROFIT_CURRENCY = 'EUR';
+
+/**
+ * Concrete rather than mocked: the page hands this object straight to a child and a spec compares
+ * it by value, which a `createMock` proxy cannot satisfy - two proxies are never deeply equal.
+ */
+export function createAccountingSettings(): BaseAccountingSettings {
+  return {
+    calculatePastCostBasis: true,
+    costBasisMethod: undefined,
+    includeCrypto2crypto: true,
+    includeGasCosts: true,
+    profitCurrency: PROFIT_CURRENCY,
+    taxfreeAfterPeriod: undefined,
+  };
+}
+
+/**
+ * A report is a wide zod-inferred object of which these pages read five fields. `createMock` fills
+ * the rest, so adding a field to the schema does not break every fixture here.
+ */
+export function createReport(overrides: Partial<Report> = {}): Report {
+  return createMock<Report>({
+    endTs: 1_600_100_000,
+    identifier: LATEST_REPORT_ID,
+    processedActions: 10,
+    settings: createAccountingSettings(),
+    startTs: 1_600_000_000,
+    totalActions: 10,
+    ...overrides,
+  });
+}
+
+export function createReports(entries: Report[]): Reports {
+  return {
+    entries,
+    entriesFound: entries.length,
+    entriesLimit: entries.length,
+  };
+}
+
+/**
+ * The pages only ever count these, so the contents are irrelevant - what matters is the length.
+ */
+export function createMissingAcquisitions(count: number): MissingAcquisition[] {
+  return Array.from({ length: count }, () => createMock<MissingAcquisition>({}));
+}
+
+export function createMissingPrices(count: number): MissingPrice[] {
+  return Array.from({ length: count }, () => createMock<MissingPrice>({}));
+}
+
+export function createActionableItems(overrides: Partial<ReportActionableItem> = {}): ReportActionableItem {
+  return {
+    eventsSkippedNoRule: 0,
+    missingAcquisitions: [],
+    missingPrices: [],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
Closes #12998. Batch C of #12964, following batch B (#12997).

Seven route pages, one commit each: the extraction and its specs together, so a file's work reverts as a unit.

## What changed

Every page keeps only its wiring. The logic moved to a sibling `use-*.ts`, and where it was genuinely pure it moved to a plain module instead, which is where the sharpest edges turned out to be.

| Page | Extracted to | Page stmts | New module |
|---|---|---|---|
| `reports/[id]` | `use-report-detail.ts` | 93% | 98% |
| `reports/index` | `use-reports-page.ts` | 84% | 100% |
| `airdrops/index` | `airdrop-rows.ts` + `use-airdrops-page.ts` | 70% | 100% / 92% |
| `assets/[identifier]` | `use-asset-detail.ts` | 95% | 93% |
| `staking/[[location]]` | `use-staking-page.ts` + `staking-pages.ts` | 74% | 100% |
| `balances/exchange/[[exchange]]` | `use-exchange-balances-page.ts` | 68% | 98% |
| `statistics/snapshots/index` | `snapshot-query.ts` + `use-snapshots-page.ts` | 67% | 100% / 100% |

Two pages already had a partial extraction with no spec (`use-reports-page-actions.ts`, `use-asset-page-actions.ts`); both are now at 100%.

Full suite: 954 files, 9958 tests, green. All 7 `rwt check` gates pass.

## The `reports/` pair

The issue asked this be decided early. **They do not share a composable** — unlike batch B's `Match*Pinned` they are not near-twins. What they share is a round-trip query contract that neither page spec would catch alone:

- `index` sends `?openReportActionable=true`, `[id]` consumes it on mount and clears it
- `[id]` sends back `?regenerate=true&start&end`, `index` consumes it on mount and clears it

Both directions are covered from both ends, plus shared fixtures in `tests/unit/utils/reports-test-data.ts`. The ordering matters and is asserted: the query is cleared *before* the regeneration starts, so a reload does not run it twice.

## Optional route params

Both pages that take one treat the absent case as a real state:

- `staking/[[location]]` — with nothing remembered it stays on the picker; with a remembered location it redirects there; a location in the route is written back so it becomes the remembered one; clearing the dropdown clears the memory and navigates nowhere.
- `balances/exchange/[[exchange]]` — with no exchange the page exposes no balances and highlights no tab.

## Three fixes made along the way

- `reports/[id]` passed a `:symbol` prop to `ProfitLossOverview`, which declares no such prop. It fell through to `$attrs` and rendered as a stray DOM attribute. Removed.
- `assets/[identifier]` computed its collection id as `(id && parseInt(id)) || undefined`, which the nullish-coalescing rule rejects once it lives in a `.ts` file. Rewritten to be explicit about the two cases that must read as absent (a zero id and an unparsable one), both covered.
- `balances/exchange/[[exchange]]` called `useRouter()` twice. Collapsed to one.

## For review

`balances/exchange/[[exchange]]` seeds `modelSelectedTab` from the route prop once and never updates it, so navigating between exchanges leaves the previously highlighted tab in place. That is existing behaviour, preserved here rather than changed. The tabs are links so navigation still works; only the highlight is affected. Worth a separate look.

## Two testing traps this batch hit

Both are in the issue for batch D, but they are worth stating here because they make a test pass for the wrong reason:

- **`isVisible()` is unreliable on a detached wrapper.** It returned `true` for an element whose rendered HTML plainly showed `style="display: none"`. Four of these pages toggle with `v-show`, so the specs read the style attribute instead.
- **A `data-testid` in a stub template is overwritten** by the one on the page's own tag, and an inline stub object has no component name, so it can be found by neither. Stubs that need querying are declared with `defineComponent`.

Every behavioural claim was negative-controlled: the guard was broken, the named test watched go red, then restored. One of those controls **passed**, which was the finding — the symbol-over-name fallback test had only a symbol in its fixture, so either order produced the same string. It was re-aimed before being kept.

## Not in this batch

`asset-manager/more/solana-token-migration` is deliberately out; it belongs with the `/asset-manager/more/*` e2e smokes in batch E.