### PR TITLE
fix: point the log menu, and a cancelled sync, at the truth

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Cancelling a running sync from the task centre no longer leaves the sync progress panel reading "Sync Complete". It says the sync was cancelled, and shows the same alert icon it already used for a sync that finished with warnings.
 * :bug:`-` The Help menu's logs directory entry now opens the directory rotki is actually logging to. If you had set a custom log directory it opened the default one instead, so being told to check the logs sent you to a folder with nothing in it.
 * :bug:`-` Logging in again takes the balance snapshot your net worth graph is built from, when one is due by your balance save frequency. Since 1.44.0 that snapshot was only taken if you left rotki open for ten minutes or synced your history, so opening rotki for a quick look and closing it left a gap in the graph.
 * :bug:`-` The buttons that ignore or unignore the selected assets in the asset manager, in non-fungible balances and in the blockchain accounts selection mode are labelled "Ignore" and "Unignore" again, and their tooltips say what they do. They read "Exclude" and "Include" and claimed to add or remove actions from the profit and loss report, which is not what they do to an asset.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The Help menu's logs directory entry now opens the directory rotki is actually logging to. If you had set a custom log directory it opened the default one instead, so being told to check the logs sent you to a folder with nothing in it.
 * :bug:`-` Logging in again takes the balance snapshot your net worth graph is built from, when one is due by your balance save frequency. Since 1.44.0 that snapshot was only taken if you left rotki open for ten minutes or synced your history, so opening rotki for a quick look and closing it left a gap in the graph.
 * :bug:`-` The buttons that ignore or unignore the selected assets in the asset manager, in non-fungible balances and in the blockchain accounts selection mode are labelled "Ignore" and "Unignore" again, and their tooltips say what they do. They read "Exclude" and "Include" and claimed to add or remove actions from the profit and loss report, which is not what they do to an asset.
 * :release:`1.44.0 <2026-08-21>`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* :bug:`-` Cancelling a running sync from the task centre no longer leaves the sync progress panel reading "Sync Complete". It says the sync was cancelled, and shows the same alert icon it already used for a sync that finished with warnings.
+* :bug:`-` Cancelling a running sync from the task centre no longer leaves the sync progress panel claiming it completed. The panel says the sync was cancelled, and the grouped rows inside it ("9 chains complete") no longer report a clean completion for chains, locations, decoding or protocol caches that were cancelled or failed, which contradicted the rows they contained.
 * :bug:`-` The Help menu's logs directory entry now opens the directory rotki is actually logging to. If you had set a custom log directory it opened the default one instead, so being told to check the logs sent you to a folder with nothing in it.
 * :bug:`-` Logging in again takes the balance snapshot your net worth graph is built from, when one is due by your balance save frequency. Since 1.44.0 that snapshot was only taken if you left rotki open for ten minutes or synced your history, so opening rotki for a quick look and closing it left a gap in the graph.
 * :bug:`-` The buttons that ignore or unignore the selected assets in the asset manager, in non-fungible balances and in the blockchain accounts selection mode are labelled "Ignore" and "Unignore" again, and their tooltips say what they do. They read "Exclude" and "Include" and claimed to add or remove actions from the profit and loss report, which is not what they do to an asset.

--- a/frontend/app/electron/main/log-service.ts
+++ b/frontend/app/electron/main/log-service.ts
@@ -59,7 +59,12 @@ export class LogService {
     checkInterval: 60_000,
   };
 
