### PR TITLE
fix(frontend): drop unresolvable keys from /names

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.spec.ts
@@ -127,6 +127,63 @@ describe('useAddressNameResolution', () => {
       expect(get(addressName)).toBe('eth_name');
     });
 
+    it('should leave every address of a rejected batch unresolved', async () => {
+      enableAliasNames(true);
+      vi.mocked(api.getAddressesNames).mockRejectedValue(new Error('Given value Kraken 1 is not a valid ethereum address'));
+
+      const firstName = resolution.useAddressName(() => '0xCC00000000000000000000000000000000000003');
+      const secondName = resolution.useAddressName(() => '0xCC00000000000000000000000000000000000004');
+
+      expect(get(firstName)).toBeUndefined();
+      expect(get(secondName)).toBeUndefined();
+
+      vi.advanceTimersByTime(2500);
+      await flushPromises();
+
+      expect(api.getAddressesNames).toHaveBeenCalledWith([
+        { address: '0xCC00000000000000000000000000000000000003', blockchain: Blockchain.ETH },
+        { address: '0xCC00000000000000000000000000000000000004', blockchain: Blockchain.ETH },
+      ]);
+      expect(get(firstName)).toBeUndefined();
+      expect(get(secondName)).toBeUndefined();
+      expect(resolution.isAddressNamePending('0xCC00000000000000000000000000000000000003')).toBe(false);
+    });
+
+    it('should keep a label that is not an address out of the request', async () => {
+      enableAliasNames(true);
+      const address = '0xDD00000000000000000000000000000000000005';
+      vi.mocked(api.getAddressesNames).mockResolvedValue([
+        { address, blockchain: Blockchain.ETH, name: 'kept_name' },
+      ]);
+
+      const addressName = resolution.useAddressName(() => address, () => Blockchain.ETH);
+      const labelName = resolution.useAddressName(() => 'Kraken 1', () => Blockchain.ETH);
+
+      expect(get(addressName)).toBeUndefined();
+      expect(get(labelName)).toBeUndefined();
+
+      vi.advanceTimersByTime(2500);
+      await flushPromises();
+
+      expect(api.getAddressesNames).toHaveBeenCalledWith([{ address, blockchain: Blockchain.ETH }]);
+      expect(get(addressName)).toBe('kept_name');
+      expect(get(labelName)).toBeUndefined();
+    });
+
+    it('should keep an address of the wrong ecosystem out of the request', async () => {
+      enableAliasNames(true);
+      vi.mocked(api.getAddressesNames).mockResolvedValue([]);
+
+      const wrongEcosystem = resolution.useAddressName(() => '1Dk75NPu6QXxMxRECfz6VM6oXq3XwprsDF', () => Blockchain.ETH);
+
+      expect(get(wrongEcosystem)).toBeUndefined();
+
+      vi.advanceTimersByTime(2500);
+      await flushPromises();
+
+      expect(api.getAddressesNames).not.toHaveBeenCalled();
+    });
+
     it('should return undefined when enableAliasNames is false', async () => {
       enableAliasNames(false);
       vi.mocked(api.getAddressesNames).mockResolvedValue(mockedResult);

--- a/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-name-resolution.ts
@@ -4,7 +4,7 @@ import type {
   AddressBookSimplePayload,
   AddressNameRequestPayload,
 } from '@/modules/accounts/address-book/eth-names';
-import { Blockchain, isValidBchAddress, isValidBtcAddress, isValidEthAddress, isValidSolanaAddress } from '@rotki/common';
+import { Blockchain, isValidAddress, isValidBchAddress, isValidBtcAddress, isValidEthAddress, isValidSolanaAddress } from '@rotki/common';
 import { useAddressNamesStore } from '@/modules/accounts/address-book/use-address-names-store';
 import { useAddressesNamesApi } from '@/modules/accounts/address-book/use-addresses-names-api';
 import { isBlockchain } from '@/modules/core/common/chains';
@@ -96,20 +96,38 @@ export const useAddressNameResolution = createSharedComposable((): UseAddressNam
 
   const createKey = (address: string, chain: string): string => `${address}#${chain}`;
 
+  function isAddressResolvable(address: string, chain: string): boolean {
+    if (get(evmChainIds).includes(chain))
+      return isValidEthAddress(address);
+
+    if (get(solanaChainIds).includes(chain))
+      return isValidSolanaAddress(address);
+
+    if (get(bitcoinChainIds).includes(chain))
+      return isValidBtcAddress(address) || isValidBchAddress(address);
+
+    return isValidAddress(address);
+  }
+
   const fetchAddressesNames = async (keys: string[]) => {
     const payload: AddressNameRequestPayload[] = [];
     for (const key of keys) {
       const [address, blockchain] = key.split('#');
-      if (isBlockchain(blockchain))
+      if (isBlockchain(blockchain) && isAddressResolvable(address, blockchain))
         payload.push({ address, blockchain });
     }
 
     let result: AddressBookEntry[];
-    try {
-      result = await getAddressesNames(payload);
+    if (payload.length > 0) {
+      try {
+        result = await getAddressesNames(payload);
+      }
+      catch (error: unknown) {
+        logger.error(error);
+        result = [];
+      }
     }
-    catch (error: unknown) {
-      logger.error(error);
+    else {
       result = [];
     }
 
@@ -117,8 +135,7 @@ export const useAddressNameResolution = createSharedComposable((): UseAddressNam
     for (const entry of result) resultMap.set(createKey(entry.address, entry.blockchain ?? ''), entry);
 
     return function* (): Generator<{ key: string; item: AddressBookEntry | undefined }, void> {
-      for (const entry of payload) {
-        const key = createKey(entry.address, entry.blockchain);
+      for (const key of keys) {
         yield { item: resultMap.get(key), key };
       }
     };

--- a/frontend/app/src/modules/history/balances/use-divergence-selection.spec.ts
+++ b/frontend/app/src/modules/history/balances/use-divergence-selection.spec.ts
@@ -13,7 +13,11 @@ vi.mock('@/modules/core/common/use-supported-chains', () => ({
   useSupportedChains: (): object => ({
     getEvmChainName: (chain: string): string | undefined => chain === 'eth' ? 'ethereum' : undefined,
     isEvm: (chain: string): boolean => chain === 'eth',
-    matchChain: (location: string): string | undefined => ['eth', 'ethereum'].includes(location) ? 'eth' : undefined,
+    matchChain: (location: string): string | undefined => {
+      if (['eth', 'ethereum'].includes(location))
+        return 'eth';
+      return ['btc', 'bitcoin'].includes(location) ? 'btc' : undefined;
+    },
   }),
 }));
 
@@ -66,6 +70,17 @@ describe('useDivergenceSelection', () => {
     expect(get(result.modelSelectedChain)).toBe('eth');
     expect(get(result.modelSelectedLocationLabel)).toBe('0xA');
     expect(get(result.selectedEvmChain)).toBe('ethereum');
+  });
+
+  it('should not offer a location label from a non-evm chain', async () => {
+    useHistoryStore().setLocationLabels([
+      { location: 'bitcoin', locationLabel: '1Dk75NPu6QXxMxRECfz6VM6oXq3XwprsDF' },
+    ]);
+    const { result } = mountSelection();
+    await nextTick();
+
+    expect(get(result.chainOptions)).toStrictEqual(['eth']);
+    expect(get(result.locationLabelOptions)).toStrictEqual([{ location: 'eth', locationLabel: '0xA' }]);
   });
 
   it('should fetch the location labels on mount', () => {

--- a/frontend/app/src/modules/history/use-location-labels.spec.ts
+++ b/frontend/app/src/modules/history/use-location-labels.spec.ts
@@ -56,6 +56,15 @@ describe('useLocationLabels', () => {
     expect(getBlockchainLocation('unknown')).toBeUndefined();
   });
 
+  it('should not send an exchange location to address resolution', () => {
+    const exchangeItem: LocationLabel = { location: 'kraken', locationLabel: 'Kraken 1' };
+    const { getAccountName, isAccountNamePending } = useLocationLabels(ref(undefined));
+
+    expect(getAccountName(exchangeItem)).toBeUndefined();
+    expect(isAccountNamePending(exchangeItem)).toBe(false);
+    expect(mockGetAddressName).not.toHaveBeenCalled();
+  });
+
   it('should expose the tags and tracked label of a registered account', () => {
     trackAccount();
     const { getTags, getTrackedAccountLabel } = useLocationLabels(ref(undefined));


### PR DESCRIPTION
`fetchAddressesNames` builds one `/names` batch out of whatever its callers ask a name
for. The backend deserializes every entry against its own ecosystem and rejects the whole
request over a single bad one, so one unresolvable key costs every other address in that
batch its name.

The guard goes at the choke point rather than at the call sites: a key only enters the
payload if its address is valid for the chain it is queried on, reusing the evm / solana /
bitcoin id lists the module already derives from `supportedChains`. Three consequences:

- dropped keys are still yielded, so they settle as unknown instead of being re-queued on
  every read. This also covers a pre-existing case, a chain that fails `isBlockchain` used
  to vanish from both the payload and the yield;
- a batch where everything is dropped makes no request at all, instead of POSTing `[]`;
- a rejected request still leaves every address in the batch unresolved, which is the
  behaviour the tests pin.

## Reachability

This is hardening, not a user-visible fix, which is why it targets `develop` and carries no
changelog entry. The poisoning is real but not reachable from shipped UI today: the only
consumer is `BalanceDivergenceView`, behind `VITE_ACCOUNTING_UPDATE`, already pre-filtered
to EVM addresses, and `/locations/labels` cannot pair a non-address label with an EVM
location. Worth noting for anyone reading the backend: `/names` validates *every*
ecosystem, not just EVM, so junk 400s on solana and bitcoin too.

## Tests

Three paths through the batch: a rejected request leaves every address in it unresolved; a
label that is not an address never reaches the payload; an address of the wrong ecosystem
does not either. The two filters upstream are pinned as well, so a later change cannot
quietly start feeding this one junk: a non-transaction-chain location is never sent for
resolution, and a non-EVM chain is not offered as a divergence location label.

Full frontend unit suite green (973 files, 10,212 tests).
