### PR TITLE
feat: resolve untracked exchange transfers

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6859,7 +6859,7 @@ Match exchange asset movements with onchain events
 
 .. http:put:: /api/(version)/history/events/match/asset_movements
 
-   Matches exchange asset movement events with corresponding events, or mark the asset movement as having no corresponding event.
+   Matches exchange asset movement events with corresponding events, resolves an asset movement as moving to/from an untracked address, or mark the asset movement as having no corresponding event. Resolving as external turns a withdrawal into a payment (spend/payment) and a deposit into income (receive/payment), so the whole amount is accounted instead of only the movement's fee. The event stops being an asset movement and becomes a plain history event keeping its identifier, group and location, and the original direction is recorded in the event extra data. The group's fee is rewritten alongside it as a plain spend/fee, so the group does not end up half asset movement and half history event; both rules carry the same treatment, so the fee is accounted as before. Unlinking restores the original asset movement and its fee.
 
    .. note::
       This endpoint is only available for premium users
@@ -6879,6 +6879,7 @@ Match exchange asset movements with onchain events
 
    :reqjson int asset_movement: DB identifier of the asset movement to match
    :reqjson list[int][optional] matched_events: List of DB identifiers of events to match with the asset movement. The asset movement is marked as having no match if this parameter is omitted or an empty list.