-  private get logDirectory(): string {
+  /**
+   * The directory logs are actually written to. Follows `LOGDIR` and so can differ
+   * from {@link defaultLogDirectory} — anything pointing a user at their logs must
+   * read this, not the platform default.
+   */
+  get logDirectory(): string {
     return this._logDirectory;
   }
 

--- a/frontend/app/electron/main/menu.spec.ts
+++ b/frontend/app/electron/main/menu.spec.ts
@@ -1,0 +1,73 @@
+import type { AppConfig } from '@electron/main/app-config';
+import type { LogService } from '@electron/main/log-service';
+import type { SettingsManager } from '@electron/main/settings-manager';
+import type { MenuItemConstructorOptions } from 'electron';
+import { createMock } from '@test/utils/create-mock';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MenuManager } from './menu';
+
+// The menu is built once and handed to electron, so the template is the only place a
+// test can read what an entry will do. `buildFromTemplate` captures it; nothing else
+// of electron is exercised here.
+const { buildFromTemplateMock, getPathMock, openPathMock } = vi.hoisted(() => ({
+  buildFromTemplateMock: vi.fn<(template: MenuItemConstructorOptions[]) => unknown>(),
+  getPathMock: vi.fn<(name: string) => string>(),
+  openPathMock: vi.fn<(path: string) => Promise<string>>(),
+}));
+
+vi.mock('electron', () => ({
+  app: { getPath: getPathMock, name: 'rotki' },
+  BrowserWindow: class {},
+  Menu: {
+    buildFromTemplate: buildFromTemplateMock,
+    setApplicationMenu: vi.fn(),
+  },
+  shell: { openExternal: vi.fn(), openPath: openPathMock },
+}));
+
+/**
+ * The one seam this spec covers: Help ▸ Logs Directory must open the directory the
+ * running app actually logs to, which `LogService` owns and can reconfigure, not the
+ * platform default. The two differ exactly when a user sets a custom log directory —
+ * so the fixture keeps them different on purpose.
+ */
+describe('menuManager', () => {
+  const DEFAULT_LOGS = '/home/user/.config/rotki/logs';
+  const CONFIGURED_LOGS = '/mnt/custom/rotki-logs';
+
+  let template: MenuItemConstructorOptions[];
+
+  function submenuOf(label: string): MenuItemConstructorOptions[] {
+    const menu = template.find(item => item.label === label);
+    expect(menu?.submenu).toBeInstanceOf(Array);
+    return Array.isArray(menu?.submenu) ? menu.submenu : [];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPathMock.mockReturnValue(DEFAULT_LOGS);
+    openPathMock.mockResolvedValue('');
+    buildFromTemplateMock.mockImplementation((built) => {
+      template = built;
+      return { getMenuItemById: (): undefined => undefined, removeAllListeners: vi.fn() };
+    });
+
+    const logger = createMock<LogService>({ logDirectory: CONFIGURED_LOGS });
+    const settings = createMock<SettingsManager>({ appSettings: { displayTray: false, persistStore: false } });
+    // Booleans left off a `createMock` proxy read back truthy, so both platform gates
+    // are set explicitly — otherwise the template grows the mac and debug menus.
+    const config = createMock<AppConfig>({ isDev: false, isMac: false });
+
+    new MenuManager(logger, settings, config).initialize({ onDisplayTrayChanged: vi.fn() });
+  });
+
+  it('should open the configured log directory, not the platform default', () => {
+    const item = submenuOf('&Help').find(entry => entry.label === 'Logs Directory');
+    expect(item).toBeDefined();
+
+    item?.click?.(createMock(), undefined, createMock());
+
+    expect(openPathMock).toHaveBeenCalledWith(CONFIGURED_LOGS);
+    expect(openPathMock).not.toHaveBeenCalledWith(DEFAULT_LOGS);
+  });
+});

