### PR TITLE
fix: make privacy mode actually hide things

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` The task centre now scrambles the addresses it shows while privacy mode is on. Rows such as "Querying transactions for 0x..." and account additions printed the real address, so the one setting meant to make rotki safe to screen-share or screenshot did not cover the panel that is open while you work.
 * :bug:`-` Privacy mode no longer renders every balance as zero, or smaller than it really is, depending on the scramble multiplier you set. A multiplier below 1 shrank every number instead of hiding it, and 0 turned them all into zeros, which read as rotki losing your balances rather than concealing them. Randomly generated multipliers could also land below 1, so this could happen without you setting anything.
 * :bug:`-` Cancelling a running sync from the task centre no longer leaves the sync progress panel claiming it completed. The panel says the sync was cancelled, and the grouped rows inside it ("9 chains complete") no longer report a clean completion for chains, locations, decoding or protocol caches that were cancelled or failed, which contradicted the rows they contained.
 * :bug:`-` The Help menu's logs directory entry now opens the directory rotki is actually logging to. If you had set a custom log directory it opened the default one instead, so being told to check the logs sent you to a folder with nothing in it.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Privacy mode no longer renders every balance as zero, or smaller than it really is, depending on the scramble multiplier you set. A multiplier below 1 shrank every number instead of hiding it, and 0 turned them all into zeros, which read as rotki losing your balances rather than concealing them. Randomly generated multipliers could also land below 1, so this could happen without you setting anything.
 * :bug:`-` Cancelling a running sync from the task centre no longer leaves the sync progress panel claiming it completed. The panel says the sync was cancelled, and the grouped rows inside it ("9 chains complete") no longer report a clean completion for chains, locations, decoding or protocol caches that were cancelled or failed, which contradicted the rows they contained.
 * :bug:`-` The Help menu's logs directory entry now opens the directory rotki is actually logging to. If you had set a custom log directory it opened the default one instead, so being told to check the logs sent you to a folder with nothing in it.
 * :bug:`-` Logging in again takes the balance snapshot your net worth graph is built from, when one is due by your balance save frequency. Since 1.44.0 that snapshot was only taken if you left rotki open for ten minutes or synced your history, so opening rotki for a quick look and closing it left a gap in the graph.

--- a/frontend/app/src/modules/assets/amount-display/use-number-scrambler.spec.ts
+++ b/frontend/app/src/modules/assets/amount-display/use-number-scrambler.spec.ts
@@ -1,0 +1,36 @@
+import { bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { useNumberScrambler } from './use-number-scrambler';
+
+/**
+ * The seam: the single place a displayed amount is scrambled, reached by every amount component
+ * through `use-scrambled-value` and directly by the statistics store. It is handed an unvalidated
+ * user setting, so these tests pin what it does with a bad one.
+ */
+describe('useNumberScrambler', () => {
+  const value = bigNumberify(1234.5);
+
+  it('should return the value untouched when scrambling is off', () => {
+    const scrambled = useNumberScrambler({ enabled: false, multiplier: 0, value });
+
+    expect(get(scrambled).toString()).toBe('1234.5');
+  });
+
+  it('should never render a scrambled amount as zero', () => {
+    const scrambled = useNumberScrambler({ enabled: true, multiplier: 0, value });
+
+    expect(get(scrambled).isZero()).toBe(false);
+  });
+
+  it('should not render a scrambled amount smaller than the real one', () => {
+    const scrambled = useNumberScrambler({ enabled: true, multiplier: 0.5, value });
+
+    expect(get(scrambled).isGreaterThanOrEqualTo(value)).toBe(true);
+  });
+
+  it('should still scramble with a valid multiplier', () => {
+    const scrambled = useNumberScrambler({ enabled: true, multiplier: 3, value });
+
+    expect(get(scrambled).toString()).toBe('3703.5');
+  });
+});

--- a/frontend/app/src/modules/assets/amount-display/use-number-scrambler.ts
+++ b/frontend/app/src/modules/assets/amount-display/use-number-scrambler.ts
@@ -1,5 +1,6 @@
 import type { BigNumber } from '@rotki/common';
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import { normalizeScrambleMultiplier } from '@/modules/session/session-utils';
 
 export interface ScramblerOptions {
   value: MaybeRefOrGetter<BigNumber>;
@@ -13,6 +14,6 @@ export function useNumberScrambler(options: ScramblerOptions): ComputedRef<BigNu
     if (!toValue(options.enabled))
       return value;
 
-    return value.multipliedBy(toValue(options.multiplier));
+    return value.multipliedBy(normalizeScrambleMultiplier(toValue(options.multiplier)));
   });
 }

--- a/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTask.spec.ts
@@ -1,6 +1,9 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
-import { describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { msg } from '@/message-key';
 import PendingTask from '@/modules/core/notifications/PendingTask.vue';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
 import {
   type Activity,
   ActivityKind,
@@ -38,6 +41,12 @@ function createWrapper(props: Partial<InstanceType<typeof PendingTask>['$props']
 }
 
 describe('pendingTask', () => {
+  const ADDRESS = '0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1';
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
   it('should show the title and subtitle at the top level', () => {
     const text = createWrapper({ activity: activity({ subtitle: 'Ethereum' }) }).text();
 
@@ -178,6 +187,48 @@ describe('pendingTask', () => {
     await wrapper.find('button').trigger('click');
 
     expect(wrapper.emitted('cancel')).toHaveLength(1);
+  });
+
+  it('should scramble an address in the subtitle while privacy mode is on', () => {
+    // The panel is one of the few places a real address is rendered from a task's own payload, and
+    // it never learned about `scrambleData` — the setting that exists so a screen can be shared.
+    useSettingsRepo().updateFrontend({ scrambleData: true, scrambleMultiplier: 7 });
+
+    const text = createWrapper({
+      activity: activity({
+        subtitle: { key: msg.$t('task_center.activity.tx_sync.address'), params: { address: ADDRESS, chain: 'Ethereum' } },
+      }),
+    }).text();
+
+    expect(text).not.toContain(ADDRESS);
+  });
+
+  it('should leave the address alone while privacy mode is off', () => {
+    useSettingsRepo().updateFrontend({ scrambleData: false });
+
+    const text = createWrapper({
+      activity: activity({
+        subtitle: { key: msg.$t('task_center.activity.tx_sync.address'), params: { address: ADDRESS, chain: 'Ethereum' } },
+      }),
+    }).text();
+
+    expect(text).toContain(ADDRESS);
+  });
+
+  it('should scramble every address when a batch joins several into one param', () => {
+    // `use-account-addition-batch` joins the added addresses into a single param, so scrambling
+    // only a whole-string match would leak all of them.
+    const second = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+    useSettingsRepo().updateFrontend({ scrambleData: true, scrambleMultiplier: 7 });
+
+    const text = createWrapper({
+      activity: activity({
+        subtitle: { key: msg.$t('task_center.activity.accounts.add'), params: { address: `${ADDRESS},\n${second}` } },
+      }),
+    }).text();
+
+    expect(text).not.toContain(ADDRESS);
+    expect(text).not.toContain(second);
   });
 
   it('should render no cancel control when the caller withholds it', () => {

--- a/frontend/app/src/modules/core/notifications/PendingTask.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTask.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { useScramble } from '@/modules/settings/use-scramble';
 import { type ActivityOutcome, activityOutcome } from '@/modules/task-center/activity-outcome';
 import { formatElapsed } from '@/modules/task-center/core/elapsed';
 import { isTerminalStatus } from '@/modules/task-center/core/status';
-import { type Activity, ActivityStatus, type ActivitySteps, resolveText } from '@/modules/task-center/core/types';
+import { type Activity, ActivityStatus, type ActivitySteps, type ActivityText, resolveText } from '@/modules/task-center/core/types';
 
 const { activity, cancellable, nested = false, now, percentage, steps } = defineProps<{
   activity: Activity;
@@ -24,8 +25,44 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
+const { scrambleAddress } = useScramble();
+
+/**
+ * Rewrites a param that may hold one address or several.
+ *
+ * @remarks
+ * A batch joins several addresses into one string, so each is scrambled separately and the
+ * separators put back verbatim. `scrambleAddress` returns its input unchanged while privacy mode
+ * is off, so this needs no condition of its own.
+ *
+ * @param value a subtitle param, which is only rewritten when it is a string
+ * @returns the value with each address replaced
+ */
+function scrambleAddresses(value: unknown): unknown {
+  if (typeof value !== 'string')
+    return value;
+
+  return value
+    .split(/([\s,]+)/)
+    .map(part => (/^[\s,]*$/.test(part) ? part : scrambleAddress(part)))
+    .join('');
+}
+
+/**
+ * The subtitle with its address param scrambled, before {@link resolveText} interpolates it —
+ * afterwards nothing can tell the address apart from the wording around it. Every producer that
+ * carries an address passes it as `address`, so that is the one key rewritten.
+ */
+const displaySubtitle = computed<ActivityText | undefined>(() => {
+  const value = activity.subtitle;
+  if (value === undefined || typeof value === 'string' || value.params?.address === undefined)
+    return value;
+
+  return { ...value, params: { ...value.params, address: scrambleAddresses(value.params.address) } };
+});
+
 // Resolved here rather than at submit time, so a language change updates work already in flight.
-const subtitle = computed<string | undefined>(() => resolveText(t, activity.subtitle));
+const subtitle = computed<string | undefined>(() => resolveText(t, get(displaySubtitle)));
 
 // A child of "History refresh" reads better as "Ethereum" than as "Transaction sync / Ethereum":
 // a chain and its accounts carry the same title, so under a parent the subtitle is the identity.

--- a/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
@@ -1,5 +1,6 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
-import { assert, describe, expect, it } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { assert, beforeEach, describe, expect, it } from 'vitest';
 import PendingTaskNode from '@/modules/core/notifications/PendingTaskNode.vue';
 import { buildTree } from '@/modules/task-center/core/tree';
 import {
@@ -53,6 +54,10 @@ function createWrapper(): VueWrapper {
 }
 
 describe('pendingTaskNode', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
   /**
    * Collapsed at every level, the job's own fan-out included. The rolled-up row already says what
    * is running and how far along; unfolding eleven chains times four accounts into a 400px drawer

--- a/frontend/app/src/modules/core/notifications/PendingTasks.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTasks.spec.ts
@@ -1,4 +1,5 @@
 import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PendingTasks from '@/modules/core/notifications/PendingTasks.vue';
 import { assembleActivityModel } from '@/modules/task-center/core/model';
@@ -59,6 +60,7 @@ const umbrellaId = makeActivityId(ActivityKind.HISTORY_SYNC);
 
 describe('pendingTasks', () => {
   beforeEach(() => {
+    setActivePinia(createPinia());
     set(activities, []);
     confirmCancel.mockClear();
   });

--- a/frontend/app/src/modules/session/session-utils.ts
+++ b/frontend/app/src/modules/session/session-utils.ts
@@ -1,3 +1,29 @@
+const MIN_SCRAMBLE_MULTIPLIER = 1;
+
+/**
+ * Bounds the multiplier every scramble function is computed against.
+ *
+ * @remarks
+ * Below 1 a scrambled value comes out *smaller* than the real one, and at 0 it collapses to zero
+ * and hides nothing. The setting is user-editable and written through unvalidated, so this is the
+ * correctness boundary rather than the inputs. Small values are lifted rather than clamped flat,
+ * so they stay distinct from one another.
+ *
+ * @param multiplier the raw setting value, which may be negative, zero or not a number
+ * @returns a multiplier of at least {@link MIN_SCRAMBLE_MULTIPLIER}
+ */
+export function normalizeScrambleMultiplier(multiplier: number): number {
+  if (!Number.isFinite(multiplier) || multiplier < 0)
+    return MIN_SCRAMBLE_MULTIPLIER;
+
+  return multiplier < MIN_SCRAMBLE_MULTIPLIER ? multiplier + MIN_SCRAMBLE_MULTIPLIER : multiplier;
+}
+
+/**
+ * Picks the multiplier a session scrambles with when the user has not chosen one.
+ *
+ * @returns a value in [1, 10] with three decimals
+ */
 export function generateRandomScrambleMultiplier(): number {
-  return Math.floor(500 + Math.random() * 9500) / 1000;
+  return Math.floor(1000 + Math.random() * 9000) / 1000;
 }

--- a/frontend/app/src/modules/settings/use-scramble.spec.ts
+++ b/frontend/app/src/modules/settings/use-scramble.spec.ts
@@ -54,6 +54,13 @@ describe('useScramble', () => {
       expect(consistOfNumbers(result)).toBe(true);
     });
 
+    it('should keep identifiers distinct when the multiplier is zero', () => {
+      store.updateFrontend({ scrambleData: true, scrambleMultiplier: 0 });
+      const { scrambleIdentifier } = useScramble();
+
+      expect(scrambleIdentifier('123456')).not.toEqual(scrambleIdentifier('654321'));
+    });
+
     it('should scramble integer', () => {
       const { scrambleInteger } = useScramble();
       const result = scrambleInteger(42);

--- a/frontend/app/src/modules/settings/use-scramble.ts
+++ b/frontend/app/src/modules/settings/use-scramble.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, Ref } from 'vue';
 import { findAddressKnownPrefix } from '@/modules/core/common/display/truncate';
-import { generateRandomScrambleMultiplier } from '@/modules/session/session-utils';
+import { generateRandomScrambleMultiplier, normalizeScrambleMultiplier } from '@/modules/session/session-utils';
 import { useSetting } from '@/modules/settings/use-setting';
 
 interface UseScrambleReturn {
@@ -29,13 +29,14 @@ export function useScramble(): UseScrambleReturn {
 
   const scrambleData = logicOr(scrambleSetting, logicNot(shouldShowAmount));
 
+  /** Every scramble function below reads the multiplier through here, never the raw setting. */
+  const boundedMultiplier = computed<number>(() => normalizeScrambleMultiplier(+get(scrambleMultiplier)));
+
   const scrambleAddress = (address: string): string => {
     if (!get(scrambleData))
       return address;
 
-    let multiplier = +get(scrambleMultiplier);
-    if (multiplier < 1)
-      multiplier += 1;
+    const multiplier = get(boundedMultiplier);
 
     const knownPrefix = findAddressKnownPrefix(address);
 
@@ -60,7 +61,7 @@ export function useScramble(): UseScrambleReturn {
   };
 
   const scrambleInteger = (number: number, min = 0, max = -1): number => {
-    const multiplied = Math.floor(number * number * get(scrambleMultiplier)) + min;
+    const multiplied = Math.floor(number * number * get(boundedMultiplier)) + min;
 
     if (max > -1)
       return (multiplied % (max - min)) + min;
@@ -83,9 +84,7 @@ export function useScramble(): UseScrambleReturn {
     if (!get(scrambleData))
       return timestamp;
 
-    let multiplier = +get(scrambleMultiplier);
-    if (multiplier < 1)
-      multiplier += 1;
+    const multiplier = get(boundedMultiplier);
 
     /**
      * Deterministic offset using prime-based factors to ensure all date


### PR DESCRIPTION
Two privacy fixes: the scramble multiplier could make numbers wrong rather than hidden, and the task centre never scrambled at all. Both pre-existing, both verified in the running app.

### 1. The scramble multiplier was unbounded

`scrambleMultiplier` is a user setting written straight through with no validation, and both inputs that edit it are unbounded. At **0** every scrambled amount rendered as **0** — not hidden, just wrong, and it reads as rotki having lost your balances. Below 1 was its own failure: every number came out *smaller* than reality. The generator produced 0.5-10, so roughly one session in nineteen did that without the user setting anything.

What made this worth looking at properly: two of the four scramble functions (`scrambleAddress`, `scrambleTimestamp`) already carried an inline `if (multiplier < 1) multiplier += 1`, so the hazard was known — it just never reached the two places that mattered. `useNumberScrambler` is the single point every displayed amount passes through, and `scrambleInteger` backs every scrambled identifier, where 0 collapsed them all onto one value.

All four now read the multiplier through one shared `normalizeScrambleMultiplier`, which keeps the existing lift-by-one convention rather than clamping flat, so distinct settings stay distinct. The generator starts at 1.

The two inputs are deliberately left unbounded. A `min` would fight the field while someone types "0.5", and the read side has to hold the boundary regardless, because it also covers multipliers already persisted from before this change.

### 2. The task centre printed real addresses

Neither `modules/task-center/` nor `modules/core/notifications/` mentioned scrambling anywhere, so every row naming an address showed the real one while privacy mode was on — the setting that exists precisely so a screen can be shared or screenshotted.

Scrambling has to happen *before* the text is resolved: once `t` has interpolated the address into a sentence, nothing can distinguish it from the wording around it. Every producer carrying an address passes it as an `address` param, so that key is rewritten before resolution. Account additions join several addresses into one param, so each is scrambled separately and the separators restored.

Known boundary: a future producer that names the param differently, or puts a bare address in the plain-string subtitle form, would leak silently. The alternative — sniffing every param for something address-shaped — has no reliable oracle for bitcoin and solana addresses, so keying on the param name is the narrower and more honest option. No current producer uses the plain-string form for an address.

This makes a leaf row a settings consumer, so the specs mounting the tree around it now need a pinia.

### Testing

Each fix was written test-first and confirmed in both directions: the spec failing against unfixed code on the intended assertion, then green, then the fixed line broken on its own to confirm only the expected test goes red. The identifier control is the clearest — breaking `scrambleInteger`'s bound alone produced `expected '200000' to not deeply equal '200000'`, both identifiers collapsed onto one value.

Verified in the app on top of this branch: values grow rather than shrink at a multiplier of 0.5, balances stay non-zero at 0, and task centre rows show scrambled addresses.

`test:unit` over the affected modules (1153 in settings/amount-display/statistics, 320 in notifications/task-center), `typecheck`, `lint:file` and `knip` all pass.