+   :reqjson bool[optional] external: When true (and matched_events is empty) the asset movement is resolved as moving to/from an untracked address: a withdrawal becomes a payment (spend/payment) and a deposit becomes income (receive/payment), and the group's fee becomes a plain spend/fee. False by default.
 
    **Example Response**:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`6206` A deposit or withdrawal on an exchange whose counterpart is not tracked can now be marked as income or payment.
 * :feature:`9110` Sonic is now a fully supported EVM chain. Transactions and balances can be tracked on it.
 * :release:`1.44.0 <2026-08-21>`
 * :feature:`12171` rotki now includes a local Model Context Protocol server that lets compatible AI assistants run read only analysis over your history events and balances, look up asset details and cached historical prices, and use rotki's event taxonomy.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -1270,6 +1270,8 @@
     },
     "dialog": {
       "confirm_ignore": "Ignore this movement?",
+      "confirm_mark_external": "Resolve as an external payment?",
+      "confirm_mark_external_in": "Resolve as external income?",
       "confirm_match": "Confirm Match",
       "description": "Select an unmatched asset movement and find matching blockchain transactions to link them together.",
       "empty": {
@@ -1284,14 +1286,20 @@
       "ignore_tooltip": "Mark this asset movement as having no corresponding event.",
       "ignored_description": "These asset movements have been marked as having no corresponding event. Restore them to retry matching.",
       "manual_action": "Manual Action",
+      "mark_external": "Mark external",
+      "mark_external_in_tooltip": "Resolve this deposit as income from an untracked source, so its whole amount is accounted and not just the fee.",
+      "mark_external_tooltip": "Resolve this withdrawal as a payment to an untracked address, so its whole amount is accounted and not just the fee.",
       "matching_for": "Finding matches for the following asset movement.",
       "matching_hint": "You can select one or more events to link.",
       "no_ignored": "No ignored asset movements.",
+      "no_match_untracked_destination": "No matches can be found: the destination address {address} is not tracked by rotki, so no corresponding event can exist in your history. Mark this withdrawal as a payment instead.",
       "no_matches_found": "No potential matches found. Try adjusting the time range.",
       "no_unmatched": "All asset movements have been matched.",
       "only_expected_assets": "Only show \nsame assets",
       "only_expected_assets_hint": "When enabled, only show events that are from or to addresses that belong to your tracked accounts, with matching amounts and timestamps.",
       "recommended": "Recommended",
+      "resolved_income": "Resolved as income",
+      "resolved_payment": "Resolved as payment",
       "restore": "Restore",
       "restore_tooltip": "Restore this asset movement to the unmatched list.",
       "search_description": "Search for events within the specified criteria:",
@@ -1304,7 +1312,10 @@
       "time_range_short": "Range (h)",
       "title": "Match Asset Movements",
       "tolerance_short": "Tolerance (%)",
-      "transaction_column": "Transaction"
+      "transaction_column": "Transaction",
+      "untracked_destination": "Destination not tracked",
+      "untracked_destination_tooltip": "The destination address {address} is not tracked by rotki, so no corresponding event can exist in your history. Resolve this withdrawal by marking it as a payment.",
+      "untracked_reason": "{label}: no match can exist"
     },
     "fiat_hint": {
       "label": "Fiat",
@@ -1314,6 +1325,10 @@
       "free_tooltip": "Asset movement matching requires a minimum of {tier} tier. {link} to unlock this feature.",
       "link": "Upgrade",
       "premium_tooltip": "Asset movement matching requires a minimum of {tier} tier. Your current tier is {currentTier}. {link} to unlock it."
+    },
+    "resolved": {
+      "external_deposit": "Deposit resolved as income from an untracked source.",
+      "external_withdrawal": "Withdrawal resolved as a payment to an untracked address."
     },
     "settings": {
       "amount_tolerance": {
@@ -1880,7 +1895,7 @@
       "ignore_tooltip": "Mark this bridge transaction as having no corresponding event.",
       "ignored_description": "These bridge transactions have been marked as having no corresponding event. Restore them to retry matching.",
       "manual_action": "Manual Action",
-      "mark_external": "External",
+      "mark_external": "Mark external",
       "mark_external_in_tooltip": "Resolve this bridge withdrawal as income from an external (untracked) source.",
       "mark_external_tooltip": "Resolve this bridge deposit as a payment to an external (untracked) address.",
       "matching_for_in": "Finding the counterpart for this bridge in.",

--- a/frontend/app/src/modules/history/api/events/use-asset-movement-matching-api.ts
+++ b/frontend/app/src/modules/history/api/events/use-asset-movement-matching-api.ts
@@ -11,7 +11,7 @@ interface AssetMovementMatchSuggestions {
 interface UseAssetMovementMatchingApiReturn {
   getUnmatchedAssetMovements: (onlyIgnored?: boolean) => Promise<string[]>;
   getAssetMovementMatches: (assetMovement: string, timeRange: number, onlyExpectedAssets: boolean, tolerance: string) => Promise<AssetMovementMatchSuggestions>;
-  matchAssetMovements: (assetMovement: number, matchedEvents?: number[]) => Promise<boolean>;
+  matchAssetMovements: (assetMovement: number, matchedEvents?: number[], external?: boolean) => Promise<boolean>;
   unlinkAssetMovement: (identifier: number) => Promise<boolean>;
   triggerAssetMovementMatching: () => Promise<PendingTask>;
 }
@@ -32,9 +32,24 @@ export function useAssetMovementMatchingApi(): UseAssetMovementMatchingApiReturn
       tolerance,
     });
 
-  const matchAssetMovements = async (assetMovement: number, matchedEvents?: number[]): Promise<boolean> =>
+  /**
+   * Resolves an asset movement, either by linking it to events or by declaring it unmatchable.
+   *
+   * @remarks
+   * Without matched events the movement is marked as having no match, unless `external` is set,
+   * which resolves it as moving to or from an untracked address instead: a withdrawal becomes a
+   * payment and a deposit becomes income.
+   *
+   * @param assetMovement - identifier of the movement's own event
+   * @param matchedEvents - identifiers of the events to link; an empty or absent list resolves the
+   * movement without a counterpart
+   * @param external - resolve the movement as external rather than as having no match
+   * @returns whether the backend accepted the resolution
+   */
+  const matchAssetMovements = async (assetMovement: number, matchedEvents?: number[], external = false): Promise<boolean> =>
     api.put<boolean>('/history/events/match/asset_movements', {
       assetMovement,
+      ...(external && { external }),
       ...(matchedEvents && matchedEvents.length > 0 && { matchedEvents }),
     });
 

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
@@ -3,6 +3,7 @@ import { startPromise } from '@shared/utils';
 import AssetMovementMatchingSettingsMenu from '@/modules/history/events/AssetMovementMatchingSettingsMenu.vue';
 import { UNMATCHED_ACTIONS, type UnmatchedActionPayload } from '@/modules/history/events/unmatched-actions';
 import UnmatchedMovementsList from '@/modules/history/events/UnmatchedMovementsList.vue';
+import UnmatchedResolutionStrip from '@/modules/history/events/UnmatchedResolutionStrip.vue';
 import { useAssetMovementActions } from '@/modules/history/events/use-asset-movement-actions';
 import { type UnmatchedAssetMovement, useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
 
@@ -39,12 +40,16 @@ const {
   confirmIgnoreAllFiat,
   confirmIgnoreSelected,
   confirmRestoreSelected,
+  dismissResolution,
   fiatMovements,
   ignoreLoading,
   ignoreMovement,
+  markExternal,
   restoreMovement,
   modelSelectedIgnored,
   modelSelectedUnmatched,
+  resolutionNotice,
+  undoResolution,
 } = useAssetMovementActions({ onActionComplete });
 
 const buttonSize = computed<'sm' | 'lg'>(() => isPinned ? 'sm' : 'lg');
@@ -63,9 +68,10 @@ function handleAction({ action, item }: UnmatchedActionPayload<UnmatchedAssetMov
     case UNMATCHED_ACTIONS.SHOW_IN_EVENTS:
       emit('show-in-events', item);
       break;
-    // movements have no counterpart to create or mark external
-    case UNMATCHED_ACTIONS.CREATE_COUNTERPART:
     case UNMATCHED_ACTIONS.MARK_EXTERNAL:
+      startPromise(markExternal(item));
+      break;
+    case UNMATCHED_ACTIONS.CREATE_COUNTERPART:
       break;
   }
 }
@@ -104,6 +110,16 @@ onBeforeMount(async () => {
       </RuiChip>
     </RuiTab>
   </RuiTabs>
+
+  <UnmatchedResolutionStrip
+    v-if="resolutionNotice"
+    :message="resolutionNotice.message"
+    :loading="ignoreLoading"
+    class="shrink-0"
+    :class="isPinned ? 'mx-3 mt-3' : 'mt-4'"
+    @undo="startPromise(undoResolution())"
+    @dismiss="dismissResolution()"
+  />
 
   <!-- Pinned bypasses RuiTabItems: it sizes itself from its content and hides the overflow, so
        in a bounded column the bottom of the panel - the pager - is silently cut off. Rendering

--- a/frontend/app/src/modules/history/events/PotentialMatchesDialog.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
 import PotentialMatchesContent from '@/modules/history/events/PotentialMatchesContent.vue';
+import { useMovementUnmatchableExplanation } from '@/modules/history/events/use-untracked-movement-destination';
 import { PinnedNames } from '@/modules/session/types';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 import { usePinnedPanel } from '@/modules/shell/pinned/use-pinned-panel';
@@ -18,6 +19,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 const { pin } = usePinnedPanel(PinnedNames.MATCH_ASSET_MOVEMENTS);
+const { unmatchableExplanation: emptyExplanation } = useMovementUnmatchableExplanation(() => movement);
 
 function closeDialog(): void {
   set(modelValue, false);
@@ -68,6 +70,7 @@ function showPotentialMatchInEvents(data: { identifier: number; groupIdentifier:
 
       <PotentialMatchesContent
         :movement="movement"
+        :empty-explanation="emptyExplanation"
         @close="closeDialog()"
         @matched="onMatched()"
         @show-in-events="showPotentialMatchInEvents($event)"

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsCards.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsCards.vue
@@ -8,6 +8,7 @@ import UnmatchedActions from '@/modules/history/events/UnmatchedActions.vue';
 import UnmatchedCardList from '@/modules/history/events/UnmatchedCardList.vue';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
+import HashLink from '@/modules/shell/components/HashLink.vue';
 
 // The pinned presentation of unmatched movements. Layout only - see UnmatchedMovementsList.
 const selected = defineModel<string[]>('selected', { required: true });
@@ -38,6 +39,7 @@ const { t } = useI18n({ useScope: 'global' });
     :items="rows"
     :row-key="(row: UnmatchedMovementRow) => row.groupIdentifier"
     :highlighted="(row: UnmatchedMovementRow) => row.groupIdentifier === highlightedGroupIdentifier"
+    :accented="(row: UnmatchedMovementRow) => row.untrackedDestination"
     :empty-description="emptyDescription"
     :loading="loading"
   >
@@ -53,6 +55,15 @@ const { t } = useI18n({ useScope: 'global' });
         <BadgeDisplay class="!normal-case">
           {{ item.typeLabel }}
         </BadgeDisplay>
+        <RuiChip
+          v-if="item.resolvedAsExternal"
+          size="sm"
+          color="info"
+          class="!py-0"
+          data-testid="unmatched-row-resolved"
+        >
+          {{ item.resolvedLabel }}
+        </RuiChip>
         <LocationDisplay
           class="[&_div]:!justify-start [&_span]:!text-caption [&_span]:!text-rui-text-secondary"
           size="16px"
@@ -81,6 +92,36 @@ const { t } = useI18n({ useScope: 'global' });
           :timestamp="item.timestamp"
           milliseconds
         />
+      </div>
+    </template>
+
+    <template #warning="{ item }">
+      <div
+        v-if="item.untrackedDestination"
+        class="flex items-start gap-1.5 rounded px-2 py-1 text-caption bg-rui-warning/10 text-rui-warning"
+        data-testid="unmatched-card-untracked-reason"
+      >
+        <RuiIcon
+          size="14"
+          name="lu-triangle-alert"
+          class="shrink-0 mt-0.5"
+        />
+        <div class="flex flex-col items-start gap-0.5 min-w-0">
+          <i18n-t
+            scope="global"
+            keypath="asset_movement_matching.dialog.untracked_reason"
+            tag="span"
+          >
+            <template #label>
+              <strong>{{ item.untrackedLabel }}</strong>
+            </template>
+          </i18n-t>
+          <HashLink
+            v-if="item.destinationAddress"
+            class="[&_span]:!text-caption"
+            :text="item.destinationAddress"
+          />
+        </div>
       </div>
     </template>
 

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsTable.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsTable.vue
@@ -7,8 +7,10 @@ import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import HistoryEventAsset from '@/modules/history/events/HistoryEventAsset.vue';
 import { UNMATCHED_LAYOUTS, type UnmatchedActionPayload, type UnmatchedRowActionSpec } from '@/modules/history/events/unmatched-actions';
 import UnmatchedActions from '@/modules/history/events/UnmatchedActions.vue';
+import UnmatchedUntrackedBadge from '@/modules/history/events/UnmatchedUntrackedBadge.vue';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
+import HashLink from '@/modules/shell/components/HashLink.vue';
 
 // The dialog presentation of unmatched movements. Layout only - see UnmatchedMovementsList.
 const selected = defineModel<string[]>('selected', { required: true });
@@ -115,9 +117,31 @@ function getRowClass(row: UnmatchedMovementRow): string {
         </div>
       </template>
       <template #item.eventSubtype="{ row }">
-        <BadgeDisplay>
-          {{ row.typeLabel }}
-        </BadgeDisplay>
+        <div class="flex flex-col items-start gap-1">
+          <BadgeDisplay>
+            {{ row.typeLabel }}
+          </BadgeDisplay>
+          <template v-if="row.untrackedDestination">
+            <UnmatchedUntrackedBadge
+              :label="row.untrackedLabel"
+              :tooltip="row.untrackedTooltip"
+            />
+            <HashLink
+              v-if="row.destinationAddress"
+              class="[&_span]:!text-caption"
+              :text="row.destinationAddress"
+            />
+          </template>
+          <RuiChip
+            v-if="row.resolvedAsExternal"
+            size="sm"
+            color="info"
+            class="!py-0"
+            data-testid="unmatched-row-resolved"
+          >
+            {{ row.resolvedLabel }}
+          </RuiChip>
+        </div>
       </template>
       <template #item.location="{ row }">
         <LocationDisplay

--- a/frontend/app/src/modules/history/events/UnmatchedUntrackedBadge.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedUntrackedBadge.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-// Marks a bridge leg whose counterpart address rotki does not track, so no counterpart event
-// can ever be decoded for it. The wording arrives from the row - see use-unmatched-bridge-rows.
 defineProps<{
   label: string;
   tooltip: string;
@@ -14,19 +12,17 @@ defineProps<{
     tooltip-class="max-w-80"
   >
     <template #activator>
-      <RuiChip
-        size="sm"
-        color="warning"
-        class="!py-0"
+      <span
+        class="inline-flex items-center gap-1 whitespace-nowrap rounded px-1.5 py-0.5 text-caption bg-rui-warning/10 text-rui-warning"
+        data-testid="unmatched-untracked-badge"
       >
-        <span class="flex items-center gap-1">
-          <RuiIcon
-            size="14"
-            name="lu-triangle-alert"
-          />
-          {{ label }}
-        </span>
-      </RuiChip>
+        <RuiIcon
+          class="shrink-0"
+          size="14"
+          name="lu-triangle-alert"
+        />
+        {{ label }}
+      </span>
     </template>
     {{ tooltip }}
   </RuiTooltip>

--- a/frontend/app/src/modules/history/events/asset-movement-resolution.ts
+++ b/frontend/app/src/modules/history/events/asset-movement-resolution.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+/**
+ * How an unmatched asset movement was resolved, stamped by the backend on the event it rewrote.
+ *
+ * @remarks
+ * The same `matchedAssetMovement` key also carries ordinary match metadata (the counterpart's group
+ * and exchange), which shares none of these fields - hence a resolution is recognised by
+ * `resolution`, not by the key's presence.
+ */
+export const MatchedAssetMovementResolution = z.object({
+  direction: z.enum(['deposit', 'withdrawal']).nullish(),
+  resolution: z.literal('external').nullish(),
+});

--- a/frontend/app/src/modules/history/events/schemas.ts
+++ b/frontend/app/src/modules/history/events/schemas.ts
@@ -1,6 +1,7 @@
 import { type BigNumber, HistoryEventEntryType, NumericString } from '@rotki/common';
 import { z } from 'zod';
 import { CollectionCommonFields } from '@/modules/core/common/collection';
+import { MatchedAssetMovementResolution } from '@/modules/history/events/asset-movement-resolution';
 import { EntryMeta } from '@/modules/history/meta';
 
 const CommonHistoryEvent = z.object({
@@ -31,6 +32,10 @@ export type EvmHistoryEvent = z.infer<typeof EvmHistoryEvent>;
 
 export const OnlineHistoryEvent = CommonHistoryEvent.extend({
   entryType: z.literal(HistoryEventEntryType.HISTORY_EVENT),
+  /** Declared so the resolution stamp survives parsing: zod strips what a schema does not name. */
+  extraData: z.object({
+    matchedAssetMovement: MatchedAssetMovementResolution.nullish(),
+  }).nullish(),
   txRef: z.string().optional(),
 });
 

--- a/frontend/app/src/modules/history/events/use-asset-movement-actions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-asset-movement-actions.spec.ts
@@ -7,6 +7,7 @@ const { spies } = vi.hoisted(() => ({
     matchAssetMovements: vi.fn<(id: number) => Promise<boolean>>().mockResolvedValue(true),
     unlinkAssetMovement: vi.fn<(id: number) => Promise<boolean>>().mockResolvedValue(true),
     refreshUnmatchedAssetMovements: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    resolveExternal: vi.fn<(id: number) => Promise<{ message: string; success: boolean }>>().mockResolvedValue({ message: '', success: true }),
     showConfirm: vi.fn(),
   },
 }));
@@ -26,6 +27,7 @@ vi.mock('@/modules/history/events/use-unmatched-asset-movements', () => ({
     unmatchedMovements: computed<UnmatchedAssetMovement[]>(() => get(unmatchedMovementsRef)),
     ignoredMovements: computed<UnmatchedAssetMovement[]>(() => get(ignoredMovementsRef)),
     refreshUnmatchedAssetMovements: spies.refreshUnmatchedAssetMovements,
+    resolveExternal: spies.resolveExternal,
   }),
 }));
 
@@ -44,11 +46,12 @@ function createMockMovement(overrides: {
   identifier?: number;
   asset?: string;
   isFiat?: boolean;
+  eventSubtype?: string;
 } = {}): UnmatchedAssetMovement {
   return {
     groupIdentifier: overrides.groupIdentifier ?? 'group1',
-    // @ts-expect-error partial mock for testing - only identifier is needed
-    events: { entry: { identifier: overrides.identifier ?? 1 } },
+    // @ts-expect-error partial mock for testing - only identifier and subtype are read
+    events: { entry: { identifier: overrides.identifier ?? 1, eventSubtype: overrides.eventSubtype ?? 'spend' } },
     asset: overrides.asset ?? 'ETH',
     isFiat: overrides.isFiat ?? false,
   };
@@ -99,7 +102,11 @@ describe('use-asset-movement-actions', () => {
       expect(composable).toHaveProperty('confirmIgnoreSelected');
       expect(composable).toHaveProperty('confirmRestoreSelected');
       expect(composable).toHaveProperty('ignoreMovement');
+      expect(composable).toHaveProperty('markExternal');
       expect(composable).toHaveProperty('restoreMovement');
+      expect(composable).toHaveProperty('resolutionNotice');
+      expect(composable).toHaveProperty('dismissResolution');
+      expect(composable).toHaveProperty('undoResolution');
     });
 
     it('should initialize refs with default values', () => {
@@ -534,7 +541,103 @@ describe('use-asset-movement-actions', () => {
       expect(spies.refreshUnmatchedAssetMovements).toHaveBeenCalledOnce();
       expect(get(composable.modelSelectedUnmatched)).toEqual([]);
     });
+  });
 
+  describe('markExternal', () => {
+    it('should resolve the movement as external and report it with an undo', async () => {
+      const { composable, onActionComplete } = setupWithCallback();
+      const movement = createMockMovement({ identifier: 7 });
+
+      await composable.markExternal(movement);
+
+      expect(spies.resolveExternal).toHaveBeenCalledWith(7);
+      expect(spies.refreshUnmatchedAssetMovements).toHaveBeenCalledOnce();
+      expect(onActionComplete).toHaveBeenCalledOnce();
+      expect(get(composable.resolutionNotice)?.movement).toBe(movement);
+      expect(get(composable.ignoreLoading)).toBe(false);
+    });
+
+    it('should word the notice by direction, so a deposit does not read as a payment out', async () => {
+      const composable = setupWithoutCallback();
+
+      await composable.markExternal(createMockMovement({ eventSubtype: 'spend' }));
+      const withdrawalMessage = get(composable.resolutionNotice)?.message;
+
+      await composable.markExternal(createMockMovement({ eventSubtype: 'receive', groupIdentifier: 'g2' }));
+
+      expect(get(composable.resolutionNotice)?.message).not.toBe(withdrawalMessage);
+    });
+
+    it('should not report a resolution the backend rejected', async () => {
+      spies.resolveExternal.mockResolvedValueOnce({ message: 'nope', success: false });
+      const { composable, onActionComplete } = setupWithCallback();
+
+      await composable.markExternal(createMockMovement());
+
+      expect(get(composable.resolutionNotice)).toBeUndefined();
+      expect(spies.refreshUnmatchedAssetMovements).not.toHaveBeenCalled();
+      expect(onActionComplete).not.toHaveBeenCalled();
+    });
+
+    it('should clear the loading flag when the resolution throws', async () => {
+      spies.resolveExternal.mockRejectedValueOnce(new Error('boom'));
+      const composable = setupWithoutCallback();
+
+      await expect(composable.markExternal(createMockMovement())).rejects.toThrow('boom');
+
+      expect(get(composable.ignoreLoading)).toBe(false);
+    });
+  });
+
+  describe('resolution notice', () => {
+    it('should restore the resolved movement when the notice is undone', async () => {
+      const composable = setupWithoutCallback();
+      await composable.markExternal(createMockMovement({ identifier: 7 }));
+
+      await composable.undoResolution();
+
+      expect(spies.unlinkAssetMovement).toHaveBeenCalledWith(7);
+      expect(get(composable.resolutionNotice)).toBeUndefined();
+    });
+
+    it('should do nothing when undone with no notice held', async () => {
+      const composable = setupWithoutCallback();
+
+      await composable.undoResolution();
+
+      expect(spies.unlinkAssetMovement).not.toHaveBeenCalled();
+    });
+
+    it('should drop the notice when the resolved movement is restored from its own row', async () => {
+      const composable = setupWithoutCallback();
+      const movement = createMockMovement({ groupIdentifier: 'g1' });
+      await composable.markExternal(movement);
+
+      await composable.restoreMovement(movement);
+
+      expect(get(composable.resolutionNotice)).toBeUndefined();
+    });
+
+    it('should keep the notice when a different movement is restored', async () => {
+      const composable = setupWithoutCallback();
+      await composable.markExternal(createMockMovement({ groupIdentifier: 'g1' }));
+
+      await composable.restoreMovement(createMockMovement({ groupIdentifier: 'g2', identifier: 2 }));
+
+      expect(get(composable.resolutionNotice)).toBeDefined();
+    });
+
+    it('should drop the notice when dismissed', async () => {
+      const composable = setupWithoutCallback();
+      await composable.markExternal(createMockMovement());
+
+      composable.dismissResolution();
+
+      expect(get(composable.resolutionNotice)).toBeUndefined();
+    });
+  });
+
+  describe('confirmIgnoreAllFiat batch loading', () => {
     it('should set ignoreLoading during batch operation', async () => {
       set(unmatchedMovementsRef, [
         createMockMovement({ isFiat: true, identifier: 1 }),

--- a/frontend/app/src/modules/history/events/use-asset-movement-actions.ts
+++ b/frontend/app/src/modules/history/events/use-asset-movement-actions.ts
@@ -3,10 +3,22 @@ import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useAssetMovementMatchingApi } from '@/modules/history/api/events/use-asset-movement-matching-api';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
 import { type UnmatchedAssetMovement, useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
+import { getAssetMovementsType } from '@/modules/history/management/forms/utils';
 
 interface UseAssetMovementActionsOptions {
   /** Awaited after a single movement is ignored or restored (not after the bulk actions), letting the caller refresh its own view. */
   onActionComplete?: () => Promise<void>;
+}
+
+/**
+ * What the panel says about the resolution the user just made, and the movement an undo
+ * would restore. The wording is decided here rather than by the presentation, since it
+ * depends on the direction: a resolved withdrawal is a payment out, a resolved deposit is
+ * income.
+ */
+interface MovementResolutionNotice {
+  message: string;
+  movement: UnmatchedAssetMovement;
 }
 
 interface UseAssetMovementActionsReturn {
@@ -14,11 +26,15 @@ interface UseAssetMovementActionsReturn {
   ignoreLoading: Readonly<Ref<boolean>>;
   modelSelectedIgnored: Ref<string[]>;
   modelSelectedUnmatched: Ref<string[]>;
+  resolutionNotice: Readonly<Ref<MovementResolutionNotice | undefined>>;
   confirmIgnoreAllFiat: () => void;
   confirmIgnoreSelected: () => void;
   confirmRestoreSelected: () => void;
+  dismissResolution: () => void;
   ignoreMovement: (movement: UnmatchedAssetMovement) => Promise<void>;
+  markExternal: (movement: UnmatchedAssetMovement) => Promise<void>;
   restoreMovement: (movement: UnmatchedAssetMovement) => Promise<void>;
+  undoResolution: () => Promise<void>;
 }
 
 export function useAssetMovementActions(
@@ -32,6 +48,7 @@ export function useAssetMovementActions(
     ignoredMovements,
     unmatchedMovements,
     refreshUnmatchedAssetMovements,
+    resolveExternal,
   } = useUnmatchedAssetMovements();
 
   const { matchAssetMovements, unlinkAssetMovement } = useAssetMovementMatchingApi();
@@ -40,6 +57,7 @@ export function useAssetMovementActions(
   const ignoreLoading = shallowRef<boolean>(false);
   const modelSelectedUnmatched = ref<string[]>([]);
   const modelSelectedIgnored = ref<string[]>([]);
+  const notice = shallowRef<MovementResolutionNotice>();
 
   const fiatMovements = computed<UnmatchedAssetMovement[]>(() =>
     get(unmatchedMovements).filter(movement => movement.isFiat),
@@ -65,12 +83,57 @@ export function useAssetMovementActions(
     set(ignoreLoading, true);
     try {
       await unlinkAssetMovement(getMovementIdentifier(movement));
+      if (get(notice)?.movement.groupIdentifier === movement.groupIdentifier)
+        dismissResolution();
+
       await refreshUnmatchedAssetMovements();
       await onActionComplete?.();
     }
     finally {
       set(ignoreLoading, false);
     }
+  }
+
+  /**
+   * Resolves a movement whose counterpart is not tracked: a withdrawal becomes a payment and
+   * a deposit becomes income, so the whole amount is accounted rather than just the fee.
+   *
+   * @remarks
+   * Like ignoring, this is undone by the same unlink call the Restore action uses, so it reports
+   * itself with an undo affordance in the panel it was triggered from instead of asking first with
+   * a modal. Only the latest resolution is held, which costs nothing durable: the movement also
+   * lands in the ignored tab and keeps a Restore there long after the notice is gone.
+   *
+   * @param movement - the movement to resolve; a rejected resolution leaves no notice behind
+   */
+  async function markExternal(movement: UnmatchedAssetMovement): Promise<void> {
+    set(ignoreLoading, true);
+    try {
+      const { success } = await resolveExternal(getMovementIdentifier(movement));
+      if (success) {
+        await refreshUnmatchedAssetMovements();
+        await onActionComplete?.();
+        set(notice, {
+          message: getAssetMovementsType(getEventEntryFromCollection(movement.events).entry.eventSubtype) === 'deposit'
+            ? t('asset_movement_matching.resolved.external_deposit')
+            : t('asset_movement_matching.resolved.external_withdrawal'),
+          movement,
+        });
+      }
+    }
+    finally {
+      set(ignoreLoading, false);
+    }
+  }
+
+  function dismissResolution(): void {
+    set(notice, undefined);
+  }
+
+  async function undoResolution(): Promise<void> {
+    const current = get(notice);
+    if (current)
+      await restoreMovement(current.movement);
   }
 
   async function ignoreSelectedMovements(groupIdentifiers: string[]): Promise<void> {
@@ -148,11 +211,15 @@ export function useAssetMovementActions(
     confirmIgnoreAllFiat,
     confirmIgnoreSelected,
     confirmRestoreSelected,
+    dismissResolution,
     fiatMovements,
     ignoreLoading: readonly(ignoreLoading),
     ignoreMovement,
+    markExternal,
     restoreMovement,
     modelSelectedIgnored,
     modelSelectedUnmatched,
+    resolutionNotice: shallowReadonly(notice),
+    undoResolution,
   };
 }

--- a/frontend/app/src/modules/history/events/use-tracked-addresses.ts
+++ b/frontend/app/src/modules/history/events/use-tracked-addresses.ts
@@ -1,0 +1,43 @@
+import type { Ref } from 'vue';
+import { useAccountLoadState } from '@/modules/accounts/use-account-load-state';
+import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
+
+interface UseTrackedAddressesReturn {
+  /** ⚠️ Only an answer once {@link accountsRead} is true. */
+  isAddressTracked: (address: string | undefined | null) => boolean;
+  /** The accounts have been read, so a negative {@link isAddressTracked} means untracked. */
+  accountsRead: Readonly<Ref<boolean>>;
+}
+
+/**
+ * Whether rotki tracks an address, across every chain: an address tracked anywhere counts as
+ * tracked, so a negative answer means no decoded event for it can exist in the history at
+ * all. That is what makes it the deciding question for an unmatched row - both for a bridge
+ * leg and for an exchange withdrawal, whose counterpart can then only be external.
+ *
+ * ⚠️ The store only ever *gains* addresses, so a negative answer is worthless until the accounts
+ * have been read: before that an empty store is indistinguishable from a user tracking nothing,
+ * and every address on screen looks untracked. That is what {@link accountsRead} is for.
+ */
+export const useTrackedAddresses = createSharedComposable((): UseTrackedAddressesReturn => {
+  const { addresses } = useAccountAddresses();
+  const { ready } = useAccountLoadState();
+
+  const trackedAddresses = computed<Set<string>>(() => {
+    const tracked = new Set<string>();
+    for (const chainAddresses of Object.values(get(addresses))) {
+      for (const address of chainAddresses)
+        tracked.add(address.toLowerCase());
+    }
+    return tracked;
+  });
+
+  function isAddressTracked(address: string | undefined | null): boolean {
+    return !!address && get(trackedAddresses).has(address.toLowerCase());
+  }
+
+  return {
+    accountsRead: ready,
+    isAddressTracked,
+  };
+});

--- a/frontend/app/src/modules/history/events/use-unmatched-asset-movements.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-asset-movements.ts
@@ -37,6 +37,7 @@ interface UseUnmatchedAssetMovementsReturn {
   autoMatchMovement: (linkedMovement: LinkedMovementMatch) => Promise<boolean>;
   fetchUnmatchedAssetMovements: (onlyIgnored?: boolean) => Promise<void>;
   matchAssetMovement: (assetMovementId: number, matchedEventIds: number[]) => Promise<ActionStatus>;
+  resolveExternal: (assetMovementId: number) => Promise<ActionStatus>;
   refreshUnmatchedAssetMovements: (skipIgnored?: boolean) => Promise<void>;
   triggerAssetMovementAutoMatching: () => Promise<void>;
 }
@@ -162,6 +163,32 @@ export const useUnmatchedAssetMovements = createSharedComposable((): UseUnmatche
     }
   };
 
+  /**
+   * Resolves a movement as moving to or from an untracked address.
+   *
+   * @remarks
+   * Reports failure through the shared error dialog, but stays silent on success: the caller
+   * surfaces the outcome with an undo affordance instead.
+   *
+   * @param assetMovementId - identifier of the movement's own event
+   */
+  const resolveExternal = async (assetMovementId: number): Promise<ActionStatus> => {
+    try {
+      const success = await matchAssetMovementsApi(assetMovementId, undefined, true);
+
+      if (success)
+        signalEventsModified();
+
+      return { message: '', success };
+    }
+    catch (error: unknown) {
+      const message = getErrorMessage(error);
+      logger.error('Failed to resolve asset movement as external:', error);
+      showErrorMessage(t('actions.asset_movement_matching.error.title'), t('actions.asset_movement_matching.error.description', { error: message }));
+      return { message, success: false };
+    }
+  };
+
   const refreshUnmatchedAssetMovements = async (skipIgnored = false): Promise<void> => {
     await fetchUnmatchedAssetMovements();
     if (!skipIgnored) {
@@ -223,6 +250,7 @@ export const useUnmatchedAssetMovements = createSharedComposable((): UseUnmatche
     loading,
     matchAssetMovement,
     refreshUnmatchedAssetMovements,
+    resolveExternal,
     triggerAssetMovementAutoMatching,
     unmatchedCount,
     unmatchedMovements,

--- a/frontend/app/src/modules/history/events/use-unmatched-movement-rows.spec.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-movement-rows.spec.ts
@@ -1,0 +1,167 @@
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
+import { createAssetMovementEvent, createOnlineHistoryEvent } from '@test/utils/history-events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UNMATCHED_ACTIONS, type UnmatchedRowActionSpec } from '@/modules/history/events/unmatched-actions';
+import { type UnmatchedMovementRow, useUnmatchedMovementRows } from '@/modules/history/events/use-unmatched-movement-rows';
+
+/**
+ * The seam: the row model decides what a movement is called and what may be done to it, and
+ * every word it picks depends on the direction. A withdrawal leaves the exchange (a payment
+ * out), a deposit arrives on it (income in), which is also what the backend writes when
+ * either is resolved as external. Anything here that reads the same for both directions
+ * describes half the rows wrongly.
+ */
+
+const { spies } = vi.hoisted(() => ({
+  spies: {
+    isDestinationUntracked: vi.fn<() => boolean>(() => false),
+  },
+}));
+
+vi.mock('@/modules/history/events/use-untracked-movement-destination', () => ({
+  getMovementDestinationAddress: (): string | undefined => undefined,
+  useUntrackedMovementDestination: (): object => ({
+    isDestinationUntracked: spies.isDestinationUntracked,
+  }),
+}));
+
+/** Wraps one event as the single-entry group the panel receives. */
+function movementFor(entry: HistoryEventEntry): UnmatchedAssetMovement {
+  return {
+    asset: 'ETH',
+    events: { entry, eventAccountingRuleStatus: entry.eventAccountingRuleStatus },
+    groupIdentifier: 'group1',
+    isFiat: false,
+  };
+}
+
+/** Creates an unresolved movement, whose direction still lives in its subtype. */
+function createMockMovement(eventSubtype: 'spend' | 'receive'): UnmatchedAssetMovement {
+  return movementFor(createAssetMovementEvent({ eventSubtype, eventType: 'exchange transfer', location: 'kraken' }));
+}
+
+/** Creates a movement carrying the stamp the backend writes when it resolves one as external. */
+function createResolvedMovement(direction: 'deposit' | 'withdrawal'): UnmatchedAssetMovement {
+  return movementFor(createOnlineHistoryEvent({
+    eventSubtype: 'payment',
+    eventType: direction === 'deposit' ? 'receive' : 'spend',
+    extraData: { matchedAssetMovement: { direction, resolution: 'external' } },
+    location: 'kraken',
+  }));
+}
+
+/** Creates a plain history event in the ignored tab that the backend never resolved. */
+function createUnstampedMovement(): UnmatchedAssetMovement {
+  return movementFor(createOnlineHistoryEvent({ eventSubtype: 'payment', eventType: 'receive', location: 'kraken' }));
+}
+
+/**
+ * Builds the row and its action spec, which is what every assertion here reads.
+ *
+ * @param movement - the single movement the model is given
+ * @param showRestore - render it as an ignored row rather than an unmatched one
+ */
+function rowForMovement(
+  movement: UnmatchedAssetMovement,
+  showRestore = false,
+): { row: UnmatchedMovementRow; spec: UnmatchedRowActionSpec } {
+  const { rows, specFor } = useUnmatchedMovementRows({
+    matchDisabled: false,
+    movements: [movement],
+    showRestore,
+  });
+  const row = get(rows)[0];
+  return { row, spec: specFor(row) };
+}
+
+/** Narrows {@link rowForMovement} to the common case of an unresolved movement. */
+function rowFor(
+  eventSubtype: 'spend' | 'receive',
+  showRestore = false,
+): { row: UnmatchedMovementRow; spec: UnmatchedRowActionSpec } {
+  return rowForMovement(createMockMovement(eventSubtype), showRestore);
+}
+
+describe('use-unmatched-movement-rows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spies.isDestinationUntracked.mockReturnValue(false);
+  });
+
+  describe('mark external', () => {
+    it('should ask about a payment out when confirming a withdrawal', () => {
+      expect(rowFor('spend').spec.confirms?.[UNMATCHED_ACTIONS.MARK_EXTERNAL]?.message).toBe(
+        'asset_movement_matching.dialog.confirm_mark_external',
+      );
+    });
+
+    it('should ask about income in when confirming a deposit', () => {
+      expect(rowFor('receive').spec.confirms?.[UNMATCHED_ACTIONS.MARK_EXTERNAL]?.message).toBe(
+        'asset_movement_matching.dialog.confirm_mark_external_in',
+      );
+    });
+
+    it('should describe the action itself by direction too', () => {
+      expect(rowFor('spend').spec.markExternal?.tooltip).toBe('asset_movement_matching.dialog.mark_external_tooltip');
+      expect(rowFor('receive').spec.markExternal?.tooltip).toBe('asset_movement_matching.dialog.mark_external_in_tooltip');
+    });
+
+    it('should offer the action on every row, so an unmatchable movement is never stuck', () => {
+      expect(rowFor('spend').spec.markExternal).toBeDefined();
+      expect(rowFor('receive').spec.markExternal).toBeDefined();
+    });
+
+    it('should skip the confirm and emphasize when the destination is known to be untracked', () => {
+      spies.isDestinationUntracked.mockReturnValue(true);
+
+      const { row, spec } = rowFor('spend');
+
+      expect(row.untrackedDestination).toBe(true);
+      expect(spec.markExternal?.emphasize).toBe(true);
+      expect(spec.confirms?.[UNMATCHED_ACTIONS.MARK_EXTERNAL]).toBeUndefined();
+    });
+
+    it('should still ask before ignoring an untracked row, so the skip is specific', () => {
+      spies.isDestinationUntracked.mockReturnValue(true);
+
+      expect(rowFor('spend').spec.confirms?.[UNMATCHED_ACTIONS.IGNORE]).toBeDefined();
+    });
+  });
+
+  it('should label the row by direction', () => {
+    expect(rowFor('spend').row.direction).toBe('withdrawal');
+    expect(rowFor('receive').row.direction).toBe('deposit');
+  });
+
+  it('should not claim an untracked destination on an already ignored row', () => {
+    spies.isDestinationUntracked.mockReturnValue(true);
+
+    expect(rowFor('spend', true).row.untrackedDestination).toBe(false);
+  });
+
+  describe('an already resolved row', () => {
+    it('should take its direction from the stamp of a resolved deposit', () => {
+      const { row } = rowForMovement(createResolvedMovement('deposit'), true);
+
+      expect(row.direction).toBe('deposit');
+      expect(row.resolvedAsExternal).toBe(true);
+      expect(row.resolvedLabel).toBe('asset_movement_matching.dialog.resolved_income');
+    });
+
+    it('should take its direction from the stamp of a resolved withdrawal', () => {
+      const { row } = rowForMovement(createResolvedMovement('withdrawal'), true);
+
+      expect(row.direction).toBe('withdrawal');
+      expect(row.resolvedLabel).toBe('asset_movement_matching.dialog.resolved_payment');
+    });
+
+    it('should not mark a merely ignored movement as resolved', () => {
+      expect(rowFor('receive', true).row.resolvedAsExternal).toBe(false);
+    });
+
+    it('should not mark an unstamped history event as resolved', () => {
+      expect(rowForMovement(createUnstampedMovement(), true).row.resolvedAsExternal).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-unmatched-movement-rows.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-movement-rows.ts
@@ -1,9 +1,44 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
+import { HistoryEventEntryType } from '@rotki/common';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
-import { UNMATCHED_ACTIONS, type UnmatchedRowActionLabels, type UnmatchedRowActionSpec } from '@/modules/history/events/unmatched-actions';
+import { UNMATCHED_ACTIONS, type UnmatchedRowActionLabels, type UnmatchedRowActionSpec, type UnmatchedRowConfirms, type UnmatchedRowOptionalAction } from '@/modules/history/events/unmatched-actions';
+import { getMovementDestinationAddress, useUntrackedMovementDestination } from '@/modules/history/events/use-untracked-movement-destination';
 import { getAssetMovementsType } from '@/modules/history/management/forms/utils';
+
+/**
+ * The backend's own record of having resolved a movement as external, if this event carries one.
+ *
+ * @param entry - the movement's own event, resolved or not
+ * @returns the stamp, or `undefined` for anything the backend did not resolve
+ */
+function externalResolution(entry: HistoryEventEntry): { direction?: string | null } | undefined {
+  if (entry.entryType !== HistoryEventEntryType.HISTORY_EVENT)
+    return undefined;
+
+  const stamp = entry.extraData?.matchedAssetMovement;
+  return stamp?.resolution === 'external' ? stamp : undefined;
+}
+
+/**
+ * Which way the funds moved.
+ *
+ * @remarks
+ * An asset movement says so in its subtype. One resolved as external is no longer an asset movement
+ * at all and kept the same subtype for either direction (`payment`), so its direction is read from
+ * the stamp the backend wrote for exactly this purpose rather than inferred from its event type.
+ *
+ * @param entry - the movement's own event, resolved or not
+ * @returns `deposit` when the funds arrived on the exchange, `withdrawal` when they left it
+ */
+function movementDirection(entry: HistoryEventEntry): 'deposit' | 'withdrawal' {
+  const resolution = externalResolution(entry);
+  if (resolution)
+    return resolution.direction === 'deposit' ? 'deposit' : 'withdrawal';
+
+  return getAssetMovementsType(entry.eventSubtype);
+}
 
 /** One unmatched asset movement, with its wording already decided. See [[UnmatchedBridgeRow]]. */
 export interface UnmatchedMovementRow {
@@ -16,6 +51,16 @@ export interface UnmatchedMovementRow {
   location: string;
   timestamp: number;
   original: UnmatchedAssetMovement;
+  /** A withdrawal is resolved as a payment out, a deposit as income. */
+  direction: 'deposit' | 'withdrawal';
+  destinationAddress?: string;
+  /** Only ever true for a withdrawal - see {@link getMovementDestinationAddress}. */
+  untrackedDestination: boolean;
+  untrackedLabel: string;
+  untrackedTooltip: string;
+  /** The row was already resolved as a payment or as income, rather than merely ignored. */
+  resolvedAsExternal: boolean;
+  resolvedLabel: string;
 }
 
 interface UseUnmatchedMovementRowsOptions {
@@ -35,14 +80,15 @@ interface UseUnmatchedMovementRowsReturn {
 }
 
 /**
- * The asset-movement surface's model. Movements have no counterpart to resolve, so their
- * spec is the same for every row - it is still built per row so the two surfaces answer the
- * same question the same way.
+ * The asset-movement surface's model: what the rows are, what they are called, and what may
+ * be done to them. It has no notion of a table, a card or a pinned rail - the host picks a
+ * presentation and both are handed the same rows and the same action specs.
  */
 export function useUnmatchedMovementRows(options: UseUnmatchedMovementRowsOptions): UseUnmatchedMovementRowsReturn {
   const { movements, showRestore, matchDisabled } = options;
 
   const { t } = useI18n({ useScope: 'global' });
+  const { isDestinationUntracked } = useUntrackedMovementDestination();
 
   const labels = computed<UnmatchedRowActionLabels>(() => ({
     findMatch: t('asset_movement_matching.dialog.find_match'),
@@ -58,15 +104,28 @@ export function useUnmatchedMovementRows(options: UseUnmatchedMovementRowsOption
     toValue(movements).map((movement) => {
       const { entry, ...meta } = getEventEntryFromCollection(movement.events);
       const eventEntry = { ...entry, ...meta };
+      const ignored = !!toValue(showRestore);
+      const address = getMovementDestinationAddress(eventEntry);
+      const direction = movementDirection(eventEntry);
+      const resolvedAsExternal = externalResolution(eventEntry) !== undefined;
       return {
+        destinationAddress: address,
+        direction,
         entry: eventEntry,
         eventSubtype: entry.eventSubtype,
         groupIdentifier: movement.groupIdentifier,
         isFiat: movement.isFiat,
         location: entry.location,
         original: movement,
+        resolvedAsExternal,
+        resolvedLabel: direction === 'deposit'
+          ? t('asset_movement_matching.dialog.resolved_income')
+          : t('asset_movement_matching.dialog.resolved_payment'),
         timestamp: entry.timestamp,
-        typeLabel: getAssetMovementsType(entry.eventSubtype),
+        typeLabel: direction,
+        untrackedDestination: !ignored && isDestinationUntracked(eventEntry),
+        untrackedLabel: t('asset_movement_matching.dialog.untracked_destination'),
+        untrackedTooltip: t('asset_movement_matching.dialog.untracked_destination_tooltip', { address: address ?? '' }),
       };
     }),
   );
@@ -83,15 +142,52 @@ export function useUnmatchedMovementRows(options: UseUnmatchedMovementRowsOption
       : t('asset_movement_matching.dialog.no_unmatched'),
   );
 
-  function specFor(_row: UnmatchedMovementRow): UnmatchedRowActionSpec {
-    return {
-      confirms: {
-        [UNMATCHED_ACTIONS.IGNORE]: {
-          confirmLabel: t('asset_movement_matching.dialog.ignore'),
-          message: t('asset_movement_matching.dialog.confirm_ignore'),
-        },
+  /**
+   * What the row asks before it acts.
+   *
+   * @remarks
+   * A verified untracked destination has only one correct outcome, so it does not ask at all.
+   * Everywhere else it asks about the outcome that direction actually produces: one message about
+   * a payment either way misdescribes half of what is being confirmed.
+   *
+   * @param row - the row the actions belong to
+   * @returns the confirms by action; anything absent runs on click
+   */
+  function confirmsFor(row: UnmatchedMovementRow): UnmatchedRowConfirms {
+    const confirms: UnmatchedRowConfirms = {
+      [UNMATCHED_ACTIONS.IGNORE]: {
+        confirmLabel: t('asset_movement_matching.dialog.ignore'),
+        message: t('asset_movement_matching.dialog.confirm_ignore'),
       },
+    };
+
+    if (!row.untrackedDestination) {
+      confirms[UNMATCHED_ACTIONS.MARK_EXTERNAL] = {
+        confirmLabel: t('asset_movement_matching.dialog.mark_external'),
+        message: row.direction === 'withdrawal'
+          ? t('asset_movement_matching.dialog.confirm_mark_external')
+          : t('asset_movement_matching.dialog.confirm_mark_external_in'),
+      };
+    }
+
+    return confirms;
+  }
+
+  function markExternalFor(row: UnmatchedMovementRow): UnmatchedRowOptionalAction {
+    return {
+      emphasize: row.untrackedDestination,
+      label: t('asset_movement_matching.dialog.mark_external'),
+      tooltip: row.direction === 'withdrawal'
+        ? t('asset_movement_matching.dialog.mark_external_tooltip')
+        : t('asset_movement_matching.dialog.mark_external_in_tooltip'),
+    };
+  }
+
+  function specFor(row: UnmatchedMovementRow): UnmatchedRowActionSpec {
+    return {
+      confirms: confirmsFor(row),
       labels: get(labels),
+      markExternal: markExternalFor(row),
       matchDisabled: !!toValue(matchDisabled),
       showRestore: !!toValue(showRestore),
     };

--- a/frontend/app/src/modules/history/events/use-untracked-bridge-counterpart.ts
+++ b/frontend/app/src/modules/history/events/use-untracked-bridge-counterpart.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, MaybeRefOrGetter } from 'vue';
 import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
-import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
+import { useTrackedAddresses } from '@/modules/history/events/use-tracked-addresses';
 
 interface UseUntrackedBridgeCounterpartReturn {
   isCounterpartUntracked: (transaction: UnmatchedBridgeTransaction) => boolean;
@@ -55,20 +55,14 @@ export function canCreateBridgeCounterpart(transaction: UnmatchedBridgeTransacti
  * considered tracked, so the guidance only appears when a match is truly impossible.
  */
 export const useUntrackedBridgeCounterpart = createSharedComposable((): UseUntrackedBridgeCounterpartReturn => {
-  const { addresses } = useAccountAddresses();
-
-  const trackedAddresses = computed<Set<string>>(() => {
-    const tracked = new Set<string>();
-    for (const chainAddresses of Object.values(get(addresses))) {
-      for (const address of chainAddresses)
-        tracked.add(address.toLowerCase());
-    }
-    return tracked;
-  });
+  const { accountsRead, isAddressTracked } = useTrackedAddresses();
 
   function isCounterpartUntracked(transaction: UnmatchedBridgeTransaction): boolean {
+    if (!get(accountsRead))
+      return false;
+
     const address = getBridgeCounterpartAddress(transaction);
-    return address !== undefined && !get(trackedAddresses).has(address.toLowerCase());
+    return address !== undefined && !isAddressTracked(address);
   }
 
   return {

--- a/frontend/app/src/modules/history/events/use-untracked-movement-destination.spec.ts
+++ b/frontend/app/src/modules/history/events/use-untracked-movement-destination.spec.ts
@@ -1,0 +1,101 @@
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import { createAssetMovementEvent, createEvmEvent } from '@test/utils/history-events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getMovementDestinationAddress,
+  useUntrackedMovementDestination,
+} from '@/modules/history/events/use-untracked-movement-destination';
+
+/**
+ * The seam: which movements may be called unmatchable because their counterpart is not
+ * tracked. Only a withdrawal qualifies -- a deposit's recorded address is usually the
+ * exchange's own deposit address, so answering for one would flag nearly every deposit.
+ */
+
+const trackedAddressesRef = ref<Record<string, string[]>>({});
+const accountsReadyRef = ref<boolean>(true);
+
+vi.mock('@/modules/balances/blockchain/use-account-addresses', () => ({
+  useAccountAddresses: (): object => ({
+    addresses: computed<Record<string, string[]>>(() => get(trackedAddressesRef)),
+  }),
+}));
+
+vi.mock('@/modules/accounts/use-account-load-state', () => ({
+  useAccountLoadState: (): object => ({
+    ready: computed<boolean>(() => get(accountsReadyRef)),
+  }),
+}));
+
+/**
+ * Creates an asset movement as the exchange reported it.
+ *
+ * @param overrides - omitting `address` means the exchange recorded none, which is not the same as
+ * recording an untracked one
+ */
+function createEntry(overrides: { eventSubtype?: string; address?: string | null } = {}): HistoryEventEntry {
+  return createAssetMovementEvent({
+    eventSubtype: overrides.eventSubtype ?? 'spend',
+    extraData: overrides.address === undefined ? null : { address: overrides.address },
+  });
+}
+
+describe('use-untracked-movement-destination', () => {
+  beforeEach(() => {
+    set(trackedAddressesRef, { eth: ['0xTracked'] });
+    set(accountsReadyRef, true);
+  });
+
+  describe('getMovementDestinationAddress', () => {
+    it('should return the recorded address of a withdrawal', () => {
+      expect(getMovementDestinationAddress(createEntry({ address: '0xdef' }))).toBe('0xdef');
+    });
+
+    it('should return nothing for a deposit, whose address is the exchange side', () => {
+      expect(getMovementDestinationAddress(createEntry({ address: '0xdef', eventSubtype: 'receive' }))).toBeUndefined();
+    });
+
+    it('should return nothing when the exchange recorded no address', () => {
+      expect(getMovementDestinationAddress(createEntry())).toBeUndefined();
+    });
+
+    it('should return nothing for an event that is not an asset movement', () => {
+      expect(getMovementDestinationAddress(createEvmEvent({ extraData: { address: '0xdef' } }))).toBeUndefined();
+    });
+  });
+
+  describe('isDestinationUntracked', () => {
+    it('should be true for a withdrawal to an address rotki does not track', () => {
+      const { isDestinationUntracked } = useUntrackedMovementDestination();
+
+      expect(isDestinationUntracked(createEntry({ address: '0xUntracked' }))).toBe(true);
+    });
+
+    it('should be false for a withdrawal to a tracked address, ignoring case', () => {
+      const { isDestinationUntracked } = useUntrackedMovementDestination();
+
+      expect(isDestinationUntracked(createEntry({ address: '0xTRACKED' }))).toBe(false);
+    });
+
+    it('should be false without a recorded address, since nothing is known', () => {
+      const { isDestinationUntracked } = useUntrackedMovementDestination();
+
+      expect(isDestinationUntracked(createEntry())).toBe(false);
+    });
+
+    it('should be false before the accounts have been read, however untracked the address looks', () => {
+      set(trackedAddressesRef, {});
+      set(accountsReadyRef, false);
+      const { isDestinationUntracked } = useUntrackedMovementDestination();
+
+      expect(isDestinationUntracked(createEntry({ address: '0xUntracked' }))).toBe(false);
+    });
+
+    it('should count an address tracked on any chain as tracked', () => {
+      set(trackedAddressesRef, { optimism: ['0xElsewhere'] });
+      const { isDestinationUntracked } = useUntrackedMovementDestination();
+
+      expect(isDestinationUntracked(createEntry({ address: '0xElsewhere' }))).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-untracked-movement-destination.ts
+++ b/frontend/app/src/modules/history/events/use-untracked-movement-destination.ts
@@ -1,0 +1,86 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
+import { HistoryEventEntryType } from '@rotki/common';
+import { getEventEntryFromCollection } from '@/modules/history/event-utils';
+import { useTrackedAddresses } from '@/modules/history/events/use-tracked-addresses';
+
+interface UseUntrackedMovementDestinationReturn {
+  isDestinationUntracked: (entry: HistoryEventEntry) => boolean;
+}
+
+/**
+ * The address an exchange withdrawal was sent to, as reported by the exchange.
+ *
+ * @remarks
+ * Deposits are deliberately not covered. A deposit's recorded address is the address the funds
+ * arrived at, which for most exchanges is the exchange's own deposit address rather than the
+ * sender - so checking it against the tracked accounts would call nearly every deposit untracked.
+ * A deposit is still resolvable as income, it just gets no such hint.
+ *
+ * @param entry - the movement's own event
+ * @returns the destination address, or `undefined` for anything but a withdrawal that recorded one
+ */
+export function getMovementDestinationAddress(entry: HistoryEventEntry): string | undefined {
+  if (entry.entryType !== HistoryEventEntryType.ASSET_MOVEMENT_EVENT || entry.eventSubtype !== 'spend')
+    return undefined;
+
+  return entry.extraData?.address ?? undefined;
+}
+
+/**
+ * Detects exchange withdrawals sent to an address rotki does not track. Such a movement can
+ * never be matched -- rotki only decodes transactions of tracked addresses, so no counterpart
+ * event can exist -- and the funds left for good, which makes resolving it as a payment the
+ * correct action. `use-untracked-bridge-counterpart.ts` answers the same question for a bridge leg.
+ */
+export const useUntrackedMovementDestination = createSharedComposable((): UseUntrackedMovementDestinationReturn => {
+  const { accountsRead, isAddressTracked } = useTrackedAddresses();
+
+  function isDestinationUntracked(entry: HistoryEventEntry): boolean {
+    if (!get(accountsRead))
+      return false;
+
+    const address = getMovementDestinationAddress(entry);
+    return address !== undefined && !isAddressTracked(address);
+  }
+
+  return {
+    isDestinationUntracked,
+  };
+});
+
+interface UseMovementUnmatchableExplanationReturn {
+  /** Undefined when no movement is selected, or when a match is still possible. */
+  unmatchableExplanation: ComputedRef<string | undefined>;
+}
+
+/**
+ * Explanation for the potential-matches search when a withdrawal cannot be matched because its
+ * destination address is untracked, pointing the user to the external resolution instead.
+ *
+ * @param movement - the movement the search is running for, if any
+ */
+export function useMovementUnmatchableExplanation(
+  movement: MaybeRefOrGetter<UnmatchedAssetMovement | undefined>,
+): UseMovementUnmatchableExplanationReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const { isDestinationUntracked } = useUntrackedMovementDestination();
+
+  const unmatchableExplanation = computed<string | undefined>(() => {
+    const value = toValue(movement);
+    if (!value)
+      return undefined;
+
+    const { entry, ...meta } = getEventEntryFromCollection(value.events);
+    const eventEntry = { ...entry, ...meta };
+    if (!isDestinationUntracked(eventEntry))
+      return undefined;
+
+    return t('asset_movement_matching.dialog.no_match_untracked_destination', {
+      address: getMovementDestinationAddress(eventEntry) ?? '',
+    });
+  });
+
+  return { unmatchableExplanation };
+}

--- a/frontend/app/tests/unit/utils/history-events.ts
+++ b/frontend/app/tests/unit/utils/history-events.ts
@@ -1,0 +1,54 @@
+import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
+import {
+  type AssetMovementEvent,
+  type EvmHistoryEvent,
+  HistoryEventAccountingRuleStatus,
+  type HistoryEventEntry,
+  type OnlineHistoryEvent,
+} from '@/modules/history/events/schemas';
+
+/**
+ * The fields every history event carries, so a factory only has to state what its own case needs.
+ *
+ * @remarks
+ * These are plain objects rather than `createMock` proxies on purpose: consumers spread an entry
+ * (`{ ...entry, ...meta }`), and a proxy's `ownKeys` come from its `vi.fn()` target, so every
+ * override would be silently dropped by the spread.
+ */
+const commonFields = {
+  amount: bigNumberify('1'),
+  asset: 'ETH',
+  eventAccountingRuleStatus: HistoryEventAccountingRuleStatus.PROCESSED,
+  eventSubtype: 'spend',
+  eventType: 'trade',
+  groupIdentifier: 'group1',
+  hidden: false,
+  identifier: 1,
+  ignoredInAccounting: false,
+  location: 'ethereum',
+  locationLabel: null,
+  sequenceIndex: 0,
+  states: [],
+  timestamp: 1000000,
+};
+
+/** Creates an exchange deposit or withdrawal. */
+export function createAssetMovementEvent(
+  overrides: Partial<Omit<AssetMovementEvent, 'entryType'>> = {},
+): HistoryEventEntry {
+  return { ...commonFields, extraData: null, entryType: HistoryEventEntryType.ASSET_MOVEMENT_EVENT, ...overrides };
+}
+
+/** Creates a plain history event, which is what an asset movement becomes once resolved as external. */
+export function createOnlineHistoryEvent(
+  overrides: Partial<Omit<OnlineHistoryEvent, 'entryType'>> = {},
+): HistoryEventEntry {
+  return { ...commonFields, entryType: HistoryEventEntryType.HISTORY_EVENT, ...overrides };
+}
+
+/** Creates a decoded on-chain event. */
+export function createEvmEvent(
+  overrides: Partial<Omit<EvmHistoryEvent, 'entryType'>> = {},
+): HistoryEventEntry {
+  return { ...commonFields, address: null, counterparty: null, extraData: null, txRef: 'tx1', entryType: HistoryEventEntryType.EVM_EVENT, ...overrides };
+}

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -190,6 +190,7 @@ from rotkehlchen.tasks.events import (
     get_already_matched_event_ids,
     get_unmatched_asset_movements,
     process_asset_movements,
+    resolve_asset_movement_external,
     should_exclude_possible_match,
     update_asset_movement_matched_event,
 )
@@ -4334,11 +4335,38 @@ class RestAPI:
             self,
             asset_movement_identifier: int,
             matched_event_identifiers: list[int],
+            external: bool = False,
     ) -> Response:
-        """Match an exchange asset movement to onchain event(s), or mark the movement as having
-        no match if no matched_event_identifiers are specified.
+        """Match an exchange asset movement to onchain event(s), resolve it as moving to/from
+        an untracked address, or mark the movement as having no match if no
+        matched_event_identifiers are specified.
+
+        Resolving as external turns a withdrawal into a payment and a deposit into income,
+        so the whole amount is accounted instead of only the movement's fee.
         """
+        events_db = DBHistoryEvents(database=self.rotkehlchen.data.db)
         if len(matched_event_identifiers) == 0:
+            if external:
+                with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
+                    events = events_db.get_history_events_internal(
+                        cursor=cursor,
+                        filter_query=HistoryEventFilterQuery.make(
+                            identifiers=[asset_movement_identifier],
+                        ),
+                    )
+
+                if len(events) != 1:
+                    return api_response(wrap_in_fail_result(
+                        message=f'No event found in the DB for identifier {asset_movement_identifier}',  # noqa: E501
+                    ), HTTPStatus.BAD_REQUEST)
+
+                if not resolve_asset_movement_external(events_db=events_db, event=events[0]):
+                    return api_response(wrap_in_fail_result(
+                        message=f'Event with identifier {asset_movement_identifier} is not an asset movement deposit or withdrawal',  # noqa: E501
+                    ), HTTPStatus.BAD_REQUEST)
+
+                return api_response(OK_RESULT)
+
             # No matched event specified. Mark as having no match so this movement will be ignored.
             with self.rotkehlchen.data.db.conn.write_ctx() as write_cursor:
                 write_cursor.execute(
@@ -4348,7 +4376,6 @@ class RestAPI:
                 )
             return api_response(OK_RESULT)
 
-        events_db = DBHistoryEvents(database=self.rotkehlchen.data.db)
         asset_movement, matched_events, fee_event = None, [], None
         with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
             for event in events_db.get_history_events_internal(
@@ -4523,7 +4550,8 @@ class RestAPI:
         in which case there is an entry for both.
 
         For matches created by this app, events are restored from backups saved prior to matching,
-        including event type/subtype, notes, and counterparty.
+        including event type/subtype, notes, and counterparty. Also clears an external
+        resolution or no-match marker if the movement only had that.
         """
         with self.rotkehlchen.data.db.conn.read_ctx() as cursor:
             linked_ids = defaultdict(list)
@@ -4545,6 +4573,28 @@ class RestAPI:
                         'asset movement or its match for any matched pairs in the DB.'
                     )), HTTPStatus.BAD_REQUEST)
 
+                # Restore the original movement if it was resolved as external. The whole
+                # group is restored since resolving rewrites the movement's fee alongside
+                # it; events with no backup are skipped, so a merely ignored movement (which
+                # was never rewritten) is unaffected.
+                group_event_ids = [x[0] for x in write_cursor.execute(
+                    'SELECT identifier FROM history_events WHERE group_identifier='
+                    '(SELECT group_identifier FROM history_events WHERE identifier=?)',
+                    (identifier,),
+                )]
+                DBHistoryEvents.maybe_restore_history_events_from_backup(
+                    write_cursor=write_cursor,
+                    identifiers=group_event_ids,
+                )
+                write_cursor.executemany(
+                    'DELETE FROM history_events_mappings '
+                    'WHERE parent_identifier=? AND name=? AND value=?',
+                    [(
+                        event_id,
+                        HISTORY_MAPPING_KEY_STATE,
+                        HistoryMappingState.MATCHED.serialize_for_db(),
+                    ) for event_id in group_event_ids],
+                )
                 return api_response(OK_RESULT)
 
         with self.rotkehlchen.data.db.conn.write_ctx() as write_cursor:

--- a/rotkehlchen/api/v1/resources.py
+++ b/rotkehlchen/api/v1/resources.py
@@ -4034,10 +4034,11 @@ class MatchAssetMovementsResource(BaseMethodView):
     @require_loggedin_user()
     @require_premium_user(active_check=False)
     @use_kwargs(put_schema, location='json')
-    def put(self, asset_movement: int, matched_events: list[int]) -> Response:
+    def put(self, asset_movement: int, matched_events: list[int], external: bool) -> Response:
         return self.rest_api.match_asset_movements(
             asset_movement_identifier=asset_movement,
             matched_event_identifiers=matched_events,
+            external=external,
         )
 
     @require_loggedin_user()

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -5365,6 +5365,19 @@ class GetUnmatchedAssetMovementsSchema(Schema):
 class MatchAssetMovementsSchema(Schema):
     asset_movement = fields.Integer(required=True)
     matched_events = fields.List(fields.Integer(required=True), required=False, load_default=list)
+    external = fields.Boolean(required=False, load_default=False)
+
+    @validates_schema
+    def validate_schema(
+            self,
+            data: dict[str, Any],
+            **_kwargs: Any,
+    ) -> None:
+        if data['external'] and len(data['matched_events']) != 0:
+            raise ValidationError(
+                message='external cannot be combined with matched_events',
+                field_name='external',
+            )
 
 
 class FindPossibleMatchesSchema(Schema):

--- a/rotkehlchen/tasks/events.py
+++ b/rotkehlchen/tasks/events.py
@@ -3,8 +3,9 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from operator import itemgetter
 from time import perf_counter
-from typing import TYPE_CHECKING, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal
 
+from rotkehlchen.api.v1.types import IncludeExcludeFilterData
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.chain.decoding.constants import CPT_GAS
@@ -13,6 +14,7 @@ from rotkehlchen.chain.evm.decoding.monerium.constants import CPT_MONERIUM
 from rotkehlchen.chain.hyperliquid.constants import CPT_HYPER
 from rotkehlchen.constants import HOUR_IN_SECONDS
 from rotkehlchen.constants.assets import A_DAI, A_GLM, A_MKR, A_REP, A_SAI
+from rotkehlchen.constants.location_details import get_formatted_location_name
 from rotkehlchen.constants.resolver import SOLANA_CHAIN_DIRECTIVE, identifier_to_evm_chain
 from rotkehlchen.constants.timing import SAI_DAI_MIGRATION_TS
 from rotkehlchen.db.cache import IGNORED_CUSTOMIZED_EVENT_DUPLICATE_PREFIX, DBCacheStatic
@@ -23,7 +25,7 @@ from rotkehlchen.db.constants import (
     HistoryEventLinkType,
     HistoryMappingState,
 )
-from rotkehlchen.db.filtering import AssetMovementMatchFilterQuery
+from rotkehlchen.db.filtering import AssetMovementMatchFilterQuery, HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.db.utils import get_query_chunks
@@ -99,6 +101,8 @@ MANUALLY_MATCHABLE_ASSET_MAP: Final = {
     for asset in asset_group
 }
 AMOUNT_DIFFERENCE_THRESHOLD: Final = FVal('0.1')  # 10% threshold for duplicate detection
+# extra_data key holding an asset movement's match or external resolution
+MATCHED_ASSET_MOVEMENT_KEY: Final = 'matched_asset_movement'
 
 
 def _amounts_within_threshold(amount_a: FVal, amount_b: FVal) -> bool:
@@ -1078,7 +1082,7 @@ def update_asset_movement_matched_event(
     if matched_event.extra_data is None:
         matched_event.extra_data = {}
 
-    matched_event.extra_data['matched_asset_movement'] = {
+    matched_event.extra_data[MATCHED_ASSET_MOVEMENT_KEY] = {
         'group_identifier': asset_movement.group_identifier,
         'exchange': asset_movement.location.serialize(),
     }
@@ -1117,7 +1121,7 @@ def update_asset_movement_matched_event(
             # Keep movement to movement matches symmetric in links and metadata.
             if asset_movement.extra_data is None:
                 asset_movement.extra_data = {}
-            asset_movement.extra_data['matched_asset_movement'] = {
+            asset_movement.extra_data[MATCHED_ASSET_MOVEMENT_KEY] = {
                 'group_identifier': matched_event.group_identifier,
                 'exchange': matched_event.location.serialize(),
             }
@@ -1136,6 +1140,114 @@ def update_asset_movement_matched_event(
                     HistoryEventLinkType.ASSET_MOVEMENT_MATCH.serialize_for_db(),
                 ),
             )
+
+
+def resolve_asset_movement_external(
+        events_db: DBHistoryEvents,
+        event: HistoryBaseEntry,
+) -> bool:
+    """Resolve an unmatched asset movement as moving to/from an untracked address.
+
+    A withdrawal becomes a payment (SPEND/PAYMENT) and a deposit becomes income
+    (RECEIVE/PAYMENT), so the accounting rules of those combinations apply and the whole
+    amount is accounted instead of only the movement's fee. The event stops being an asset
+    movement -- an AssetMovement is by definition an EXCHANGE_TRANSFER -- so it is rewritten
+    as a plain history event that keeps its identifier, group, location and extra data, and
+    is stamped with the resolution and the movement's original direction.
+
+    The group's fee is rewritten alongside it, as a plain SPEND/FEE, so the group does not
+    end up half asset movement and half history event: the per-row actions in the frontend
+    hide a movement fee's own edit and delete because a movement is edited as a group, which
+    would leave the fee unreachable, and the report would file the two halves of one transfer
+    under different accounting event types. The rules for exchange transfer/fee and spend/fee
+    carry the same treatment, so the fee is accounted as before.
+
+    Both edits save a backup so unlinking restores the original movement and fee. Returns
+    False when the event is not an asset movement deposit or withdrawal.
+    """
+    if not isinstance(event, AssetMovement):
+        return False
+
+    symbol = event.asset.resolve_to_asset_with_symbol().symbol
+    location_name = get_formatted_location_name(event.location)
+    if event.event_subtype == HistoryEventSubType.SPEND:
+        direction = 'withdrawal'
+        event_type = HistoryEventType.SPEND
+        notes = f'Send {event.amount} {symbol} from {location_name} to an untracked address'
+    elif event.event_subtype == HistoryEventSubType.RECEIVE:
+        direction = 'deposit'
+        event_type = HistoryEventType.RECEIVE
+        notes = f'Receive {event.amount} {symbol} in {location_name} from an untracked address'
+    else:
+        return False  # a fee event has no untracked counterpart of its own
+
+    if event.notes is not None:  # movement notes are the user's own, so they are kept
+        notes = f'{notes}. {event.notes}'
+
+    extra_data: dict[str, Any] = dict(event.extra_data) if event.extra_data is not None else {}
+    extra_data[MATCHED_ASSET_MOVEMENT_KEY] = {'resolution': 'external', 'direction': direction}
+    resolved: list[HistoryEvent] = [HistoryEvent(
+        identifier=event.identifier,
+        group_identifier=event.group_identifier,
+        sequence_index=event.sequence_index,
+        timestamp=event.timestamp,
+        location=event.location,
+        location_label=event.location_label,
+        asset=event.asset,
+        amount=event.amount,
+        notes=notes,
+        event_type=event_type,
+        event_subtype=HistoryEventSubType.PAYMENT,
+        extra_data=extra_data,
+    )]
+    with events_db.db.conn.read_ctx() as cursor:
+        for fee_event in events_db.get_history_events_internal(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(
+                entry_types=IncludeExcludeFilterData(
+                    values=[HistoryBaseEntryType.ASSET_MOVEMENT_EVENT],
+                ),
+                group_identifiers=[event.group_identifier],
+                event_subtypes=[HistoryEventSubType.FEE],
+            ),
+        ):
+            fee_symbol = fee_event.asset.resolve_to_asset_with_symbol().symbol
+            fee_notes = f'Pay {fee_event.amount} {fee_symbol} as {location_name} {direction} fee'
+            if fee_event.notes is not None:
+                fee_notes = f'{fee_notes}. {fee_event.notes}'
+
+            fee_extra_data = dict(fee_event.extra_data) if fee_event.extra_data is not None else None  # noqa: E501
+
+            resolved.append(HistoryEvent(
+                identifier=fee_event.identifier,
+                group_identifier=fee_event.group_identifier,
+                sequence_index=fee_event.sequence_index,
+                timestamp=fee_event.timestamp,
+                location=fee_event.location,
+                location_label=fee_event.location_label,
+                asset=fee_event.asset,
+                amount=fee_event.amount,
+                notes=fee_notes,
+                event_type=HistoryEventType.SPEND,
+                event_subtype=HistoryEventSubType.FEE,
+                extra_data=fee_extra_data,
+            ))
+
+    with events_db.db.conn.write_ctx() as write_cursor:
+        for resolved_event in resolved:
+            events_db.edit_history_event(
+                write_cursor=write_cursor,
+                event=resolved_event,
+                mapping_state=HistoryMappingState.MATCHED,
+                save_backup=True,
+            )
+        write_cursor.execute(
+            'INSERT OR IGNORE INTO history_event_link_ignores(event_id, link_type) '
+            'VALUES(?, ?)',
+            (event.identifier, HistoryEventLinkType.ASSET_MOVEMENT_MATCH.serialize_for_db()),
+        )
+
+    return True
 
 
 def should_exclude_possible_match(

--- a/rotkehlchen/tests/api/test_event_matching.py
+++ b/rotkehlchen/tests/api/test_event_matching.py
@@ -21,6 +21,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.asset_movement import (
     AssetMovement,
     AssetMovementExtraData,
+    AssetMovementTransferSubtype,
 )
 from rotkehlchen.history.events.structures.base import HistoryBaseEntryType, HistoryEvent
 from rotkehlchen.history.events.structures.eth2 import EthWithdrawalEvent
@@ -448,6 +449,187 @@ def test_mark_asset_movement_no_match(rotkehlchen_api_server: APIServer) -> None
             'SELECT left_event_id, right_event_id FROM history_event_links WHERE link_type=?',
             (HistoryEventLinkType.ASSET_MOVEMENT_MATCH.serialize_for_db(),),
         ).fetchall() == [(asset_movement.identifier, matched_event_id)]
+
+
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize(('movement_subtype', 'expected_type', 'expected_direction', 'expected_notes'), [  # noqa: E501
+    (
+        HistoryEventSubType.SPEND,
+        HistoryEventType.SPEND,
+        'withdrawal',
+        'Send 0.1 ETH from Kraken to an untracked address',
+    ), (
+        HistoryEventSubType.RECEIVE,
+        HistoryEventType.RECEIVE,
+        'deposit',
+        'Receive 0.1 ETH in Kraken from an untracked address',
+    ),
+])
+def test_resolve_asset_movement_as_external(
+        rotkehlchen_api_server: APIServer,
+        movement_subtype: AssetMovementTransferSubtype,
+        expected_type: HistoryEventType,
+        expected_direction: str,
+        expected_notes: str,
+) -> None:
+    """Resolving an asset movement as external turns a withdrawal into a payment
+    (SPEND/PAYMENT) and a deposit into income (RECEIVE/PAYMENT) so the whole amount is
+    accounted instead of only the fee. The movement stops being an asset movement, keeps
+    its extra data, gets stamped with the resolution and its original direction and is
+    ignored; the group's fee is rewritten alongside it as a plain spend fee, and unlink
+    restores both.
+    """
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    dbevents = DBHistoryEvents(rotki.data.db)
+    with rotki.data.db.conn.write_ctx() as write_cursor:
+        dbevents.add_history_events(
+            write_cursor=write_cursor,
+            history=[(movement := AssetMovement(
+                identifier=1,
+                location=Location.KRAKEN,
+                event_subtype=movement_subtype,
+                timestamp=(timestamp := TimestampMS(1510000000000)),
+                asset=A_ETH,
+                amount=FVal('0.1'),
+                unique_id='1',
+                location_label='Kraken 1',
+                extra_data=AssetMovementExtraData(address=(address := make_evm_address())),
+            )), (fee_event := AssetMovement(
+                identifier=2,
+                group_identifier=movement.group_identifier,
+                location=Location.KRAKEN,
+                event_subtype=HistoryEventSubType.FEE,
+                timestamp=timestamp,
+                asset=A_ETH,
+                amount=FVal('0.001'),
+                location_label='Kraken 1',
+            ))],
+        )
+
+    assert_simple_ok_response(requests.put(
+        url=api_url_for(rotkehlchen_api_server, 'matchassetmovementsresource'),
+        json={'asset_movement': 1, 'matched_events': [], 'external': True},
+    ))
+    with rotki.data.db.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT event_id FROM history_event_link_ignores WHERE link_type=?',
+            (HistoryEventLinkType.ASSET_MOVEMENT_MATCH.serialize_for_db(),),
+        ).fetchall() == [(1,)]
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM history_events_mappings '
+            'WHERE parent_identifier=? AND name=? AND value=?',
+            (1, HISTORY_MAPPING_KEY_STATE, HistoryMappingState.MATCHED.serialize_for_db()),
+        ).fetchone()[0] == 1
+        events = dbevents.get_history_events_internal(
+            cursor=cursor,
+            filter_query=HistoryEventFilterQuery.make(
+                order_by_rules=[('history_events_identifier', True)],
+            ),
+        )
+
+    assert events == [HistoryEvent(
+        identifier=1,
+        group_identifier=movement.group_identifier,
+        sequence_index=0,
+        timestamp=timestamp,
+        location=Location.KRAKEN,
+        location_label='Kraken 1',
+        asset=A_ETH,
+        amount=FVal('0.1'),
+        notes=expected_notes,
+        event_type=expected_type,
+        event_subtype=HistoryEventSubType.PAYMENT,
+        extra_data={
+            'address': address,
+            'matched_asset_movement': {
+                'resolution': 'external',
+                'direction': expected_direction,
+            },
+        },
+    ), HistoryEvent(  # the fee is rewritten alongside it, so the group stays one kind of event
+        identifier=2,
+        group_identifier=movement.group_identifier,
+        sequence_index=1,
+        timestamp=timestamp,
+        location=Location.KRAKEN,
+        location_label='Kraken 1',
+        asset=A_ETH,
+        amount=FVal('0.001'),
+        notes=f'Pay 0.001 ETH as Kraken {expected_direction} fee',
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+    )]
+
+    # the movement is no longer listed as unmatched
+    movements, _ = get_unmatched_asset_movements(database=rotki.data.db)
+    assert len(movements) == 0
+
+    # unlinking restores the original movement and clears the ignore marker
+    assert_simple_ok_response(requests.delete(
+        url=api_url_for(rotkehlchen_api_server, 'matchassetmovementsresource'),
+        json={'identifier': 1},
+    ))
+    _check_all_unlinked(dbevents=dbevents, original_events=[movement, fee_event])
+    movements, _ = get_unmatched_asset_movements(database=rotki.data.db)
+    assert len(movements) == 1
+
+
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+def test_resolve_asset_movement_as_external_errors(rotkehlchen_api_server: APIServer) -> None:
+    """Only an asset movement deposit or withdrawal can be resolved as external, and the
+    resolution cannot be combined with a match.
+    """
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    with rotki.data.db.conn.write_ctx() as write_cursor:
+        DBHistoryEvents(rotki.data.db).add_history_events(
+            write_cursor=write_cursor,
+            history=[AssetMovement(
+                identifier=1,
+                location=Location.KRAKEN,
+                event_subtype=HistoryEventSubType.FEE,
+                timestamp=TimestampMS(1510000000000),
+                asset=A_ETH,
+                amount=FVal('0.001'),
+                unique_id='1',
+            ), HistoryEvent(
+                identifier=2,
+                group_identifier='xyz',
+                sequence_index=0,
+                location=Location.EXTERNAL,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                timestamp=TimestampMS(1510000000001),
+                asset=A_ETH,
+                amount=FVal('0.1'),
+            )],
+        )
+
+    for identifier in (1, 2):  # a fee event and a plain history event are both rejected
+        assert_error_response(
+            response=requests.put(
+                url=api_url_for(rotkehlchen_api_server, 'matchassetmovementsresource'),
+                json={'asset_movement': identifier, 'external': True},
+            ),
+            contained_in_msg=f'Event with identifier {identifier} is not an asset movement deposit or withdrawal',  # noqa: E501
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    assert_error_response(
+        response=requests.put(
+            url=api_url_for(rotkehlchen_api_server, 'matchassetmovementsresource'),
+            json={'asset_movement': 42, 'external': True},
+        ),
+        contained_in_msg='No event found in the DB for identifier 42',
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
+    assert_error_response(
+        response=requests.put(
+            url=api_url_for(rotkehlchen_api_server, 'matchassetmovementsresource'),
+            json={'asset_movement': 1, 'matched_events': [2], 'external': True},
+        ),
+        contained_in_msg='external cannot be combined with matched_events',
+        status_code=HTTPStatus.BAD_REQUEST,
+    )
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])

--- a/rotkehlchen/tests/unit/accounting/test_exchanges.py
+++ b/rotkehlchen/tests/unit/accounting/test_exchanges.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from contextlib import suppress
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +19,7 @@ from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.swap import create_swap_events
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.tasks.events import resolve_asset_movement_external
 from rotkehlchen.tests.utils.accounting import accounting_create_and_process_history
 from rotkehlchen.tests.utils.exchanges import mock_normal_coinbase_query
 from rotkehlchen.tests.utils.history import prices
@@ -218,6 +219,74 @@ def test_asset_movement_fee_respects_accounting_rules(
     fee_event = fee_events[0]
     assert fee_event.taxable_amount == ZERO
     assert fee_event.asset == A_BTC
+
+
+@pytest.mark.parametrize('have_decoders', [True])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(1.5)])
+@pytest.mark.parametrize('ethereum_accounts', [[]])
+@pytest.mark.parametrize('added_exchanges', [[]])
+@pytest.mark.parametrize('initialize_accounting_rules', [True])
+def test_asset_movement_resolved_as_external_is_accounted(
+        rotkehlchen_api_server_with_exchanges: APIServer,
+) -> None:
+    """A withdrawal to an untracked address is only taxed on its fee until it is resolved
+    as external. Resolving it turns it into a payment, so the whole amount is spent.
+    """
+    rotki = rotkehlchen_api_server_with_exchanges.rest_api.rotkehlchen
+    dbevents = DBHistoryEvents(rotki.data.db)
+    with rotki.data.db.user_write() as write_cursor:
+        dbevents.add_history_events(
+            write_cursor=write_cursor,
+            history=create_swap_events(  # acquire the BTC first, so there is a cost basis
+                timestamp=TimestampMS(1611426200000),
+                location=Location.COINBASE,
+                group_identifier='1xyz',
+                spend=AssetAmount(asset=A_EUR, amount=(btc_cost := FVal(1000))),
+                receive=AssetAmount(asset=A_BTC, amount=ONE),
+            ),
+        )
+        withdrawal = AssetMovement(
+            timestamp=TimestampMS(1611426201000),
+            location=Location.COINBASE,
+            event_subtype=HistoryEventSubType.SPEND,
+            asset=A_BTC,
+            amount=(withdrawn_amount := FVal('0.5')),
+        )
+        withdrawal.identifier = dbevents.add_history_event(
+            write_cursor=write_cursor,
+            event=withdrawal,
+        )
+        dbevents.add_history_event(
+            write_cursor=write_cursor,
+            event=AssetMovement(
+                group_identifier=withdrawal.group_identifier,
+                timestamp=TimestampMS(1611426201000),
+                location=Location.COINBASE,
+                event_subtype=HistoryEventSubType.FEE,
+                asset=A_BTC,
+                amount=(fee_amount := FVal('0.00001')),
+            ),
+        )
+
+    def taxable_overview() -> dict[str, Any]:
+        """The report overview, which unlike the report data is read back per report id."""
+        return accounting_create_and_process_history(
+            rotki=rotki,
+            start_ts=Timestamp(0),
+            end_ts=Timestamp(1611426233),
+        )[0]['overview']
+
+    # unresolved, the movement contributes nothing and only its fee is a taxable spend
+    assert (overview := taxable_overview())[str(AccountingEventType.ASSET_MOVEMENT)]['taxable'] == str(-fee_amount * btc_cost)  # noqa: E501
+    assert str(AccountingEventType.TRANSACTION_EVENT) not in overview
+
+    # Resolved as external, the whole withdrawn amount is spent at its cost basis, and the
+    # fee is still taxed for the same amount -- the rules for exchange transfer/fee and
+    # spend/fee carry the same treatment, so rewriting the fee only moves which accounting
+    # event type it is filed under, keeping both halves of the transfer in the same bucket.
+    assert resolve_asset_movement_external(events_db=dbevents, event=withdrawal) is True
+    assert (overview := taxable_overview())[str(AccountingEventType.TRANSACTION_EVENT)]['taxable'] == str(-(withdrawn_amount + fee_amount) * btc_cost)  # noqa: E501
+    assert str(AccountingEventType.ASSET_MOVEMENT) not in overview
 
 
 @pytest.mark.parametrize('have_decoders', [True])


### PR DESCRIPTION
An exchange deposit or withdrawal whose counterpart address is not tracked can never be matched, and until now only its fee counted in the tax report. It can now be resolved from the unmatched asset movements panel: a withdrawal becomes a payment (spend/payment) and a deposit becomes income (receive/payment), so the whole amount is accounted.

The event stops being an asset movement, since an AssetMovement is by definition an exchange transfer, and is rewritten as a plain history event keeping its identifier, group, location and extra data, stamped with the resolution and its original direction. The group's fee is rewritten alongside it as a plain spend/fee so the group does not end up half asset movement and half history event; both rules carry the same treatment, so the fee is accounted exactly as before. Both edits save a backup, and unlinking restores the movement and its fee.

The frontend offers the action on every unmatched row, worded by direction, and emphasizes it without a confirm when the withdrawal destination is verifiably untracked. Deposits are excluded from that check on purpose: their recorded address is usually the exchange's own deposit address, so it would flag nearly every deposit.

Closes #6206