--- a/frontend/app/electron/main/menu.ts
+++ b/frontend/app/electron/main/menu.ts
@@ -149,7 +149,7 @@ export class MenuManager {
         },
         {
           label: 'Logs Directory',
-          click: () => this.openPath(app.getPath('logs')),
+          click: () => this.openPath(this.logger.logDirectory),
         },
         {
           id: DATA_DIRECTORY_ID,

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5923,6 +5923,10 @@
     "events": "Events",
     "explanation": "The first sync downloads and decodes your entire on-chain history locally. You can keep using rotki; results appear as they are ready.",
     "explanation_etherscan_hint": "A personal (free) Etherscan API key speeds this up significantly.",
+    "finished_chains": "{count} chain finished | {count} chains finished",
+    "finished_decoding": "{count} chain decoding finished | {count} chains decoding finished",
+    "finished_locations": "{count} location finished | {count} locations finished",
+    "finished_protocol_cache": "{count} protocol finished | {count} protocols finished",
     "locations_label": "location | locations",
     "period": {
       "beginning": "Beginning"

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5911,6 +5911,7 @@
   "sync_progress": {
     "chains_label": "chain | chains",
     "complete": "Sync Complete",
+    "complete_cancelled": "Sync Cancelled",
     "complete_with_warnings": "Sync Complete with warnings",
     "completed_chains": "{count} chain complete | {count} chains complete",
     "completed_decoding": "{count} chain decoded | {count} chains decoded",

--- a/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.spec.ts
@@ -54,6 +54,24 @@ describe('modules/sync-progress/components/ChainProgressList', () => {
     };
   }
 
+  /** A chain the user cancelled part way: some addresses done, the rest stopped. */
+  function createCancelledChainProgress(chain: string, completed: number, total: number): ChainProgress {
+    return {
+      addresses: Array.from({ length: total }, (_, i) => ({
+        address: `0x${chain}${i.toString().padStart(38, '0')}`,
+        status: i < completed ? AddressStatus.COMPLETE : AddressStatus.CANCELLED,
+      })),
+      cancelled: total - completed,
+      chain,
+      completed,
+      failed: 0,
+      inProgress: 0,
+      pending: 0,
+      progress: 100,
+      total,
+    };
+  }
+
   function createWrapper(chains: ChainProgress[]): VueWrapper<InstanceType<typeof ChainProgressList>> {
     return mount(ChainProgressList, {
       global: {
@@ -117,7 +135,31 @@ describe('modules/sync-progress/components/ChainProgressList', () => {
       wrapper = createWrapper(chains);
 
       expect(wrapper.findAll('[data-testid="chain-item"]')).toHaveLength(0);
+      // "Finished", not "complete" — the group summary must not claim a clean finish for a
+      // chain that failed.
+      expect(wrapper.text()).toContain('sync_progress.finished_chains');
+    });
+
+    it('should not call a cancelled group complete', () => {
+      const chains = [
+        createChainProgress('eth', 3, 3),
+        createCancelledChainProgress('gnosis', 1, 3),
+      ];
+      wrapper = createWrapper(chains);
+
+      expect(wrapper.text()).toContain('sync_progress.finished_chains');
+      expect(wrapper.text()).not.toContain('sync_progress.completed_chains');
+    });
+
+    it('should still say complete when every chain finished cleanly', () => {
+      const chains = [
+        createChainProgress('eth', 3, 3),
+        createChainProgress('optimism', 3, 3),
+      ];
+      wrapper = createWrapper(chains);
+
       expect(wrapper.text()).toContain('sync_progress.completed_chains');
+      expect(wrapper.text()).not.toContain('sync_progress.finished_chains');
     });
   });
 
@@ -226,27 +268,28 @@ describe('modules/sync-progress/components/ChainProgressList', () => {
   });
 
   describe('cancelled chains', () => {
-    it('should treat cancelled chains as completed', () => {
+    it('should treat cancelled chains as settled', () => {
       const chains = [
         createChainProgress('eth', 1, 3),
         { ...createChainProgress('optimism', 2, 3), cancelled: 1 },
       ];
       wrapper = createWrapper(chains);
 
-      // optimism has 2 completed + 1 cancelled = 3 total, so it's done
-      expect(wrapper.text()).toContain('sync_progress.completed_chains');
+      // optimism has 2 completed + 1 cancelled = 3 total, so it is settled and moves into the
+      // group — which then says "finished" rather than claiming a clean completion.
+      expect(wrapper.text()).toContain('sync_progress.finished_chains');
     });
 
-    it('should show warning color when completed section has cancelled chains', () => {
+    it('should show the alert icon in warning color when the group has cancelled chains', () => {
       const chains = [
         { ...createChainProgress('optimism', 2, 3), cancelled: 1 },
       ];
       wrapper = createWrapper(chains);
 
       const icons = wrapper.findAll('[data-testid="icon"]');
-      const checkIcon = icons.find(icon => icon.text() === 'lu-circle-check');
-      expect(checkIcon).toBeDefined();
-      expect(checkIcon?.classes()).toContain('text-rui-warning');
+      const alertIcon = icons.find(icon => icon.text() === 'lu-circle-alert');
+      expect(alertIcon).toBeDefined();
+      expect(alertIcon?.classes()).toContain('text-rui-warning');
     });
 
     it('should show success color when completed section has no cancelled chains', () => {

--- a/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/ChainProgressList.vue
@@ -34,6 +34,20 @@ const completedIconColor = computed<string>(() => {
   return get(hasCancelledChains) ? 'text-rui-warning' : 'text-rui-success';
 });
 
+// The group holds every *settled* chain, which includes cancelled and failed ones. Calling that
+// "complete" contradicts the rows inside it, which already say cancelled or failed — so only a
+// clean group claims completion, and any other mix says it finished.
+const cleanFinish = computed<boolean>(() => !get(hasFailedChains) && !get(hasCancelledChains));
+
+const completedLabel = computed<string>(() => {
+  const count = get(completedCount);
+  return get(cleanFinish)
+    ? t('sync_progress.completed_chains', { count }, count)
+    : t('sync_progress.finished_chains', { count }, count);
+});
+
+const completedIcon = computed<string>(() => (get(cleanFinish) ? 'lu-circle-check' : 'lu-circle-alert'));
+
 function toggleCompleted(): void {
   set(showCompleted, !get(showCompleted));
 }
@@ -58,11 +72,11 @@ function toggleCompleted(): void {
         @click="toggleCompleted()"
       >
         <RuiIcon
-          name="lu-circle-check"
+          :name="completedIcon"
           :class="completedIconColor"
           size="16"
         />
-        <span>{{ t('sync_progress.completed_chains', { count: completedCount }, completedCount) }}</span>
+        <span>{{ completedLabel }}</span>
         <RuiIcon
           name="lu-chevron-down"
           size="16"
@@ -78,11 +92,11 @@ function toggleCompleted(): void {
           @click="toggleCompleted()"
         >
           <RuiIcon
-            name="lu-circle-check"
+            :name="completedIcon"
             :class="completedIconColor"
             size="16"
           />
-          <span>{{ t('sync_progress.completed_chains', { count: completedCount }, completedCount) }}</span>
+          <span>{{ completedLabel }}</span>
           <RuiIcon
             name="lu-chevron-up"
             size="16"

--- a/frontend/app/src/modules/shell/sync-progress/components/DecodingProgressList.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/DecodingProgressList.spec.ts
@@ -156,8 +156,10 @@ describe('modules/sync-progress/components/DecodingProgressList', () => {
       expect(items).toHaveLength(1);
       expect(items[0].attributes('data-chain')).toBe('optimism');
 
-      // Cancelled item should be in the completed toggle
-      expect(wrapper.text()).toContain('sync_progress.completed_decoding');
+      // The cancelled item settles into the group, whose label then says the group finished
+      // rather than claiming every chain in it was decoded.
+      expect(wrapper.text()).toContain('sync_progress.finished_decoding');
+      expect(wrapper.text()).not.toContain('sync_progress.completed_decoding');
     });
 
     it('should show cancelled items when completed toggle is clicked', async () => {
@@ -168,7 +170,7 @@ describe('modules/sync-progress/components/DecodingProgressList', () => {
       wrapper = createWrapper(decoding);
 
       const buttons = wrapper.findAll('button');
-      const toggleButton = buttons.find(btn => btn.text().includes('sync_progress.completed_decoding'));
+      const toggleButton = buttons.find(btn => btn.text().includes('sync_progress.finished_decoding'));
       await toggleButton?.trigger('click');
 
       const items = wrapper.findAll('[data-testid="decoding-item"]');

--- a/frontend/app/src/modules/shell/sync-progress/components/DecodingProgressList.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/DecodingProgressList.vue
@@ -30,6 +30,17 @@ const hasInProgress = computed<boolean>(() => get(inProgressDecoding).length > 0
 const completedCount = computed<number>(() => get(completedDecoding).length);
 const hasCompleted = computed<boolean>(() => !!get(completedCount));
 
+// Cancelled decoding lands in this group as well, and "decoded" would be a claim about work that
+// did not happen.
+const completedLabel = computed<string>(() => {
+  const count = get(completedCount);
+  return get(hasCancelledItems)
+    ? t('sync_progress.finished_decoding', { count }, count)
+    : t('sync_progress.completed_decoding', { count }, count);
+});
+
+const completedIcon = computed<string>(() => (get(hasCancelledItems) ? 'lu-circle-alert' : 'lu-circle-check'));
+
 function toggleCompleted(): void {
   set(showCompleted, !get(showCompleted));
 }
@@ -54,11 +65,11 @@ function toggleCompleted(): void {
         @click="toggleCompleted()"
       >
         <RuiIcon
-          name="lu-circle-check"
+          :name="completedIcon"
           :class="completedIconColor"
           size="16"
         />
-        <span>{{ t('sync_progress.completed_decoding', { count: completedCount }, completedCount) }}</span>
+        <span>{{ completedLabel }}</span>
         <RuiIcon
           name="lu-chevron-down"
           size="16"
@@ -74,11 +85,11 @@ function toggleCompleted(): void {
           @click="toggleCompleted()"
         >
           <RuiIcon
-            name="lu-circle-check"
+            :name="completedIcon"
             :class="completedIconColor"
             size="16"
           />
-          <span>{{ t('sync_progress.completed_decoding', { count: completedCount }, completedCount) }}</span>
+          <span>{{ completedLabel }}</span>
           <RuiIcon
             name="lu-chevron-up"
             size="16"

--- a/frontend/app/src/modules/shell/sync-progress/components/LocationProgressList.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/LocationProgressList.spec.ts
@@ -153,30 +153,32 @@ describe('modules/sync-progress/components/LocationProgressList', () => {
   });
 
   describe('cancelled locations', () => {
-    it('should treat cancelled locations as completed', () => {
+    it('should treat cancelled locations as settled', () => {
       const locations = [
         createLocationProgress('kraken', 'Kraken', LocationStatus.QUERYING),
         createLocationProgress('binance', 'Binance', LocationStatus.CANCELLED),
       ];
       wrapper = createWrapper(locations);
 
-      // binance is cancelled so it should be in the completed section
-      expect(wrapper.text()).toContain('sync_progress.completed_locations');
+      // binance is cancelled so it settles into the group, which then says the group finished
+      // rather than claiming every location in it completed.
+      expect(wrapper.text()).toContain('sync_progress.finished_locations');
+      expect(wrapper.text()).not.toContain('sync_progress.completed_locations');
       const items = wrapper.findAll('[data-testid="location-item"]');
       expect(items).toHaveLength(1);
       expect(items[0].attributes('data-location')).toBe('kraken');
     });
 
-    it('should show warning color when completed section has cancelled locations', () => {
+    it('should show the alert icon in warning color when the group has cancelled locations', () => {
       const locations = [
         createLocationProgress('binance', 'Binance', LocationStatus.CANCELLED),
       ];
       wrapper = createWrapper(locations);
 
       const icons = wrapper.findAll('[data-testid="icon"]');
-      const checkIcon = icons.find(icon => icon.text() === 'lu-circle-check');
-      expect(checkIcon).toBeDefined();
-      expect(checkIcon?.classes()).toContain('text-rui-warning');
+      const alertIcon = icons.find(icon => icon.text() === 'lu-circle-alert');
+      expect(alertIcon).toBeDefined();
+      expect(alertIcon?.classes()).toContain('text-rui-warning');
     });
 
     it('should show success color when completed section has no cancelled locations', () => {

--- a/frontend/app/src/modules/shell/sync-progress/components/LocationProgressList.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/LocationProgressList.vue
@@ -27,6 +27,17 @@ const completedIconColor = computed<string>(() =>
   get(hasCancelledLocations) ? 'text-rui-warning' : 'text-rui-success',
 );
 
+// A cancelled location sits in this group too, so the summary must not claim completion for it —
+// the rows inside already say cancelled.
+const completedLabel = computed<string>(() => {
+  const count = get(completedCount);
+  return get(hasCancelledLocations)
+    ? t('sync_progress.finished_locations', { count }, count)
+    : t('sync_progress.completed_locations', { count }, count);
+});
+
+const completedIcon = computed<string>(() => (get(hasCancelledLocations) ? 'lu-circle-alert' : 'lu-circle-check'));
+
 function toggleCompleted(): void {
   set(showCompleted, !get(showCompleted));
 }
@@ -51,11 +62,11 @@ function toggleCompleted(): void {
         @click="toggleCompleted()"
       >
         <RuiIcon
-          name="lu-circle-check"
+          :name="completedIcon"
           :class="completedIconColor"
           size="16"
         />
-        <span>{{ t('sync_progress.completed_locations', { count: completedCount }, completedCount) }}</span>
+        <span>{{ completedLabel }}</span>
         <RuiIcon
           name="lu-chevron-down"
           size="16"
@@ -71,11 +82,11 @@ function toggleCompleted(): void {
           @click="toggleCompleted()"
         >
           <RuiIcon
-            name="lu-circle-check"
+            :name="completedIcon"
             :class="completedIconColor"
             size="16"
           />
-          <span>{{ t('sync_progress.completed_locations', { count: completedCount }, completedCount) }}</span>
+          <span>{{ completedLabel }}</span>
           <RuiIcon
             name="lu-chevron-up"
             size="16"

--- a/frontend/app/src/modules/shell/sync-progress/components/ProtocolCacheProgressList.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/ProtocolCacheProgressList.spec.ts
@@ -159,8 +159,10 @@ describe('modules/sync-progress/components/ProtocolCacheProgressList', () => {
       expect(items).toHaveLength(1);
       expect(items[0].attributes('data-chain')).toBe('optimism');
 
-      // Cancelled item should be in the completed toggle
-      expect(wrapper.text()).toContain('sync_progress.completed_protocol_cache');
+      // The cancelled item settles into the group, whose label then says the group finished
+      // rather than claiming every protocol in it was refreshed.
+      expect(wrapper.text()).toContain('sync_progress.finished_protocol_cache');
+      expect(wrapper.text()).not.toContain('sync_progress.completed_protocol_cache');
     });
 
     it('should show cancelled items when completed toggle is clicked', async () => {
@@ -171,7 +173,7 @@ describe('modules/sync-progress/components/ProtocolCacheProgressList', () => {
       wrapper = createWrapper(protocolCache);
 
       const buttons = wrapper.findAll('button');
-      const toggleButton = buttons.find(btn => btn.text().includes('sync_progress.completed_protocol_cache'));
+      const toggleButton = buttons.find(btn => btn.text().includes('sync_progress.finished_protocol_cache'));
       await toggleButton?.trigger('click');
 
       const items = wrapper.findAll('[data-testid="protocol-cache-item"]');

--- a/frontend/app/src/modules/shell/sync-progress/components/ProtocolCacheProgressList.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/ProtocolCacheProgressList.vue
@@ -30,6 +30,17 @@ const hasInProgress = computed<boolean>(() => get(inProgressCache).length > 0);
 const completedCount = computed<number>(() => get(completedCache).length);
 const hasCompleted = computed<boolean>(() => !!get(completedCount));
 
+// A cancelled protocol never got refreshed, so the summary says the group finished rather than
+// claiming every one of them was refreshed.
+const completedLabel = computed<string>(() => {
+  const count = get(completedCount);
+  return get(hasCancelledItems)
+    ? t('sync_progress.finished_protocol_cache', { count }, count)
+    : t('sync_progress.completed_protocol_cache', { count }, count);
+});
+
+const completedIcon = computed<string>(() => (get(hasCancelledItems) ? 'lu-circle-alert' : 'lu-circle-check'));
+
 function toggleCompleted(): void {
   set(showCompleted, !get(showCompleted));
 }
@@ -54,11 +65,11 @@ function toggleCompleted(): void {
         @click="toggleCompleted()"
       >
         <RuiIcon
-          name="lu-circle-check"
+          :name="completedIcon"
           :class="completedIconColor"
           size="16"
         />
-        <span>{{ t('sync_progress.completed_protocol_cache', { count: completedCount }, completedCount) }}</span>
+        <span>{{ completedLabel }}</span>
         <RuiIcon
           name="lu-chevron-down"
           size="16"
@@ -74,11 +85,11 @@ function toggleCompleted(): void {
           @click="toggleCompleted()"
         >
           <RuiIcon
-            name="lu-circle-check"
+            :name="completedIcon"
             :class="completedIconColor"
             size="16"
           />
-          <span>{{ t('sync_progress.completed_protocol_cache', { count: completedCount }, completedCount) }}</span>
+          <span>{{ completedLabel }}</span>
           <RuiIcon
             name="lu-chevron-up"
             size="16"

--- a/frontend/app/src/modules/shell/sync-progress/components/SyncProgressHeader.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/components/SyncProgressHeader.spec.ts
@@ -18,6 +18,7 @@ const {
   mockHasCancelled,
   mockHasCancelledDecoding,
   mockHasCancelledProtocolCache,
+  mockHasWarnings,
   mockOverallProgress,
   mockPhase,
   mockProtocolCache,
@@ -32,6 +33,7 @@ const {
     mockHasCancelled: ref<boolean>(false),
     mockHasCancelledDecoding: ref<boolean>(false),
     mockHasCancelledProtocolCache: ref<boolean>(false),
+    mockHasWarnings: ref<boolean>(false),
     mockOverallProgress: ref<number>(0),
     mockPhase: ref<SyncPhase>('idle'),
     mockProtocolCache: ref<ProtocolCacheProgress[]>([]),
@@ -48,6 +50,7 @@ vi.mock('../use-sync-progress', () => ({
     hasCancelled: mockHasCancelled,
     hasCancelledDecoding: mockHasCancelledDecoding,
     hasCancelledProtocolCache: mockHasCancelledProtocolCache,
+    hasWarnings: mockHasWarnings,
     overallProgress: mockOverallProgress,
     phase: mockPhase,
     protocolCache: mockProtocolCache,
@@ -97,6 +100,7 @@ describe('modules/sync-progress/components/SyncProgressHeader', () => {
     set(mockHasCancelled, false);
     set(mockHasCancelledDecoding, false);
     set(mockHasCancelledProtocolCache, false);
+    set(mockHasWarnings, false);
   }
 
   beforeEach(() => {
@@ -122,6 +126,26 @@ describe('modules/sync-progress/components/SyncProgressHeader', () => {
       wrapper = createWrapper();
 
       expect(wrapper.text()).toContain('sync_progress.complete');
+      // `sync_progress.complete` is a prefix of both other keys, so a bare `toContain`
+      // cannot tell them apart. Rule the other two out explicitly.
+      expect(wrapper.text()).not.toContain('sync_progress.complete_cancelled');
+      expect(wrapper.text()).not.toContain('sync_progress.complete_with_warnings');
+    });
+
+    it('should say the sync was cancelled when the user cancelled it', () => {
+      set(mockPhase, SyncPhase.COMPLETE);
+      set(mockHasCancelled, true);
+      wrapper = createWrapper();
+
+      expect(wrapper.text()).toContain('sync_progress.complete_cancelled');
+    });
+
+    it('should still show the warnings title when nothing was cancelled', () => {
+      set(mockPhase, SyncPhase.COMPLETE);
+      set(mockHasWarnings, true);
+      wrapper = createWrapper();
+
+      expect(wrapper.text()).toContain('sync_progress.complete_with_warnings');
     });
   });
 
@@ -142,15 +166,16 @@ describe('modules/sync-progress/components/SyncProgressHeader', () => {
       expect(icons.some(icon => icon.text() === 'lu-circle-check')).toBe(true);
     });
 
-    it('should show warning color when complete with cancelled items', () => {
+    it('should show the alert icon in warning colour when complete with cancelled items', () => {
       set(mockPhase, SyncPhase.COMPLETE);
       set(mockHasCancelled, true);
       wrapper = createWrapper();
 
       const icons = wrapper.findAll('[data-testid="icon"]');
-      const checkIcon = icons.find(icon => icon.text() === 'lu-circle-check');
-      expect(checkIcon).toBeDefined();
-      expect(checkIcon?.classes()).toContain('text-rui-warning');
+      expect(icons.some(icon => icon.text() === 'lu-circle-check')).toBe(false);
+      const alertIcon = icons.find(icon => icon.text() === 'lu-circle-alert');
+      expect(alertIcon).toBeDefined();
+      expect(alertIcon?.classes()).toContain('text-rui-warning');
     });
 
     it('should show success icon when complete without cancelled items', () => {

--- a/frontend/app/src/modules/shell/sync-progress/components/SyncProgressHeader.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/SyncProgressHeader.vue
@@ -38,7 +38,7 @@ const showSpinner = computed<boolean>(() => get(isSyncing) && get(overallProgres
 
 const statusIcon = computed<string>(() => {
   if (get(isComplete))
-    return get(hasWarnings) ? 'lu-circle-alert' : 'lu-circle-check';
+    return (get(hasCancelled) || get(hasWarnings)) ? 'lu-circle-alert' : 'lu-circle-check';
   return 'lu-loader-circle';
 });
 
@@ -48,10 +48,17 @@ const statusColor = computed<string>(() => {
   return 'text-rui-primary';
 });
 
+// A cancel is the user's own doing, so it is the more informative thing to say when it
+// coincides with warnings — hence it wins over `complete_with_warnings` rather than
+// earning a third combined string.
 const title = computed<string>(() => {
-  if (get(isComplete))
-    return get(hasWarnings) ? t('sync_progress.complete_with_warnings') : t('sync_progress.complete');
-  return t('sync_progress.title');
+  if (!get(isComplete))
+    return t('sync_progress.title');
+
+  if (get(hasCancelled))
+    return t('sync_progress.complete_cancelled');
+
+  return get(hasWarnings) ? t('sync_progress.complete_with_warnings') : t('sync_progress.complete');
 });
 
 const decodingTotal = computed<number>(() => get(decoding).length);


### PR DESCRIPTION
Three small, independent fixes where the app pointed at or named the wrong thing. All three are pre-existing on `bugfixes` and `develop` alike (the four touched source files are byte-identical on both), so they target the patch line.

### 1. Help menu opened the wrong log directory

`menu.ts` opened `app.getPath('logs')`, the platform default, while `LogService` keeps a separate reconfigurable `_logDirectory` that follows `LOGDIR`. A user with a custom log directory was told to check the logs and sent to a folder that has none.

`logDirectory` is now public on `LogService` and the menu reads it. `menu.ts` had no spec at all; the new one captures the built menu template and drives the entry's click, with the configured and default paths deliberately different so the assertion can tell them apart.

Verified in the running app: with `log-dir` pointed at a temp directory, the entry opens that directory.

### 2. A cancelled sync said it completed

The sync progress header read "Sync Complete" after cancelling from the task centre. `statusColor` already accounted for `hasCancelled`, so the row was tinted warning-coloured; only `title` and `statusIcon` were not, so the words and the icon disagreed with the colour.

A cancel now wins over warnings in the title, since it is the user's own doing and the more informative thing to say when both are true, rather than earning a third combined string.

### 3. Settled groups claimed completion

Found while verifying 2 in the app, not by any spec: with the header fixed, the panel contradicted itself. The four progress lists collapse every *settled* entry into one summary row labelled "N chains complete" — and settled includes cancelled and failed, so the summary disagreed both with the header above it and with the rows inside it, which already read as cancelled.

Each list already computed a cancelled flag and spent it only on the icon colour, leaving an amber check reading "complete". The words and the icon now follow the same flag: a mixed group says it finished, only a clean one claims completion. Chains cover failed the same way, which had the same lie.

### Testing

Each fix was written test-first and confirmed in both directions: the spec failing against the unfixed code on the intended assertion, then green after, then the fixed line re-broken on its own to confirm only the expected test goes red. Breaking the group label without touching the group icon, for instance, leaves the icon tests green.

Six pre-existing tests asserted the old behaviour and were updated rather than worked around; one was named "should treat cancelled chains as completed", which is the bug stated as a requirement.

`test:unit` (270 in the touched folder), `typecheck`, `lint:file`, `check:linked-keys` and `knip` all pass.
