### PR TITLE
Frontend coverage batch D: the liquity staking cluster

### DIFF
--- a/frontend/app/src/modules/staking/liquity/LiquityPage.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/LiquityPage.spec.ts
@@ -1,0 +1,149 @@
+import type { useLiquityPage } from '@/modules/staking/liquity/use-liquity-page';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import LiquityPage from '@/modules/staking/liquity/LiquityPage.vue';
+
+const fetch = vi.fn(async (): Promise<void> => {});
+
+const pageState = vi.hoisted((): { moduleEnabled: boolean; premium: boolean } => ({
+  moduleEnabled: true,
+  premium: true,
+}));
+
+const StakingDetailsStub = defineComponent({
+  emits: ['refresh'],
+  name: 'LiquityStakingDetailsStub',
+  template: '<div data-testid="staking-details"><slot name="modules" /></div>',
+});
+
+const PlaceholderStub = defineComponent({
+  name: 'LiquityStakingPagePlaceholderStub',
+  props: { text: { default: '', type: String } },
+  template: '<div data-testid="no-premium" />',
+});
+
+const ModuleNotActiveStub = defineComponent({
+  name: 'ModuleNotActiveStub',
+  props: { modules: { default: () => [], type: Array } },
+  template: '<div data-testid="module-not-active" />',
+});
+
+vi.mock('@/modules/staking/liquity/use-liquity-page', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/staking/liquity/use-liquity-page')>(
+    '@/modules/staking/liquity/use-liquity-page',
+  );
+  const { computed, shallowRef } = await import('vue');
+  return {
+    LIQUITY_MODULES: actual.LIQUITY_MODULES,
+    useLiquityPage: (): ReturnType<typeof useLiquityPage> => ({
+      fetch,
+      moduleEnabled: computed(() => pageState.moduleEnabled),
+      premium: shallowRef(pageState.premium),
+    }),
+  };
+});
+
+describe('modules/staking/liquity/LiquityPage', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LiquityPage>>;
+
+  function mountPage(): VueWrapper<InstanceType<typeof LiquityPage>> {
+    return mount(LiquityPage, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          ActiveModules: { props: ['modules'], template: '<div data-testid="active-modules" />' },
+          LiquityStakingDetails: StakingDetailsStub,
+          LiquityStakingPagePlaceholder: PlaceholderStub,
+          ModuleNotActive: ModuleNotActiveStub,
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    pageState.moduleEnabled = true;
+    pageState.premium = true;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  describe('without premium', () => {
+    beforeEach(() => {
+      pageState.premium = false;
+    });
+
+    it('should show only the upsell placeholder', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(PlaceholderStub).exists()).toBe(true);
+      expect(wrapper.findComponent(StakingDetailsStub).exists()).toBe(false);
+      expect(wrapper.findComponent(ModuleNotActiveStub).exists()).toBe(false);
+    });
+
+    it('should hand it the liquity copy, not another page\'s', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(PlaceholderStub).props('text')).toBe('liquity_page.no_premium');
+    });
+
+    it('should take precedence over the module being off', () => {
+      pageState.moduleEnabled = false;
+
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(PlaceholderStub).exists()).toBe(true);
+      expect(wrapper.findComponent(ModuleNotActiveStub).exists()).toBe(false);
+    });
+  });
+
+  describe('with premium but the module off', () => {
+    beforeEach(() => {
+      pageState.moduleEnabled = false;
+    });
+
+    it('should ask for the module to be activated', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(ModuleNotActiveStub).exists()).toBe(true);
+      expect(wrapper.findComponent(StakingDetailsStub).exists()).toBe(false);
+    });
+
+    it('should name the liquity module', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(ModuleNotActiveStub).props('modules')).toEqual(['liquity']);
+    });
+  });
+
+  describe('with premium and the module on', () => {
+    it('should show the staking details', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.findComponent(StakingDetailsStub).exists()).toBe(true);
+      expect(wrapper.findComponent(PlaceholderStub).exists()).toBe(false);
+      expect(wrapper.findComponent(ModuleNotActiveStub).exists()).toBe(false);
+    });
+
+    it('should offer the module toggle in the details header', () => {
+      wrapper = mountPage();
+
+      expect(wrapper.find('[data-testid=active-modules]').exists()).toBe(true);
+    });
+
+    it('should refetch when the details ask for a refresh', () => {
+      wrapper = mountPage();
+
+      wrapper.findComponent(StakingDetailsStub).vm.$emit('refresh', true);
+
+      expect(fetch).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/LiquityPage.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityPage.vue
@@ -1,52 +1,13 @@
 <script setup lang="ts">
-import { useHistoricCachePriceStore } from '@/modules/assets/prices/use-historic-cache-price-store';
-import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
-import { usePremium } from '@/modules/premium/use-premium';
-import { Module, useModuleEnabled } from '@/modules/session/use-module-enabled';
 import ActiveModules from '@/modules/settings/modules/ActiveModules.vue';
 import ModuleNotActive from '@/modules/settings/modules/ModuleNotActive.vue';
-import { useSetting } from '@/modules/settings/use-setting';
 import LiquityStakingDetails from '@/modules/staking/liquity/LiquityStakingDetails.vue';
 import LiquityStakingPagePlaceholder from '@/modules/staking/liquity/LiquityStakingPagePlaceholder.vue';
-import { useLiquityDataFetching } from '@/modules/staking/liquity/use-liquity-data-fetching';
-
-const modules = [Module.LIQUITY];
-const { enabled: moduleEnabled } = useModuleEnabled(modules[0]);
-const { fetchPools, fetchStaking, fetchStatistics } = useLiquityDataFetching();
-const { resetProtocolStatsPriceQueryStatus } = useHistoricCachePriceStore();
-const currencySymbol = useSetting('currencySymbol');
-const premium = usePremium();
-const { fetchPrices } = usePriceTaskManager();
-
-const LUSD_ID = 'eip155:1/erc20:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0';
-const LQTY_ID = 'eip155:1/erc20:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D';
-
-async function fetch(refresh = false) {
-  resetProtocolStatsPriceQueryStatus('liquity');
-
-  await Promise.all([
-    fetchStaking(refresh),
-    fetchPools(refresh),
-    fetchStatistics(refresh),
-    fetchPrices({
-      ignoreCache: refresh,
-      selectedAssets: [LUSD_ID, LQTY_ID, 'ETH'],
-    }),
-  ]);
-}
-
-watchImmediate(moduleEnabled, async (enabled) => {
-  if (enabled)
-    await fetch();
-});
-
-watch(currencySymbol, async () => {
-  if (get(moduleEnabled)) {
-    await fetch(true);
-  }
-});
+import { LIQUITY_MODULES, useLiquityPage } from '@/modules/staking/liquity/use-liquity-page';
 
 const { t } = useI18n({ useScope: 'global' });
+
+const { fetch, moduleEnabled, premium } = useLiquityPage();
 </script>
 
 <template>
@@ -54,17 +15,20 @@ const { t } = useI18n({ useScope: 'global' });
     <LiquityStakingPagePlaceholder
       v-if="!premium"
       :text="t('liquity_page.no_premium')"
+      data-testid="no-premium"
     />
     <ModuleNotActive
       v-else-if="!moduleEnabled"
-      :modules="modules"
+      :modules="LIQUITY_MODULES"
+      data-testid="module-not-active"
     />
     <LiquityStakingDetails
       v-else
+      data-testid="staking-details"
       @refresh="fetch($event)"
     >
       <template #modules>
-        <ActiveModules :modules="modules" />
+        <ActiveModules :modules="LIQUITY_MODULES" />
       </template>
     </LiquityStakingDetails>
   </div>

--- a/frontend/app/src/modules/staking/liquity/LiquityPools.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/LiquityPools.spec.ts
@@ -1,0 +1,90 @@
+import { bigNumberify, type LiquityPoolDetailEntry } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import LiquityPools from '@/modules/staking/liquity/LiquityPools.vue';
+
+const isActive = vi.hoisted(() => ({ current: false }));
+
+vi.mock('@/modules/task-center/use-task-center', async () => {
+  const { computed } = await import('vue');
+  return {
+    useTaskCenter: (): Record<string, unknown> => ({
+      useIsActive: () => computed(() => isActive.current),
+    }),
+  };
+});
+
+const BalanceDisplayStub = defineComponent({
+  name: 'BalanceDisplayStub',
+  props: {
+    asset: { default: '', type: String },
+    iconSize: { default: '', type: String },
+    loading: { default: false, type: Boolean },
+    value: { default: null, type: Object },
+  },
+  template: '<div data-testid="balance" />',
+});
+
+function pool(): LiquityPoolDetailEntry {
+  const balance = (asset: string, amount: number): { amount: ReturnType<typeof bigNumberify>; asset: string; value: ReturnType<typeof bigNumberify> } => ({
+    amount: bigNumberify(amount),
+    asset,
+    value: bigNumberify(amount),
+  });
+
+  return {
+    deposited: balance('LUSD', 500),
+    gains: balance('ETH', 1),
+    rewards: balance('LQTY', 5),
+  };
+}
+
+describe('modules/staking/liquity/LiquityPools', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LiquityPools>>;
+
+  function mountComponent(poolValue: LiquityPoolDetailEntry | null): VueWrapper<InstanceType<typeof LiquityPools>> {
+    return mount(LiquityPools, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: { BalanceDisplay: BalanceDisplayStub },
+      },
+      props: { pool: poolValue },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    isActive.current = false;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should show no balances without a pool position', () => {
+    wrapper = mountComponent(null);
+
+    expect(wrapper.findComponent(BalanceDisplayStub).exists()).toBe(false);
+  });
+
+  it('should show the deposit, the rewards and the liquidation gains', () => {
+    wrapper = mountComponent(pool());
+
+    const balances = wrapper.findAllComponents(BalanceDisplayStub);
+    expect(balances).toHaveLength(3);
+    expect(balances.map(item => item.props('asset'))).toEqual(['LUSD', 'LQTY', 'ETH']);
+  });
+
+  it('should pass the pool activity through as the loading state', () => {
+    isActive.current = true;
+
+    wrapper = mountComponent(pool());
+
+    expect(wrapper.findComponent(BalanceDisplayStub).props('loading')).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/LiquityProxyInformation.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/LiquityProxyInformation.spec.ts
@@ -1,0 +1,76 @@
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { defineComponent } from 'vue';
+import LiquityProxyInformation from '@/modules/staking/liquity/LiquityProxyInformation.vue';
+
+const HashLinkStub = defineComponent({
+  name: 'HashLinkStub',
+  props: { text: { default: '', type: String } },
+  template: '<div data-testid="hash-link">{{ text }}</div>',
+});
+
+const DividerStub = defineComponent({
+  name: 'DividerStub',
+  template: '<hr data-testid="divider" />',
+});
+
+describe('modules/staking/liquity/LiquityProxyInformation', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LiquityProxyInformation>>;
+
+  function mountComponent(proxyInformation: Record<string, string[]>): VueWrapper<InstanceType<typeof LiquityProxyInformation>> {
+    return mount(LiquityProxyInformation, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          HashLink: HashLinkStub,
+          RuiDivider: DividerStub,
+          // The contents live in a menu that only renders once opened.
+          RuiMenu: { template: '<div><slot /></div>' },
+        },
+      },
+      props: { proxyInformation },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should link the owner and each of its proxies', () => {
+    wrapper = mountComponent({ '0xaaa': ['0xproxy1', '0xproxy2'] });
+
+    const links = wrapper.findAllComponents(HashLinkStub).map(item => item.props('text'));
+    expect(links).toEqual(['0xaaa', '0xproxy1', '0xproxy2']);
+  });
+
+  it('should separate owners with a divider, but not trail one after the last', () => {
+    wrapper = mountComponent({ '0xaaa': ['0xproxy1'], '0xbbb': ['0xproxy2'] });
+
+    expect(wrapper.findAllComponents(DividerStub)).toHaveLength(1);
+  });
+
+  it('should show no divider for a single owner', () => {
+    wrapper = mountComponent({ '0xaaa': ['0xproxy1'] });
+
+    expect(wrapper.findComponent(DividerStub).exists()).toBe(false);
+  });
+
+  it('should show one divider fewer than the number of owners', () => {
+    wrapper = mountComponent({ '0xaaa': ['0xp1'], '0xbbb': ['0xp2'], '0xccc': ['0xp3'] });
+
+    expect(wrapper.findAllComponents(DividerStub)).toHaveLength(2);
+  });
+
+  it('should render nothing for an empty record', () => {
+    wrapper = mountComponent({});
+
+    expect(wrapper.findComponent(HashLinkStub).exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/LiquityStake.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/LiquityStake.spec.ts
@@ -1,0 +1,98 @@
+import { bigNumberify, type LiquityStakingDetailEntry } from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import LiquityStake from '@/modules/staking/liquity/LiquityStake.vue';
+
+const isActive = vi.hoisted(() => ({ current: false }));
+
+vi.mock('@/modules/task-center/use-task-center', async () => {
+  const { computed } = await import('vue');
+  return {
+    useTaskCenter: (): Record<string, unknown> => ({
+      useIsActive: () => computed(() => isActive.current),
+    }),
+  };
+});
+
+const BalanceDisplayStub = defineComponent({
+  name: 'BalanceDisplayStub',
+  props: {
+    asset: { default: '', type: String },
+    iconSize: { default: '', type: String },
+    loading: { default: false, type: Boolean },
+    value: { default: null, type: Object },
+  },
+  template: '<div data-testid="balance" />',
+});
+
+function stake(): LiquityStakingDetailEntry {
+  const balance = (asset: string, amount: number): { amount: ReturnType<typeof bigNumberify>; asset: string; value: ReturnType<typeof bigNumberify> } => ({
+    amount: bigNumberify(amount),
+    asset,
+    value: bigNumberify(amount),
+  });
+
+  return {
+    ethRewards: balance('ETH', 1),
+    lusdRewards: balance('LUSD', 2),
+    staked: balance('LQTY', 100),
+  };
+}
+
+describe('modules/staking/liquity/LiquityStake', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LiquityStake>>;
+
+  function mountComponent(props: { stake?: LiquityStakingDetailEntry | null } = {}): VueWrapper<InstanceType<typeof LiquityStake>> {
+    return mount(LiquityStake, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: { BalanceDisplay: BalanceDisplayStub },
+      },
+      props,
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    isActive.current = false;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should say nothing is staked when there is no stake', () => {
+    wrapper = mountComponent();
+
+    expect(wrapper.text()).toContain('loan_stake.no_lqty_staked');
+    expect(wrapper.findComponent(BalanceDisplayStub).exists()).toBe(false);
+  });
+
+  it('should treat an explicit null the same as an absent stake', () => {
+    wrapper = mountComponent({ stake: null });
+
+    expect(wrapper.text()).toContain('loan_stake.no_lqty_staked');
+  });
+
+  it('should show the staked amount and both reward assets', () => {
+    wrapper = mountComponent({ stake: stake() });
+
+    const balances = wrapper.findAllComponents(BalanceDisplayStub);
+    expect(balances).toHaveLength(3);
+    expect(balances.map(item => item.props('asset'))).toEqual(['LQTY', 'LUSD', 'ETH']);
+    expect(wrapper.text()).not.toContain('loan_stake.no_lqty_staked');
+  });
+
+  it('should pass the staking activity through as the loading state', () => {
+    isActive.current = true;
+
+    wrapper = mountComponent({ stake: stake() });
+
+    expect(wrapper.findComponent(BalanceDisplayStub).props('loading')).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/LiquityStakingDetails.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/LiquityStakingDetails.spec.ts
@@ -1,0 +1,172 @@
+import type { StatsPriceQueryData } from '@/modules/core/messaging/types';
+import type { useLiquityStakingDetails } from '@/modules/staking/liquity/use-liquity-staking-details';
+import type { ActivitySteps } from '@/modules/task-center/core/types';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import LiquityStakingDetails from '@/modules/staking/liquity/LiquityStakingDetails.vue';
+
+interface DetailsState {
+  loading: boolean;
+  priceStatus: StatsPriceQueryData | undefined;
+  proxies: Record<string, string[]> | null;
+  queryStatus: ActivitySteps | undefined;
+}
+
+const detailsState = vi.hoisted((): DetailsState => ({
+  loading: false,
+  priceStatus: undefined,
+  proxies: null,
+  queryStatus: undefined,
+}));
+
+const ProxyInfoStub = defineComponent({
+  name: 'LiquityProxyInformationStub',
+  props: { proxyInformation: { default: undefined, type: Object } },
+  template: '<div data-testid="proxy-info" />',
+});
+
+const AccountSelectorStub = defineComponent({
+  name: 'BlockchainAccountSelectorStub',
+  props: { field: { default: undefined, type: Object }, modelValue: { default: () => [], type: Array }, source: { default: undefined, type: Object } },
+  template: '<div data-testid="account-selector" />',
+});
+
+const HistoryViewStub = defineComponent({
+  name: 'HistoryEventsViewStub',
+  props: { restrictions: { default: undefined, type: Object }, sectionTitle: { default: '', type: String } },
+  template: '<div data-testid="history-view" />',
+});
+
+vi.mock('@/modules/staking/liquity/use-liquity-staking-details', async () => {
+  const { computed, ref } = await import('vue');
+  return {
+    useLiquityStakingDetails: (): ReturnType<typeof useLiquityStakingDetails> => ({
+      accountFilter: computed(() => [{ address: '0xaaa', chain: 'eth' }]),
+      aggregatedStake: computed(() => null),
+      aggregatedStakingPool: computed(() => null),
+      aggregatedStatistic: computed(() => null),
+      availableAddresses: computed(() => ['0xaaa']),
+      liquityHistoricPriceStatus: computed(() => detailsState.priceStatus),
+      loading: computed(() => detailsState.loading),
+      modelSelectedAccounts: ref([]),
+      proxyInformation: computed(() => detailsState.proxies),
+      stakingQueryStatus: computed(() => detailsState.queryStatus),
+    }),
+  };
+});
+
+describe('modules/staking/liquity/LiquityStakingDetails', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LiquityStakingDetails>>;
+
+  function mountComponent(): VueWrapper<InstanceType<typeof LiquityStakingDetails>> {
+    return mount(LiquityStakingDetails, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          BlockchainAccountSelector: AccountSelectorStub,
+          HistoryEventsView: HistoryViewStub,
+          LiquityPools: { props: ['pool'], template: '<div data-testid="pools" />' },
+          LiquityProxyInformation: ProxyInfoStub,
+          LiquityStake: { props: ['stake'], template: '<div data-testid="stake" />' },
+          LiquityStatistics: { props: ['statistic', 'pool'], template: '<div data-testid="statistics" />' },
+          TablePageLayout: { props: ['title', 'child'], template: '<div><slot name="buttons" /><slot /></div>' },
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    detailsState.loading = false;
+    detailsState.priceStatus = undefined;
+    detailsState.proxies = null;
+    detailsState.queryStatus = undefined;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should ask its parent to refresh, rather than refreshing itself', async () => {
+    wrapper = mountComponent();
+
+    await wrapper.find('[data-testid=liquity-refresh]').trigger('click');
+
+    expect(wrapper.emitted('refresh')).toEqual([[true]]);
+  });
+
+  it('should offer the addresses that hold a position to the account selector', () => {
+    wrapper = mountComponent();
+
+    expect(wrapper.findComponent(AccountSelectorStub).props('source')).toMatchObject({
+      usableAddresses: ['0xaaa'],
+    });
+  });
+
+  it('should restrict the events view to liquity on the selected accounts', () => {
+    wrapper = mountComponent();
+
+    expect(wrapper.findComponent(HistoryViewStub).props('restrictions')).toMatchObject({
+      externalAccounts: [{ address: '0xaaa', chain: 'eth' }],
+      protocols: ['liquity'],
+    });
+  });
+
+  describe('the proxy section', () => {
+    it('should stay hidden with no proxies and nothing loading', () => {
+      wrapper = mountComponent();
+
+      expect(wrapper.findComponent(ProxyInfoStub).exists()).toBe(false);
+      expect(wrapper.find('[data-testid=liquity-query-status]').exists()).toBe(false);
+    });
+
+    it('should show the proxies once there are some', () => {
+      detailsState.proxies = { '0xaaa': ['0xproxy'] };
+
+      wrapper = mountComponent();
+
+      expect(wrapper.findComponent(ProxyInfoStub).props('proxyInformation')).toEqual({ '0xaaa': ['0xproxy'] });
+    });
+  });
+
+  describe('the query progress', () => {
+    it('should stay hidden while loading with no progress to report', () => {
+      detailsState.loading = true;
+
+      wrapper = mountComponent();
+
+      expect(wrapper.find('[data-testid=liquity-query-status]').exists()).toBe(false);
+    });
+
+    it('should show once loading and a staking count is known', () => {
+      detailsState.loading = true;
+      detailsState.queryStatus = { current: 3, total: 10 };
+
+      wrapper = mountComponent();
+
+      expect(wrapper.find('[data-testid=liquity-query-status]').exists()).toBe(true);
+    });
+
+    it('should show for a historic price count alone', () => {
+      detailsState.loading = true;
+      detailsState.priceStatus = { counterparty: 'liquity', processed: 2, total: 5 };
+
+      wrapper = mountComponent();
+
+      expect(wrapper.find('[data-testid=liquity-query-status]').exists()).toBe(true);
+    });
+
+    it('should stay hidden when a count is known but nothing is loading', () => {
+      detailsState.queryStatus = { current: 3, total: 10 };
+
+      wrapper = mountComponent();
+
+      expect(wrapper.find('[data-testid=liquity-query-status]').exists()).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/LiquityStakingDetails.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityStakingDetails.vue
@@ -1,31 +1,13 @@
 <script setup lang="ts">
-import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
-import {
-  type AssetBalance,
-  type Balance,
-  Blockchain,
-  HistoryEventEntryType,
-  type LiquityPoolDetailEntry,
-  type LiquityPoolDetails,
-  type LiquityStakingDetailEntry,
-  type LiquityStakingDetails,
-  type LiquityStatisticDetails,
-} from '@rotki/common';
-import { getAccountAddress } from '@/modules/accounts/account-utils';
+import { Blockchain, HistoryEventEntryType } from '@rotki/common';
 import BlockchainAccountSelector from '@/modules/accounts/BlockchainAccountSelector.vue';
-import { useHistoricCachePriceStore } from '@/modules/assets/prices/use-historic-cache-price-store';
-import { zeroBalance } from '@/modules/core/common/data/bignumbers';
-import { balanceSum } from '@/modules/core/common/data/calculation';
-import { uniqueStrings } from '@/modules/core/common/data/data';
 import HistoryEventsView from '@/modules/history/events/HistoryEventsView.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 import LiquityPools from '@/modules/staking/liquity/LiquityPools.vue';
 import LiquityProxyInformation from '@/modules/staking/liquity/LiquityProxyInformation.vue';
 import LiquityStake from '@/modules/staking/liquity/LiquityStake.vue';
 import LiquityStatistics from '@/modules/staking/liquity/LiquityStatistics.vue';
-import { useLiquityStore } from '@/modules/staking/liquity/use-liquity-store';
-import { ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
-import { useTaskCenter } from '@/modules/task-center/use-task-center';
+import { useLiquityStakingDetails } from '@/modules/staking/liquity/use-liquity-staking-details';
 
 const emit = defineEmits<{
   refresh: [refresh: boolean];
@@ -35,196 +17,24 @@ defineSlots<{
   modules: () => any;
 }>();
 
-const selectedAccounts = ref<BlockchainAccount<AddressData>[]>([]);
-const liquityStore = useLiquityStore();
-const { staking, stakingPools, statistics } = storeToRefs(liquityStore);
-const { useActivity, useIsActive } = useTaskCenter();
-const stakingActivity = useActivity(ActivityKind.LIQUITY, ActivityPart.STAKING);
-const stakingQueryStatus = computed(() => get(stakingActivity)?.steps);
-
-const { getProtocolStatsPriceQueryStatus } = useHistoricCachePriceStore();
-const liquityHistoricPriceStatus = getProtocolStatsPriceQueryStatus('liquity');
-
-const loading = useIsActive(ActivityKind.LIQUITY, ActivityPart.STAKING);
-
 const chains = [Blockchain.ETH];
 
 const { t } = useI18n({ useScope: 'global' });
 
-const accountFilter = useArrayMap(selectedAccounts, account => ({
-  address: getAccountAddress(account),
-  chain: account.chain,
-}));
+const {
+  accountFilter,
+  aggregatedStake,
+  aggregatedStakingPool,
+  aggregatedStatistic,
+  availableAddresses,
+  liquityHistoricPriceStatus,
+  loading,
+  modelSelectedAccounts,
+  proxyInformation,
+  stakingQueryStatus,
+} = useLiquityStakingDetails();
 
-const aggregatedStake = computed<LiquityStakingDetailEntry | null>(() => {
-  const allStakes: LiquityStakingDetails = get(staking);
-  const selectedAddresses = get(selectedAccounts).map(account => getAccountAddress(account));
-
-  const filteredStakes: LiquityStakingDetailEntry[] = [];
-
-  for (const address in allStakes) {
-    const stake = allStakes[address];
-    if (selectedAddresses.length > 0 && !selectedAddresses.includes(address))
-      continue;
-
-    if (stake.balances)
-      filteredStakes.push(stake.balances);
-
-    if (stake.proxies)
-      filteredStakes.push(...Object.values(stake.proxies));
-  }
-
-  let stakes: LiquityStakingDetailEntry | null = null;
-
-  filteredStakes.forEach((stake) => {
-    if (stakes === null) {
-      stakes = { ...stake };
-    }
-    else {
-      let key: keyof LiquityStakingDetailEntry;
-      for (key in stakes) {
-        stakes[key] = {
-          ...stakes[key],
-          ...balanceSum(stakes[key], stake[key]),
-        };
-      }
-    }
-  });
-  return stakes;
-});
-
-const aggregatedStakingPool = computed<LiquityPoolDetailEntry | null>(() => {
-  const allPools: LiquityPoolDetails = get(stakingPools);
-  const selectedAddresses = get(selectedAccounts).map(account => getAccountAddress(account));
-  const filteredPools: LiquityPoolDetailEntry[] = [];
-
-  for (const address in allPools) {
-    const pool = allPools[address];
-    if (selectedAddresses.length > 0 && !selectedAddresses.includes(address))
-      continue;
-
-    if (pool.balances)
-      filteredPools.push(pool.balances);
-
-    if (pool.proxies)
-      filteredPools.push(...Object.values(pool.proxies));
-  }
-
-  let pools: LiquityPoolDetailEntry | null = null;
-  filteredPools.forEach((pool) => {
-    if (pools === null) {
-      pools = { ...pool };
-    }
-    else {
-      let key: keyof LiquityPoolDetailEntry;
-      for (key in pools) {
-        pools[key] = {
-          ...pools[key],
-          ...balanceSum(pools[key], pool[key]),
-        };
-      }
-    }
-  });
-
-  return pools;
-});
-
-const proxyInformation = computed<Record<string, string[]> | null>(() => {
-  const proxies: Record<string, string[]> = {};
-  const allStakes: LiquityStakingDetails = get(staking);
-  const allPools: LiquityPoolDetails = get(stakingPools);
-
-  const selectedAddresses = get(selectedAccounts).map(account => getAccountAddress(account));
-
-  const addToProxies = (mainAddress: string, proxyAddresses: string[]) => {
-    if (!proxies[mainAddress])
-      proxies[mainAddress] = proxyAddresses;
-    else
-      proxies[mainAddress] = [...proxies[mainAddress], ...proxyAddresses].filter(uniqueStrings);
-  };
-
-  selectedAddresses.forEach((address) => {
-    const pool = allPools[address];
-    if (pool && pool.proxies) {
-      const poolProxies = Object.keys(pool.proxies);
-      if (poolProxies.length > 0)
-        addToProxies(address, poolProxies);
-    }
-
-    const stake = allStakes[address];
-    if (stake && stake.proxies) {
-      const stakeProxies = Object.keys(stake.proxies);
-      if (stakeProxies.length > 0)
-        addToProxies(address, stakeProxies);
-    }
-  });
-
-  if (Object.keys(proxies).length === 0)
-    return null;
-
-  return proxies;
-});
-
-const aggregatedStatistic = computed<LiquityStatisticDetails | null>(() => {
-  const allStatistics = get(statistics);
-
-  if (!allStatistics)
-    return null;
-
-  const selectedAddresses = get(selectedAccounts).map(account => getAccountAddress(account));
-
-  if (selectedAddresses.length === 0)
-    return allStatistics.globalStats ?? null;
-
-  if (!allStatistics.byAddress)
-    return null;
-
-  let aggregatedStatistic: LiquityStatisticDetails | null = null;
-  for (const address in allStatistics.byAddress) {
-    if (!selectedAddresses.includes(address))
-      continue;
-
-    const statistic = allStatistics.byAddress[address];
-    if (aggregatedStatistic === null) {
-      aggregatedStatistic = { ...statistic };
-    }
-    else {
-      const { stabilityPoolGains, stakingGains, ...remaining } = statistic;
-
-      let key: keyof typeof remaining;
-
-      for (key in remaining)
-        aggregatedStatistic[key] = aggregatedStatistic[key].plus(remaining[key]);
-
-      const mergeAssetBalances = (items1: AssetBalance[], items2: AssetBalance[]) => {
-        const aggregated = [...items1, ...items2];
-
-        const uniqueAssets = aggregated.map(({ asset }) => asset).filter(uniqueStrings);
-
-        return uniqueAssets.map(asset => ({
-          asset,
-          ...aggregated
-            .filter((item: AssetBalance) => asset === item.asset)
-            .reduce((previous: Balance, current: Balance) => balanceSum(previous, current), zeroBalance()),
-        }));
-      };
-
-      aggregatedStatistic.stakingGains = mergeAssetBalances(aggregatedStatistic.stakingGains, stakingGains);
-      aggregatedStatistic.stabilityPoolGains = mergeAssetBalances(
-        aggregatedStatistic.stabilityPoolGains,
-        stabilityPoolGains,
-      );
-    }
-  }
-
-  return aggregatedStatistic;
-});
-
-const availableAddresses = computed(() =>
-  [...Object.keys(get(staking)), ...Object.keys(get(stakingPools))].filter(uniqueStrings),
-);
-
-function refresh() {
+function refresh(): void {
   emit('refresh', true);
 }
 </script>
@@ -246,6 +56,7 @@ function refresh() {
               color="primary"
               size="lg"
               :loading="loading"
+              data-testid="liquity-refresh"
               @click="refresh()"
             >
               <template #prepend>
@@ -260,7 +71,7 @@ function refresh() {
     </template>
     <div class="grid md:grid-cols-2 gap-x-4 gap-y-2">
       <BlockchainAccountSelector
-        v-model="selectedAccounts"
+        v-model="modelSelectedAccounts"
         :source="{ chains, usableAddresses: availableAddresses }"
         :field="{ dense: true, label: t('liquity_staking_details.select_account') }"
       />
@@ -277,6 +88,7 @@ function refresh() {
         <div
           v-if="loading && (stakingQueryStatus || liquityHistoricPriceStatus)"
           class="flex items-center gap-3 text-rui-text-secondary text-sm"
+          data-testid="liquity-query-status"
         >
           <RuiProgress
             thickness="2"

--- a/frontend/app/src/modules/staking/liquity/LiquityStakingPagePlaceholder.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/LiquityStakingPagePlaceholder.spec.ts
@@ -1,0 +1,86 @@
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import LiquityStakingPagePlaceholder from '@/modules/staking/liquity/LiquityStakingPagePlaceholder.vue';
+
+const isMdAndDown = vi.hoisted(() => ({ current: false }));
+
+// `useBreakpoint` is auto-imported from the ui-library, not from the app.
+vi.mock('@rotki/ui-library', async (importOriginal) => {
+  const { computed } = await import('vue');
+  return {
+    ...(await importOriginal<typeof import('@rotki/ui-library')>()),
+    useBreakpoint: (): Record<string, unknown> => ({ isMdAndDown: computed(() => isMdAndDown.current) }),
+  };
+});
+
+const AppImageStub = defineComponent({
+  name: 'AppImageStub',
+  props: { src: { default: '', type: String } },
+  template: '<img data-testid="placeholder-image" :src="src" >',
+});
+
+const UpsellStub = defineComponent({
+  name: 'GetPremiumPlaceholderStub',
+  props: { title: { default: '', type: String } },
+  template: '<div data-testid="premium-upsell" />',
+});
+
+describe('modules/staking/liquity/LiquityStakingPagePlaceholder', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LiquityStakingPagePlaceholder>>;
+
+  function mountComponent(): VueWrapper<InstanceType<typeof LiquityStakingPagePlaceholder>> {
+    return mount(LiquityStakingPagePlaceholder, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          AppImage: AppImageStub,
+          GetPremiumPlaceholder: UpsellStub,
+        },
+      },
+      props: { text: 'the liquity copy' },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    isMdAndDown.current = false;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should show the premium upsell over the preview images', () => {
+    wrapper = mountComponent();
+
+    expect(wrapper.find('[data-testid=premium-upsell]').exists()).toBe(true);
+    expect(wrapper.findAllComponents(AppImageStub)).toHaveLength(3);
+  });
+
+  it('should show the copy it was given, rather than another page\'s', () => {
+    wrapper = mountComponent();
+
+    expect(wrapper.findComponent(UpsellStub).props('title')).toBe('the liquity copy');
+  });
+
+  it('should use the wide statistics preview on a large screen', () => {
+    wrapper = mountComponent();
+
+    const sources = wrapper.findAllComponents(AppImageStub).map(item => item.props('src') ?? '');
+    expect(sources.some(src => src.includes('liquity_staking_statistics.png'))).toBe(true);
+    expect(sources.some(src => src.includes('_mobile'))).toBe(false);
+  });
+
+  it('should swap to the mobile statistics preview on a small screen', () => {
+    isMdAndDown.current = true;
+
+    wrapper = mountComponent();
+
+    const sources = wrapper.findAllComponents(AppImageStub).map(item => item.props('src') ?? '');
+    expect(sources.some(src => src.includes('liquity_staking_statistics_mobile.png'))).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/LiquityStakingPagePlaceholder.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityStakingPagePlaceholder.vue
@@ -3,7 +3,10 @@ import { getPublicPlaceholderImagePath } from '@/modules/core/common/file/file';
 import AppImage from '@/modules/shell/components/AppImage.vue';
 import GetPremiumPlaceholder from '@/modules/shell/components/GetPremiumPlaceholder.vue';
 
-const { t } = useI18n({ useScope: 'global' });
+const { text } = defineProps<{
+  text: string;
+}>();
+
 const { isMdAndDown } = useBreakpoint();
 
 const getFullPath = getPublicPlaceholderImagePath;
@@ -30,7 +33,7 @@ const getFullPath = getPublicPlaceholderImagePath;
 
     <GetPremiumPlaceholder
       class="absolute z-1 pt-40 top-0 left-1/2 transform -translate-x-1/2"
-      :title="t('eth2_page.no_premium')"
+      :title="text"
     />
   </div>
 </template>

--- a/frontend/app/src/modules/staking/liquity/LiquityStatistics.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/LiquityStatistics.spec.ts
@@ -1,0 +1,175 @@
+import type { useLiquityStatistics } from '@/modules/staking/liquity/use-liquity-statistics';
+import {
+  type Balance,
+  type BigNumber,
+  bigNumberify,
+  type LiquityStatisticDetails,
+} from '@rotki/common';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type ShallowRef } from 'vue';
+import { LUSD_ID } from '@/modules/staking/liquity/liquity-assets';
+import { StatisticView } from '@/modules/staking/liquity/liquity-statistics';
+import LiquityStatistics from '@/modules/staking/liquity/LiquityStatistics.vue';
+
+interface StatsState {
+  deposited: Balance | null;
+  pnl: BigNumber | null;
+  selection?: ShallowRef<StatisticView>;
+  statistic: LiquityStatisticDetails | null;
+}
+
+const statsState = vi.hoisted((): StatsState => ({
+  deposited: null,
+  pnl: null,
+  statistic: null,
+}));
+
+const BalanceDisplayStub = defineComponent({
+  name: 'BalanceDisplayStub',
+  props: { asset: { default: '', type: String }, loading: { default: false, type: Boolean }, value: { default: null, type: Object } },
+  template: '<div />',
+});
+
+const PnlRowStub = defineComponent({
+  name: 'LiquityPnlRowStub',
+  props: { loading: { default: false, type: Boolean }, value: { default: null, type: Object } },
+  template: '<div data-testid="pnl-row" />',
+});
+
+const AssetListStub = defineComponent({
+  name: 'LiquityAssetBalanceListStub',
+  props: { balances: { default: () => [], type: Array }, emptyLabel: { default: '', type: String }, loading: { default: false, type: Boolean } },
+  template: '<div />',
+});
+
+vi.mock('@/modules/staking/liquity/use-liquity-statistics', async () => {
+  const { computed, shallowRef: shallowRefFn } = await import('vue');
+  return {
+    useLiquityStatistics: (): ReturnType<typeof useLiquityStatistics> => {
+      statsState.selection = shallowRefFn<StatisticView>(StatisticView.HISTORICAL);
+      return {
+        loading: computed(() => false),
+        modelSelection: statsState.selection,
+        statisticWithAdjustedPrice: computed(() => statsState.statistic),
+        totalDepositedStabilityPoolBalance: computed(() => statsState.deposited),
+        totalPnl: computed(() => statsState.pnl),
+        totalWithdrawnStabilityPoolBalance: computed(() => null),
+      };
+    },
+  };
+});
+
+function statistic(overrides: Partial<LiquityStatisticDetails> = {}): LiquityStatisticDetails {
+  return {
+    stabilityPoolGains: [],
+    stakingGains: [],
+    totalDepositedStabilityPool: bigNumberify(0),
+    totalDepositedStabilityPoolValue: bigNumberify(0),
+    totalValueGainsStabilityPool: bigNumberify(7),
+    totalValueGainsStaking: bigNumberify(3),
+    totalWithdrawnStabilityPool: bigNumberify(0),
+    totalWithdrawnStabilityPoolValue: bigNumberify(0),
+    ...overrides,
+  };
+}
+
+describe('modules/staking/liquity/LiquityStatistics', () => {
+  let wrapper: VueWrapper<InstanceType<typeof LiquityStatistics>>;
+
+  /** The view model the mocked composable published, once the component has been mounted. */
+  function viewModel(): ShallowRef<StatisticView> {
+    const model = statsState.selection;
+    if (!model)
+      throw new Error('mount the component before reaching for its view model');
+
+    return model;
+  }
+
+  function mountComponent(): VueWrapper<InstanceType<typeof LiquityStatistics>> {
+    return mount(LiquityStatistics, {
+      global: {
+        plugins: [createPinia()],
+        provide: libraryDefaults,
+        stubs: {
+          BalanceDisplay: BalanceDisplayStub,
+          FiatDisplay: { props: ['value', 'loading'], template: '<div />' },
+          LiquityAssetBalanceList: AssetListStub,
+          LiquityPnlRow: PnlRowStub,
+          LiquityStatisticRow: { props: ['label'], template: '<div><slot /></div>' },
+          // The detail rows live inside a collapsed accordion, so a pass-through is what puts
+          // them in the tree at all.
+          RuiAccordion: { template: '<div><slot /></div>' },
+          RuiAccordions: { template: '<div><slot /></div>' },
+        },
+      },
+    });
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    statsState.deposited = null;
+    statsState.pnl = null;
+    statsState.statistic = null;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('should say there is nothing to show without statistics', () => {
+    wrapper = mountComponent();
+
+    expect(wrapper.find('[data-testid=no-statistics]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=total-gains-staking]').exists()).toBe(false);
+  });
+
+  it('should show the totals once there are statistics', () => {
+    statsState.statistic = statistic();
+
+    wrapper = mountComponent();
+
+    expect(wrapper.find('[data-testid=no-statistics]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=total-gains-stability-pool]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=total-gains-staking]').exists()).toBe(true);
+  });
+
+  it('should price the stability-pool totals in LUSD', () => {
+    statsState.statistic = statistic();
+    statsState.deposited = { amount: bigNumberify(1000), value: bigNumberify(1000) };
+
+    wrapper = mountComponent();
+
+    expect(wrapper.findComponent(BalanceDisplayStub).props('asset')).toBe(LUSD_ID);
+  });
+
+  it('should hide the profit row until there is a figure', () => {
+    statsState.statistic = statistic();
+
+    wrapper = mountComponent();
+
+    expect(wrapper.findComponent(PnlRowStub).exists()).toBe(false);
+  });
+
+  it('should show the profit row once there is a figure', () => {
+    statsState.statistic = statistic();
+    statsState.pnl = bigNumberify(42);
+
+    wrapper = mountComponent();
+
+    expect(wrapper.findComponent(PnlRowStub).props('value')).toStrictEqual(bigNumberify(42));
+  });
+
+  it('should offer both views, bound to the shared model', () => {
+    statsState.statistic = statistic();
+
+    wrapper = mountComponent();
+
+    expect(wrapper.find('[data-testid=view-current]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=view-historical]').exists()).toBe(true);
+    expect(get(viewModel())).toBe(StatisticView.HISTORICAL);
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/LiquityStatistics.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityStatistics.vue
@@ -1,164 +1,31 @@
 <script setup lang="ts">
-import { type AssetBalance, type Balance, type BigNumber, type LiquityPoolDetailEntry, type LiquityStatisticDetails, One, Zero } from '@rotki/common';
+import type { LiquityPoolDetailEntry, LiquityStatisticDetails } from '@rotki/common';
 import { FiatDisplay } from '@/modules/assets/amount-display/components';
-import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
-import { bigNumberSum } from '@/modules/core/common/data/calculation';
 import BalanceDisplay from '@/modules/shell/components/display/BalanceDisplay.vue';
+import { LUSD_ID } from '@/modules/staking/liquity/liquity-assets';
+import { StatisticView } from '@/modules/staking/liquity/liquity-statistics';
 import LiquityAssetBalanceList from '@/modules/staking/liquity/LiquityAssetBalanceList.vue';
 import LiquityPnlRow from '@/modules/staking/liquity/LiquityPnlRow.vue';
 import LiquityStatisticRow from '@/modules/staking/liquity/LiquityStatisticRow.vue';
-import { ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
-import { useTaskCenter } from '@/modules/task-center/use-task-center';
+import { useLiquityStatistics } from '@/modules/staking/liquity/use-liquity-statistics';
 
 const { pool = null, statistic = null } = defineProps<{
   statistic?: LiquityStatisticDetails | null;
   pool?: LiquityPoolDetailEntry | null;
 }>();
 
-const selection = ref<'historical' | 'current'>('historical');
-
 const { t } = useI18n({ useScope: 'global' });
-const { getAssetPrice, useAssetPrice } = usePriceUtils();
-const LUSD_ID = 'eip155:1/erc20:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0';
-const lusdPrice = useAssetPrice(LUSD_ID);
 
-function priceOrOne(asset: string): BigNumber {
-  const price = getAssetPrice(asset);
-  return price && price.gt(0) ? price : One;
-}
-
-const lusdPriceOrOne = computed<BigNumber>(() => {
-  const price = get(lusdPrice);
-  return price && price.gt(0) ? price : One;
-});
-
-const { useIsActive } = useTaskCenter();
-const loading = useIsActive(ActivityKind.LIQUITY, ActivityPart.STATISTICS);
-
-const statisticWithAdjustedPrice = computed<LiquityStatisticDetails | null>(() => {
-  if (!statistic)
-    return null;
-
-  if (get(selection) === 'historical')
-    return statistic;
-
-  const stakingGains = statistic.stakingGains.map((stakingGain: AssetBalance) => {
-    const price = getAssetPrice(stakingGain.asset, One);
-
-    return {
-      ...stakingGain,
-      value: price.gt(0) ? stakingGain.amount.multipliedBy(price) : Zero,
-    };
-  });
-
-  const stabilityPoolGains = statistic.stabilityPoolGains.map((stabilityPoolGain: AssetBalance) => {
-    const price = getAssetPrice(stabilityPoolGain.asset, One);
-
-    return {
-      ...stabilityPoolGain,
-      value: price.gt(0) ? stabilityPoolGain.amount.multipliedBy(price) : Zero,
-    };
-  });
-
-  const totalValueGainsStabilityPool = bigNumberSum(stabilityPoolGains.map(({ value }) => value));
-
-  const totalValueGainsStaking = bigNumberSum(stakingGains.map(({ value }) => value));
-
-  return {
-    ...statistic,
-    stabilityPoolGains,
-    stakingGains,
-    totalDepositedStabilityPoolValue: statistic.totalDepositedStabilityPool.multipliedBy(get(lusdPriceOrOne)),
-    totalValueGainsStabilityPool,
-    totalValueGainsStaking,
-    totalWithdrawnStabilityPoolValue: statistic.totalWithdrawnStabilityPool.multipliedBy(get(lusdPriceOrOne)),
-  };
-});
-
-const totalDepositedStabilityPoolBalance = computed<Balance | null>(() => {
-  const data = get(statisticWithAdjustedPrice);
-  if (!data)
-    return null;
-
-  return {
-    amount: data.totalDepositedStabilityPool,
-    value: data.totalDepositedStabilityPoolValue,
-  };
-});
-
-const totalWithdrawnStabilityPoolBalance = computed<Balance | null>(() => {
-  const data = get(statisticWithAdjustedPrice);
-  if (!data)
-    return null;
-
-  return {
-    amount: data.totalWithdrawnStabilityPool,
-    value: data.totalWithdrawnStabilityPoolValue,
-  };
-});
-
-/**
- * Calculate the estimated PnL, by finding difference between these two things:
- * - Total LUSD that user have lost in stability pool, and find the current price.
- * - Current price of all asset user have now + total gains from the stability pool.
- *
- * The calculation:
- * A = Total Deposited Stability Pool - Total Withdrawn Stability Pool
- * LG = Liquidity gains in current price.
- * R = Rewards incurrent price.
- * B = Total Gains Stability Pool + LG + R
- * C = (A - Current deposited amount) in current price
- * PnL = B - C
- *
- * @param totalDepositedStabilityPool
- * @param totalWithdrawnStabilityPool
- * @param totalValueGainsStabilityPool
- * @param poolGains
- * @param poolRewards
- * @param poolDeposited
- * @return BigNumber
- */
-function calculatePnl(
-  totalDepositedStabilityPool: BigNumber,
-  totalWithdrawnStabilityPool: BigNumber,
-  totalValueGainsStabilityPool: BigNumber,
-  poolGains: AssetBalance,
-  poolRewards: AssetBalance,
-  poolDeposited: AssetBalance,
-): ComputedRef<BigNumber> {
-  return computed(() => {
-    const expectedAmount = totalDepositedStabilityPool.minus(totalWithdrawnStabilityPool);
-
-    const liquidationGainsInCurrentPrice = poolGains.amount.multipliedBy(priceOrOne(poolGains.asset));
-
-    const rewardsInCurrentPrice = poolRewards.amount.multipliedBy(priceOrOne(poolRewards.asset));
-
-    const totalWithdrawals = totalValueGainsStabilityPool
-      .plus(liquidationGainsInCurrentPrice)
-      .plus(rewardsInCurrentPrice);
-
-    const diffDeposited = expectedAmount.minus(poolDeposited.amount);
-
-    const diffDepositedInCurrentUsdPrice = diffDeposited.multipliedBy(get(lusdPriceOrOne));
-
-    return totalWithdrawals.minus(diffDepositedInCurrentUsdPrice);
-  });
-}
-
-const totalPnl = computed<BigNumber | null>(() => {
-  if (!statistic || !pool)
-    return null;
-
-  return get(
-    calculatePnl(
-      statistic.totalDepositedStabilityPool,
-      statistic.totalWithdrawnStabilityPool,
-      statistic.totalValueGainsStabilityPool,
-      pool.gains,
-      pool.rewards,
-      pool.deposited,
-    ),
-  );
+const {
+  loading,
+  modelSelection,
+  statisticWithAdjustedPrice,
+  totalDepositedStabilityPoolBalance,
+  totalPnl,
+  totalWithdrawnStabilityPoolBalance,
+} = useLiquityStatistics({
+  pool: () => pool,
+  statistic: () => statistic,
 });
 </script>
 
@@ -170,15 +37,21 @@ const totalPnl = computed<BigNumber | null>(() => {
           {{ t('liquity_statistic.title') }}
         </h6>
         <RuiButtonGroup
-          v-model="selection"
+          v-model="modelSelection"
           required
           variant="outlined"
           color="primary"
         >
-          <RuiButton model-value="current">
+          <RuiButton
+            :model-value="StatisticView.CURRENT"
+            data-testid="view-current"
+          >
             {{ t('liquity_statistic.switch.current') }}
           </RuiButton>
-          <RuiButton model-value="historical">
+          <RuiButton
+            :model-value="StatisticView.HISTORICAL"
+            data-testid="view-historical"
+          >
             {{ t('liquity_statistic.switch.historical') }}
           </RuiButton>
         </RuiButtonGroup>
@@ -194,6 +67,7 @@ const totalPnl = computed<BigNumber | null>(() => {
             :value="statisticWithAdjustedPrice.totalValueGainsStabilityPool"
             :loading="loading"
             class="font-bold"
+            data-testid="total-gains-stability-pool"
           />
         </div>
         <div class="flex justify-between">
@@ -204,6 +78,7 @@ const totalPnl = computed<BigNumber | null>(() => {
             :value="statisticWithAdjustedPrice.totalValueGainsStaking"
             :loading="loading"
             class="font-bold"
+            data-testid="total-gains-staking"
           />
         </div>
       </div>
@@ -222,6 +97,7 @@ const totalPnl = computed<BigNumber | null>(() => {
                   :asset="LUSD_ID"
                   :value="totalDepositedStabilityPoolBalance"
                   :loading="loading"
+                  data-testid="total-deposited"
                 />
               </LiquityStatisticRow>
               <LiquityStatisticRow
@@ -231,6 +107,7 @@ const totalPnl = computed<BigNumber | null>(() => {
                   :asset="LUSD_ID"
                   :value="totalWithdrawnStabilityPoolBalance"
                   :loading="loading"
+                  data-testid="total-withdrawn"
                 />
               </LiquityStatisticRow>
               <LiquityStatisticRow
@@ -271,6 +148,7 @@ const totalPnl = computed<BigNumber | null>(() => {
     <div
       v-else
       class="text-center text-rui-text-secondary pb-4"
+      data-testid="no-statistics"
     >
       {{ t('liquity_statistic.no_statistics') }}
     </div>

--- a/frontend/app/src/modules/staking/liquity/liquity-aggregation.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/liquity-aggregation.spec.ts
@@ -1,0 +1,339 @@
+import {
+  type AssetBalance,
+  bigNumberify,
+  type LiquityPoolDetails,
+  type LiquityStakingDetailEntry,
+  type LiquityStakingDetails,
+  type LiquityStatisticDetails,
+  type LiquityStatistics,
+} from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateEntries,
+  aggregateStatistics,
+  collectAvailableAddresses,
+  collectProxies,
+  mergeAssetBalances,
+} from './liquity-aggregation';
+
+const OWNER_A = '0xaaa';
+const OWNER_B = '0xbbb';
+const PROXY_A = '0xproxy-a';
+const PROXY_B = '0xproxy-b';
+
+function assetBalance(asset: string, amount: number, value = amount * 2): AssetBalance {
+  return { amount: bigNumberify(amount), asset, value: bigNumberify(value) };
+}
+
+function stake(staked: number, ethRewards = 0, lusdRewards = 0): LiquityStakingDetailEntry {
+  return {
+    ethRewards: assetBalance('ETH', ethRewards),
+    lusdRewards: assetBalance('LUSD', lusdRewards),
+    staked: assetBalance('LQTY', staked),
+  };
+}
+
+function statistic(overrides: Partial<LiquityStatisticDetails> = {}): LiquityStatisticDetails {
+  return {
+    stabilityPoolGains: [],
+    stakingGains: [],
+    totalDepositedStabilityPool: bigNumberify(0),
+    totalDepositedStabilityPoolValue: bigNumberify(0),
+    totalValueGainsStabilityPool: bigNumberify(0),
+    totalValueGainsStaking: bigNumberify(0),
+    totalWithdrawnStabilityPool: bigNumberify(0),
+    totalWithdrawnStabilityPoolValue: bigNumberify(0),
+    ...overrides,
+  };
+}
+
+describe('modules/staking/liquity/aggregateEntries', () => {
+  it('should be null when there is nothing at all', () => {
+    expect(aggregateEntries({}, [])).toBeNull();
+  });
+
+  it('should be null when the owner holds neither a balance nor a proxy', () => {
+    const source: LiquityStakingDetails = { [OWNER_A]: { balances: null, proxies: null } };
+
+    expect(aggregateEntries(source, [])).toBeNull();
+  });
+
+  it('should return the single owned balance untouched', () => {
+    const source: LiquityStakingDetails = { [OWNER_A]: { balances: stake(100), proxies: null } };
+
+    const total = aggregateEntries(source, []);
+
+    expect(total?.staked.amount.toNumber()).toBe(100);
+    expect(total?.staked.asset).toBe('LQTY');
+  });
+
+  it('should sum every field across owners', () => {
+    const source: LiquityStakingDetails = {
+      [OWNER_A]: { balances: stake(100, 1, 10), proxies: null },
+      [OWNER_B]: { balances: stake(50, 2, 20), proxies: null },
+    };
+
+    const total = aggregateEntries(source, []);
+
+    expect(total?.staked.amount.toNumber()).toBe(150);
+    expect(total?.ethRewards.amount.toNumber()).toBe(3);
+    expect(total?.lusdRewards.amount.toNumber()).toBe(30);
+  });
+
+  it('should sum the value alongside the amount', () => {
+    const source: LiquityStakingDetails = {
+      [OWNER_A]: { balances: stake(100), proxies: null },
+      [OWNER_B]: { balances: stake(50), proxies: null },
+    };
+
+    expect(aggregateEntries(source, [])?.staked.value.toNumber()).toBe(300);
+  });
+
+  it('should keep the asset identifier while summing', () => {
+    const source: LiquityStakingDetails = {
+      [OWNER_A]: { balances: stake(100), proxies: null },
+      [OWNER_B]: { balances: stake(50), proxies: null },
+    };
+
+    expect(aggregateEntries(source, [])?.staked.asset).toBe('LQTY');
+  });
+
+  it('should include balances held through a proxy', () => {
+    const source: LiquityStakingDetails = {
+      [OWNER_A]: { balances: stake(100), proxies: { [PROXY_A]: stake(25), [PROXY_B]: stake(25) } },
+    };
+
+    expect(aggregateEntries(source, [])?.staked.amount.toNumber()).toBe(150);
+  });
+
+  it('should include a proxy balance when the owner has none of their own', () => {
+    const source: LiquityStakingDetails = {
+      [OWNER_A]: { balances: null, proxies: { [PROXY_A]: stake(25) } },
+    };
+
+    expect(aggregateEntries(source, [])?.staked.amount.toNumber()).toBe(25);
+  });
+
+  describe('the account filter', () => {
+    const source: LiquityStakingDetails = {
+      [OWNER_A]: { balances: stake(100), proxies: null },
+      [OWNER_B]: { balances: stake(50), proxies: null },
+    };
+
+    it('should treat an empty selection as every address', () => {
+      expect(aggregateEntries(source, [])?.staked.amount.toNumber()).toBe(150);
+    });
+
+    it('should keep only the selected address', () => {
+      expect(aggregateEntries(source, [OWNER_B])?.staked.amount.toNumber()).toBe(50);
+    });
+
+    it('should be null when the selection matches no address', () => {
+      expect(aggregateEntries(source, ['0xnobody'])).toBeNull();
+    });
+  });
+
+  it('should not mutate the source entries', () => {
+    const owned = stake(100);
+    const source: LiquityStakingDetails = {
+      [OWNER_A]: { balances: owned, proxies: null },
+      [OWNER_B]: { balances: stake(50), proxies: null },
+    };
+
+    aggregateEntries(source, []);
+
+    expect(owned.staked.amount.toNumber()).toBe(100);
+  });
+
+  it('should serve pool details, which have the same shape', () => {
+    const pools: LiquityPoolDetails = {
+      [OWNER_A]: {
+        balances: {
+          deposited: assetBalance('LUSD', 500),
+          gains: assetBalance('ETH', 1),
+          rewards: assetBalance('LQTY', 5),
+        },
+        proxies: null,
+      },
+    };
+
+    expect(aggregateEntries(pools, [])?.deposited.amount.toNumber()).toBe(500);
+  });
+});
+
+describe('modules/staking/liquity/collectProxies', () => {
+  const staking: LiquityStakingDetails = {
+    [OWNER_A]: { balances: null, proxies: { [PROXY_A]: stake(1) } },
+  };
+  const pools: LiquityPoolDetails = {};
+
+  it('should be null when no address was selected', () => {
+    // With no account filter there is no owner to attribute a proxy to.
+    expect(collectProxies(staking, pools, [])).toBeNull();
+  });
+
+  it('should be null when the selected address holds no proxy', () => {
+    expect(collectProxies(staking, pools, [OWNER_B])).toBeNull();
+  });
+
+  it('should list the proxies of a selected address', () => {
+    expect(collectProxies(staking, pools, [OWNER_A])).toEqual({ [OWNER_A]: [PROXY_A] });
+  });
+
+  it('should combine the staking and pool proxies of one address', () => {
+    const withPool: LiquityPoolDetails = {
+      [OWNER_A]: { balances: null, proxies: { [PROXY_B]: { deposited: assetBalance('LUSD', 1), gains: assetBalance('ETH', 0), rewards: assetBalance('LQTY', 0) } } },
+    };
+
+    expect(collectProxies(staking, withPool, [OWNER_A])).toEqual({ [OWNER_A]: [PROXY_B, PROXY_A] });
+  });
+
+  it('should list a proxy once when it serves both staking and a pool', () => {
+    const samePool: LiquityPoolDetails = {
+      [OWNER_A]: { balances: null, proxies: { [PROXY_A]: { deposited: assetBalance('LUSD', 1), gains: assetBalance('ETH', 0), rewards: assetBalance('LQTY', 0) } } },
+    };
+
+    expect(collectProxies(staking, samePool, [OWNER_A])).toEqual({ [OWNER_A]: [PROXY_A] });
+  });
+
+  it('should key the proxies by their owner', () => {
+    const twoOwners: LiquityStakingDetails = {
+      [OWNER_A]: { balances: null, proxies: { [PROXY_A]: stake(1) } },
+      [OWNER_B]: { balances: null, proxies: { [PROXY_B]: stake(1) } },
+    };
+
+    expect(collectProxies(twoOwners, pools, [OWNER_A, OWNER_B])).toEqual({
+      [OWNER_A]: [PROXY_A],
+      [OWNER_B]: [PROXY_B],
+    });
+  });
+});
+
+describe('modules/staking/liquity/mergeAssetBalances', () => {
+  it('should sum two entries naming the same asset', () => {
+    const merged = mergeAssetBalances([assetBalance('ETH', 1)], [assetBalance('ETH', 2)]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].amount.toNumber()).toBe(3);
+    expect(merged[0].value.toNumber()).toBe(6);
+  });
+
+  it('should keep entries for different assets apart', () => {
+    const merged = mergeAssetBalances([assetBalance('ETH', 1)], [assetBalance('LUSD', 2)]);
+
+    expect(merged.map(item => item.asset)).toEqual(['ETH', 'LUSD']);
+  });
+
+  it('should carry a list through when the other is empty', () => {
+    expect(mergeAssetBalances([assetBalance('ETH', 1)], [])[0].amount.toNumber()).toBe(1);
+    expect(mergeAssetBalances([], [assetBalance('ETH', 1)])[0].amount.toNumber()).toBe(1);
+  });
+
+  it('should be empty when both are', () => {
+    expect(mergeAssetBalances([], [])).toEqual([]);
+  });
+});
+
+describe('modules/staking/liquity/aggregateStatistics', () => {
+  it('should be null without statistics', () => {
+    expect(aggregateStatistics(null, [])).toBeNull();
+  });
+
+  describe('with no address selected', () => {
+    it('should use the global figure the backend aggregated', () => {
+      const statistics: LiquityStatistics = {
+        globalStats: statistic({ totalValueGainsStaking: bigNumberify(99) }),
+      };
+
+      expect(aggregateStatistics(statistics, [])?.totalValueGainsStaking.toNumber()).toBe(99);
+    });
+
+    it('should be null when there is no global figure', () => {
+      expect(aggregateStatistics({ byAddress: {} }, [])).toBeNull();
+    });
+
+    it('should not fall back to the per-address figures', () => {
+      const statistics: LiquityStatistics = {
+        byAddress: { [OWNER_A]: statistic({ totalValueGainsStaking: bigNumberify(5) }) },
+      };
+
+      expect(aggregateStatistics(statistics, [])).toBeNull();
+    });
+  });
+
+  describe('with addresses selected', () => {
+    const statistics: LiquityStatistics = {
+      byAddress: {
+        [OWNER_A]: statistic({
+          stakingGains: [assetBalance('ETH', 1)],
+          totalValueGainsStaking: bigNumberify(10),
+        }),
+        [OWNER_B]: statistic({
+          stakingGains: [assetBalance('ETH', 2), assetBalance('LUSD', 7)],
+          totalValueGainsStaking: bigNumberify(20),
+        }),
+      },
+      globalStats: statistic({ totalValueGainsStaking: bigNumberify(999) }),
+    };
+
+    it('should use the selected address rather than the global figure', () => {
+      expect(aggregateStatistics(statistics, [OWNER_A])?.totalValueGainsStaking.toNumber()).toBe(10);
+    });
+
+    it('should sum the numeric totals across selected addresses', () => {
+      expect(aggregateStatistics(statistics, [OWNER_A, OWNER_B])?.totalValueGainsStaking.toNumber()).toBe(30);
+    });
+
+    it('should merge the gain lists per asset', () => {
+      const total = aggregateStatistics(statistics, [OWNER_A, OWNER_B]);
+
+      const eth = total?.stakingGains.find(item => item.asset === 'ETH');
+      expect(eth?.amount.toNumber()).toBe(3);
+      expect(total?.stakingGains.find(item => item.asset === 'LUSD')?.amount.toNumber()).toBe(7);
+    });
+
+    it('should be null when no statistics are broken down by address', () => {
+      expect(aggregateStatistics({ globalStats: statistic() }, [OWNER_A])).toBeNull();
+    });
+
+    it('should be null when the selection matches no address with statistics', () => {
+      expect(aggregateStatistics(statistics, ['0xnobody'])).toBeNull();
+    });
+
+    it('should not mutate the source statistics', () => {
+      aggregateStatistics(statistics, [OWNER_A, OWNER_B]);
+
+      expect(statistics.byAddress?.[OWNER_A].totalValueGainsStaking.toNumber()).toBe(10);
+      expect(statistics.byAddress?.[OWNER_A].stakingGains).toHaveLength(1);
+    });
+  });
+});
+
+describe('modules/staking/liquity/collectAvailableAddresses', () => {
+  it('should list an address that only stakes', () => {
+    const staking: LiquityStakingDetails = { [OWNER_A]: { balances: stake(1), proxies: null } };
+
+    expect(collectAvailableAddresses(staking, {})).toEqual([OWNER_A]);
+  });
+
+  it('should list an address that only pools', () => {
+    const pools: LiquityPoolDetails = {
+      [OWNER_B]: { balances: { deposited: assetBalance('LUSD', 1), gains: assetBalance('ETH', 0), rewards: assetBalance('LQTY', 0) }, proxies: null },
+    };
+
+    expect(collectAvailableAddresses({}, pools)).toEqual([OWNER_B]);
+  });
+
+  it('should list an address doing both only once', () => {
+    const staking: LiquityStakingDetails = { [OWNER_A]: { balances: stake(1), proxies: null } };
+    const pools: LiquityPoolDetails = {
+      [OWNER_A]: { balances: { deposited: assetBalance('LUSD', 1), gains: assetBalance('ETH', 0), rewards: assetBalance('LQTY', 0) }, proxies: null },
+    };
+
+    expect(collectAvailableAddresses(staking, pools)).toEqual([OWNER_A]);
+  });
+
+  it('should be empty with nothing at all', () => {
+    expect(collectAvailableAddresses({}, {})).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/liquity-aggregation.ts
+++ b/frontend/app/src/modules/staking/liquity/liquity-aggregation.ts
@@ -1,0 +1,173 @@
+import type {
+  AssetBalance,
+  Balance,
+  LiquityPoolDetails,
+  LiquityStakingDetails,
+  LiquityStatisticDetails,
+  LiquityStatistics,
+} from '@rotki/common';
+import { zeroBalance } from '@/modules/core/common/data/bignumbers';
+import { balanceSum } from '@/modules/core/common/data/calculation';
+import { uniqueStrings } from '@/modules/core/common/data/data';
+
+/** A position held directly, through DS proxies, or both. Staking and pool details share it. */
+interface DetailWithProxies<T> {
+  balances: T | null;
+  proxies: Record<string, T> | null;
+}
+
+/** A fixed set of named asset balances: staked/rewards, or deposited/gains/rewards. */
+type BalanceEntry = Record<string, AssetBalance>;
+
+/**
+ * Every entry for the given addresses, own balances and proxies alike.
+ *
+ * @param selectedAddresses - an empty list means every address, as an absent account filter does
+ */
+function selectEntries<T extends BalanceEntry>(
+  source: Record<string, DetailWithProxies<T>>,
+  selectedAddresses: string[],
+): T[] {
+  const selected: T[] = [];
+
+  for (const address in source) {
+    if (selectedAddresses.length > 0 && !selectedAddresses.includes(address))
+      continue;
+
+    const detail = source[address];
+    if (detail.balances)
+      selected.push(detail.balances);
+
+    if (detail.proxies)
+      selected.push(...Object.values(detail.proxies));
+  }
+
+  return selected;
+}
+
+/**
+ * Sums the selected entries field by field.
+ *
+ * @remarks
+ * Each field keeps its asset identifier: `balanceSum` returns only an amount and a value, and every
+ * entry names the same asset for a given field.
+ *
+ * @returns the summed entry, or `null` when nothing was selected
+ */
+export function aggregateEntries<T extends BalanceEntry>(
+  source: Record<string, DetailWithProxies<T>>,
+  selectedAddresses: string[],
+): T | null {
+  return selectEntries(source, selectedAddresses).reduce<T | null>((total, entry) => {
+    // This copy is what keeps the store's objects intact; later fields are reassigned, not mutated.
+    if (total === null)
+      return { ...entry };
+
+    for (const key in total)
+      total[key] = { ...total[key], ...balanceSum(total[key], entry[key]) };
+
+    return total;
+  }, null);
+}
+
+/**
+ * The proxies each selected address holds a position through, across staking and pools.
+ *
+ * @param selectedAddresses - only these count; with no account filter there is no owner to
+ * attribute a proxy to, so nothing is reported
+ * @returns the proxies by owner, or `null` when there are none
+ */
+export function collectProxies(
+  staking: LiquityStakingDetails,
+  pools: LiquityPoolDetails,
+  selectedAddresses: string[],
+): Record<string, string[]> | null {
+  const proxies: Record<string, string[]> = {};
+
+  const add = (owner: string, addresses: string[]): void => {
+    proxies[owner] = proxies[owner] === undefined
+      ? addresses
+      : [...proxies[owner], ...addresses].filter(uniqueStrings);
+  };
+
+  for (const address of selectedAddresses) {
+    for (const source of [pools[address], staking[address]]) {
+      const owned = Object.keys(source?.proxies ?? {});
+      if (owned.length > 0)
+        add(address, owned);
+    }
+  }
+
+  return Object.keys(proxies).length === 0 ? null : proxies;
+}
+
+/** Sums two lists of asset balances into one entry per asset. */
+export function mergeAssetBalances(first: AssetBalance[], second: AssetBalance[]): AssetBalance[] {
+  const combined = [...first, ...second];
+
+  return combined
+    .map(({ asset }) => asset)
+    .filter(uniqueStrings)
+    .map(asset => ({
+      asset,
+      ...combined
+        .filter(item => item.asset === asset)
+        .reduce<Balance>((previous, current) => balanceSum(previous, current), zeroBalance()),
+    }));
+}
+
+/**
+ * The statistics to display.
+ *
+ * @remarks
+ * With no account filter this is the global figure the backend already aggregated; with one it is
+ * the selected addresses summed together.
+ *
+ * @returns the statistics, or `null` when neither is available
+ */
+export function aggregateStatistics(
+  statistics: LiquityStatistics | null,
+  selectedAddresses: string[],
+): LiquityStatisticDetails | null {
+  if (!statistics)
+    return null;
+
+  if (selectedAddresses.length === 0)
+    return statistics.globalStats ?? null;
+
+  const byAddress = statistics.byAddress;
+  if (!byAddress)
+    return null;
+
+  let total: LiquityStatisticDetails | null = null;
+
+  for (const address in byAddress) {
+    if (!selectedAddresses.includes(address))
+      continue;
+
+    const statistic = byAddress[address];
+    if (total === null) {
+      total = { ...statistic };
+      continue;
+    }
+
+    const { stabilityPoolGains, stakingGains, ...totals } = statistic;
+
+    let key: keyof typeof totals;
+    for (key in totals)
+      total[key] = total[key].plus(totals[key]);
+
+    total.stakingGains = mergeAssetBalances(total.stakingGains, stakingGains);
+    total.stabilityPoolGains = mergeAssetBalances(total.stabilityPoolGains, stabilityPoolGains);
+  }
+
+  return total;
+}
+
+/** Every address holding a liquity position, whether staked, pooled, or both. */
+export function collectAvailableAddresses(
+  staking: LiquityStakingDetails,
+  pools: LiquityPoolDetails,
+): string[] {
+  return [...Object.keys(staking), ...Object.keys(pools)].filter(uniqueStrings);
+}

--- a/frontend/app/src/modules/staking/liquity/liquity-assets.ts
+++ b/frontend/app/src/modules/staking/liquity/liquity-assets.ts
@@ -1,0 +1,14 @@
+/** The stability pool is denominated in LUSD, so its totals are priced against this asset. */
+export const LUSD_ID = 'eip155:1/erc20:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0';
+
+/** The staking and reward token. */
+const LQTY_ID = 'eip155:1/erc20:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D';
+
+/**
+ * Every asset a liquity position can be denominated in.
+ *
+ * @remarks
+ * Pre-fetched by the page so the statistics have prices to re-value against without a per-row
+ * lookup.
+ */
+export const LIQUITY_PRICED_ASSETS = [LUSD_ID, LQTY_ID, 'ETH'];

--- a/frontend/app/src/modules/staking/liquity/liquity-statistics.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/liquity-statistics.spec.ts
@@ -1,0 +1,251 @@
+import {
+  type AssetBalance,
+  bigNumberify,
+  type LiquityPoolDetailEntry,
+  type LiquityStatisticDetails,
+  One,
+} from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import {
+  calculatePnl,
+  orOne,
+  type PriceLookup,
+  priceOrOne,
+  repriceStatistic,
+  StatisticView,
+} from './liquity-statistics';
+
+function assetBalance(asset: string, amount: number, value = amount): AssetBalance {
+  return { amount: bigNumberify(amount), asset, value: bigNumberify(value) };
+}
+
+function statistic(overrides: Partial<LiquityStatisticDetails> = {}): LiquityStatisticDetails {
+  return {
+    stabilityPoolGains: [],
+    stakingGains: [],
+    totalDepositedStabilityPool: bigNumberify(0),
+    totalDepositedStabilityPoolValue: bigNumberify(0),
+    totalValueGainsStabilityPool: bigNumberify(0),
+    totalValueGainsStaking: bigNumberify(0),
+    totalWithdrawnStabilityPool: bigNumberify(0),
+    totalWithdrawnStabilityPoolValue: bigNumberify(0),
+    ...overrides,
+  };
+}
+
+function pool(overrides: Partial<LiquityPoolDetailEntry> = {}): LiquityPoolDetailEntry {
+  return {
+    deposited: assetBalance('LUSD', 0),
+    gains: assetBalance('ETH', 0),
+    rewards: assetBalance('LQTY', 0),
+    ...overrides,
+  };
+}
+
+/** Prices every asset it knows; anything else has no price at all. */
+function pricesOf(prices: Record<string, number>): PriceLookup {
+  return (asset: string) => asset in prices ? bigNumberify(prices[asset]) : undefined;
+}
+
+describe('modules/staking/liquity/orOne', () => {
+  it('should use a real price', () => {
+    expect(orOne(bigNumberify(5)).toNumber()).toBe(5);
+  });
+
+  it('should fall back to one when there is no price', () => {
+    expect(orOne(undefined)).toStrictEqual(One);
+  });
+
+  it('should fall back to one for a zero price, which would collapse the row', () => {
+    expect(orOne(bigNumberify(0))).toStrictEqual(One);
+  });
+});
+
+describe('modules/staking/liquity/priceOrOne', () => {
+  it('should look the asset price up', () => {
+    expect(priceOrOne(pricesOf({ ETH: 3000 }), 'ETH').toNumber()).toBe(3000);
+  });
+
+  it('should fall back to one for an unpriced asset', () => {
+    expect(priceOrOne(pricesOf({}), 'ETH')).toStrictEqual(One);
+  });
+});
+
+describe('modules/staking/liquity/repriceStatistic', () => {
+  const recorded = statistic({
+    stabilityPoolGains: [assetBalance('ETH', 2, 100)],
+    stakingGains: [assetBalance('LQTY', 10, 20)],
+    totalDepositedStabilityPool: bigNumberify(1000),
+    totalDepositedStabilityPoolValue: bigNumberify(1000),
+    totalValueGainsStabilityPool: bigNumberify(100),
+    totalValueGainsStaking: bigNumberify(20),
+    totalWithdrawnStabilityPool: bigNumberify(400),
+    totalWithdrawnStabilityPoolValue: bigNumberify(400),
+  });
+
+  it('should return the recorded figures untouched on the historical view', () => {
+    const priced = repriceStatistic(recorded, StatisticView.HISTORICAL, pricesOf({ ETH: 3000 }), bigNumberify(2));
+
+    expect(priced).toBe(recorded);
+  });
+
+  describe('on the current view', () => {
+    const priceOf = pricesOf({ ETH: 3000, LQTY: 5 });
+
+    it('should re-value each gain at its current price', () => {
+      const priced = repriceStatistic(recorded, StatisticView.CURRENT, priceOf, One);
+
+      expect(priced.stabilityPoolGains[0].value.toNumber()).toBe(6000);
+      expect(priced.stakingGains[0].value.toNumber()).toBe(50);
+    });
+
+    it('should keep the amounts as they were', () => {
+      const priced = repriceStatistic(recorded, StatisticView.CURRENT, priceOf, One);
+
+      expect(priced.stabilityPoolGains[0].amount.toNumber()).toBe(2);
+    });
+
+    it('should total the re-valued gains', () => {
+      const priced = repriceStatistic(recorded, StatisticView.CURRENT, priceOf, One);
+
+      expect(priced.totalValueGainsStabilityPool.toNumber()).toBe(6000);
+      expect(priced.totalValueGainsStaking.toNumber()).toBe(50);
+    });
+
+    it('should re-value the LUSD totals at the LUSD price', () => {
+      const priced = repriceStatistic(recorded, StatisticView.CURRENT, priceOf, bigNumberify(2));
+
+      expect(priced.totalDepositedStabilityPoolValue.toNumber()).toBe(2000);
+      expect(priced.totalWithdrawnStabilityPoolValue.toNumber()).toBe(800);
+    });
+
+    it('should leave an unpriced gain at its amount, not at zero', () => {
+      // An unknown price is not a claim that the asset is worthless, so it is multiplied by 1.
+      const priced = repriceStatistic(recorded, StatisticView.CURRENT, pricesOf({}), One);
+
+      expect(priced.stabilityPoolGains[0].value.toNumber()).toBe(2);
+      expect(priced.totalValueGainsStabilityPool.toNumber()).toBe(2);
+    });
+
+    it('should value a gain priced explicitly at zero as zero', () => {
+      const priced = repriceStatistic(recorded, StatisticView.CURRENT, pricesOf({ ETH: 0 }), One);
+
+      expect(priced.stabilityPoolGains[0].value.toNumber()).toBe(0);
+    });
+
+    it('should not mutate the recorded statistic', () => {
+      repriceStatistic(recorded, StatisticView.CURRENT, priceOf, bigNumberify(2));
+
+      expect(recorded.stabilityPoolGains[0].value.toNumber()).toBe(100);
+      expect(recorded.totalDepositedStabilityPoolValue.toNumber()).toBe(1000);
+    });
+
+    it('should total an empty gain list as zero', () => {
+      const priced = repriceStatistic(statistic(), StatisticView.CURRENT, priceOf, One);
+
+      expect(priced.totalValueGainsStaking.toNumber()).toBe(0);
+    });
+  });
+});
+
+describe('modules/staking/liquity/calculatePnl', () => {
+  it('should be the gains when nothing was consumed by a liquidation', () => {
+    // Deposited 1000, withdrew 400, and 600 is still in the pool: nothing was lost.
+    const result = calculatePnl(
+      statistic({
+        totalDepositedStabilityPool: bigNumberify(1000),
+        totalValueGainsStabilityPool: bigNumberify(50),
+        totalWithdrawnStabilityPool: bigNumberify(400),
+      }),
+      pool({ deposited: assetBalance('LUSD', 600) }),
+      pricesOf({}),
+      One,
+    );
+
+    expect(result.toNumber()).toBe(50);
+  });
+
+  it('should subtract the LUSD a liquidation consumed', () => {
+    // 600 should be there but only 500 is, so 100 LUSD went to liquidations.
+    const result = calculatePnl(
+      statistic({
+        totalDepositedStabilityPool: bigNumberify(1000),
+        totalValueGainsStabilityPool: bigNumberify(50),
+        totalWithdrawnStabilityPool: bigNumberify(400),
+      }),
+      pool({ deposited: assetBalance('LUSD', 500) }),
+      pricesOf({}),
+      One,
+    );
+
+    expect(result.toNumber()).toBe(-50);
+  });
+
+  it('should price the consumed LUSD at the given LUSD price', () => {
+    const result = calculatePnl(
+      statistic({
+        totalDepositedStabilityPool: bigNumberify(1000),
+        totalValueGainsStabilityPool: bigNumberify(50),
+        totalWithdrawnStabilityPool: bigNumberify(400),
+      }),
+      pool({ deposited: assetBalance('LUSD', 500) }),
+      pricesOf({}),
+      bigNumberify(2),
+    );
+
+    expect(result.toNumber()).toBe(-150);
+  });
+
+  it('should add the liquidation gains at their current price', () => {
+    const result = calculatePnl(
+      statistic({ totalDepositedStabilityPool: bigNumberify(0) }),
+      pool({ gains: assetBalance('ETH', 2) }),
+      pricesOf({ ETH: 3000 }),
+      One,
+    );
+
+    expect(result.toNumber()).toBe(6000);
+  });
+
+  it('should add the rewards at their current price', () => {
+    const result = calculatePnl(
+      statistic({ totalDepositedStabilityPool: bigNumberify(0) }),
+      pool({ rewards: assetBalance('LQTY', 10) }),
+      pricesOf({ LQTY: 5 }),
+      One,
+    );
+
+    expect(result.toNumber()).toBe(50);
+  });
+
+  it('should count an unpriced gain at its face amount rather than dropping it', () => {
+    const result = calculatePnl(
+      statistic({ totalDepositedStabilityPool: bigNumberify(0) }),
+      pool({ gains: assetBalance('ETH', 2) }),
+      pricesOf({}),
+      One,
+    );
+
+    expect(result.toNumber()).toBe(2);
+  });
+
+  it('should combine every part', () => {
+    const result = calculatePnl(
+      statistic({
+        totalDepositedStabilityPool: bigNumberify(1000),
+        totalValueGainsStabilityPool: bigNumberify(50),
+        totalWithdrawnStabilityPool: bigNumberify(400),
+      }),
+      pool({
+        deposited: assetBalance('LUSD', 500),
+        gains: assetBalance('ETH', 1),
+        rewards: assetBalance('LQTY', 10),
+      }),
+      pricesOf({ ETH: 3000, LQTY: 5 }),
+      One,
+    );
+
+    // gains 50 + eth 3000 + lqty 50, less the 100 LUSD consumed
+    expect(result.toNumber()).toBe(3000);
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/liquity-statistics.ts
+++ b/frontend/app/src/modules/staking/liquity/liquity-statistics.ts
@@ -1,0 +1,114 @@
+import {
+  type AssetBalance,
+  type BigNumber,
+  type LiquityPoolDetailEntry,
+  type LiquityStatisticDetails,
+  One,
+  Zero,
+} from '@rotki/common';
+import { bigNumberSum } from '@/modules/core/common/data/calculation';
+
+/** Which prices the statistics are shown at: those recorded at the time, or today's. */
+export const StatisticView = {
+  CURRENT: 'current',
+  HISTORICAL: 'historical',
+} as const;
+
+export type StatisticView = typeof StatisticView[keyof typeof StatisticView];
+
+/** Resolves an asset's price, or `undefined` when it has none. */
+export type PriceLookup = (asset: string) => BigNumber | undefined;
+
+/**
+ * A usable multiplier for an amount.
+ *
+ * @returns the price, or 1 when there is none or it is zero, so the amount is left unscaled rather
+ * than collapsed to nothing
+ */
+export function orOne(price: BigNumber | undefined): BigNumber {
+  return price?.gt(0) ? price : One;
+}
+
+/** {@link orOne} for an asset whose price has to be looked up. */
+export function priceOrOne(priceOf: PriceLookup, asset: string): BigNumber {
+  return orOne(priceOf(asset));
+}
+
+/**
+ * Re-values gains at today's price.
+ *
+ * @remarks
+ * No price and a zero price differ: an unpriced asset is multiplied by 1 and keeps its amount as
+ * its value, while one priced at zero is worth zero.
+ */
+function repriceGains(gains: AssetBalance[], priceOf: PriceLookup): AssetBalance[] {
+  return gains.map((gain) => {
+    const price = priceOf(gain.asset) ?? One;
+    return {
+      ...gain,
+      value: price.gt(0) ? gain.amount.multipliedBy(price) : Zero,
+    };
+  });
+}
+
+/**
+ * The statistics for the chosen view.
+ *
+ * @param view - `historical` returns the recorded figures untouched; `current` re-values every gain
+ * and both LUSD totals at today's prices
+ * @param lusdPrice - already resolved, since the stability pool totals are denominated in LUSD
+ */
+export function repriceStatistic(
+  statistic: LiquityStatisticDetails,
+  view: StatisticView,
+  priceOf: PriceLookup,
+  lusdPrice: BigNumber,
+): LiquityStatisticDetails {
+  if (view === StatisticView.HISTORICAL)
+    return statistic;
+
+  const stakingGains = repriceGains(statistic.stakingGains, priceOf);
+  const stabilityPoolGains = repriceGains(statistic.stabilityPoolGains, priceOf);
+
+  return {
+    ...statistic,
+    stabilityPoolGains,
+    stakingGains,
+    totalDepositedStabilityPoolValue: statistic.totalDepositedStabilityPool.multipliedBy(lusdPrice),
+    totalValueGainsStabilityPool: bigNumberSum(stabilityPoolGains.map(({ value }) => value)),
+    totalValueGainsStaking: bigNumberSum(stakingGains.map(({ value }) => value)),
+    totalWithdrawnStabilityPoolValue: statistic.totalWithdrawnStabilityPool.multipliedBy(lusdPrice),
+  };
+}
+
+/**
+ * Estimated profit or loss on the stability pool.
+ *
+ * @remarks
+ * The difference between what came out and what went missing:
+ *
+ * - `A` = deposited - withdrawn, the LUSD that should still be in the pool
+ * - `B` = recorded gains + liquidation gains + rewards, all at today's price
+ * - `C` = (A - what is actually deposited now) at today's LUSD price, the LUSD consumed by
+ *   liquidations
+ * - PnL = B - C
+ */
+export function calculatePnl(
+  statistic: LiquityStatisticDetails,
+  pool: LiquityPoolDetailEntry,
+  priceOf: PriceLookup,
+  lusdPrice: BigNumber,
+): BigNumber {
+  const expectedAmount = statistic.totalDepositedStabilityPool.minus(statistic.totalWithdrawnStabilityPool);
+
+  const liquidationGains = pool.gains.amount.multipliedBy(priceOrOne(priceOf, pool.gains.asset));
+  const rewards = pool.rewards.amount.multipliedBy(priceOrOne(priceOf, pool.rewards.asset));
+
+  const totalWithdrawals = statistic.totalValueGainsStabilityPool
+    .plus(liquidationGains)
+    .plus(rewards);
+
+  const consumed = expectedAmount.minus(pool.deposited.amount).multipliedBy(lusdPrice);
+
+  return totalWithdrawals.minus(consumed);
+}

--- a/frontend/app/src/modules/staking/liquity/use-liquity-data-fetching.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-data-fetching.spec.ts
@@ -1,11 +1,12 @@
-import type { WorkStatus } from '@/modules/task-center/core/types';
 import { runSpecWith } from '@test/utils/mocks/native-task';
 import { createPinia, setActivePinia } from 'pinia';
-import { err } from 'plainfp/result';
+import { err, ok } from 'plainfp/result';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Module } from '@/modules/core/common/modules';
-import { Cancelled } from '@/modules/core/tasks/task-result';
+import { Cancelled, TaskFailed } from '@/modules/core/tasks/task-result';
+import { ActivityPart, type WorkStatus } from '@/modules/task-center/core/types';
 import { useLiquityDataFetching } from './use-liquity-data-fetching';
+import { useLiquityStore } from './use-liquity-store';
 import '@test/i18n';
 
 const mockFetchLiquityBalances = vi.fn();
@@ -39,8 +40,14 @@ vi.mock('@/modules/staking/liquity/use-liquity-api', () => ({
   })),
 }));
 
+const mockPremium = ref<boolean>(true);
 vi.mock('@/modules/premium/use-premium', () => ({
-  usePremium: vi.fn((): Ref<boolean> => ref<boolean>(true)),
+  usePremium: vi.fn((): Ref<boolean> => mockPremium),
+}));
+
+const notifyError = vi.fn();
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: vi.fn((): Record<string, unknown> => ({ notifyError })),
 }));
 
 const mockActiveModules = ref<string[]>([Module.LIQUITY]);
@@ -53,6 +60,7 @@ describe('useLiquityDataFetching', () => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
     set(mockActiveModules, [Module.LIQUITY]);
+    set(mockPremium, true);
     workStatus = { ...IDLE };
     // Default to a cancelled outcome so the success mapper (schema parse) never runs unless a test
     // opts in; a cancellation is non-actionable, so it also asserts no error notification.
@@ -146,6 +154,92 @@ describe('useLiquityDataFetching', () => {
       await fetchBalances();
 
       expect(submitTask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the premium guard', () => {
+    beforeEach(() => {
+      set(mockPremium, false);
+    });
+
+    it('should still fetch balances, which are free', async () => {
+      const { fetchBalances } = useLiquityDataFetching();
+      await fetchBalances();
+
+      expect(submitTask).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+      ['fetchPools' as const],
+      ['fetchStaking' as const],
+      ['fetchStatistics' as const],
+    ])('should skip %s without premium', async (name) => {
+      const fetching = useLiquityDataFetching();
+      await fetching[name]();
+
+      expect(submitTask).not.toHaveBeenCalled();
+    });
+
+    it('should skip the premium fetches even on an explicit refresh', async () => {
+      const { fetchStaking } = useLiquityDataFetching();
+      await fetchStaking(true);
+
+      expect(submitTask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a successful fetch', () => {
+    it('should validate the response and store it', async () => {
+      const staking = { '0xaaa': { balances: null, proxies: null } };
+      runTaskResult.mockResolvedValue(ok(staking));
+
+      const { fetchStaking } = useLiquityDataFetching();
+      await fetchStaking();
+
+      // `runTaskResult` stands in for the whole `runTask`, so the query callback itself never
+      // runs here; the claim is that the outcome is validated and written to the store.
+      expect(get(useLiquityStore().staking)).toEqual(staking);
+      expect(notifyError).not.toHaveBeenCalled();
+    });
+
+    it('should keep each fetch on its own part of the activity', async () => {
+      runTaskResult.mockResolvedValue(ok({}));
+
+      const { fetchStatistics } = useLiquityDataFetching();
+      await fetchStatistics();
+
+      expect(submitTask.mock.calls[0][0].id).toContain(ActivityPart.STATISTICS);
+    });
+  });
+
+  describe('a failed fetch', () => {
+    it('should report an actionable failure with the backend message', async () => {
+      runTaskResult.mockResolvedValue(err(TaskFailed({ message: 'backend said no' })));
+
+      const { fetchPools } = useLiquityDataFetching();
+      await fetchPools();
+
+      expect(notifyError).toHaveBeenCalledTimes(1);
+      expect(notifyError.mock.calls[0][1]).toContain('backend said no');
+    });
+
+    it('should stay quiet on a cancellation, which is not a failure', async () => {
+      runTaskResult.mockResolvedValue(err(Cancelled({ message: 'cancelled' })));
+
+      const { fetchPools } = useLiquityDataFetching();
+      await fetchPools();
+
+      expect(notifyError).not.toHaveBeenCalled();
+    });
+
+    it('should name the failing part in its own message', async () => {
+      runTaskResult.mockResolvedValue(err(TaskFailed({ message: 'nope' })));
+
+      const { fetchStatistics } = useLiquityDataFetching();
+      await fetchStatistics();
+
+      // The four fetches must not share one error string, or the toast names the wrong data.
+      expect(notifyError.mock.calls[0][0]).toContain('liquity_statistics');
     });
   });
 });

--- a/frontend/app/src/modules/staking/liquity/use-liquity-data-fetching.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-data-fetching.ts
@@ -1,3 +1,4 @@
+import type { PendingTask } from '@/modules/core/tasks/types';
 import {
   LiquityBalancesWithCollateralInfo,
   LiquityPoolDetails,
@@ -24,6 +25,22 @@ interface UseLiquityDataFetchingReturn {
   fetchStatistics: (refresh?: boolean) => Promise<void>;
 }
 
+/** What separates one liquity fetch from another; everything else is shared. */
+interface FetchDefinition {
+  /** The user-facing failure description, given the backend's message. */
+  errorDescription: (message: string) => string;
+  /** The user-facing failure title. */
+  errorTitle: () => string;
+  /** Which part of the liquity activity this fetch reports as. */
+  part: ActivityPart;
+  /** Whether the fetch needs premium. Balances are free; the backend rejects the other three. */
+  premiumOnly: boolean;
+  /** Starts the backend query, which runs as a task. */
+  query: () => Promise<PendingTask>;
+  /** Validates the response and writes it to the store. */
+  store: (result: unknown) => void;
+}
+
 export function useLiquityDataFetching(): UseLiquityDataFetchingReturn {
   const isPremium = usePremium();
   const activeModules = useSetting('activeModules');
@@ -43,8 +60,11 @@ export function useLiquityDataFetching(): UseLiquityDataFetchingReturn {
   }
 
   /**
-   * Skip when the module is off, an activity for this part is already live, or it has completed
-   * before and this is not a refresh. The components read the same activity for their loading
+   * Whether a fetch should go ahead.
+   *
+   * @remarks
+   * Skipped when the module is off, an activity for this part is already live, or it has completed
+   * before and this is not a refresh. The components read that same activity for their loading
    * display, so there is no second copy of this state to keep in step.
    */
   function canFetch(part: ActivityPart, refresh: boolean): boolean {
@@ -52,151 +72,84 @@ export function useLiquityDataFetching(): UseLiquityDataFetchingReturn {
     return isModuleActive() && !status.active && (!status.everCompleted || refresh);
   }
 
-  function notifyFailure(part: ActivityPart, error: TaskError, errorTitle: string, errorMessage: string): void {
-    logger.error(`action failure for liquity ${part}:`, error);
-    notifyError(errorTitle, errorMessage);
-  }
+  /**
+   * Wraps one {@link FetchDefinition} in the task shape, the guards and the failure handling that
+   * all four liquity fetches share.
+   */
+  function createFetch(definition: FetchDefinition): (refresh?: boolean) => Promise<void> {
+    const { errorDescription, errorTitle, part, premiumOnly, query, store } = definition;
 
-  async function fetchBalances(refresh = false): Promise<void> {
-    if (!canFetch(ActivityPart.BALANCES, refresh))
-      return;
+    return async (refresh = false): Promise<void> => {
+      if (premiumOnly && !get(isPremium))
+        return;
 
-    const outcome = await submitTask({
-      id: makeActivityId(ActivityKind.LIQUITY, ActivityPart.BALANCES),
-      kind: ActivityKind.LIQUITY,
-      rerunnable: true,
-      // Derived from decoded history events, so a completed decode makes this stale. Restores what
-      // `clearDependedSection` did before it was deleted.
-      staleAfter: [{ kind: ActivityKind.TX_DECODING }],
-      run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
-        await runTask<LiquityBalancesWithCollateralInfo>(
-          async () => fetchLiquityBalances(),
+      if (!canFetch(part, refresh))
+        return;
+
+      const outcome = await submitTask({
+        id: makeActivityId(ActivityKind.LIQUITY, part),
+        kind: ActivityKind.LIQUITY,
+        rerunnable: true,
+        // Derived from decoded history events, so a completed decode makes this stale.
+        staleAfter: [{ kind: ActivityKind.TX_DECODING }],
+        run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
+          await runTask<unknown>(async () => query()),
+          store,
         ),
-        (result) => {
-          set(balances, LiquityBalancesWithCollateralInfo.parse(result));
-        },
-      ),
-      subtitle: activityLabel(ActivityKind.LIQUITY, ActivityPart.BALANCES),
-      title: t('task_center.group.liquity'),
-    });
+        subtitle: activityLabel(ActivityKind.LIQUITY, part),
+        title: t('task_center.group.liquity'),
+      });
 
-    onActionableError(outcome, (error) => {
-      notifyFailure(
-        ActivityPart.BALANCES,
-        error,
-        t('actions.defi.liquity_balances.error.title'),
-        t('actions.defi.liquity_balances.error.description', { message: error.message }),
-      );
-    });
+      onActionableError(outcome, (error) => {
+        logger.error(`action failure for liquity ${part}:`, error);
+        notifyError(errorTitle(), errorDescription(error.message));
+      });
+    };
   }
 
-  async function fetchPools(refresh = false): Promise<void> {
-    if (!get(isPremium))
-      return;
+  const fetchBalances = createFetch({
+    errorDescription: (message: string) => t('actions.defi.liquity_balances.error.description', { message }),
+    errorTitle: () => t('actions.defi.liquity_balances.error.title'),
+    part: ActivityPart.BALANCES,
+    premiumOnly: false,
+    query: async () => fetchLiquityBalances(),
+    store: (result) => {
+      set(balances, LiquityBalancesWithCollateralInfo.parse(result));
+    },
+  });
 
-    if (!canFetch(ActivityPart.POOLS, refresh))
-      return;
+  const fetchPools = createFetch({
+    errorDescription: (message: string) => t('actions.defi.liquity_pools.error.description', { message }),
+    errorTitle: () => t('actions.defi.liquity_pools.error.title'),
+    part: ActivityPart.POOLS,
+    premiumOnly: true,
+    query: async () => fetchLiquityStakingPools(),
+    store: (result) => {
+      set(stakingPools, LiquityPoolDetails.parse(result));
+    },
+  });
 
-    const outcome = await submitTask({
-      id: makeActivityId(ActivityKind.LIQUITY, ActivityPart.POOLS),
-      kind: ActivityKind.LIQUITY,
-      rerunnable: true,
-      // Derived from decoded history events, so a completed decode makes this stale. Restores what
-      // `clearDependedSection` did before it was deleted.
-      staleAfter: [{ kind: ActivityKind.TX_DECODING }],
-      run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
-        await runTask<LiquityPoolDetails>(
-          async () => fetchLiquityStakingPools(),
-        ),
-        (result) => {
-          set(stakingPools, LiquityPoolDetails.parse(result));
-        },
-      ),
-      subtitle: activityLabel(ActivityKind.LIQUITY, ActivityPart.POOLS),
-      title: t('task_center.group.liquity'),
-    });
+  const fetchStaking = createFetch({
+    errorDescription: (message: string) => t('actions.defi.liquity_staking.error.description', { message }),
+    errorTitle: () => t('actions.defi.liquity_staking.error.title'),
+    part: ActivityPart.STAKING,
+    premiumOnly: true,
+    query: async () => fetchLiquityStaking(),
+    store: (result) => {
+      set(staking, LiquityStakingDetails.parse(result));
+    },
+  });
 
-    onActionableError(outcome, (error) => {
-      notifyFailure(
-        ActivityPart.POOLS,
-        error,
-        t('actions.defi.liquity_pools.error.title'),
-        t('actions.defi.liquity_pools.error.description', { message: error.message }),
-      );
-    });
-  }
-
-  async function fetchStaking(refresh = false): Promise<void> {
-    if (!get(isPremium))
-      return;
-
-    if (!canFetch(ActivityPart.STAKING, refresh))
-      return;
-
-    const outcome = await submitTask({
-      id: makeActivityId(ActivityKind.LIQUITY, ActivityPart.STAKING),
-      kind: ActivityKind.LIQUITY,
-      rerunnable: true,
-      // Derived from decoded history events, so a completed decode makes this stale. Restores what
-      // `clearDependedSection` did before it was deleted.
-      staleAfter: [{ kind: ActivityKind.TX_DECODING }],
-      run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
-        await runTask<LiquityStakingDetails>(
-          async () => fetchLiquityStaking(),
-        ),
-        (result) => {
-          set(staking, LiquityStakingDetails.parse(result));
-        },
-      ),
-      subtitle: activityLabel(ActivityKind.LIQUITY, ActivityPart.STAKING),
-      title: t('task_center.group.liquity'),
-    });
-
-    onActionableError(outcome, (error) => {
-      notifyFailure(
-        ActivityPart.STAKING,
-        error,
-        t('actions.defi.liquity_staking.error.title'),
-        t('actions.defi.liquity_staking.error.description', { message: error.message }),
-      );
-    });
-  }
-
-  async function fetchStatistics(refresh = false): Promise<void> {
-    if (!get(isPremium))
-      return;
-
-    if (!canFetch(ActivityPart.STATISTICS, refresh))
-      return;
-
-    const outcome = await submitTask({
-      id: makeActivityId(ActivityKind.LIQUITY, ActivityPart.STATISTICS),
-      kind: ActivityKind.LIQUITY,
-      rerunnable: true,
-      // Derived from decoded history events, so a completed decode makes this stale. Restores what
-      // `clearDependedSection` did before it was deleted.
-      staleAfter: [{ kind: ActivityKind.TX_DECODING }],
-      run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
-        await runTask<LiquityStatistics>(
-          async () => fetchLiquityStatistics(),
-        ),
-        (result) => {
-          set(statistics, LiquityStatistics.parse(result));
-        },
-      ),
-      subtitle: activityLabel(ActivityKind.LIQUITY, ActivityPart.STATISTICS),
-      title: t('task_center.group.liquity'),
-    });
-
-    onActionableError(outcome, (error) => {
-      notifyFailure(
-        ActivityPart.STATISTICS,
-        error,
-        t('actions.defi.liquity_statistics.error.title'),
-        t('actions.defi.liquity_statistics.error.description', { message: error.message }),
-      );
-    });
-  }
+  const fetchStatistics = createFetch({
+    errorDescription: (message: string) => t('actions.defi.liquity_statistics.error.description', { message }),
+    errorTitle: () => t('actions.defi.liquity_statistics.error.title'),
+    part: ActivityPart.STATISTICS,
+    premiumOnly: true,
+    query: async () => fetchLiquityStatistics(),
+    store: (result) => {
+      set(statistics, LiquityStatistics.parse(result));
+    },
+  });
 
   return {
     fetchBalances,

--- a/frontend/app/src/modules/staking/liquity/use-liquity-page.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-page.spec.ts
@@ -1,0 +1,191 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { Ref } from 'vue';
+import { withSetup } from '@test/utils/with-setup';
+import flushPromises from 'flush-promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LIQUITY_PRICED_ASSETS } from './liquity-assets';
+import { useLiquityPage } from './use-liquity-page';
+
+const {
+  currencySymbol,
+  fetchPools,
+  fetchPrices,
+  fetchStaking,
+  fetchStatistics,
+  moduleEnabled,
+  resetProtocolStatsPriceQueryStatus,
+} = vi.hoisted(() => {
+  // Given real refs in `beforeEach`; `vi.hoisted` runs before the imports, so nothing can be
+  // constructed here.
+  const currencySymbol: { current?: Ref<string> } = {};
+  const moduleEnabled: { current?: Ref<boolean> } = {};
+
+  return {
+    currencySymbol,
+    fetchPools: vi.fn(async (): Promise<void> => {}),
+    fetchPrices: vi.fn(async (): Promise<void> => {}),
+    fetchStaking: vi.fn(async (): Promise<void> => {}),
+    fetchStatistics: vi.fn(async (): Promise<void> => {}),
+    moduleEnabled,
+    resetProtocolStatsPriceQueryStatus: vi.fn(),
+  };
+});
+
+function required<T>(slot: { current?: T }, name: string): T {
+  if (slot.current === undefined)
+    throw new Error(`${name} was not set up`);
+
+  return slot.current;
+}
+
+vi.mock('@/modules/session/use-module-enabled', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/session/use-module-enabled')>(
+    '@/modules/session/use-module-enabled',
+  );
+  return {
+    ...actual,
+    useModuleEnabled: (): { enabled: Ref<boolean> } => ({ enabled: required(moduleEnabled, 'moduleEnabled') }),
+  };
+});
+
+vi.mock('@/modules/staking/liquity/use-liquity-data-fetching', () => ({
+  useLiquityDataFetching: (): Record<string, unknown> => ({ fetchPools, fetchStaking, fetchStatistics }),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-cache-price-store', () => ({
+  useHistoricCachePriceStore: (): Record<string, unknown> => ({ resetProtocolStatsPriceQueryStatus }),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
+  usePriceTaskManager: (): Record<string, unknown> => ({ fetchPrices }),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (): Ref<string> => required(currencySymbol, 'currencySymbol'),
+}));
+
+vi.mock('@/modules/premium/use-premium', async () => {
+  const { shallowRef } = await import('vue');
+  return { usePremium: (): Ref<boolean> => shallowRef(true) };
+});
+
+describe('modules/staking/liquity/useLiquityPage', () => {
+  // Both watchers stay live for as long as the harness does, so a leftover one would refetch
+  // during a later test.
+  const mounted: VueWrapper[] = [];
+
+  function setup(): ReturnType<typeof useLiquityPage> {
+    const { result, wrapper } = withSetup(() => useLiquityPage());
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { shallowRef } = await import('vue');
+    currencySymbol.current = shallowRef('EUR');
+    moduleEnabled.current = shallowRef(false);
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  it('should not fetch while the module is off', async () => {
+    setup();
+    await flushPromises();
+
+    expect(fetchStaking).not.toHaveBeenCalled();
+    expect(fetchPools).not.toHaveBeenCalled();
+    expect(fetchStatistics).not.toHaveBeenCalled();
+  });
+
+  it('should fetch immediately when the module is already on', async () => {
+    set(required(moduleEnabled, 'moduleEnabled'), true);
+
+    setup();
+    await flushPromises();
+
+    expect(fetchStaking).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fetch as soon as the module is switched on', async () => {
+    setup();
+    await flushPromises();
+
+    set(required(moduleEnabled, 'moduleEnabled'), true);
+    await flushPromises();
+
+    expect(fetchStaking).toHaveBeenCalledWith(false);
+    expect(fetchPools).toHaveBeenCalledWith(false);
+    expect(fetchStatistics).toHaveBeenCalledWith(false);
+  });
+
+  it('should clear the previous price progress before fetching', async () => {
+    set(required(moduleEnabled, 'moduleEnabled'), true);
+
+    setup();
+    await flushPromises();
+
+    expect(resetProtocolStatsPriceQueryStatus).toHaveBeenCalledWith('liquity');
+    expect(resetProtocolStatsPriceQueryStatus.mock.invocationCallOrder[0])
+      .toBeLessThan(fetchStaking.mock.invocationCallOrder[0]);
+  });
+
+  it('should pre-fetch a price for every liquity asset', async () => {
+    set(required(moduleEnabled, 'moduleEnabled'), true);
+
+    setup();
+    await flushPromises();
+
+    expect(fetchPrices).toHaveBeenCalledWith({
+      ignoreCache: false,
+      selectedAssets: LIQUITY_PRICED_ASSETS,
+    });
+  });
+
+  describe('when the profit currency changes', () => {
+    it('should refetch, ignoring the cache, because every value is denominated in it', async () => {
+      set(required(moduleEnabled, 'moduleEnabled'), true);
+      setup();
+      await flushPromises();
+      vi.clearAllMocks();
+
+      set(required(currencySymbol, 'currencySymbol'), 'USD');
+      await flushPromises();
+
+      expect(fetchStaking).toHaveBeenCalledWith(true);
+      expect(fetchPrices).toHaveBeenCalledWith({ ignoreCache: true, selectedAssets: LIQUITY_PRICED_ASSETS });
+    });
+
+    it('should not refetch while the module is off', async () => {
+      setup();
+      await flushPromises();
+
+      set(required(currencySymbol, 'currencySymbol'), 'USD');
+      await flushPromises();
+
+      expect(fetchStaking).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should refresh on demand, ignoring the cache', async () => {
+    set(required(moduleEnabled, 'moduleEnabled'), true);
+    const { fetch } = setup();
+    await flushPromises();
+    vi.clearAllMocks();
+
+    await fetch(true);
+
+    expect(fetchStaking).toHaveBeenCalledWith(true);
+  });
+
+  it('should expose the module state and premium status the page branches on', async () => {
+    const { moduleEnabled: enabled, premium } = setup();
+    await flushPromises();
+
+    expect(get(enabled)).toBe(false);
+    expect(get(premium)).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/use-liquity-page.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-page.ts
@@ -1,0 +1,58 @@
+import type { Ref } from 'vue';
+import { useHistoricCachePriceStore } from '@/modules/assets/prices/use-historic-cache-price-store';
+import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
+import { usePremium } from '@/modules/premium/use-premium';
+import { Module, useModuleEnabled } from '@/modules/session/use-module-enabled';
+import { useSetting } from '@/modules/settings/use-setting';
+import { LIQUITY_PRICED_ASSETS } from '@/modules/staking/liquity/liquity-assets';
+import { useLiquityDataFetching } from '@/modules/staking/liquity/use-liquity-data-fetching';
+
+/** The modules this page depends on, as the module components expect them. */
+export const LIQUITY_MODULES = [Module.LIQUITY];
+
+interface UseLiquityPageReturn {
+  fetch: (refresh?: boolean) => Promise<void>;
+  moduleEnabled: Readonly<Ref<boolean>>;
+  premium: Ref<boolean>;
+}
+
+export function useLiquityPage(): UseLiquityPageReturn {
+  const { enabled: moduleEnabled } = useModuleEnabled(Module.LIQUITY);
+  const { fetchPools, fetchStaking, fetchStatistics } = useLiquityDataFetching();
+  const { resetProtocolStatsPriceQueryStatus } = useHistoricCachePriceStore();
+  const { fetchPrices } = usePriceTaskManager();
+  const currencySymbol = useSetting('currencySymbol');
+  const premium = usePremium();
+
+  async function fetch(refresh = false): Promise<void> {
+    // The previous run's per-asset progress would otherwise be read as this run's.
+    resetProtocolStatsPriceQueryStatus('liquity');
+
+    await Promise.all([
+      fetchStaking(refresh),
+      fetchPools(refresh),
+      fetchStatistics(refresh),
+      fetchPrices({
+        ignoreCache: refresh,
+        selectedAssets: LIQUITY_PRICED_ASSETS,
+      }),
+    ]);
+  }
+
+  watchImmediate(moduleEnabled, async (enabled) => {
+    if (enabled)
+      await fetch();
+  });
+
+  // Every recorded value is denominated in the profit currency, so a change invalidates the cache.
+  watch(currencySymbol, async () => {
+    if (get(moduleEnabled))
+      await fetch(true);
+  });
+
+  return {
+    fetch,
+    moduleEnabled,
+    premium,
+  };
+}

--- a/frontend/app/src/modules/staking/liquity/use-liquity-staking-details.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-staking-details.spec.ts
@@ -1,0 +1,203 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComputedRef } from 'vue';
+import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import type { StatsPriceQueryData } from '@/modules/core/messaging/types';
+import type { ActivitySteps } from '@/modules/task-center/core/types';
+import {
+  bigNumberify,
+  type LiquityPoolDetails,
+  type LiquityStakingDetails,
+  type LiquityStatistics,
+} from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { withSetup } from '@test/utils/with-setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLiquityStakingDetails } from './use-liquity-staking-details';
+
+const OWNER_A = '0xaaa';
+const OWNER_B = '0xbbb';
+
+interface StoreState {
+  pools: LiquityPoolDetails;
+  staking: LiquityStakingDetails;
+  statistics: LiquityStatistics | null;
+}
+
+const { activity, isActive, priceStatus, storeState } = vi.hoisted(() => {
+  const activity: { current?: { steps?: ActivitySteps } } = {};
+  const priceStatus: { current?: StatsPriceQueryData } = {};
+  const storeState: StoreState = { pools: {}, staking: {}, statistics: null };
+
+  return { activity, isActive: { current: false }, priceStatus, storeState };
+});
+
+vi.mock('@/modules/staking/liquity/use-liquity-store', async () => {
+  const { computed } = await import('vue');
+  return {
+    useLiquityStore: (): Record<string, unknown> => ({
+      staking: computed(() => storeState.staking),
+      stakingPools: computed(() => storeState.pools),
+      statistics: computed(() => storeState.statistics),
+    }),
+  };
+});
+
+vi.mock('@/modules/task-center/use-task-center', async () => {
+  const { computed } = await import('vue');
+  return {
+    useTaskCenter: (): Record<string, unknown> => ({
+      useActivity: (): ComputedRef<unknown> => computed(() => activity.current),
+      useIsActive: (): ComputedRef<boolean> => computed(() => isActive.current),
+    }),
+  };
+});
+
+vi.mock('@/modules/assets/prices/use-historic-cache-price-store', async () => {
+  const { computed } = await import('vue');
+  return {
+    useHistoricCachePriceStore: (): Record<string, unknown> => ({
+      getProtocolStatsPriceQueryStatus: (): ComputedRef<unknown> => computed(() => priceStatus.current),
+    }),
+  };
+});
+
+vi.mock('pinia', async importOriginal => ({
+  ...(await importOriginal<typeof import('pinia')>()),
+  storeToRefs: (store: Record<string, unknown>): Record<string, unknown> => store,
+}));
+
+function account(address: string): BlockchainAccount<AddressData> {
+  return createMock<BlockchainAccount<AddressData>>({
+    chain: 'eth',
+    data: { address, type: 'address' },
+  });
+}
+
+function stakeOf(amount: number): LiquityStakingDetails[string] {
+  const balance = (asset: string, value: number): { amount: ReturnType<typeof bigNumberify>; asset: string; value: ReturnType<typeof bigNumberify> } => ({
+    amount: bigNumberify(value),
+    asset,
+    value: bigNumberify(value),
+  });
+
+  return {
+    balances: {
+      ethRewards: balance('ETH', 0),
+      lusdRewards: balance('LUSD', 0),
+      staked: balance('LQTY', amount),
+    },
+    proxies: null,
+  };
+}
+
+describe('modules/staking/liquity/useLiquityStakingDetails', () => {
+  const mounted: VueWrapper[] = [];
+
+  function setup(): ReturnType<typeof useLiquityStakingDetails> {
+    const { result, wrapper } = withSetup(() => useLiquityStakingDetails());
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    activity.current = undefined;
+    isActive.current = false;
+    priceStatus.current = undefined;
+    storeState.pools = {};
+    storeState.staking = {};
+    storeState.statistics = null;
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  it('should start with nothing selected, so every address is aggregated', () => {
+    storeState.staking = { [OWNER_A]: stakeOf(100), [OWNER_B]: stakeOf(50) };
+
+    const { aggregatedStake, modelSelectedAccounts } = setup();
+
+    expect(get(modelSelectedAccounts)).toEqual([]);
+    expect(get(aggregatedStake)?.staked.amount.toNumber()).toBe(150);
+  });
+
+  it('should narrow the aggregate to the selected account', () => {
+    storeState.staking = { [OWNER_A]: stakeOf(100), [OWNER_B]: stakeOf(50) };
+
+    const { aggregatedStake, modelSelectedAccounts } = setup();
+    set(modelSelectedAccounts, [account(OWNER_B)]);
+
+    expect(get(aggregatedStake)?.staked.amount.toNumber()).toBe(50);
+  });
+
+  it('should offer every address holding a position, staked or pooled', () => {
+    storeState.staking = { [OWNER_A]: stakeOf(100) };
+    // A plain literal, not `createMock`: the proxy answers every property, so `Object.keys` on it
+    // returns the mock's own method names rather than the addresses.
+    storeState.pools = { [OWNER_B]: { balances: null, proxies: null } };
+
+    expect(get(setup().availableAddresses)).toEqual([OWNER_A, OWNER_B]);
+  });
+
+  it('should build the history filter from the selected accounts', () => {
+    const { accountFilter, modelSelectedAccounts } = setup();
+    expect(get(accountFilter)).toEqual([]);
+
+    set(modelSelectedAccounts, [account(OWNER_A)]);
+
+    expect(get(accountFilter)).toEqual([{ address: OWNER_A, chain: 'eth' }]);
+  });
+
+  it('should report the staking activity progress', () => {
+    activity.current = { steps: { current: 3, total: 10 } };
+
+    expect(get(setup().stakingQueryStatus)).toEqual({ current: 3, total: 10 });
+  });
+
+  it('should report no progress when there is no activity', () => {
+    expect(get(setup().stakingQueryStatus)).toBeUndefined();
+  });
+
+  it('should follow the liquity staking activity for its loading state', () => {
+    isActive.current = true;
+
+    expect(get(setup().loading)).toBe(true);
+  });
+
+  it('should expose the historic price query status', () => {
+    priceStatus.current = { counterparty: 'liquity', processed: 2, total: 5 };
+
+    expect(get(setup().liquityHistoricPriceStatus)).toEqual({ counterparty: 'liquity', processed: 2, total: 5 });
+  });
+
+  it('should show the global statistics until an account is chosen', () => {
+    storeState.statistics = createMock<LiquityStatistics>({
+      byAddress: undefined,
+      globalStats: createMock<LiquityStatistics['globalStats']>({
+        totalValueGainsStaking: bigNumberify(42),
+      }),
+    });
+
+    const { aggregatedStatistic, modelSelectedAccounts } = setup();
+    expect(get(aggregatedStatistic)?.totalValueGainsStaking.toNumber()).toBe(42);
+
+    // With an account chosen and no per-address breakdown there is nothing to show.
+    set(modelSelectedAccounts, [account(OWNER_A)]);
+    expect(get(aggregatedStatistic)).toBeNull();
+  });
+
+  it('should surface no proxies until an account is chosen', () => {
+    storeState.staking = {
+      [OWNER_A]: { ...stakeOf(100), proxies: { '0xproxy': stakeOf(1).balances! } },
+    };
+
+    const { modelSelectedAccounts, proxyInformation } = setup();
+    expect(get(proxyInformation)).toBeNull();
+
+    set(modelSelectedAccounts, [account(OWNER_A)]);
+
+    expect(get(proxyInformation)).toEqual({ [OWNER_A]: ['0xproxy'] });
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/use-liquity-staking-details.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-staking-details.ts
@@ -1,0 +1,82 @@
+import type {
+  Account,
+  LiquityPoolDetailEntry,
+  LiquityStakingDetailEntry,
+  LiquityStatisticDetails,
+} from '@rotki/common';
+import type { ComputedRef, Ref } from 'vue';
+import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import { getAccountAddress } from '@/modules/accounts/account-utils';
+import { useHistoricCachePriceStore } from '@/modules/assets/prices/use-historic-cache-price-store';
+import {
+  aggregateEntries,
+  aggregateStatistics,
+  collectAvailableAddresses,
+  collectProxies,
+} from '@/modules/staking/liquity/liquity-aggregation';
+import { useLiquityStore } from '@/modules/staking/liquity/use-liquity-store';
+import { ActivityKind, ActivityPart, type ActivitySteps } from '@/modules/task-center/core/types';
+import { useTaskCenter } from '@/modules/task-center/use-task-center';
+
+interface UseLiquityStakingDetailsReturn {
+  accountFilter: ComputedRef<Account[]>;
+  aggregatedStake: ComputedRef<LiquityStakingDetailEntry | null>;
+  aggregatedStakingPool: ComputedRef<LiquityPoolDetailEntry | null>;
+  aggregatedStatistic: ComputedRef<LiquityStatisticDetails | null>;
+  availableAddresses: ComputedRef<string[]>;
+  liquityHistoricPriceStatus: ReturnType<ReturnType<typeof useHistoricCachePriceStore>['getProtocolStatsPriceQueryStatus']>;
+  loading: ComputedRef<boolean>;
+  modelSelectedAccounts: Ref<BlockchainAccount<AddressData>[]>;
+  proxyInformation: ComputedRef<Record<string, string[]> | null>;
+  stakingQueryStatus: ComputedRef<ActivitySteps | undefined>;
+}
+
+export function useLiquityStakingDetails(): UseLiquityStakingDetailsReturn {
+  const { staking, stakingPools, statistics } = storeToRefs(useLiquityStore());
+  const { useActivity, useIsActive } = useTaskCenter();
+  const { getProtocolStatsPriceQueryStatus } = useHistoricCachePriceStore();
+
+  const modelSelectedAccounts = ref<BlockchainAccount<AddressData>[]>([]);
+
+  const stakingActivity = useActivity(ActivityKind.LIQUITY, ActivityPart.STAKING);
+  const stakingQueryStatus = computed<ActivitySteps | undefined>(() => get(stakingActivity)?.steps);
+  const liquityHistoricPriceStatus = getProtocolStatsPriceQueryStatus('liquity');
+  const loading = useIsActive(ActivityKind.LIQUITY, ActivityPart.STAKING);
+
+  const selectedAddresses = computed<string[]>(() =>
+    get(modelSelectedAccounts).map(account => getAccountAddress(account)));
+
+  const accountFilter = computed<Account[]>(() =>
+    get(modelSelectedAccounts).map(account => ({
+      address: getAccountAddress(account),
+      chain: account.chain,
+    })));
+
+  const aggregatedStake = computed<LiquityStakingDetailEntry | null>(() =>
+    aggregateEntries(get(staking), get(selectedAddresses)));
+
+  const aggregatedStakingPool = computed<LiquityPoolDetailEntry | null>(() =>
+    aggregateEntries(get(stakingPools), get(selectedAddresses)));
+
+  const proxyInformation = computed<Record<string, string[]> | null>(() =>
+    collectProxies(get(staking), get(stakingPools), get(selectedAddresses)));
+
+  const aggregatedStatistic = computed<LiquityStatisticDetails | null>(() =>
+    aggregateStatistics(get(statistics), get(selectedAddresses)));
+
+  const availableAddresses = computed<string[]>(() =>
+    collectAvailableAddresses(get(staking), get(stakingPools)));
+
+  return {
+    accountFilter,
+    aggregatedStake,
+    aggregatedStakingPool,
+    aggregatedStatistic,
+    availableAddresses,
+    liquityHistoricPriceStatus,
+    loading,
+    modelSelectedAccounts,
+    proxyInformation,
+    stakingQueryStatus,
+  };
+}

--- a/frontend/app/src/modules/staking/liquity/use-liquity-statistics.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-statistics.spec.ts
@@ -1,0 +1,160 @@
+import type { VueWrapper } from '@vue/test-utils';
+import type { ComputedRef } from 'vue';
+import {
+  type BigNumber,
+  bigNumberify,
+  type LiquityPoolDetailEntry,
+  type LiquityStatisticDetails,
+} from '@rotki/common';
+import { withSetup } from '@test/utils/with-setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LUSD_ID } from './liquity-assets';
+import { StatisticView } from './liquity-statistics';
+import { useLiquityStatistics } from './use-liquity-statistics';
+
+const { isActive, prices } = vi.hoisted(() => {
+  const prices: { current: Record<string, number> } = { current: {} };
+  return { isActive: { current: false }, prices };
+});
+
+vi.mock('@/modules/assets/prices/use-price-utils', async () => {
+  const { computed } = await import('vue');
+  const { bigNumberify: toBigNumber } = await import('@rotki/common');
+  const priceOf = (asset: string): BigNumber | undefined =>
+    asset in prices.current ? toBigNumber(prices.current[asset]) : undefined;
+
+  return {
+    usePriceUtils: (): Record<string, unknown> => ({
+      getAssetPrice: priceOf,
+      useAssetPrice: (asset: string): ComputedRef<BigNumber | undefined> => computed(() => priceOf(asset)),
+    }),
+  };
+});
+
+vi.mock('@/modules/task-center/use-task-center', async () => {
+  const { computed } = await import('vue');
+  return {
+    useTaskCenter: (): Record<string, unknown> => ({
+      useIsActive: (): ComputedRef<boolean> => computed(() => isActive.current),
+    }),
+  };
+});
+
+function assetBalance(asset: string, amount: number, value = amount): { amount: BigNumber; asset: string; value: BigNumber } {
+  return { amount: bigNumberify(amount), asset, value: bigNumberify(value) };
+}
+
+function statistic(overrides: Partial<LiquityStatisticDetails> = {}): LiquityStatisticDetails {
+  return {
+    stabilityPoolGains: [],
+    stakingGains: [],
+    totalDepositedStabilityPool: bigNumberify(1000),
+    totalDepositedStabilityPoolValue: bigNumberify(1000),
+    totalValueGainsStabilityPool: bigNumberify(0),
+    totalValueGainsStaking: bigNumberify(0),
+    totalWithdrawnStabilityPool: bigNumberify(400),
+    totalWithdrawnStabilityPoolValue: bigNumberify(400),
+    ...overrides,
+  };
+}
+
+describe('modules/staking/liquity/useLiquityStatistics', () => {
+  const mounted: VueWrapper[] = [];
+
+  function setup(
+    statisticValue: LiquityStatisticDetails | null,
+    poolValue: LiquityPoolDetailEntry | null = null,
+  ): ReturnType<typeof useLiquityStatistics> {
+    const { result, wrapper } = withSetup(() => useLiquityStatistics({
+      pool: () => poolValue,
+      statistic: () => statisticValue,
+    }));
+    mounted.push(wrapper);
+    return result;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isActive.current = false;
+    prices.current = {};
+  });
+
+  afterEach(() => {
+    while (mounted.length > 0)
+      mounted.pop()?.unmount();
+  });
+
+  it('should start on the historical view', () => {
+    expect(get(setup(statistic()).modelSelection)).toBe(StatisticView.HISTORICAL);
+  });
+
+  it('should be null throughout when there are no statistics', () => {
+    const { statisticWithAdjustedPrice, totalDepositedStabilityPoolBalance, totalWithdrawnStabilityPoolBalance } = setup(null);
+
+    expect(get(statisticWithAdjustedPrice)).toBeNull();
+    expect(get(totalDepositedStabilityPoolBalance)).toBeNull();
+    expect(get(totalWithdrawnStabilityPoolBalance)).toBeNull();
+  });
+
+  it('should re-value on switching to the current view', () => {
+    prices.current = { ETH: 3000 };
+    const { modelSelection, statisticWithAdjustedPrice } = setup(statistic({
+      stabilityPoolGains: [assetBalance('ETH', 2, 100)],
+    }));
+
+    expect(get(statisticWithAdjustedPrice)?.stabilityPoolGains[0].value.toNumber()).toBe(100);
+
+    set(modelSelection, StatisticView.CURRENT);
+
+    expect(get(statisticWithAdjustedPrice)?.stabilityPoolGains[0].value.toNumber()).toBe(6000);
+  });
+
+  it('should price the LUSD totals with the LUSD price on the current view', () => {
+    prices.current = { [LUSD_ID]: 2 };
+    const { modelSelection, totalDepositedStabilityPoolBalance } = setup(statistic());
+
+    set(modelSelection, StatisticView.CURRENT);
+
+    expect(get(totalDepositedStabilityPoolBalance)?.value.toNumber()).toBe(2000);
+  });
+
+  it('should fall back to a LUSD price of one when there is none', () => {
+    const { modelSelection, totalDepositedStabilityPoolBalance } = setup(statistic());
+
+    set(modelSelection, StatisticView.CURRENT);
+
+    expect(get(totalDepositedStabilityPoolBalance)?.value.toNumber()).toBe(1000);
+  });
+
+  it('should pair each total with its own amount', () => {
+    const { totalDepositedStabilityPoolBalance, totalWithdrawnStabilityPoolBalance } = setup(statistic());
+
+    expect(get(totalDepositedStabilityPoolBalance)?.amount.toNumber()).toBe(1000);
+    expect(get(totalWithdrawnStabilityPoolBalance)?.amount.toNumber()).toBe(400);
+  });
+
+  describe('the profit and loss', () => {
+    it('should be null without a pool, which is what it is measured against', () => {
+      expect(get(setup(statistic()).totalPnl)).toBeNull();
+    });
+
+    it('should be null without statistics', () => {
+      expect(get(setup(null, { deposited: assetBalance('LUSD', 600), gains: assetBalance('ETH', 0), rewards: assetBalance('LQTY', 0) }).totalPnl)).toBeNull();
+    });
+
+    it('should be computed once both are present', () => {
+      const { totalPnl } = setup(
+        statistic({ totalValueGainsStabilityPool: bigNumberify(50) }),
+        { deposited: assetBalance('LUSD', 600), gains: assetBalance('ETH', 0), rewards: assetBalance('LQTY', 0) },
+      );
+
+      expect(get(totalPnl)?.toNumber()).toBe(50);
+    });
+  });
+
+  it('should follow the statistics activity for its loading state', () => {
+    isActive.current = true;
+
+    expect(get(setup(statistic()).loading)).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/staking/liquity/use-liquity-statistics.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-statistics.ts
@@ -1,0 +1,83 @@
+import type { Balance, BigNumber, LiquityPoolDetailEntry, LiquityStatisticDetails } from '@rotki/common';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
+import { LUSD_ID } from '@/modules/staking/liquity/liquity-assets';
+import {
+  calculatePnl,
+  orOne,
+  repriceStatistic,
+  StatisticView,
+} from '@/modules/staking/liquity/liquity-statistics';
+import { ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
+import { useTaskCenter } from '@/modules/task-center/use-task-center';
+
+interface UseLiquityStatisticsOptions {
+  /** The aggregated stability pool position, which profit and loss is measured against. */
+  pool: MaybeRefOrGetter<LiquityPoolDetailEntry | null>;
+  /** The recorded statistics to display, as the backend returned them. */
+  statistic: MaybeRefOrGetter<LiquityStatisticDetails | null>;
+}
+
+interface UseLiquityStatisticsReturn {
+  loading: ComputedRef<boolean>;
+  modelSelection: Ref<StatisticView>;
+  statisticWithAdjustedPrice: ComputedRef<LiquityStatisticDetails | null>;
+  totalDepositedStabilityPoolBalance: ComputedRef<Balance | null>;
+  totalPnl: ComputedRef<BigNumber | null>;
+  totalWithdrawnStabilityPoolBalance: ComputedRef<Balance | null>;
+}
+
+export function useLiquityStatistics(options: UseLiquityStatisticsOptions): UseLiquityStatisticsReturn {
+  const { pool, statistic } = options;
+
+  const { getAssetPrice, useAssetPrice } = usePriceUtils();
+  const { useIsActive } = useTaskCenter();
+
+  const modelSelection = shallowRef<StatisticView>(StatisticView.HISTORICAL);
+  const loading = useIsActive(ActivityKind.LIQUITY, ActivityPart.STATISTICS);
+
+  const lusdPrice = useAssetPrice(LUSD_ID);
+  const lusdPriceOrOne = computed<BigNumber>(() => orOne(get(lusdPrice)));
+
+  const statisticWithAdjustedPrice = computed<LiquityStatisticDetails | null>(() => {
+    const current = toValue(statistic);
+    if (!current)
+      return null;
+
+    return repriceStatistic(current, get(modelSelection), getAssetPrice, get(lusdPriceOrOne));
+  });
+
+  const totalDepositedStabilityPoolBalance = computed<Balance | null>(() => {
+    const data = get(statisticWithAdjustedPrice);
+    if (!data)
+      return null;
+
+    return { amount: data.totalDepositedStabilityPool, value: data.totalDepositedStabilityPoolValue };
+  });
+
+  const totalWithdrawnStabilityPoolBalance = computed<Balance | null>(() => {
+    const data = get(statisticWithAdjustedPrice);
+    if (!data)
+      return null;
+
+    return { amount: data.totalWithdrawnStabilityPool, value: data.totalWithdrawnStabilityPoolValue };
+  });
+
+  const totalPnl = computed<BigNumber | null>(() => {
+    const currentStatistic = toValue(statistic);
+    const currentPool = toValue(pool);
+    if (!currentStatistic || !currentPool)
+      return null;
+
+    return calculatePnl(currentStatistic, currentPool, getAssetPrice, get(lusdPriceOrOne));
+  });
+
+  return {
+    loading,
+    modelSelection,
+    statisticWithAdjustedPrice,
+    totalDepositedStabilityPoolBalance,
+    totalPnl,
+    totalWithdrawnStabilityPoolBalance,
+  };
+}


### PR DESCRIPTION
Closes #13002. Batch D of #12964, following batch C (#13000).

One module taken whole, `modules/staking/liquity/`. **285 uncovered statements down to 26**, 157 tests in the module. One commit.

## Coverage

| File | Before | After |
|---|---|---|
| `LiquityStakingDetails.vue` | 125 uncovered, 0% | 2, 88% |
| `LiquityStatistics.vue` | 73, 0% | 4, 85% |
| `LiquityPage.vue` | 21, 0% | **0, 100%** |
| `use-liquity-data-fetching.ts` | 20, 61% | 11, 74% |
| `LiquityPools.vue` / `LiquityStake.vue` | 12, 0% / 10, 0% | **0, 100%** each |
| `LiquityProxyInformation.vue` | 11, 0% | 2, 82% |
| `LiquityStakingPagePlaceholder.vue` | 6, 0% | **0, 100%** |
| new: `liquity-aggregation.ts` | — | **100%** |
| new: `liquity-statistics.ts` | — | **100%** |
| new: `use-liquity-statistics.ts` / `use-liquity-page.ts` | — | **100%** each |
| new: `use-liquity-staking-details.ts` | — | 96% |

## The near-twin question

Same shape as batch B's `Match*Pinned`, and the answer was yes: `aggregatedStake` and `aggregatedStakingPool` were the same algorithm written twice. A `LiquityStakingDetail` and a `LiquityPoolDetail` are structurally identical (`{ balances: T | null, proxies: Record<string, T> | null }`), so both now call one generic `aggregateEntries`.

## Improvements taken alongside the extraction

- **`use-liquity-data-fetching.ts`: four near-identical fetchers collapsed into one.** They differed in five values and shared ~150 lines of task plumbing, guards and error handling. Now a `createFetch` over a small definition. The premium guard that staking, pools and statistics carry, and that balances deliberately does not, was previously **untested**; it is now covered in both directions.
- **`liquity-assets.ts`** gives the LUSD and LQTY identifiers one home. `LUSD_ID` had been declared separately in two components.
- **The view toggle is an `as const` object** (`StatisticView`) rather than a bare `'historical' | 'current'` union, per the repo convention for new types. The existing `KrakenStakingEventType` enum is left alone: that file is not part of this batch.
- `calculatePnl` returned a `ComputedRef` that its only caller immediately unwrapped inside another `computed`. It is a plain function now.

## Two things the tests corrected

Both were mistakes in what I wrote, caught by running the specs rather than by reading:

- I documented re-pricing as valuing an **unpriced** gain at zero. It does not: the price defaults to `1`, so an unpriced gain keeps its amount as its value, and only an **explicit zero** price collapses it. The comment and the test now say so, and both cases are covered separately. An unknown price is not a claim that an asset is worthless.
- A per-iteration defensive copy in the aggregation reduce was redundant. Removing it left every test green, which was the finding: the first entry is already copied and every later field is reassigned rather than mutated, so one copy is enough. I confirmed the test still pins the copy that matters before keeping the simpler loop.

## Deliberately not covered

`LiquityPnlRow.vue` (6 statements) has no branch at all: it is a label, a tooltip and a value passed straight through. A mount-only test would move the coverage number without proving anything, which the issue rules out. The residual 11 in `use-liquity-data-fetching.ts` are the per-fetch query and store callbacks, which the shared task harness short-circuits by design.

## Testing notes

Every behavioural claim was negative-controlled: the guard was broken, the named test watched go red, then restored. That covered the address filter, proxy inclusion, the defensive copy, the historical/current gate, the PnL sign, both module gates on the page, and the premium asymmetry.

Two traps worth recording for batch E:

- **A collapsed `RuiAccordion` renders none of its contents**, so the statistics detail rows need a pass-through stub, exactly like a teleporting dialog.
- **`useBreakpoint` is auto-imported from `@rotki/ui-library`**, not from the app, so a responsive branch is mocked at that module.

Full suite green: 966 files, 10094 tests. All 7 `rwt check` gates pass.