### PR TITLE
fix(prices): use main asset for collection members

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Historical prices of a token that exists on several chains now come from the main asset it is grouped with, so WETH on Arbitrum, Optimism and Base is priced as ETH. They used to be priced on their own and could come back at roughly half of ETH's value.
 * :bug:`-` The task centre now scrambles the addresses it shows while privacy mode is on. Rows such as "Querying transactions for 0x..." and account additions printed the real address, so the one setting meant to make rotki safe to screen-share or screenshot did not cover the panel that is open while you work.
 * :bug:`-` Privacy mode no longer renders every balance as zero, or smaller than it really is, depending on the scramble multiplier you set. A multiplier below 1 shrank every number instead of hiding it, and 0 turned them all into zeros, which read as rotki losing your balances rather than concealing them. Randomly generated multipliers could also land below 1, so this could happen without you setting anything.
 * :bug:`-` Cancelling a running sync from the task centre no longer leaves the sync progress panel claiming it completed. The panel says the sync was cancelled, and the grouped rows inside it ("9 chains complete") no longer report a clean completion for chains, locations, decoding or protocol caches that were cancelled or failed, which contradicted the rows they contained.

--- a/rotkehlchen/history/price.py
+++ b/rotkehlchen/history/price.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 from rotkehlchen.api.websockets.typedefs import ProgressUpdateSubType, WSMessageType
 from rotkehlchen.assets.asset import Asset, EvmToken
+from rotkehlchen.assets.resolver import AssetResolver
 from rotkehlchen.chain.evm.decoding.uniswap.constants import CPT_UNISWAP_V2, CPT_UNISWAP_V3
 from rotkehlchen.chain.evm.decoding.uniswap.v3.utils import get_uniswap_v3_position_price
 from rotkehlchen.chain.evm.utils import lp_price_from_uniswaplike_pool_contract
@@ -287,6 +288,22 @@ class PriceHistorian:
 
             if aggregated_price != ZERO:
                 return Price(aggregated_price)
+
+        # Last resort: an asset that is a non-main member of a collection is the same
+        # asset on another chain, so it must be priced as the collection's main asset.
+        # Without this, each member is priced through its own oracle mapping and members
+        # whose mapping differs from the main asset's silently get a different price.
+        # Mirrors Inquirer._maybe_replace_asset so current and historical prices agree.
+        if (
+            (main_asset_id := AssetResolver.get_collection_main_asset(from_asset.identifier)) is not None and  # noqa: E501
+            main_asset_id != from_asset.identifier  # the main asset is a member of its own collection  # noqa: E501
+        ):
+            return PriceHistorian._get_cached_price_or_query(
+                from_asset=Asset(main_asset_id),
+                to_asset=to_asset,
+                timestamp=timestamp,
+                max_seconds_distance=max_seconds_distance,
+            )
 
         return None
 

--- a/rotkehlchen/tests/api/test_data_import.py
+++ b/rotkehlchen/tests/api/test_data_import.py
@@ -54,14 +54,6 @@ if TYPE_CHECKING:
     from rotkehlchen.tests.fixtures.websockets import WebsocketReader
 
 
-@pytest.fixture(name='historical_price_oracles_order')
-def fixture_historical_price_oracles_order(
-        cryptocompare_historical_price_oracles_order: tuple,
-) -> tuple:
-    """Override to use CryptoCompare-first order for VCR cassette compatibility."""
-    return cryptocompare_historical_price_oracles_order
-
-
 mocked_prices = {
     'BTC': {
         'USD': {
@@ -501,6 +493,7 @@ def test_data_import_custom_format(rotkehlchen_api_server: APIServer, file_uploa
 
 @pytest.mark.parametrize('legacy_messages_via_websockets', [True])
 @pytest.mark.vcr(filter_query_parameters=['api_key'])
+@pytest.mark.freeze_time('2026-08-27 12:00:00 GMT')  # pin coingecko's 1 year history window
 def test_data_import_binance_history(
         rotkehlchen_api_server: APIServer,
         websocket_connection: WebsocketReader,

--- a/rotkehlchen/tests/unit/test_price_historian.py
+++ b/rotkehlchen/tests/unit/test_price_historian.py
@@ -14,11 +14,13 @@ from rotkehlchen.constants.assets import (
     A_AAVE,
     A_BTC,
     A_CRV,
+    A_ETH,
     A_ETH_MATIC,
     A_ETH_POL,
     A_LINK,
     A_POL,
     A_USD,
+    A_WETH_ARB,
 )
 from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.constants.resolver import strethaddress_to_identifier
@@ -51,14 +53,6 @@ if TYPE_CHECKING:
     from rotkehlchen.assets.asset import FiatAsset
     from rotkehlchen.globaldb.handler import GlobalDBHandler
     from rotkehlchen.inquirer import Inquirer
-
-
-@pytest.fixture(name='historical_price_oracles_order')
-def fixture_historical_price_oracles_order(
-        cryptocompare_historical_price_oracles_order: tuple,
-) -> tuple:
-    """Override to use CryptoCompare-first order for VCR cassette compatibility."""
-    return cryptocompare_historical_price_oracles_order
 
 
 mocked_prices = {
@@ -471,7 +465,7 @@ def test_oracle_instance_caches_price(price_historian):
         mock_add.assert_called_with([HistoricalPrice(
             from_asset=A_BTC,
             to_asset=A_USD,
-            source=HistoricalPriceOracle.CRYPTOCOMPARE,
+            source=HistoricalPriceOracle.DEFILLAMA,
             timestamp=expected_timestamp,
             price=expected_price,
         )])
@@ -590,7 +584,7 @@ def test_uniswap_v2_position_price_query(price_historian: PriceHistorian):
         timestamp=Timestamp(1742814047),
     )
 
-    assert price.is_close('3591639.375183')
+    assert price.is_close('3606838.214124')
 
 
 @pytest.mark.vcr(filter_query_parameters=['apikey', 'api_key'])
@@ -610,7 +604,7 @@ def test_uniswap_v3_position_price_query(price_historian: PriceHistorian):
         timestamp=Timestamp(1742829743),
     )
 
-    assert price.is_close('91.707127')
+    assert price.is_close('91.901195')
 
 
 @pytest.mark.vcr(filter_query_parameters=['api_key'])
@@ -716,3 +710,54 @@ def test_historical_price_underlying_tokens_unpriced_when_a_leg_is_missing(
         max_seconds_distance=3600,
     )
     assert price is None
+
+
+def test_historical_price_collection_member_uses_main_asset(
+        globaldb: GlobalDBHandler,
+        inquirer: Inquirer,  # pylint: disable=unused-argument
+) -> None:
+    """Test that a non-main collection member is priced as the collection's main asset.
+
+    WETH on arbitrum is in the same collection as ETH, but its own cryptocompare mapping
+    points at the thin WETH ticker instead of ETH, so prices cached against the token
+    itself can be wildly off. Regression test: the main asset's price must win.
+    """
+    globaldb.add_single_historical_price(HistoricalPrice(
+        from_asset=A_ETH, to_asset=A_USD, price=Price(FVal('2561.88')),
+        timestamp=(query_timestamp := Timestamp(1726869600)),
+        source=HistoricalPriceOracle.MANUAL,
+    ))
+    globaldb.add_single_historical_price(HistoricalPrice(  # the bad price seen in the wild
+        from_asset=A_WETH_ARB, to_asset=A_USD, price=Price(FVal('1013.49')),
+        timestamp=query_timestamp, source=HistoricalPriceOracle.CRYPTOCOMPARE,
+    ))
+
+    assert PriceHistorian.get_price_for_special_asset(
+        from_asset=A_WETH_ARB,
+        to_asset=A_USD,
+        timestamp=query_timestamp,
+        max_seconds_distance=HOUR_IN_SECONDS,
+    ) == Price(FVal('2561.88'))
+
+
+def test_historical_price_collection_main_asset_is_not_redirected_to_itself(
+        globaldb: GlobalDBHandler,
+        inquirer: Inquirer,  # pylint: disable=unused-argument
+) -> None:
+    """Test that the main asset of a collection is not redirected to itself.
+
+    get_collection_main_asset returns the main asset for every member, the main asset
+    included, so an unguarded redirect would make ETH query its own price through here
+    and recurse endlessly once a cache miss escalates to a remote query.
+    """
+    globaldb.add_single_historical_price(HistoricalPrice(
+        from_asset=A_ETH, to_asset=A_USD, price=Price(FVal('2561.88')),
+        timestamp=(query_timestamp := Timestamp(1726869600)),
+        source=HistoricalPriceOracle.MANUAL,
+    ))
+    assert PriceHistorian.get_price_for_special_asset(  # ETH needs no special handling,
+        from_asset=A_ETH,  # so this must decline instead of resolving its own price
+        to_asset=A_USD,
+        timestamp=query_timestamp,
+        max_seconds_distance=HOUR_IN_SECONDS,
+    ) is None


### PR DESCRIPTION
Current prices already resolve a collection member to its main asset in Inquirer._maybe_replace_asset, but historical prices did not, so each member was priced through its own oracle mapping. WETH on arbitrum, optimism and base map to cryptocompare's thin WETH ticker while mainnet WETH maps to ETH, so their EUR prices came back at roughly half of ETH's for stretches of 2024.

Redirect to the collection main asset as a last resort in get_price_for_special_asset, after the existing special cases, so a member with underlying tokens keeps resolving through those. The main asset is a member of its own collection, so guard against redirecting an asset to itself or a cache miss recurses.