### PR TITLE
refactor(frontend): remove ui-library deprecated props

### DIFF
--- a/frontend/app/src/modules/accounts/AccountAssetSelectionActions.vue
+++ b/frontend/app/src/modules/accounts/AccountAssetSelectionActions.vue
@@ -27,7 +27,7 @@ const { t } = useI18n({ useScope: 'global' });
     class="flex gap-3"
   >
     <RuiTooltip
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>
@@ -47,7 +47,7 @@ const { t } = useI18n({ useScope: 'global' });
 
     <template v-if="selectionMode">
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>
@@ -70,7 +70,7 @@ const { t } = useI18n({ useScope: 'global' });
       </RuiTooltip>
       <div class="border-l border-default pl-3">
         <RuiTooltip
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           :open-delay="400"
         >
           <template #activator>

--- a/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
+++ b/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
@@ -31,7 +31,7 @@ async function doImport() {
   <div>
     <RuiMenu
       :options="{ placement: 'bottom-end' }"
-      menu-class="max-w-[24rem]"
+      :class-names="{ menu: 'max-w-[24rem]' }"
       close-on-content-click
     >
       <template #activator="{ attrs }">

--- a/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
+++ b/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
@@ -30,7 +30,7 @@ async function doImport() {
 <template>
   <div>
     <RuiMenu
-      :popper="{ placement: 'bottom-end' }"
+      :options="{ placement: 'bottom-end' }"
       menu-class="max-w-[24rem]"
       close-on-content-click
     >

--- a/frontend/app/src/modules/accounts/AccountChains.vue
+++ b/frontend/app/src/modules/accounts/AccountChains.vue
@@ -83,7 +83,7 @@ function reset() {
     >
       <RuiTooltip
         :close-delay="0"
-        tooltip-class="!-ml-1"
+        :class-names="{ tooltip: '!-ml-1' }"
       >
         <template #activator>
           <div

--- a/frontend/app/src/modules/accounts/AccountTokenDetectionControls.vue
+++ b/frontend/app/src/modules/accounts/AccountTokenDetectionControls.vue
@@ -32,7 +32,7 @@ function redetectAllClicked(): void {
       color="primary"
     >
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/accounts/IconTokenDisplay.vue
+++ b/frontend/app/src/modules/accounts/IconTokenDisplay.vue
@@ -35,7 +35,7 @@ async function navigateToAsset(asset: AssetBalance): Promise<void> {
       <RuiTooltip
         :disabled="!shouldShowAmount"
         :close-delay="0"
-        tooltip-class="!-ml-1"
+        :class-names="{ tooltip: '!-ml-1' }"
       >
         <template #activator>
           <div

--- a/frontend/app/src/modules/accounts/ModuleActivator.vue
+++ b/frontend/app/src/modules/accounts/ModuleActivator.vue
@@ -76,7 +76,7 @@ const loading = isAccountOperationRunning();
       >
         <RuiTooltip
           class="flex"
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           :open-delay="400"
         >
           <template #activator>

--- a/frontend/app/src/modules/accounts/QueriedAddressDialog.vue
+++ b/frontend/app/src/modules/accounts/QueriedAddressDialog.vue
@@ -142,7 +142,7 @@ function close() {
             />
           </div>
           <RuiTooltip
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             :open-delay="400"
           >
             <template #activator>

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
@@ -48,7 +48,7 @@ async function doImport() {
 <template>
   <div>
     <RuiMenu
-      :popper="{ placement: 'bottom-end' }"
+      :options="{ placement: 'bottom-end' }"
       menu-class="max-w-[24rem]"
       close-on-content-click
     >

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
@@ -49,7 +49,7 @@ async function doImport() {
   <div>
     <RuiMenu
       :options="{ placement: 'bottom-end' }"
-      menu-class="max-w-[24rem]"
+      :class-names="{ menu: 'max-w-[24rem]' }"
       close-on-content-click
     >
       <template #activator="{ attrs }">

--- a/frontend/app/src/modules/accounts/address-book/AddressDeleteButton.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressDeleteButton.vue
@@ -36,7 +36,7 @@ function handleDelete(): void {
 <template>
   <RuiTooltip
     v-if="canDelete"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/accounts/address-book/AddressEditButton.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressEditButton.vue
@@ -26,7 +26,7 @@ function openAddressBookForm() {
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/accounts/address-book/EthNamesHint.vue
+++ b/frontend/app/src/modules/accounts/address-book/EthNamesHint.vue
@@ -4,7 +4,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <div>
-    <RuiMenu :popper="{ placement: 'right' }">
+    <RuiMenu :options="{ placement: 'right' }">
       <template #activator="{ attrs }">
         <RuiButton
           variant="text"

--- a/frontend/app/src/modules/accounts/balances/DetectEvmAccounts.vue
+++ b/frontend/app/src/modules/accounts/balances/DetectEvmAccounts.vue
@@ -12,7 +12,7 @@ const { detectEvmAccounts } = useBlockchainAccountManagement();
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'right' }"
+    :options="{ placement: 'right' }"
     :open-delay="400"
     tooltip-class="max-w-[16rem]"
   >

--- a/frontend/app/src/modules/accounts/balances/DetectEvmAccounts.vue
+++ b/frontend/app/src/modules/accounts/balances/DetectEvmAccounts.vue
@@ -14,7 +14,7 @@ const { detectEvmAccounts } = useBlockchainAccountManagement();
   <RuiTooltip
     :options="{ placement: 'right' }"
     :open-delay="400"
-    tooltip-class="max-w-[16rem]"
+    :class-names="{ tooltip: 'max-w-[16rem]' }"
   >
     <template #activator>
       <RuiButton

--- a/frontend/app/src/modules/accounts/balances/DetectTokenChainsSelection.vue
+++ b/frontend/app/src/modules/accounts/balances/DetectTokenChainsSelection.vue
@@ -46,7 +46,7 @@ watch(open, (isOpen) => {
 <template>
   <RuiMenu
     v-model="open"
-    :popper="{ placement: 'bottom', offsetSkid: 35 }"
+    :options="{ offset: { crossAxis: 35 }, placement: 'bottom' }"
   >
     <template #activator="{ attrs }">
       <RuiButton

--- a/frontend/app/src/modules/accounts/balances/NonFungibleBalancesFilter.vue
+++ b/frontend/app/src/modules/accounts/balances/NonFungibleBalancesFilter.vue
@@ -49,7 +49,7 @@ const { t } = useI18n({ useScope: 'global' });
       </div>
     </div>
     <div>
-      <RuiMenu :popper="{ placement: 'bottom-end' }">
+      <RuiMenu :options="{ placement: 'bottom-end' }">
         <template #activator="{ attrs }">
           <RuiButton
             variant="outlined"

--- a/frontend/app/src/modules/accounts/blockchain/BtcAddressInput.vue
+++ b/frontend/app/src/modules/accounts/blockchain/BtcAddressInput.vue
@@ -127,7 +127,7 @@ defineExpose({
       />
       <div>
         <RuiTooltip
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           :open-delay="400"
         >
           <template #activator>

--- a/frontend/app/src/modules/accounts/blockchain/TokenDetection.vue
+++ b/frontend/app/src/modules/accounts/blockchain/TokenDetection.vue
@@ -17,7 +17,7 @@ const { t } = useI18n({ useScope: 'global' });
   <div class="flex items-center justify-end">
     {{ detectedTokens.total }}
     <RuiTooltip
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/accounts/blockchain/WalletImportSelection.vue
+++ b/frontend/app/src/modules/accounts/blockchain/WalletImportSelection.vue
@@ -48,7 +48,7 @@ onBeforeMount(async () => {
 <template>
   <RuiMenu
     menu-class="max-w-[16rem] w-[16rem] [&>div]:p-4"
-    :popper="{ placement: 'right-end' }"
+    :options="{ placement: 'right-end' }"
   >
     <template #activator="{ attrs }">
       <slot v-bind="{ attrs }" />

--- a/frontend/app/src/modules/accounts/blockchain/WalletImportSelection.vue
+++ b/frontend/app/src/modules/accounts/blockchain/WalletImportSelection.vue
@@ -47,7 +47,7 @@ onBeforeMount(async () => {
 
 <template>
   <RuiMenu
-    menu-class="max-w-[16rem] w-[16rem] [&>div]:p-4"
+    :class-names="{ menu: 'max-w-[16rem] w-[16rem] [&>div]:p-4' }"
     :options="{ placement: 'right-end' }"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/accounts/blockchain/eth2/Eth2ValidatorLimitTooltip.vue
+++ b/frontend/app/src/modules/accounts/blockchain/eth2/Eth2ValidatorLimitTooltip.vue
@@ -12,7 +12,7 @@ const { validatorsLimitInfo } = useEthStaking();
     v-if="validatorsLimitInfo.showWarning"
     :open-delay="300"
     persist-on-tooltip-hover
-    tooltip-class="max-w-[12rem]"
+    :class-names="{ tooltip: 'max-w-[12rem]' }"
   >
     <template #activator>
       <RuiIcon

--- a/frontend/app/src/modules/accounts/management/AccountFormApiKeyMenu.vue
+++ b/frontend/app/src/modules/accounts/management/AccountFormApiKeyMenu.vue
@@ -73,7 +73,7 @@ watch(open, async (isOpen) => {
   <RuiMenu
     v-if="visible"
     v-model="open"
-    menu-class="w-[26rem] max-w-[90vw]"
+    :class-names="{ menu: 'w-[26rem] max-w-[90vw]' }"
     :options="{ placement: 'bottom-end' }"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/accounts/management/AccountFormApiKeyMenu.vue
+++ b/frontend/app/src/modules/accounts/management/AccountFormApiKeyMenu.vue
@@ -74,7 +74,7 @@ watch(open, async (isOpen) => {
     v-if="visible"
     v-model="open"
     menu-class="w-[26rem] max-w-[90vw]"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
   >
     <template #activator="{ attrs }">
       <RuiButton

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalancesForm.vue
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalancesForm.vue
@@ -127,7 +127,7 @@ defineExpose({
         @update:model-value="touch('asset')"
       />
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/assets/AssetActionButton.vue
+++ b/frontend/app/src/modules/assets/AssetActionButton.vue
@@ -16,7 +16,7 @@ const emit = defineEmits<{
 <template>
   <RuiTooltip
     :open-delay="200"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
   >
     <template #activator>
       <RuiButton

--- a/frontend/app/src/modules/assets/AssetDetailsBase.vue
+++ b/frontend/app/src/modules/assets/AssetDetailsBase.vue
@@ -132,7 +132,7 @@ watch(menuOpened, (menuOpened) => {
     :key="asset.identifier"
     v-model="menuOpened"
     class="flex"
-    menu-class="w-[16rem] max-w-[90%]"
+    :class-names="{ menu: 'w-[16rem] max-w-[90%]' }"
     :options="{ placement: 'bottom-start' }"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/assets/AssetDetailsBase.vue
+++ b/frontend/app/src/modules/assets/AssetDetailsBase.vue
@@ -133,7 +133,7 @@ watch(menuOpened, (menuOpened) => {
     v-model="menuOpened"
     class="flex"
     menu-class="w-[16rem] max-w-[90%]"
-    :popper="{ placement: 'bottom-start' }"
+    :options="{ placement: 'bottom-start' }"
   >
     <template #activator="{ attrs }">
       <ReuseImage

--- a/frontend/app/src/modules/assets/admin/AssetIconForm.vue
+++ b/frontend/app/src/modules/assets/admin/AssetIconForm.vue
@@ -99,7 +99,7 @@ defineExpose({
       >
         <RuiTooltip
           v-if="preview && refreshable"
-          :popper="{ placement: 'right' }"
+          :options="{ placement: 'right' }"
           :open-delay="400"
           class="absolute -top-3 -right-3"
         >

--- a/frontend/app/src/modules/assets/admin/RestoreAssetDbButton.vue
+++ b/frontend/app/src/modules/assets/admin/RestoreAssetDbButton.vue
@@ -94,7 +94,7 @@ function showDoneConfirmation() {
 <template>
   <RuiMenu
     v-if="dropdown"
-    :popper="{ placement: 'left-start' }"
+    :options="{ placement: 'left-start' }"
   >
     <template #activator="{ attrs }">
       <RuiButton

--- a/frontend/app/src/modules/assets/admin/UnderlyingTokenWeightHint.vue
+++ b/frontend/app/src/modules/assets/admin/UnderlyingTokenWeightHint.vue
@@ -4,7 +4,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetActions.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetActions.vue
@@ -65,7 +65,7 @@ watch(() => ignoredHandling, (handling) => {
       />
       <div class="border-l border-default pl-3">
         <RuiTooltip
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           :open-delay="400"
         >
           <template #activator>

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
@@ -206,7 +206,7 @@ onBeforeMount(async () => {
       </RuiButton>
       <RuiMenu
         v-model="openAction"
-        :popper="{ placement: 'bottom-end' }"
+        :options="{ placement: 'bottom-end' }"
       >
         <template #activator="{ attrs }">
           <RuiButton
@@ -222,7 +222,7 @@ onBeforeMount(async () => {
         <RuiTooltip
           :open-delay="400"
           class="w-full"
-          :popper="{ placement: 'left' }"
+          :options="{ placement: 'left' }"
           tooltip-class="max-w-[200px]"
         >
           <template #activator>

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
@@ -223,7 +223,7 @@ onBeforeMount(async () => {
           :open-delay="400"
           class="w-full"
           :options="{ placement: 'left' }"
-          tooltip-class="max-w-[200px]"
+          :class-names="{ tooltip: 'max-w-[200px]' }"
         >
           <template #activator>
             <RuiButton

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.vue
@@ -350,7 +350,7 @@ defineExpose({
       <RuiAccordions>
         <RuiAccordion
           header-grow
-          header-class="p-4"
+          :class-names="{ header: 'p-4' }"
         >
           <template #header>
             {{ t('asset_form.optional') }}

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetIgnoreSwitch.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetIgnoreSwitch.vue
@@ -43,7 +43,7 @@ const tooltipMessage = computed<string>(() =>
 <template>
   <div class="flex justify-start items-center gap-2">
     <RuiTooltip
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
       tooltip-class="max-w-[10rem]"
       :disabled="!isIgnoringDisabled || isLoading"

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetIgnoreSwitch.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetIgnoreSwitch.vue
@@ -45,7 +45,7 @@ const tooltipMessage = computed<string>(() =>
     <RuiTooltip
       :options="{ placement: 'top' }"
       :open-delay="400"
-      tooltip-class="max-w-[10rem]"
+      :class-names="{ tooltip: 'max-w-[10rem]' }"
       :disabled="!isIgnoringDisabled || isLoading"
     >
       <template #activator>
@@ -63,7 +63,7 @@ const tooltipMessage = computed<string>(() =>
 
     <RuiMenu
       v-if="showMoreOptions"
-      menu-class="w-[15rem]"
+      :class-names="{ menu: 'w-[15rem]' }"
       close-on-content-click
     >
       <template #activator="{ attrs }">

--- a/frontend/app/src/modules/assets/amount-display/CurrencyDropdown.vue
+++ b/frontend/app/src/modules/assets/amount-display/CurrencyDropdown.vue
@@ -76,7 +76,7 @@ watch(visible, (isVisible, wasVisible) => {
 <template>
   <RuiMenu
     v-model="visible"
-    menu-class="w-[22rem]"
+    :class-names="{ menu: 'w-[22rem]' }"
     :options="{ placement: 'bottom' }"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/assets/amount-display/CurrencyDropdown.vue
+++ b/frontend/app/src/modules/assets/amount-display/CurrencyDropdown.vue
@@ -77,7 +77,7 @@ watch(visible, (isVisible, wasVisible) => {
   <RuiMenu
     v-model="visible"
     menu-class="w-[22rem]"
-    :popper="{ placement: 'bottom' }"
+    :options="{ placement: 'bottom' }"
   >
     <template #activator="{ attrs }">
       <MenuTooltipButton

--- a/frontend/app/src/modules/assets/amount-display/components/ManualPriceIndicator.vue
+++ b/frontend/app/src/modules/assets/amount-display/components/ManualPriceIndicator.vue
@@ -4,7 +4,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
     class="self-center mr-2 cursor-pointer"
   >

--- a/frontend/app/src/modules/assets/amount-display/components/OracleBadge.vue
+++ b/frontend/app/src/modules/assets/amount-display/components/OracleBadge.vue
@@ -7,7 +7,7 @@ defineProps<{
 <template>
   <RuiChip
     color="warning"
-    content-class="!text-[10px]"
+    :class-names="{ content: '!text-[10px]' }"
     class="font-bold leading-3 uppercase !p-0.5 mb-0.5 mt-0.5"
     size="sm"
   >

--- a/frontend/app/src/modules/assets/detection/NewlyDetectedAssetToolbar.vue
+++ b/frontend/app/src/modules/assets/detection/NewlyDetectedAssetToolbar.vue
@@ -34,7 +34,7 @@ const pillLabels = usePillBarLabels();
     <div class="flex gap-4 justify-between grow">
       <div class="flex gap-4 content-center">
         <RuiTooltip
-          :popper="{ placement: 'bottom' }"
+          :options="{ placement: 'bottom' }"
           :open-delay="500"
         >
           <template #activator>
@@ -55,7 +55,7 @@ const pillLabels = usePillBarLabels();
 
         <div>
           <RuiTooltip
-            :popper="{ placement: 'bottom' }"
+            :options="{ placement: 'bottom' }"
             :open-delay="500"
           >
             <template #activator>
@@ -75,7 +75,7 @@ const pillLabels = usePillBarLabels();
           </RuiTooltip>
 
           <RuiTooltip
-            :popper="{ placement: 'bottom' }"
+            :options="{ placement: 'bottom' }"
             :open-delay="500"
           >
             <template #activator>
@@ -96,7 +96,7 @@ const pillLabels = usePillBarLabels();
         </div>
       </div>
 
-      <HintMenuIcon :popper="{ placement: 'left-start' }">
+      <HintMenuIcon :options="{ placement: 'left-start' }">
         {{ t('asset_table.newly_detected.subtitle') }}
       </HintMenuIcon>
     </div>

--- a/frontend/app/src/modules/assets/prices/components/oracle/OracleCacheActionsCell.vue
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OracleCacheActionsCell.vue
@@ -12,7 +12,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/auth/AboutButton.vue
+++ b/frontend/app/src/modules/auth/AboutButton.vue
@@ -12,7 +12,7 @@ function show() {
 <template>
   <RuiTooltip
     :text="t('account_management.about_tooltip')"
-    :popper="{ placement: 'top', offsetDistance: 0 }"
+    :options="{ offset: 0, placement: 'top' }"
   >
     <template #activator>
       <RuiButton

--- a/frontend/app/src/modules/auth/login/LoginRememberOptions.vue
+++ b/frontend/app/src/modules/auth/login/LoginRememberOptions.vue
@@ -45,7 +45,7 @@ const { isPackaged } = useInterop();
         :open-delay="400"
         :close-delay="0"
         class="ml-2"
-        tooltip-class="max-w-[16rem]"
+        :class-names="{ tooltip: 'max-w-[16rem]' }"
         :text="t('login.remember_password_tooltip')"
       >
         <template #activator>

--- a/frontend/app/src/modules/auth/login/PasswordConfirmationDialog.vue
+++ b/frontend/app/src/modules/auth/login/PasswordConfirmationDialog.vue
@@ -75,7 +75,7 @@ watchImmediate(display, async (isDisplayed) => {
     max-width="500"
     persistent
   >
-    <RuiCard content-class="!pt-0">
+    <RuiCard :class-names="{ content: '!pt-0' }">
       <template #header>
         {{ t('password_confirmation_dialog.title') }}
       </template>

--- a/frontend/app/src/modules/balances/BlockchainBalanceStalenessIndicator.vue
+++ b/frontend/app/src/modules/balances/BlockchainBalanceStalenessIndicator.vue
@@ -9,7 +9,7 @@ const { t } = useI18n({ useScope: 'global' });
   <RuiTooltip
     v-if="lastRefreshTimestamp"
     class="inline-flex"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/balances/nft/NftDetails.vue
+++ b/frontend/app/src/modules/balances/nft/NftDetails.vue
@@ -92,7 +92,7 @@ const fallbackData = computed(() => {
     <div class="flex items-center overflow-hidden">
       <div class="cursor-pointer">
         <RuiTooltip
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           :disabled="shouldRender"
           :open-delay="400"
           class="w-full"

--- a/frontend/app/src/modules/balances/nft/NftDetails.vue
+++ b/frontend/app/src/modules/balances/nft/NftDetails.vue
@@ -96,7 +96,7 @@ const fallbackData = computed(() => {
           :disabled="shouldRender"
           :open-delay="400"
           class="w-full"
-          tooltip-class="max-w-[10rem]"
+          :class-names="{ tooltip: 'max-w-[10rem]' }"
         >
           <template #activator>
             <div

--- a/frontend/app/src/modules/balances/nft/NftGalleryFilters.vue
+++ b/frontend/app/src/modules/balances/nft/NftGalleryFilters.vue
@@ -26,7 +26,7 @@ const chains = [Blockchain.ETH];
 </script>
 
 <template>
-  <RuiCard content-class="grid md:grid-cols-8 gap-4">
+  <RuiCard :class-names="{ content: 'grid md:grid-cols-8 gap-4' }">
     <BlockchainAccountSelector
       v-model="selectedAccounts"
       class="md:col-span-3"

--- a/frontend/app/src/modules/balances/nft/NftGalleryItem.vue
+++ b/frontend/app/src/modules/balances/nft/NftGalleryItem.vue
@@ -74,7 +74,7 @@ const mediaStyle = computed<StyleValue>(() => {
   >
     <div class="relative flex">
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :disabled="shouldRender"
         :open-delay="400"
         class="w-full"
@@ -110,7 +110,7 @@ const mediaStyle = computed<StyleValue>(() => {
 
       <RuiTooltip
         v-if="!shouldRender"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
         class="absolute right-2 bottom-2"
       >
@@ -132,7 +132,7 @@ const mediaStyle = computed<StyleValue>(() => {
     </div>
     <div class="p-4">
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
         tooltip-class="max-w-[20rem]"
         class="text-truncate block text-subtitle-1 font-medium"
@@ -144,7 +144,7 @@ const mediaStyle = computed<StyleValue>(() => {
       </RuiTooltip>
       <RuiTooltip
         v-if="item.collection"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
         tooltip-class="max-w-[20rem] text-truncate overflow-hidden"
         class="pt-1 text-truncate max-w-full"

--- a/frontend/app/src/modules/balances/nft/NftGalleryItem.vue
+++ b/frontend/app/src/modules/balances/nft/NftGalleryItem.vue
@@ -78,7 +78,7 @@ const mediaStyle = computed<StyleValue>(() => {
         :disabled="shouldRender"
         :open-delay="400"
         class="w-full"
-        tooltip-class="max-w-[10rem]"
+        :class-names="{ tooltip: 'max-w-[10rem]' }"
       >
         <template #activator>
           <ExternalLink
@@ -134,7 +134,7 @@ const mediaStyle = computed<StyleValue>(() => {
       <RuiTooltip
         :options="{ placement: 'top' }"
         :open-delay="400"
-        tooltip-class="max-w-[20rem]"
+        :class-names="{ tooltip: 'max-w-[20rem]' }"
         class="text-truncate block text-subtitle-1 font-medium"
       >
         <template #activator>
@@ -146,7 +146,7 @@ const mediaStyle = computed<StyleValue>(() => {
         v-if="item.collection"
         :options="{ placement: 'top' }"
         :open-delay="400"
-        tooltip-class="max-w-[20rem] text-truncate overflow-hidden"
+        :class-names="{ tooltip: 'max-w-[20rem] text-truncate overflow-hidden' }"
         class="pt-1 text-truncate max-w-full"
       >
         <template #activator>

--- a/frontend/app/src/modules/balances/nft/NftSorter.vue
+++ b/frontend/app/src/modules/balances/nft/NftSorter.vue
@@ -27,7 +27,7 @@ const sortProperties = [
 <template>
   <div class="flex">
     <RuiTooltip
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/balances/protocols/BalanceTopProtocols.vue
+++ b/frontend/app/src/modules/balances/protocols/BalanceTopProtocols.vue
@@ -41,7 +41,7 @@ const showMore = computed<number>(() => protocols.length - visible);
         v-if="showMore > 0"
         open-on-hover
         :close-delay="200"
-        :popper="{ placement: 'bottom' }"
+        :options="{ placement: 'bottom' }"
       >
         <template #activator="{ open, attrs }">
           <div

--- a/frontend/app/src/modules/balances/protocols/ProtocolIcon.vue
+++ b/frontend/app/src/modules/balances/protocols/ProtocolIcon.vue
@@ -26,7 +26,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
     :disabled="!showTooltip"
   >

--- a/frontend/app/src/modules/balances/protocols/ProtocolTooltipIcon.vue
+++ b/frontend/app/src/modules/balances/protocols/ProtocolTooltipIcon.vue
@@ -46,7 +46,7 @@ const name = computed<string>(() => {
     :disabled="!shouldShowAmount"
     :open-delay="100"
     persist-on-tooltip-hover
-    tooltip-class="!-ml-1"
+    :class-names="{ tooltip: '!-ml-1' }"
   >
     <template #activator>
       <ProtocolIcon

--- a/frontend/app/src/modules/balances/protocols/components/ChainBalanceTooltipIcon.vue
+++ b/frontend/app/src/modules/balances/protocols/components/ChainBalanceTooltipIcon.vue
@@ -21,7 +21,7 @@ const chainName = useChainName(() => chainId);
   <RuiTooltip
     :disabled="!shouldShowAmount"
     :close-delay="0"
-    tooltip-class="!-ml-1"
+    :class-names="{ tooltip: '!-ml-1' }"
   >
     <template #activator>
       <ChainIcon

--- a/frontend/app/src/modules/calendar/CalendarColorInput.vue
+++ b/frontend/app/src/modules/calendar/CalendarColorInput.vue
@@ -27,7 +27,7 @@ function updateModel(newValue: string) {
 <template>
   <div>
     <RuiMenu
-      :popper="{ placement: 'left' }"
+      :options="{ placement: 'left' }"
       menu-class="max-w-[18rem]"
     >
       <template #activator="{ attrs }">

--- a/frontend/app/src/modules/calendar/CalendarColorInput.vue
+++ b/frontend/app/src/modules/calendar/CalendarColorInput.vue
@@ -28,7 +28,7 @@ function updateModel(newValue: string) {
   <div>
     <RuiMenu
       :options="{ placement: 'left' }"
-      menu-class="max-w-[18rem]"
+      :class-names="{ menu: 'max-w-[18rem]' }"
     >
       <template #activator="{ attrs }">
         <div

--- a/frontend/app/src/modules/calendar/CalendarEventList.vue
+++ b/frontend/app/src/modules/calendar/CalendarEventList.vue
@@ -70,7 +70,7 @@ function onEventClicked(calendarEvent: CalendarEvent) {
         :options="{ placement: 'left' }"
         :disabled="!showTooltip"
         :open-delay="400"
-        tooltip-class="max-w-[20rem] whitespace-break-spaces"
+        :class-names="{ tooltip: 'max-w-[20rem] whitespace-break-spaces' }"
       >
         <template #activator>
           <div class="text-body-2 text-rui-text-secondary">

--- a/frontend/app/src/modules/calendar/CalendarEventList.vue
+++ b/frontend/app/src/modules/calendar/CalendarEventList.vue
@@ -67,7 +67,7 @@ function onEventClicked(calendarEvent: CalendarEvent) {
       </div>
       <RuiTooltip
         v-if="event.description"
-        :popper="{ placement: 'left' }"
+        :options="{ placement: 'left' }"
         :disabled="!showTooltip"
         :open-delay="400"
         tooltip-class="max-w-[20rem] whitespace-break-spaces"

--- a/frontend/app/src/modules/calendar/CalendarSettingsMenu.vue
+++ b/frontend/app/src/modules/calendar/CalendarSettingsMenu.vue
@@ -14,11 +14,11 @@ const showMenu = ref(false);
   <RuiMenu
     v-model="showMenu"
     menu-class="w-full max-w-96 !bg-transparent"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
   >
     <template #activator="{ attrs }">
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/calendar/CalendarSettingsMenu.vue
+++ b/frontend/app/src/modules/calendar/CalendarSettingsMenu.vue
@@ -13,7 +13,7 @@ const showMenu = ref(false);
 <template>
   <RuiMenu
     v-model="showMenu"
-    menu-class="w-full max-w-96 !bg-transparent"
+    :class-names="{ menu: 'w-full max-w-96 !bg-transparent' }"
     :options="{ placement: 'bottom-end' }"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/core/action-center/ActionCenterMenu.vue
+++ b/frontend/app/src/modules/core/action-center/ActionCenterMenu.vue
@@ -23,7 +23,7 @@ const tooltip = computed<string>(() => checking
   <RuiMenu
     v-model="open"
     :options="{ placement: 'bottom-end' }"
-    menu-class="w-[36rem] max-w-[90vw]"
+    :class-names="{ menu: 'w-[36rem] max-w-[90vw]' }"
   >
     <template #activator="{ attrs }">
       <RuiButton

--- a/frontend/app/src/modules/core/action-center/ActionCenterMenu.vue
+++ b/frontend/app/src/modules/core/action-center/ActionCenterMenu.vue
@@ -22,7 +22,7 @@ const tooltip = computed<string>(() => checking
 <template>
   <RuiMenu
     v-model="open"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
     menu-class="w-[36rem] max-w-[90vw]"
   >
     <template #activator="{ attrs }">
@@ -56,7 +56,7 @@ const tooltip = computed<string>(() => checking
 
       <RuiTooltip
         v-else
-        :popper="{ placement: 'bottom' }"
+        :options="{ placement: 'bottom' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/core/action-center/ActionCenterRow.vue
+++ b/frontend/app/src/modules/core/action-center/ActionCenterRow.vue
@@ -79,7 +79,7 @@ const lockedHint = computed<string>(() => item.minimumTier
 
     <RuiTooltip
       v-if="item.locked"
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/core/notifications/NoTasksRunning.vue
+++ b/frontend/app/src/modules/core/notifications/NoTasksRunning.vue
@@ -7,7 +7,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <RuiCard
     dense
-    content-class="flex items-center gap-4"
+    :class-names="{ content: 'flex items-center gap-4' }"
   >
     <SuccessDisplay success />
     <div class="font-medium">

--- a/frontend/app/src/modules/core/notifications/NotificationPopup.vue
+++ b/frontend/app/src/modules/core/notifications/NotificationPopup.vue
@@ -63,7 +63,7 @@ watch(showNotificationBar, (showNotificationBar) => {
       <div class="flex justify-between p-2 items-center border-t border-default">
         <RuiTooltip
           :open-delay="400"
-          :popper="{ placement: 'right' }"
+          :options="{ placement: 'right' }"
         >
           <template #activator>
             <RuiChip
@@ -79,7 +79,7 @@ watch(showNotificationBar, (showNotificationBar) => {
 
         <RuiTooltip
           :open-delay="400"
-          :popper="{ placement: 'left' }"
+          :options="{ placement: 'left' }"
         >
           <template #activator>
             <RuiButton

--- a/frontend/app/src/modules/core/notifications/PendingTask.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTask.vue
@@ -124,7 +124,7 @@ const showRing = computed<boolean>(() => get(isRunning) && get(hasDeterminatePro
     -->
     <RuiTooltip
       v-else
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>
@@ -156,7 +156,7 @@ const showRing = computed<boolean>(() => get(isRunning) && get(hasDeterminatePro
 
     <RuiTooltip
       v-if="cancellable"
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
+++ b/frontend/app/src/modules/dashboard/DashboardAssetTable.vue
@@ -133,7 +133,7 @@ watch(modelSearch, () => setPage(1));
         <RuiTooltip
           v-else-if="isPriceMissing(row.asset)"
           :open-delay="400"
-          tooltip-class="max-w-[16rem]"
+          :class-names="{ tooltip: 'max-w-[16rem]' }"
         >
           <template #activator>
             <RuiIcon

--- a/frontend/app/src/modules/dashboard/DashboardExpandableTable.vue
+++ b/frontend/app/src/modules/dashboard/DashboardExpandableTable.vue
@@ -14,7 +14,7 @@ const panel = computed<number>(() => (get(expanded) ? 0 : -1));
 </script>
 
 <template>
-  <RuiCard :content-class="!expanded ? '!py-0' : ''">
+  <RuiCard :class-names="{ content: !expanded ? '!py-0' : '' }">
     <template #custom-header>
       <div class="flex justify-between items-center flex-wrap p-4 gap-x-4 gap-y-2">
         <CardTitle>

--- a/frontend/app/src/modules/dashboard/OverallBalances.vue
+++ b/frontend/app/src/modules/dashboard/OverallBalances.vue
@@ -112,7 +112,7 @@ onMounted(() => {
 <template>
   <RuiCard
     class="overall-balances"
-    content-class="grid grid-cols-1 lg:grid-cols-12 p-2 gap-4 overflow-hidden"
+    :class-names="{ content: 'grid grid-cols-1 lg:grid-cols-12 p-2 gap-4 overflow-hidden' }"
   >
     <div
       class="lg:col-span-4 flex flex-col justify-start lg:p-4"

--- a/frontend/app/src/modules/dashboard/SnapshotActionButton.vue
+++ b/frontend/app/src/modules/dashboard/SnapshotActionButton.vue
@@ -25,7 +25,7 @@ async function forceSaveAndClose(): Promise<void> {
   <RuiMenu
     id="snapshot-action-menu"
     v-model="visible"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
     :persistent="importSnapshotDialog"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/dashboard/SnapshotActionButton.vue
+++ b/frontend/app/src/modules/dashboard/SnapshotActionButton.vue
@@ -74,7 +74,7 @@ async function forceSaveAndClose(): Promise<void> {
 
         <RuiTooltip
           :open-delay="400"
-          tooltip-class="max-w-[16rem]"
+          :class-names="{ tooltip: 'max-w-[16rem]' }"
         >
           <template #activator>
             <RuiIcon
@@ -90,7 +90,7 @@ async function forceSaveAndClose(): Promise<void> {
       <RuiTooltip
         class="mt-2"
         :open-delay="400"
-        tooltip-class="max-w-[16rem]"
+        :class-names="{ tooltip: 'max-w-[16rem]' }"
       >
         <template #activator>
           <SettingSwitch

--- a/frontend/app/src/modules/dashboard/VisibleColumnsSelector.vue
+++ b/frontend/app/src/modules/dashboard/VisibleColumnsSelector.vue
@@ -58,7 +58,7 @@ function update(value: TableColumn) {
 
 <template>
   <RuiMenu
-    menu-class="max-w-[15rem]"
+    :class-names="{ menu: 'max-w-[15rem]' }"
     :options="{ placement: 'bottom-end' }"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/dashboard/VisibleColumnsSelector.vue
+++ b/frontend/app/src/modules/dashboard/VisibleColumnsSelector.vue
@@ -59,7 +59,7 @@ function update(value: TableColumn) {
 <template>
   <RuiMenu
     menu-class="max-w-[15rem]"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
   >
     <template #activator="{ attrs }">
       <MenuTooltipButton

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotEditorToolbar.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotEditorToolbar.vue
@@ -91,7 +91,7 @@ function deleteSnapshot(): void {
       <RuiMenu
         v-if="isDirty"
         v-model="reviewOpen"
-        :popper="{ placement: 'bottom-start' }"
+        :options="{ placement: 'bottom-start' }"
       >
         <template #activator="{ attrs }">
           <RuiChip
@@ -151,7 +151,7 @@ function deleteSnapshot(): void {
 
       <RuiMenu
         v-model="overflowOpen"
-        :popper="{ placement: 'bottom-end' }"
+        :options="{ placement: 'bottom-end' }"
       >
         <template #activator="{ attrs }">
           <RuiButton

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotListTable.vue
@@ -106,7 +106,7 @@ const cols = computed<DataTableColumn<SnapshotListRow>[]>(() => [
       <div class="flex items-center justify-center gap-1">
         <RuiTooltip
           :open-delay="400"
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
         >
           <template #activator>
             <RuiButton
@@ -128,7 +128,7 @@ const cols = computed<DataTableColumn<SnapshotListRow>[]>(() => [
 
         <RuiTooltip
           :open-delay="400"
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
         >
           <template #activator>
             <RuiButton
@@ -149,7 +149,7 @@ const cols = computed<DataTableColumn<SnapshotListRow>[]>(() => [
 
         <RuiTooltip
           :open-delay="400"
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
         >
           <template #activator>
             <RuiButton

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotLocationsDrawer.vue
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotLocationsDrawer.vue
@@ -137,7 +137,7 @@ function applyDistribute(): void {
     position="right"
     :stateless="entryOpen"
     class="flex flex-col"
-    content-class="flex flex-col"
+    :class-names="{ content: 'flex flex-col' }"
     data-testid="snapshot-locations-drawer"
   >
     <div class="flex items-center justify-between gap-2 p-4 border-b border-default">

--- a/frontend/app/src/modules/dashboard/summary/BlockchainSummaryCardCreateButton.vue
+++ b/frontend/app/src/modules/dashboard/summary/BlockchainSummaryCardCreateButton.vue
@@ -34,7 +34,7 @@ function addBlockchainAccount(path: string) {
 </script>
 
 <template>
-  <RuiMenu wrapper-class="w-full">
+  <RuiMenu :class-names="{ wrapper: 'w-full' }">
     <template #activator="{ attrs }">
       <SummaryCardCreateButton v-bind="attrs">
         {{ t('dashboard.blockchain_balances.add') }}

--- a/frontend/app/src/modules/dashboard/summary/SummaryCardRefreshMenu.vue
+++ b/frontend/app/src/modules/dashboard/summary/SummaryCardRefreshMenu.vue
@@ -33,7 +33,7 @@ defineSlots<{
     v-else
     class="relative pr-1"
   >
-    <RuiMenu :popper="{ placement: 'bottom-start' }">
+    <RuiMenu :options="{ placement: 'bottom-start' }">
       <template #activator="{ attrs }">
         <RefreshButton
           :loading="loading"

--- a/frontend/app/src/modules/history/IgnoreButtons.vue
+++ b/frontend/app/src/modules/history/IgnoreButtons.vue
@@ -14,7 +14,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <div class="flex gap-2">
     <RuiTooltip
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>
@@ -36,7 +36,7 @@ const { t } = useI18n({ useScope: 'global' });
       <span>{{ t('ignore_buttons.ignore_tooltip') }}</span>
     </RuiTooltip>
     <RuiTooltip
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/history/IgnoredInAccountingIcon.vue
+++ b/frontend/app/src/modules/history/IgnoredInAccountingIcon.vue
@@ -23,7 +23,7 @@ const { t } = useI18n({ useScope: 'global' });
     </BadgeDisplay>
     <RuiTooltip
       v-else
-      :popper="{ placement: 'bottom' }"
+      :options="{ placement: 'bottom' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/history/LocationLabelSelector.spec.ts
+++ b/frontend/app/src/modules/history/LocationLabelSelector.spec.ts
@@ -24,8 +24,8 @@ const stubs = {
   EnsAvatar: true,
   LocationIcon: true,
   RuiAutoComplete: {
-    props: ['menuClass', 'options'],
-    template: `<div data-testid="autocomplete" :data-menu-class="menuClass">
+    props: ['classNames', 'options'],
+    template: `<div data-testid="autocomplete" :data-menu-class="classNames?.menu">
       <slot />
       <template v-if="options.length > 0">
         <div data-testid="selection-slot"><slot name="selection" :item="options[0]" /></div>

--- a/frontend/app/src/modules/history/LocationLabelSelector.vue
+++ b/frontend/app/src/modules/history/LocationLabelSelector.vue
@@ -119,7 +119,7 @@ const [DefineLocationItem, ReuseLocationItem] = createReusableTemplate<{ item: L
     :filter="filter"
     :label="t('transactions.filter.account')"
     variant="outlined"
-    menu-class="!min-w-full"
+    :class-names="{ menu: '!min-w-full' }"
     v-bind="$attrs"
   >
     <template #selection="{ item }">

--- a/frontend/app/src/modules/history/balances/AccountingOverlayBuckets.vue
+++ b/frontend/app/src/modules/history/balances/AccountingOverlayBuckets.vue
@@ -74,7 +74,7 @@ const affectedIndex = computed<number>(() => {
         <RuiTooltip
           v-if="excessivePrecision"
           :open-delay="200"
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
         >
           <template #activator>
             <RuiIcon
@@ -111,7 +111,7 @@ const affectedIndex = computed<number>(() => {
                address holding the same asset on several chains), so lead every row with its icon. -->
           <RuiTooltip
             :open-delay="200"
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
           >
             <template #activator>
               <LocationIcon

--- a/frontend/app/src/modules/history/balances/AccountingOverlayCell.vue
+++ b/frontend/app/src/modules/history/balances/AccountingOverlayCell.vue
@@ -132,7 +132,7 @@ const placeholder = computed<string | undefined>(() => {
       <span class="text-rui-text-disabled">{{ t('accounting_overlay.no_data') }}</span>
       <RuiTooltip
         :open-delay="300"
-        :popper="{ placement: 'left' }"
+        :options="{ placement: 'left' }"
       >
         <template #activator>
           <RuiIcon

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueDetailDrawer.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueDetailDrawer.vue
@@ -26,7 +26,7 @@ const emit = defineEmits<{
     temporary
     position="right"
     class="flex flex-col"
-    content-class="flex flex-col"
+    :class-names="{ content: 'flex flex-col' }"
     data-testid="data-issue-detail-drawer"
   >
     <DataIssueDetailContent

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuePanelCard.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuePanelCard.vue
@@ -55,7 +55,7 @@ useMutationObserver(descriptionRef, checkTruncation, { characterData: true, chil
       ? '!border-rui-primary ring-1 ring-rui-primary bg-rui-primary/5'
       : 'hover:bg-rui-grey-50 dark:hover:bg-rui-grey-900'"
     no-padding
-    content-class="overflow-hidden h-full"
+    :class-names="{ content: 'overflow-hidden h-full' }"
     data-testid="data-issues-panel-item"
     :data-active="active"
     @click="emit('open')"

--- a/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.vue
+++ b/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.vue
@@ -162,7 +162,7 @@ onMounted(() => {
 <template>
   <RuiMenu
     v-model="showMenu"
-    menu-class="w-full max-w-96"
+    :class-names="{ menu: 'w-full max-w-96' }"
     :options="{ placement: 'bottom-end' }"
     :disabled="disabled"
     class="!border-l-0"

--- a/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.vue
+++ b/frontend/app/src/modules/history/events/AssetMovementMatchingSettingsMenu.vue
@@ -163,13 +163,13 @@ onMounted(() => {
   <RuiMenu
     v-model="showMenu"
     menu-class="w-full max-w-96"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
     :disabled="disabled"
     class="!border-l-0"
   >
     <template #activator="{ attrs }">
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/history/events/BridgePotentialMatchesDialog.vue
+++ b/frontend/app/src/modules/history/events/BridgePotentialMatchesDialog.vue
@@ -61,7 +61,7 @@ function showPotentialMatchInEvents(data: { identifier: number; groupIdentifier:
     v-model="modelValue"
     max-width="1000"
   >
-    <RuiCard content-class="!pb-0">
+    <RuiCard :class-names="{ content: '!pb-0' }">
       <template #custom-header>
         <div class="flex items-center justify-between w-full px-4 pt-2">
           <CardTitle>

--- a/frontend/app/src/modules/history/events/CustomizedEventDuplicatesDialog.vue
+++ b/frontend/app/src/modules/history/events/CustomizedEventDuplicatesDialog.vue
@@ -57,7 +57,7 @@ onBeforeMount(async () => {
     max-width="1000"
   >
     <RuiCard
-      content-class="!py-0"
+      :class-names="{ content: '!py-0' }"
       divide
     >
       <template #custom-header>

--- a/frontend/app/src/modules/history/events/DuplicateRowActions.vue
+++ b/frontend/app/src/modules/history/events/DuplicateRowActions.vue
@@ -34,7 +34,7 @@ const { t } = useI18n({ useScope: 'global' });
     <RuiTooltip
       v-if="mode === 'ignored'"
       :open-delay="400"
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
     >
       <template #activator>
         <RuiButton
@@ -57,7 +57,7 @@ const { t } = useI18n({ useScope: 'global' });
     <RuiTooltip
       v-else
       :open-delay="400"
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
     >
       <template #activator>
         <RuiButton

--- a/frontend/app/src/modules/history/events/HistoryEventAction.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventAction.vue
@@ -38,7 +38,7 @@ function onEditRule(): void {
   <div class="flex items-center">
     <RuiMenu
       menu-class="max-w-[15rem] z-[100]"
-      :popper="{ placement: 'bottom-end', scroll: false, resize: false }"
+      :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'bottom-end' }"
       close-on-content-click
     >
       <template #activator="{ attrs }">

--- a/frontend/app/src/modules/history/events/HistoryEventAction.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventAction.vue
@@ -37,7 +37,7 @@ function onEditRule(): void {
 <template>
   <div class="flex items-center">
     <RuiMenu
-      menu-class="max-w-[15rem] z-[100]"
+      :class-names="{ menu: 'max-w-[15rem] z-[100]' }"
       :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'bottom-end' }"
       close-on-content-click
     >

--- a/frontend/app/src/modules/history/events/HistoryEventAsset.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventAsset.vue
@@ -59,9 +59,8 @@ watch(menuOpened, (menuOpened) => {
   <RuiMenu
     v-model="menuOpened"
     class="flex"
-    menu-class="w-[16rem] max-w-[90%] z-[100]"
+    :class-names="{ menu: 'w-[16rem] max-w-[90%] z-[100]', wrapper: 'w-full' }"
     :disabled="disableOptions"
-    wrapper-class="w-full"
     :options="{
       placement: 'bottom-start',
       strategy: 'fixed',

--- a/frontend/app/src/modules/history/events/HistoryEventStateChip.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventStateChip.vue
@@ -12,7 +12,7 @@ const config = computed(() => stateConfigs[state]);
 </script>
 
 <template>
-  <RuiTooltip :popper="{ placement: 'top', scroll: false, resize: false }">
+  <RuiTooltip :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }">
     <template #activator>
       <RuiChip
         size="sm"

--- a/frontend/app/src/modules/history/events/HistoryEventTypeCombination.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventTypeCombination.vue
@@ -61,7 +61,7 @@ const { t } = useI18n({ useScope: 'global' });
         {{ type.label }}
       </div>
       <RuiTooltip
-        :popper="{ placement: 'top', scroll: false, resize: false }"
+        :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/history/events/HistoryEventTypeCounterparty.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventTypeCounterparty.vue
@@ -72,7 +72,7 @@ const displayAddress = computed<string | undefined>(() => {
   >
     <template #icon>
       <RuiTooltip
-        :popper="{ placement: 'top', scroll: false, resize: false }"
+        :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/history/events/HistoryEventTypeLocationBadge.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventTypeLocationBadge.vue
@@ -24,7 +24,7 @@ const locationData = useLocationData(() => location);
   >
     <template #icon>
       <RuiTooltip
-        :popper="{ placement: 'top', scroll: false, resize: false }"
+        :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/history/events/HistoryEventsAction.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsAction.vue
@@ -123,7 +123,7 @@ function redecodeWithOptions(target: DecodableEventType): void {
     <RuiMenu
       v-model="showMenu"
       menu-class="max-w-[15rem] z-[100]"
-      :popper="{ placement: 'bottom-end', scroll: false, resize: false }"
+      :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'bottom-end' }"
       close-on-content-click
     >
       <template #activator="{ attrs }">

--- a/frontend/app/src/modules/history/events/HistoryEventsAction.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsAction.vue
@@ -122,7 +122,7 @@ function redecodeWithOptions(target: DecodableEventType): void {
     </RuiButton>
     <RuiMenu
       v-model="showMenu"
-      menu-class="max-w-[15rem] z-[100]"
+      :class-names="{ menu: 'max-w-[15rem] z-[100]' }"
       :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'bottom-end' }"
       close-on-content-click
     >

--- a/frontend/app/src/modules/history/events/HistoryEventsFiltersChips.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsFiltersChips.vue
@@ -58,7 +58,7 @@ const {
     <RuiTooltip
       v-if="showNegativeBalance"
       class="pb-4"
-      :popper="{ placement: 'bottom' }"
+      :options="{ placement: 'bottom' }"
       :open-delay="400"
       tooltip-class="max-w-80"
     >
@@ -80,7 +80,7 @@ const {
     <RuiTooltip
       v-if="showAccountingEvent"
       class="pb-4"
-      :popper="{ placement: 'bottom' }"
+      :options="{ placement: 'bottom' }"
       :open-delay="400"
       tooltip-class="max-w-80"
     >

--- a/frontend/app/src/modules/history/events/HistoryEventsFiltersChips.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsFiltersChips.vue
@@ -60,7 +60,7 @@ const {
       class="pb-4"
       :options="{ placement: 'bottom' }"
       :open-delay="400"
-      tooltip-class="max-w-80"
+      :class-names="{ tooltip: 'max-w-80' }"
     >
       <template #activator>
         <RuiChip
@@ -82,7 +82,7 @@ const {
       class="pb-4"
       :options="{ placement: 'bottom' }"
       :open-delay="400"
-      tooltip-class="max-w-80"
+      :class-names="{ tooltip: 'max-w-80' }"
     >
       <template #activator>
         <RuiChip

--- a/frontend/app/src/modules/history/events/HistoryEventsIdentifier.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsIdentifier.vue
@@ -177,7 +177,7 @@ const key = computed(() => {
         <RuiMenu
           v-if="extraHashCount > 0"
           v-model="hashMenuOpen"
-          :popper="{ placement: 'bottom-start' }"
+          :options="{ placement: 'bottom-start' }"
         >
           <template #activator="{ attrs }">
             <RuiButton

--- a/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
@@ -43,7 +43,7 @@ const menuOpen = ref<boolean>(false);
 
   <RuiMenu
     v-model="menuOpen"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
     menu-class="max-w-[24rem]"
     close-on-content-click
   >

--- a/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsViewButtons.vue
@@ -44,7 +44,7 @@ const menuOpen = ref<boolean>(false);
   <RuiMenu
     v-model="menuOpen"
     :options="{ placement: 'bottom-end' }"
-    menu-class="max-w-[24rem]"
+    :class-names="{ menu: 'max-w-[24rem]' }"
     close-on-content-click
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
@@ -218,7 +218,7 @@ onBeforeMount(async () => {
       <RuiTooltip
         :open-delay="400"
         :options="{ placement: 'top' }"
-        tooltip-class="max-w-80"
+        :class-names="{ tooltip: 'max-w-80' }"
       >
         <template #activator>
           <RuiButton
@@ -244,7 +244,7 @@ onBeforeMount(async () => {
         <RuiTooltip
           :open-delay="400"
           :options="{ placement: 'top' }"
-          tooltip-class="max-w-80"
+          :class-names="{ tooltip: 'max-w-80' }"
         >
           <template #activator>
             <RuiButton

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
@@ -217,7 +217,7 @@ onBeforeMount(async () => {
       </RuiButton>
       <RuiTooltip
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         tooltip-class="max-w-80"
       >
         <template #activator>
@@ -243,7 +243,7 @@ onBeforeMount(async () => {
       >
         <RuiTooltip
           :open-delay="400"
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           tooltip-class="max-w-80"
         >
           <template #activator>

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsDialog.vue
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsDialog.vue
@@ -39,7 +39,7 @@ function showInHistoryEvents(movement: UnmatchedAssetMovement): void {
     max-width="1000"
   >
     <RuiCard
-      content-class="!py-0"
+      :class-names="{ content: '!py-0' }"
       divide
     >
       <template #custom-header>

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
@@ -228,7 +228,7 @@ onBeforeMount(async () => {
         <RuiTooltip
           :open-delay="400"
           :options="{ placement: 'top' }"
-          tooltip-class="max-w-80"
+          :class-names="{ tooltip: 'max-w-80' }"
         >
           <template #activator>
             <RuiButton

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
@@ -227,7 +227,7 @@ onBeforeMount(async () => {
       >
         <RuiTooltip
           :open-delay="400"
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           tooltip-class="max-w-80"
         >
           <template #activator>

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsDialog.vue
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsDialog.vue
@@ -39,7 +39,7 @@ function showInHistoryEvents(transaction: UnmatchedBridgeTransaction): void {
     max-width="1000"
   >
     <RuiCard
-      content-class="!py-0"
+      :class-names="{ content: '!py-0' }"
       divide
     >
       <template #custom-header>

--- a/frontend/app/src/modules/history/events/PotentialMatchesDialog.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesDialog.vue
@@ -52,7 +52,7 @@ function showPotentialMatchInEvents(data: { identifier: number; groupIdentifier:
     v-model="modelValue"
     max-width="1000"
   >
-    <RuiCard content-class="!pb-0">
+    <RuiCard :class-names="{ content: '!pb-0' }">
       <template #custom-header>
         <div class="flex items-center justify-between w-full px-4 pt-2">
           <CardTitle>

--- a/frontend/app/src/modules/history/events/PotentialMatchesList.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesList.vue
@@ -142,7 +142,7 @@ watchDebounced(onlyExpectedAssets, () => {
         />
         <RuiTooltip
           :options="{ placement: 'top' }"
-          tooltip-class="max-w-80"
+          :class-names="{ tooltip: 'max-w-80' }"
         >
           <template #activator>
             <RuiCheckbox

--- a/frontend/app/src/modules/history/events/PotentialMatchesList.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesList.vue
@@ -141,7 +141,7 @@ watchDebounced(onlyExpectedAssets, () => {
           :class="isPinned ? 'w-28' : 'w-36'"
         />
         <RuiTooltip
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           tooltip-class="max-w-80"
         >
           <template #activator>

--- a/frontend/app/src/modules/history/events/RedecodeEventsButton.vue
+++ b/frontend/app/src/modules/history/events/RedecodeEventsButton.vue
@@ -26,7 +26,7 @@ const { t } = useI18n({ useScope: 'global' });
     <template #append>
       <RuiTooltip
         v-if="hasOptions"
-        :popper="{ placement: 'top', scroll: false, resize: false }"
+        :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
       >
         <template #activator>
           <RuiButton

--- a/frontend/app/src/modules/history/events/ShowInEventsButton.vue
+++ b/frontend/app/src/modules/history/events/ShowInEventsButton.vue
@@ -9,7 +9,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <RuiTooltip
     :open-delay="400"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
   >
     <template #activator>
       <RuiButton

--- a/frontend/app/src/modules/history/events/UnmatchedActions.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedActions.vue
@@ -148,7 +148,7 @@ function accept(): void {
       <!-- the jump to history stays on the line: it is how a row gets inspected, not a rare action -->
       <RuiTooltip
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
       >
         <template #activator>
           <RuiButton
@@ -173,7 +173,7 @@ function accept(): void {
       <RuiTooltip
         v-if="!spec.showRestore"
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
       >
         <template #activator>
           <RuiButton
@@ -198,7 +198,7 @@ function accept(): void {
       <RuiTooltip
         v-if="showExternalIcon"
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
       >
         <template #activator>
           <RuiButton
@@ -224,7 +224,7 @@ function accept(): void {
       <RuiMenu
         v-if="hasMenu"
         v-model="menuOpen"
-        :popper="{ placement: 'bottom-end' }"
+        :options="{ placement: 'bottom-end' }"
         close-on-content-click
       >
         <template #activator="{ attrs }">
@@ -286,7 +286,7 @@ function accept(): void {
   >
     <RuiTooltip
       :open-delay="400"
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
     >
       <template #activator>
         <RuiButton
@@ -311,7 +311,7 @@ function accept(): void {
     <RuiTooltip
       v-if="spec.showRestore"
       :open-delay="400"
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
     >
       <template #activator>
         <RuiButton
@@ -342,7 +342,7 @@ function accept(): void {
       </RuiButton>
       <RuiTooltip
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
       >
         <template #activator>
           <RuiButton
@@ -360,7 +360,7 @@ function accept(): void {
       <RuiTooltip
         v-if="spec.markExternal"
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
       >
         <template #activator>
           <RuiButton
@@ -379,7 +379,7 @@ function accept(): void {
       <RuiTooltip
         v-if="spec.createCounterpart"
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
       >
         <template #activator>
           <RuiButton

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsCards.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsCards.vue
@@ -73,7 +73,7 @@ const { t } = useI18n({ useScope: 'global' });
         <RuiTooltip
           v-if="item.isFiat"
           :open-delay="400"
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           tooltip-class="max-w-80"
         >
           <template #activator>

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsCards.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsCards.vue
@@ -74,7 +74,7 @@ const { t } = useI18n({ useScope: 'global' });
           v-if="item.isFiat"
           :open-delay="400"
           :options="{ placement: 'top' }"
-          tooltip-class="max-w-80"
+          :class-names="{ tooltip: 'max-w-80' }"
         >
           <template #activator>
             <RuiChip

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsTable.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsTable.vue
@@ -102,7 +102,7 @@ function getRowClass(row: UnmatchedMovementRow): string {
             v-if="row.isFiat"
             :open-delay="400"
             :options="{ placement: 'top' }"
-            tooltip-class="max-w-80"
+            :class-names="{ tooltip: 'max-w-80' }"
           >
             <template #activator>
               <RuiChip

--- a/frontend/app/src/modules/history/events/UnmatchedMovementsTable.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedMovementsTable.vue
@@ -101,7 +101,7 @@ function getRowClass(row: UnmatchedMovementRow): string {
           <RuiTooltip
             v-if="row.isFiat"
             :open-delay="400"
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             tooltip-class="max-w-80"
           >
             <template #activator>

--- a/frontend/app/src/modules/history/events/UnmatchedUntrackedBadge.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedUntrackedBadge.vue
@@ -8,7 +8,7 @@ defineProps<{
 <template>
   <RuiTooltip
     :open-delay="200"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     tooltip-class="max-w-80"
   >
     <template #activator>

--- a/frontend/app/src/modules/history/events/UnmatchedUntrackedBadge.vue
+++ b/frontend/app/src/modules/history/events/UnmatchedUntrackedBadge.vue
@@ -9,7 +9,7 @@ defineProps<{
   <RuiTooltip
     :open-delay="200"
     :options="{ placement: 'top' }"
-    tooltip-class="max-w-80"
+    :class-names="{ tooltip: 'max-w-80' }"
   >
     <template #activator>
       <span

--- a/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
@@ -74,7 +74,7 @@ const redecoding = useEventRedecodeStatus(() => group, () => groupEvents);
 
         <RuiTooltip
           v-if="ignoredAssets"
-          :popper="{ placement: 'top', scroll: false, resize: false }"
+          :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
           :open-delay="400"
           tooltip-class="max-w-60"
         >
@@ -174,7 +174,7 @@ const redecoding = useEventRedecodeStatus(() => group, () => groupEvents);
 
     <RuiTooltip
       v-if="ignoredAssets"
-      :popper="{ placement: 'top', scroll: false, resize: false }"
+      :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
       :open-delay="400"
       tooltip-class="max-w-60"
     >

--- a/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsGroupItem.vue
@@ -76,7 +76,7 @@ const redecoding = useEventRedecodeStatus(() => group, () => groupEvents);
           v-if="ignoredAssets"
           :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
           :open-delay="400"
-          tooltip-class="max-w-60"
+          :class-names="{ tooltip: 'max-w-60' }"
         >
           <template #activator>
             <button
@@ -176,7 +176,7 @@ const redecoding = useEventRedecodeStatus(() => group, () => groupEvents);
       v-if="ignoredAssets"
       :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
       :open-delay="400"
-      tooltip-class="max-w-60"
+      :class-names="{ tooltip: 'max-w-60' }"
     >
       <template #activator>
         <button

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
@@ -138,7 +138,7 @@ const limits = [10, 25, 50, 100];
           :options="limits"
           dense
           hide-details
-          label-class="!text-xs"
+          :class-names="{ label: '!text-xs' }"
           class="w-18"
         />
       </div>

--- a/frontend/app/src/modules/history/events/components/RedecodeConfirmationDialog.vue
+++ b/frontend/app/src/modules/history/events/components/RedecodeConfirmationDialog.vue
@@ -115,7 +115,7 @@ watch(show, (value) => {
     v-model="show"
     :max-width="700"
   >
-    <RuiCard content-class="!pt-0">
+    <RuiCard :class-names="{ content: '!pt-0' }">
       <template #header>
         {{ t('transactions.actions.redecode_events') }}
       </template>

--- a/frontend/app/src/modules/history/events/prices/EventAssetPriceUpdateDialog.vue
+++ b/frontend/app/src/modules/history/events/prices/EventAssetPriceUpdateDialog.vue
@@ -139,7 +139,7 @@ watch(modelValue, (payload) => {
     max-width="500"
     @update:model-value="close()"
   >
-    <RuiCard content-class="!pb-0">
+    <RuiCard :class-names="{ content: '!pb-0' }">
       <template #custom-header>
         <div class="flex items-center justify-between w-full px-4 pt-2">
           <CardTitle>

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictRowActions.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictRowActions.vue
@@ -20,7 +20,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <div class="flex items-center">
     <RuiTooltip
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>
@@ -42,7 +42,7 @@ const { t } = useI18n({ useScope: 'global' });
       {{ t('internal_tx_conflicts.resolution.resolve') }} ({{ actionLabel }})
     </RuiTooltip>
     <RuiTooltip
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsActions.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsActions.vue
@@ -33,7 +33,7 @@ function toggleSettings(): void {
     </template>
     <RuiTooltip
       v-else
-      :popper="{ placement: 'bottom' }"
+      :options="{ placement: 'bottom' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
@@ -329,7 +329,7 @@ defineExpose({
             class="flex items-center gap-1"
           >
             <RuiTooltip
-              :popper="{ placement: 'top' }"
+              :options="{ placement: 'top' }"
               :open-delay="400"
               tooltip-class="max-w-80"
             >

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
@@ -331,7 +331,7 @@ defineExpose({
             <RuiTooltip
               :options="{ placement: 'top' }"
               :open-delay="400"
-              tooltip-class="max-w-80"
+              :class-names="{ tooltip: 'max-w-80' }"
             >
               <template #activator>
                 <span class="truncate max-w-48 inline-block align-bottom">

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsDialog.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsDialog.vue
@@ -38,7 +38,7 @@ function showInEvents(conflict: InternalTxConflict): void {
     max-width="1000"
   >
     <RuiCard
-      content-class="!py-0"
+      :class-names="{ content: '!py-0' }"
       divide
     >
       <template #custom-header>

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsDialogHeaderActions.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsDialogHeaderActions.vue
@@ -11,7 +11,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <div class="flex items-center gap-1">
     <RuiTooltip
-      :popper="{ placement: 'bottom' }"
+      :options="{ placement: 'bottom' }"
       :open-delay="400"
     >
       <template #activator>
@@ -26,7 +26,7 @@ const { t } = useI18n({ useScope: 'global' });
       {{ t('internal_tx_conflicts.actions.settings') }}
     </RuiTooltip>
     <RuiTooltip
-      :popper="{ placement: 'bottom' }"
+      :options="{ placement: 'bottom' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/AssetMovementEventForm.vue
@@ -223,7 +223,7 @@ defineExpose({
     <RuiAccordions>
       <RuiAccordion
         data-testid="asset-movement-event-form-advance"
-        header-class="py-4"
+        :class-names="{ header: 'py-4' }"
         eager
       >
         <template #header>

--- a/frontend/app/src/modules/history/management/forms/BitcoinEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/BitcoinEventForm.vue
@@ -174,7 +174,7 @@ defineExpose({
     <RuiAccordions>
       <RuiAccordion
         data-testid="bitcoin-event-form-advance"
-        header-class="py-4"
+        :class-names="{ header: 'py-4' }"
         eager
       >
         <template #header>

--- a/frontend/app/src/modules/history/management/forms/EthBlockEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/EthBlockEventForm.vue
@@ -135,7 +135,7 @@ defineExpose({
     <RuiAccordions>
       <RuiAccordion
         data-testid="eth-block-event-form-advance"
-        header-class="py-4"
+        :class-names="{ header: 'py-4' }"
         eager
       >
         <template #header>

--- a/frontend/app/src/modules/history/management/forms/EthDepositEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/EthDepositEventForm.vue
@@ -209,7 +209,7 @@ defineExpose({
     <RuiAccordions>
       <RuiAccordion
         data-testid="eth-deposit-event-form-advance"
-        header-class="py-4"
+        :class-names="{ header: 'py-4' }"
         eager
       >
         <template #header>

--- a/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/EthWithdrawalEventForm.vue
@@ -126,7 +126,7 @@ defineExpose({
     <RuiAccordions>
       <RuiAccordion
         data-testid="eth-withdrawal-event-form-advance"
-        header-class="py-4"
+        :class-names="{ header: 'py-4' }"
         eager
       >
         <template #header>

--- a/frontend/app/src/modules/history/management/forms/EvmEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/EvmEventForm.vue
@@ -265,7 +265,7 @@ defineExpose({
     <RuiAccordions>
       <RuiAccordion
         data-testid="evm-event-form-advance"
-        header-class="py-4"
+        :class-names="{ header: 'py-4' }"
         eager
       >
         <template #header>

--- a/frontend/app/src/modules/history/management/forms/SolanaEventForm.vue
+++ b/frontend/app/src/modules/history/management/forms/SolanaEventForm.vue
@@ -175,7 +175,7 @@ defineExpose({
     <RuiAccordions>
       <RuiAccordion
         data-testid="solana-event-form-advance"
-        header-class="py-4"
+        :class-names="{ header: 'py-4' }"
         eager
       >
         <template #header>

--- a/frontend/app/src/modules/history/management/forms/common/ToggleLocationLink.vue
+++ b/frontend/app/src/modules/history/management/forms/common/ToggleLocationLink.vue
@@ -54,7 +54,7 @@ watchImmediate(() => location, () => {
   <div class="pt-1">
     <RuiTooltip
       :disabled="disabled"
-      :popper="{ placement: 'top-end' }"
+      :options="{ placement: 'top-end' }"
     >
       <template #activator>
         <RuiButton

--- a/frontend/app/src/modules/history/management/forms/swap/SwapEventNotes.vue
+++ b/frontend/app/src/modules/history/management/forms/swap/SwapEventNotes.vue
@@ -31,7 +31,7 @@ function feeLabel(index: number): string {
   <RuiAccordions>
     <RuiAccordion
       data-testid="advanced-accordion"
-      header-class="py-4"
+      :class-names="{ header: 'py-4' }"
       eager
     >
       <template #header>

--- a/frontend/app/src/modules/history/management/forms/swap/SwapSubEvent.vue
+++ b/frontend/app/src/modules/history/management/forms/swap/SwapSubEvent.vue
@@ -103,7 +103,7 @@ const userNotesLabel = computed<string>(() => {
     >
       <RuiAccordion
         data-testid="advanced-accordion"
-        header-class="py-3"
+        :class-names="{ header: 'py-3' }"
         eager
       >
         <template #header>

--- a/frontend/app/src/modules/history/redecode/HistoryRedecodeSelection.vue
+++ b/frontend/app/src/modules/history/redecode/HistoryRedecodeSelection.vue
@@ -84,7 +84,7 @@ function redecode() {
   <RuiMenu
     v-model="open"
     class="!border-0"
-    :popper="{ placement: 'bottom', offsetSkid: 35 }"
+    :options="{ offset: { crossAxis: 35 }, placement: 'bottom' }"
   >
     <template #activator="{ attrs }">
       <RuiButton

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshProtocolEvents.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshProtocolEvents.vue
@@ -97,7 +97,7 @@ defineExpose({
     >
       <RuiTooltip
         :disabled="!queryConfigs[query]?.tooltip"
-        :popper="{ placement: 'top-start' }"
+        :options="{ placement: 'top-start' }"
       >
         <template #activator>
           <div class="flex items-center">

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshSelection.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshSelection.vue
@@ -68,7 +68,7 @@ function toggleSelectAll(): void {
   <RuiMenu
     v-model="open"
     class="!border-0"
-    :popper="{ placement: 'bottom', offsetSkid: 35 }"
+    :options="{ offset: { crossAxis: 35 }, placement: 'bottom' }"
   >
     <template #activator="{ attrs }">
       <RuiButton

--- a/frontend/app/src/modules/notes/UserNotesSidebar.vue
+++ b/frontend/app/src/modules/notes/UserNotesSidebar.vue
@@ -66,7 +66,7 @@ watch(locationName, (locationName) => {
             <ReuseCountBadge :count="notesCount" />
           </template>
           <RuiTooltip
-            :popper="{ placement: 'bottom' }"
+            :options="{ placement: 'bottom' }"
             :open-delay="400"
           >
             <template #activator>

--- a/frontend/app/src/modules/premium/GetPremiumButton.vue
+++ b/frontend/app/src/modules/premium/GetPremiumButton.vue
@@ -17,7 +17,7 @@ const { isLgAndDown } = useBreakpoint();
     class="mr-2"
   >
     <RuiTooltip
-      :popper="{ placement: 'bottom' }"
+      :options="{ placement: 'bottom' }"
       :disabled="!(isLgAndDown && hideOnSmallScreen)"
       :open-delay="400"
     >

--- a/frontend/app/src/modules/reports/MissingPriceRefreshButton.vue
+++ b/frontend/app/src/modules/reports/MissingPriceRefreshButton.vue
@@ -14,7 +14,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <div class="flex items-center gap-1">
     <RuiTooltip
-      :popper="{ placement: 'right' }"
+      :options="{ placement: 'right' }"
       :open-delay="700"
       tooltip-class="max-w-[16rem]"
     >

--- a/frontend/app/src/modules/reports/MissingPriceRefreshButton.vue
+++ b/frontend/app/src/modules/reports/MissingPriceRefreshButton.vue
@@ -16,7 +16,7 @@ const { t } = useI18n({ useScope: 'global' });
     <RuiTooltip
       :options="{ placement: 'right' }"
       :open-delay="700"
-      tooltip-class="max-w-[16rem]"
+      :class-names="{ tooltip: 'max-w-[16rem]' }"
     >
       <template #activator>
         <RuiIcon

--- a/frontend/app/src/modules/reports/ProfitLossEvents.vue
+++ b/frontend/app/src/modules/reports/ProfitLossEvents.vue
@@ -208,7 +208,7 @@ onMounted(async () => {
       <template #item.group="{ row }">
         <RuiTooltip
           v-if="row.groupId && (row.groupLine.top || row.groupLine.bottom)"
-          :popper="{ placement: 'right' }"
+          :options="{ placement: 'right' }"
           :open-delay="400"
           class="h-full !block"
         >
@@ -325,7 +325,7 @@ onMounted(async () => {
       <template #item.expand="{ row }">
         <RuiTooltip
           :open-delay="400"
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
         >
           <template #activator>
             <RuiTableRowExpander

--- a/frontend/app/src/modules/reports/ReportActionableCard.vue
+++ b/frontend/app/src/modules/reports/ReportActionableCard.vue
@@ -189,7 +189,7 @@ function close() {
     no-padding
     class="overflow-hidden flex flex-col"
     :class="isPinned ? 'h-full !rounded-none' : 'max-h-[90vh]'"
-    content-class="flex flex-col flex-1 min-h-0 overflow-hidden"
+    :class-names="{ content: 'flex flex-col flex-1 min-h-0 overflow-hidden' }"
     variant="flat"
   >
     <!-- Dialog mode keeps its own header; when pinned, the rail's tab provides title + close. -->

--- a/frontend/app/src/modules/reports/ReportActionableCard.vue
+++ b/frontend/app/src/modules/reports/ReportActionableCard.vue
@@ -219,7 +219,7 @@ function close() {
       <div class="grow" />
 
       <RuiTooltip
-        :popper="{ placement: 'bottom' }"
+        :options="{ placement: 'bottom' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/reports/ReportDebugMenu.vue
+++ b/frontend/app/src/modules/reports/ReportDebugMenu.vue
@@ -10,7 +10,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <RuiMenu
     close-on-content-click
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
   >
     <template #activator="{ attrs }">
       <RuiButton

--- a/frontend/app/src/modules/reports/ReportGenerator.vue
+++ b/frontend/app/src/modules/reports/ReportGenerator.vue
@@ -93,7 +93,7 @@ onMounted(async () => {
           {{ t('common.actions.generate') }}
         </CardTitle>
         <RuiTooltip
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           :open-delay="400"
         >
           <template #activator>

--- a/frontend/app/src/modules/reports/ReportGenerator.vue
+++ b/frontend/app/src/modules/reports/ReportGenerator.vue
@@ -86,7 +86,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <RuiCard content-class="!pt-0">
+  <RuiCard :class-names="{ content: '!pt-0' }">
     <template #custom-header>
       <div class="flex justify-between px-4 py-2">
         <CardTitle>

--- a/frontend/app/src/modules/reports/ReportMissingAcquisitions.vue
+++ b/frontend/app/src/modules/reports/ReportMissingAcquisitions.vue
@@ -194,7 +194,7 @@ async function showInHistoryEvent(identifier: number) {
       <template #item.action="{ row }">
         <div class="flex items-center gap-1">
           <RuiMenu
-            :popper="{ placement: 'bottom-end' }"
+            :options="{ placement: 'bottom-end' }"
             close-on-content-click
           >
             <template #activator="{ attrs }">

--- a/frontend/app/src/modules/reports/ReportPeriodSelector.vue
+++ b/frontend/app/src/modules/reports/ReportPeriodSelector.vue
@@ -164,7 +164,7 @@ const quarterModel = computed({
         {{ t('generate.period') }}
       </div>
       <div class="flex gap-4">
-        <RuiMenu :popper="{ placement: 'bottom-end' }">
+        <RuiMenu :options="{ placement: 'bottom-end' }">
           <template #activator="{ attrs }">
             <RuiButtonGroup
               v-model="yearModel"

--- a/frontend/app/src/modules/reports/ReportProfitLossEventAction.vue
+++ b/frontend/app/src/modules/reports/ReportProfitLossEventAction.vue
@@ -89,7 +89,7 @@ async function updatePrice(): Promise<void> {
 
 <template>
   <div class="flex justify-end">
-    <RuiMenu :popper="{ placement: 'bottom-end' }">
+    <RuiMenu :options="{ placement: 'bottom-end' }">
       <template #activator="{ attrs }">
         <RuiButton
           variant="text"

--- a/frontend/app/src/modules/reports/ReportsTableMoreAction.vue
+++ b/frontend/app/src/modules/reports/ReportsTableMoreAction.vue
@@ -15,7 +15,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <RuiMenu
     menu-class="max-w-[15rem]"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
     close-on-content-click
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/reports/ReportsTableMoreAction.vue
+++ b/frontend/app/src/modules/reports/ReportsTableMoreAction.vue
@@ -14,7 +14,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <RuiMenu
-    menu-class="max-w-[15rem]"
+    :class-names="{ menu: 'max-w-[15rem]' }"
     :options="{ placement: 'bottom-end' }"
     close-on-content-click
   >

--- a/frontend/app/src/modules/settings/AssetBalanceStatisticSourceSetting.vue
+++ b/frontend/app/src/modules/settings/AssetBalanceStatisticSourceSetting.vue
@@ -48,7 +48,7 @@ watchImmediate(() => asset, (asset) => {
 
 <template>
   <RuiMenu
-    menu-class="min-w-[18rem] max-w-[20rem]"
+    :class-names="{ menu: 'min-w-[18rem] max-w-[20rem]' }"
     :options="{ placement: 'top' }"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/settings/AssetBalanceStatisticSourceSetting.vue
+++ b/frontend/app/src/modules/settings/AssetBalanceStatisticSourceSetting.vue
@@ -49,7 +49,7 @@ watchImmediate(() => asset, (asset) => {
 <template>
   <RuiMenu
     menu-class="min-w-[18rem] max-w-[20rem]"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
   >
     <template #activator="{ attrs }">
       <MenuTooltipButton

--- a/frontend/app/src/modules/settings/OnboardingSettings.vue
+++ b/frontend/app/src/modules/settings/OnboardingSettings.vue
@@ -297,7 +297,7 @@ function showResetConfirmation() {
     <RuiAccordions>
       <RuiAccordion
         data-testid="onboarding-setting-advance"
-        header-class="py-4"
+        :class-names="{ header: 'py-4' }"
         eager
       >
         <template #header>

--- a/frontend/app/src/modules/settings/PrivacyModeDropdown.vue
+++ b/frontend/app/src/modules/settings/PrivacyModeDropdown.vue
@@ -53,7 +53,7 @@ async function updateScramble(value: boolean): Promise<void> {
     <RuiMenu
       v-model="showPrivacyModeMenu"
       data-testid="privacy-menu-content"
-      menu-class="w-[22rem]"
+      :class-names="{ menu: 'w-[22rem]' }"
       :options="{ placement: 'bottom-end' }"
       :persistent="settingMenuOpen"
     >
@@ -91,7 +91,7 @@ async function updateScramble(value: boolean): Promise<void> {
       <div class="absolute right-4 top-4">
         <RuiMenu
           v-model="settingMenuOpen"
-          menu-class="w-[20rem]"
+          :class-names="{ menu: 'w-[20rem]' }"
           :options="{ placement: 'bottom-end' }"
           :close-on-content-click="false"
         >
@@ -141,8 +141,10 @@ async function updateScramble(value: boolean): Promise<void> {
           show-ticks
           hide-details
           :tick-size="12"
-          slider-class="!bg-rui-grey-200 dark:!bg-rui-grey-800"
-          tick-class="!bg-rui-grey-200 dark:!bg-rui-grey-800"
+          :class-names="{
+            slider: '!bg-rui-grey-200 dark:!bg-rui-grey-800',
+            tick: '!bg-rui-grey-200 dark:!bg-rui-grey-800',
+          }"
           vertical
           @update:model-value="changePrivacyMode($event)"
         />

--- a/frontend/app/src/modules/settings/PrivacyModeDropdown.vue
+++ b/frontend/app/src/modules/settings/PrivacyModeDropdown.vue
@@ -54,7 +54,7 @@ async function updateScramble(value: boolean): Promise<void> {
       v-model="showPrivacyModeMenu"
       data-testid="privacy-menu-content"
       menu-class="w-[22rem]"
-      :popper="{ placement: 'bottom-end' }"
+      :options="{ placement: 'bottom-end' }"
       :persistent="settingMenuOpen"
     >
       <template #activator="{ attrs }">
@@ -92,7 +92,7 @@ async function updateScramble(value: boolean): Promise<void> {
         <RuiMenu
           v-model="settingMenuOpen"
           menu-class="w-[20rem]"
-          :popper="{ placement: 'bottom-end' }"
+          :options="{ placement: 'bottom-end' }"
           :close-on-content-click="false"
         >
           <template #activator="{ attrs }">

--- a/frontend/app/src/modules/settings/SettingResetButton.vue
+++ b/frontend/app/src/modules/settings/SettingResetButton.vue
@@ -9,7 +9,7 @@ const { t } = useI18n({ useScope: 'global' });
   <RuiTooltip
     :options="{ placement: 'top' }"
     :open-delay="400"
-    tooltip-class="max-w-[12rem]"
+    :class-names="{ tooltip: 'max-w-[12rem]' }"
   >
     <template #activator>
       <RuiButton

--- a/frontend/app/src/modules/settings/SettingResetButton.vue
+++ b/frontend/app/src/modules/settings/SettingResetButton.vue
@@ -7,7 +7,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
     tooltip-class="max-w-[12rem]"
   >

--- a/frontend/app/src/modules/settings/SettingResetConfirmButton.vue
+++ b/frontend/app/src/modules/settings/SettingResetConfirmButton.vue
@@ -29,11 +29,11 @@ function cancel(): void {
   <RuiMenu
     v-model="open"
     menu-class="max-w-[14rem]"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
   >
     <template #activator="{ attrs }">
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
         :disabled="open"
       >

--- a/frontend/app/src/modules/settings/SettingResetConfirmButton.vue
+++ b/frontend/app/src/modules/settings/SettingResetConfirmButton.vue
@@ -28,7 +28,7 @@ function cancel(): void {
 <template>
   <RuiMenu
     v-model="open"
-    menu-class="max-w-[14rem]"
+    :class-names="{ menu: 'max-w-[14rem]' }"
     :options="{ placement: 'top' }"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/settings/StatisticsGraphSettings.vue
+++ b/frontend/app/src/modules/settings/StatisticsGraphSettings.vue
@@ -17,7 +17,7 @@ const showMenu = ref<boolean>(false);
 <template>
   <RuiMenu
     v-model="showMenu"
-    menu-class="min-w-[18rem] max-w-[20rem]"
+    :class-names="{ menu: 'min-w-[18rem] max-w-[20rem]' }"
     :options="{ placement: 'bottom-end' }"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/settings/StatisticsGraphSettings.vue
+++ b/frontend/app/src/modules/settings/StatisticsGraphSettings.vue
@@ -18,7 +18,7 @@ const showMenu = ref<boolean>(false);
   <RuiMenu
     v-model="showMenu"
     menu-class="min-w-[18rem] max-w-[20rem]"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
   >
     <template #activator="{ attrs }">
       <MenuTooltipButton

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleActionDialog.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleActionDialog.vue
@@ -40,7 +40,7 @@ watch(display, (value) => {
     v-model="display"
     max-width="600"
   >
-    <RuiCard content-class="!pt-0">
+    <RuiCard :class-names="{ content: '!pt-0' }">
       <template #header>
         {{ t('accounting_settings.rule.action_dialog.title') }}
       </template>

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
@@ -260,7 +260,7 @@ async function save() {
             :open-delay="400"
             :options="{ placement: 'top' }"
             class="flex items-center"
-            tooltip-class="max-w-[10rem]"
+            :class-names="{ tooltip: 'max-w-[10rem]' }"
           >
             <template #activator>
               <div class="flex items-center text-left gap-2">
@@ -280,7 +280,7 @@ async function save() {
             :open-delay="400"
             :options="{ placement: 'top' }"
             class="flex items-center"
-            tooltip-class="max-w-[10rem]"
+            :class-names="{ tooltip: 'max-w-[10rem]' }"
           >
             <template #activator>
               <div class="flex items-center text-left gap-2">
@@ -300,7 +300,7 @@ async function save() {
             :open-delay="400"
             :options="{ placement: 'top' }"
             class="flex items-center"
-            tooltip-class="max-w-[10rem]"
+            :class-names="{ tooltip: 'max-w-[10rem]' }"
           >
             <template #activator>
               <div class="flex items-center text-left gap-2">

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
@@ -258,7 +258,7 @@ async function save() {
         <template #header.taxable>
           <RuiTooltip
             :open-delay="400"
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             class="flex items-center"
             tooltip-class="max-w-[10rem]"
           >
@@ -278,7 +278,7 @@ async function save() {
         <template #header.countEntireAmountSpend>
           <RuiTooltip
             :open-delay="400"
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             class="flex items-center"
             tooltip-class="max-w-[10rem]"
           >
@@ -298,7 +298,7 @@ async function save() {
         <template #header.countCostBasisPnl>
           <RuiTooltip
             :open-delay="400"
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             class="flex items-center"
             tooltip-class="max-w-[10rem]"
           >

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSettingHeader.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleSettingHeader.vue
@@ -56,7 +56,7 @@ const { t } = useI18n({ useScope: 'global' });
         {{ t('accounting_settings.rule.add') }}
       </RuiButton>
       <RuiMenu
-        :popper="{ placement: 'bottom-end' }"
+        :options="{ placement: 'bottom-end' }"
         close-on-content-click
       >
         <template #activator="{ attrs }">

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleTable.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleTable.vue
@@ -136,7 +136,7 @@ function openEventsDialog(eventIds: number[]) {
   >
     <template #header.taxable>
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
         class="flex items-center h-full"
         tooltip-class="max-w-[10rem]"
@@ -156,7 +156,7 @@ function openEventsDialog(eventIds: number[]) {
     </template>
     <template #header.countEntireAmountSpend>
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
         class="flex items-center"
         tooltip-class="max-w-[10rem]"
@@ -176,7 +176,7 @@ function openEventsDialog(eventIds: number[]) {
     </template>
     <template #header.countCostBasisPnl>
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
         class="flex items-center"
         tooltip-class="max-w-[10rem]"

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleTable.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleTable.vue
@@ -139,7 +139,7 @@ function openEventsDialog(eventIds: number[]) {
         :options="{ placement: 'top' }"
         :open-delay="400"
         class="flex items-center h-full"
-        tooltip-class="max-w-[10rem]"
+        :class-names="{ tooltip: 'max-w-[10rem]' }"
       >
         <template #activator>
           <div class="flex items-center text-left gap-2">
@@ -159,7 +159,7 @@ function openEventsDialog(eventIds: number[]) {
         :options="{ placement: 'top' }"
         :open-delay="400"
         class="flex items-center"
-        tooltip-class="max-w-[10rem]"
+        :class-names="{ tooltip: 'max-w-[10rem]' }"
       >
         <template #activator>
           <div class="flex items-center text-left gap-2">
@@ -179,7 +179,7 @@ function openEventsDialog(eventIds: number[]) {
         :options="{ placement: 'top' }"
         :open-delay="400"
         class="flex items-center"
-        tooltip-class="max-w-[10rem]"
+        :class-names="{ tooltip: 'max-w-[10rem]' }"
       >
         <template #activator>
           <div class="flex items-center text-left gap-2">

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleWithLinkedSettingDisplay.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleWithLinkedSettingDisplay.vue
@@ -46,7 +46,7 @@ const value = computed<boolean>(() => {
     <template #icon>
       <RuiTooltip
         v-if="selectedLinkableSetting"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/settings/api-keys/BinancePairsSelector.vue
+++ b/frontend/app/src/modules/settings/api-keys/BinancePairsSelector.vue
@@ -187,7 +187,7 @@ onMounted(() => {
         </template>
       </RuiAutoComplete>
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/settings/api-keys/ServiceKey.vue
+++ b/frontend/app/src/modules/settings/api-keys/ServiceKey.vue
@@ -123,7 +123,7 @@ defineExpose({
       <RuiTooltip
         v-if="!hideActions"
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
       >
         <template #activator>
           <RuiButton

--- a/frontend/app/src/modules/settings/api-keys/ServiceKeyCard.vue
+++ b/frontend/app/src/modules/settings/api-keys/ServiceKeyCard.vue
@@ -110,7 +110,7 @@ defineExpose({
     no-padding
     class="h-full"
     :class="{ '!border-rui-success/50 bg-rui-success/5 dark:bg-rui-success/5': keySet }"
-    content-class="h-full flex flex-col"
+    :class-names="{ content: 'h-full flex flex-col' }"
   >
     <div class="grow">
       <div class="px-6 pt-6">

--- a/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/ExchangeKeysForm.vue
@@ -364,7 +364,7 @@ defineExpose({
     >
       {{ t('exchange_settings.keys') }}
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/settings/api-keys/exchange/KrakenFuturesKeys.vue
+++ b/frontend/app/src/modules/settings/api-keys/exchange/KrakenFuturesKeys.vue
@@ -52,7 +52,7 @@ function toggle(): void {
     {{ t('exchange_settings.inputs.kraken_futures_keys') }}
     <RuiTooltip
       v-if="editMode"
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>

--- a/frontend/app/src/modules/settings/data-security/backups/DatabaseBackups.vue
+++ b/frontend/app/src/modules/settings/data-security/backups/DatabaseBackups.vue
@@ -128,7 +128,7 @@ function showDeleteConfirmation(item: UserDbBackupWithId) {
     <template #item.actions="{ row }">
       <RuiTooltip
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
       >
         <template #activator>
           <RuiButton
@@ -147,7 +147,7 @@ function showDeleteConfirmation(item: UserDbBackupWithId) {
       </RuiTooltip>
       <RuiTooltip
         :open-delay="400"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
       >
         <template #activator>
           <RuiButton

--- a/frontend/app/src/modules/settings/data-security/data-management/RefreshCache.vue
+++ b/frontend/app/src/modules/settings/data-security/data-management/RefreshCache.vue
@@ -111,7 +111,7 @@ onMounted(() => {
       </RuiAutoComplete>
 
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/settings/evm/IndexerOrderSetting.vue
+++ b/frontend/app/src/modules/settings/evm/IndexerOrderSetting.vue
@@ -93,7 +93,7 @@ async function navigateToApiKeys(): Promise<void> {
 
         <RuiMenu
           v-model="showChainMenu"
-          :popper="{ placement: 'bottom-end' }"
+          :options="{ placement: 'bottom-end' }"
         >
           <template #activator="{ attrs }">
             <RuiButton

--- a/frontend/app/src/modules/settings/evm/IndexerTabLabel.vue
+++ b/frontend/app/src/modules/settings/evm/IndexerTabLabel.vue
@@ -34,7 +34,7 @@ const { t } = useI18n({ useScope: 'global' });
       />
       <span>{{ tab.name }}</span>
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/DisabledChainIcon.vue
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/DisabledChainIcon.vue
@@ -12,7 +12,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="300"
   >
     <template #activator>

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/RuleChainIcons.vue
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/RuleChainIcons.vue
@@ -13,7 +13,7 @@ defineProps<{
     <RuiTooltip
       v-for="chainId in chainIds"
       :key="chainId"
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="300"
     >
       <template #activator>

--- a/frontend/app/src/modules/settings/general/nft/NftImageRenderingSettingMenu.vue
+++ b/frontend/app/src/modules/settings/general/nft/NftImageRenderingSettingMenu.vue
@@ -11,7 +11,7 @@ const dialogOpen = ref(false);
 <template>
   <RuiMenu
     menu-class="max-w-[32rem] !z-[1]"
-    :popper="{ placement: 'bottom-end' }"
+    :options="{ placement: 'bottom-end' }"
     :persistent="dialogOpen"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/settings/general/nft/NftImageRenderingSettingMenu.vue
+++ b/frontend/app/src/modules/settings/general/nft/NftImageRenderingSettingMenu.vue
@@ -10,7 +10,7 @@ const dialogOpen = ref(false);
 
 <template>
   <RuiMenu
-    menu-class="max-w-[32rem] !z-[1]"
+    :class-names="{ menu: 'max-w-[32rem] !z-[1]' }"
     :options="{ placement: 'bottom-end' }"
     :persistent="dialogOpen"
   >

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
@@ -239,7 +239,7 @@ defineExpose({
                 size="sm"
                 color="primary"
                 class="!p-0.5 mt-2"
-                content-class="flex items-center gap-1 font-medium"
+                :class-names="{ content: 'flex items-center gap-1 font-medium' }"
               >
                 <RuiIcon
                   name="lu-check"

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
@@ -201,7 +201,7 @@ defineExpose({
           <div class="flex gap-3 items-center">
             <RuiTooltip
               v-if="!item.owned"
-              :popper="{ placement: 'top' }"
+              :options="{ placement: 'top' }"
               :open-delay="400"
             >
               <template #activator>
@@ -214,7 +214,7 @@ defineExpose({
             </RuiTooltip>
             <RuiTooltip
               v-else
-              :popper="{ placement: 'top' }"
+              :options="{ placement: 'top' }"
               :open-delay="400"
             >
               <template #activator>

--- a/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue
@@ -92,7 +92,7 @@ defineExpose({
           <div class="flex gap-3 items-center">
             <RuiTooltip
               v-if="!value.includes('localhost')"
-              :popper="{ placement: 'top' }"
+              :options="{ placement: 'top' }"
               :open-delay="400"
             >
               <template #activator>
@@ -105,7 +105,7 @@ defineExpose({
             </RuiTooltip>
             <RuiTooltip
               v-else
-              :popper="{ placement: 'top' }"
+              :options="{ placement: 'top' }"
               :open-delay="400"
             >
               <template #activator>

--- a/frontend/app/src/modules/settings/modules/ActiveModules.vue
+++ b/frontend/app/src/modules/settings/modules/ActiveModules.vue
@@ -99,7 +99,7 @@ function showConfirmation() {
     <RuiCard
       no-padding
       class="px-1 py-0.5 bg-white dark:bg-rui-grey-900"
-      content-class="flex items-center justify-center"
+      :class-names="{ content: 'flex items-center justify-center' }"
     >
       <div
         v-for="module in moduleStatus"

--- a/frontend/app/src/modules/settings/modules/ActiveModules.vue
+++ b/frontend/app/src/modules/settings/modules/ActiveModules.vue
@@ -107,7 +107,7 @@ function showConfirmation() {
         class="flex"
       >
         <RuiTooltip
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           :open-delay="400"
         >
           <template #activator>

--- a/frontend/app/src/modules/shell/app/AppDrawer.vue
+++ b/frontend/app/src/modules/shell/app/AppDrawer.vue
@@ -25,9 +25,11 @@ watchImmediate(isXlAndDown, (isXlAndDown) => {
   <RuiNavigationDrawer
     v-model="showDrawer"
     width="300"
-    :content-class="{
-      'flex flex-col border-r border-rui-grey-300 dark:border-rui-grey-800': true,
-      '!top-0 !max-h-full': isXlAndDown,
+    :class-names="{
+      content: {
+        'flex flex-col border-r border-rui-grey-300 dark:border-rui-grey-800': true,
+        '!top-0 !max-h-full': isXlAndDown,
+      },
     }"
     :mini-variant="!isXlAndDown"
     :overlay="isXlAndDown"

--- a/frontend/app/src/modules/shell/app/AssetConflictDialog.vue
+++ b/frontend/app/src/modules/shell/app/AssetConflictDialog.vue
@@ -209,7 +209,7 @@ onMounted(() => {
       <template v-else>
         <div class="flex mt-4 mb-6">
           <RuiTooltip
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             :open-delay="400"
           >
             <template #activator>
@@ -227,7 +227,7 @@ onMounted(() => {
             {{ t('conflict_dialog.keep_local_tooltip') }}
           </RuiTooltip>
           <RuiTooltip
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             :open-delay="400"
           >
             <template #activator>

--- a/frontend/app/src/modules/shell/components/AboutDataDirectory.vue
+++ b/frontend/app/src/modules/shell/components/AboutDataDirectory.vue
@@ -16,7 +16,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <div class="flex items-center justify-between">
     <RuiTooltip
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
     >
       <template #activator>
@@ -33,7 +33,7 @@ const { t } = useI18n({ useScope: 'global' });
       class="ml-2"
     >
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/shell/components/AssetIcon.vue
+++ b/frontend/app/src/modules/shell/components/AssetIcon.vue
@@ -28,8 +28,8 @@ interface AssetIconProps {
   chainIconSize?: string;
   forceChain?: string;
   /**
-   * Disables scroll event listeners on tooltip popper for better performance in virtualized lists.
-   * The tooltip still works on hover, but won't recalculate position during scroll.
+   * Disables the tooltip's ancestor scroll and resize listeners, for performance in virtualized
+   * lists. The tooltip still opens on hover, but will not recalculate its position during scroll.
    */
   optimizeForVirtualScroll?: boolean;
 }
@@ -177,11 +177,12 @@ const tooltip = computed(() => {
   };
 });
 
-// Popper options - disable scroll listeners for virtualized lists to prevent reflow during scroll
-const popperOptions = computed(() => ({
+const tooltipOptions = computed(() => ({
+  autoUpdate: {
+    resize: !optimizeForVirtualScroll,
+    scroll: !optimizeForVirtualScroll,
+  },
   placement: 'top' as const,
-  scroll: !optimizeForVirtualScroll,
-  resize: !optimizeForVirtualScroll,
 }));
 
 const usedChainIconSize = computed(() => chainIconSize || `${(Number.parseInt(size) * 50) / 100}px`);
@@ -227,7 +228,7 @@ const { copied, copy } = useCopy(() => identifier);
 
 <template>
   <RuiTooltip
-    :popper="popperOptions"
+    :options="tooltipOptions"
     :open-delay="400"
     :disabled="noTooltip || !shouldShowAmount"
     persist-on-tooltip-hover

--- a/frontend/app/src/modules/shell/components/BackButton.vue
+++ b/frontend/app/src/modules/shell/components/BackButton.vue
@@ -38,7 +38,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <RuiTooltip
     v-if="canNavigateBack || page"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/shell/components/CopyButton.vue
+++ b/frontend/app/src/modules/shell/components/CopyButton.vue
@@ -10,7 +10,7 @@ const { copy } = useClipboard({ source: () => value });
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top', offsetDistance: 0 }"
+    :options="{ offset: 0, placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/shell/components/CopyTooltip.vue
+++ b/frontend/app/src/modules/shell/components/CopyTooltip.vue
@@ -20,7 +20,7 @@ const { copied, copy } = useCopy(() => value);
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top', scroll: false, resize: false }"
+    :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
     :open-delay="200"
     :close-delay="100"
     class="text-no-wrap"

--- a/frontend/app/src/modules/shell/components/EvmChainIcon.vue
+++ b/frontend/app/src/modules/shell/components/EvmChainIcon.vue
@@ -27,7 +27,7 @@ const chainData = computed(() => ({
 <template>
   <RuiTooltip
     :disabled="!tooltip || !shouldShowAmount"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/shell/components/GlobalSearch.vue
+++ b/frontend/app/src/modules/shell/components/GlobalSearch.vue
@@ -78,7 +78,7 @@ onBeforeMount(async () => {
   <RuiDialog
     v-model="open"
     max-width="800"
-    content-class="mt-[16rem] !top-0 pb-2"
+    :class-names="{ content: 'mt-[16rem] !top-0 pb-2' }"
   >
     <template #activator="{ attrs }">
       <div
@@ -120,7 +120,7 @@ onBeforeMount(async () => {
       variant="flat"
       no-padding
       rounded="sm"
-      content-class="overflow-hidden"
+      :class-names="{ content: 'overflow-hidden' }"
     >
       <RuiAutoComplete
         ref="input"

--- a/frontend/app/src/modules/shell/components/HashLink.vue
+++ b/frontend/app/src/modules/shell/components/HashLink.vue
@@ -229,7 +229,7 @@ const tags = useAccountTags(() => text);
       :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
       :open-delay="400"
       :disabled="truncateLength === 0"
-      tooltip-class="[&_*]:font-mono"
+      :class-names="{ tooltip: '[&_*]:font-mono' }"
       persist-on-tooltip-hover
     >
       <template #activator>

--- a/frontend/app/src/modules/shell/components/HashLink.vue
+++ b/frontend/app/src/modules/shell/components/HashLink.vue
@@ -226,7 +226,7 @@ const tags = useAccountTags(() => text);
       v-if="!hideText"
       ref="tooltip"
       class="min-w-0 overflow-hidden"
-      :popper="{ placement: 'top', scroll: false, resize: false }"
+      :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
       :open-delay="400"
       :disabled="truncateLength === 0"
       tooltip-class="[&_*]:font-mono"

--- a/frontend/app/src/modules/shell/components/HelpLink.vue
+++ b/frontend/app/src/modules/shell/components/HelpLink.vue
@@ -12,7 +12,7 @@ const { href, onLinkClick } = useLinks(() => url);
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/shell/components/HintMenuIcon.vue
+++ b/frontend/app/src/modules/shell/components/HintMenuIcon.vue
@@ -10,7 +10,7 @@ defineSlots<{
 
 <template>
   <RuiMenu
-    menu-class="max-w-[25rem]"
+    :class-names="{ menu: 'max-w-[25rem]' }"
     v-bind="$attrs"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/shell/components/IconLink.vue
+++ b/frontend/app/src/modules/shell/components/IconLink.vue
@@ -11,7 +11,7 @@ const { href, onLinkClick } = useLinks(() => url);
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/shell/components/LinkButton.vue
+++ b/frontend/app/src/modules/shell/components/LinkButton.vue
@@ -23,7 +23,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <RuiTooltip
 
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="600"
   >
     <template #activator>

--- a/frontend/app/src/modules/shell/components/MenuTooltipButton.vue
+++ b/frontend/app/src/modules/shell/components/MenuTooltipButton.vue
@@ -22,7 +22,7 @@ defineSlots<{
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'bottom' }"
+    :options="{ placement: 'bottom' }"
     :open-delay="250"
     :close-delay="0"
   >

--- a/frontend/app/src/modules/shell/components/MerchantIcon.vue
+++ b/frontend/app/src/modules/shell/components/MerchantIcon.vue
@@ -37,7 +37,7 @@ const iconName = computed<string>(() => mccIconMap[code] ?? DEFAULT_ICON);
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/shell/components/OnboardingSettingsButton.vue
+++ b/frontend/app/src/modules/shell/components/OnboardingSettingsButton.vue
@@ -11,7 +11,7 @@ const { connected } = storeToRefs(useMainStore());
   <div>
     <RuiTooltip
       :text="t('backend_settings_button.tooltip')"
-      :popper="{ placement: 'top', offsetDistance: 0 }"
+      :options="{ offset: 0, placement: 'top' }"
       tooltip-class="max-w-[12rem]"
     >
       <template #activator>

--- a/frontend/app/src/modules/shell/components/OnboardingSettingsButton.vue
+++ b/frontend/app/src/modules/shell/components/OnboardingSettingsButton.vue
@@ -12,7 +12,7 @@ const { connected } = storeToRefs(useMainStore());
     <RuiTooltip
       :text="t('backend_settings_button.tooltip')"
       :options="{ offset: 0, placement: 'top' }"
-      tooltip-class="max-w-[12rem]"
+      :class-names="{ tooltip: 'max-w-[12rem]' }"
     >
       <template #activator>
         <RuiButton

--- a/frontend/app/src/modules/shell/components/PrioritizedListRow.vue
+++ b/frontend/app/src/modules/shell/components/PrioritizedListRow.vue
@@ -68,7 +68,7 @@ const emit = defineEmits<{
     <td class="text-end !pl-0">
       <RuiTooltip
         v-if="!disableDelete"
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/shell/components/RefreshButton.vue
+++ b/frontend/app/src/modules/shell/components/RefreshButton.vue
@@ -12,7 +12,7 @@ const emit = defineEmits<{
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
   >
     <template #activator>

--- a/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
+++ b/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
@@ -114,7 +114,7 @@ onMounted(() => {
     persistent
   >
     <RuiCard
-      content-class="!pt-1.5"
+      :class-names="{ content: '!pt-1.5' }"
       class="max-h-[90vh]"
     >
       <template #header>

--- a/frontend/app/src/modules/shell/components/ReportIssueEmailButton.vue
+++ b/frontend/app/src/modules/shell/components/ReportIssueEmailButton.vue
@@ -30,7 +30,7 @@ const { t } = useI18n({ useScope: 'global' });
       {{ t('help_sidebar.report_issue.dialog.submit_options.email') }}
     </RuiButton>
     <RuiMenu
-      :popper="{ placement: 'bottom-end' }"
+      :options="{ placement: 'bottom-end' }"
       close-on-content-click
     >
       <template #activator="{ attrs }">

--- a/frontend/app/src/modules/shell/components/TabNavigation.vue
+++ b/frontend/app/src/modules/shell/components/TabNavigation.vue
@@ -35,7 +35,6 @@ function getTabKey(route: RouteLocationRaw): string {
         :model-value="tab.route"
         link
         :to="tab.route"
-        :exact-path="false"
         data-testid="nav-tab"
         :data-key="getTabKey(tab.route)"
       >

--- a/frontend/app/src/modules/shell/components/UserDropdown.vue
+++ b/frontend/app/src/modules/shell/components/UserDropdown.vue
@@ -52,7 +52,7 @@ const { isDark } = useRotkiTheme();
   <div>
     <RuiMenu
       data-testid="user-menu"
-      menu-class="min-w-[10rem] max-w-[22rem]"
+      :class-names="{ menu: 'min-w-[10rem] max-w-[22rem]' }"
       close-on-content-click
     >
       <template #activator="{ attrs }">

--- a/frontend/app/src/modules/shell/components/ValueAccuracyHint.vue
+++ b/frontend/app/src/modules/shell/components/ValueAccuracyHint.vue
@@ -12,7 +12,7 @@ const notUsd = computed(() => get(currencySymbol) !== CURRENCY_USD);
   <RuiTooltip
     v-if="notUsd"
     class="mx-2 text-rui-text-secondary"
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
     tooltip-class="max-w-[10rem]"
   >

--- a/frontend/app/src/modules/shell/components/ValueAccuracyHint.vue
+++ b/frontend/app/src/modules/shell/components/ValueAccuracyHint.vue
@@ -14,7 +14,7 @@ const notUsd = computed(() => get(currencySymbol) !== CURRENCY_USD);
     class="mx-2 text-rui-text-secondary"
     :options="{ placement: 'top' }"
     :open-delay="400"
-    tooltip-class="max-w-[10rem]"
+    :class-names="{ tooltip: 'max-w-[10rem]' }"
   >
     <template #activator>
       <RuiIcon

--- a/frontend/app/src/modules/shell/components/dialogs/BigDialog.vue
+++ b/frontend/app/src/modules/shell/components/dialogs/BigDialog.vue
@@ -203,7 +203,7 @@ function promptClose() {
               v-if="!actionHidden"
               :disabled="!actionTooltip"
               :options="{ placement: 'top' }"
-              tooltip-class="max-w-80"
+              :class-names="{ tooltip: 'max-w-80' }"
             >
               <template #activator>
                 <BigDialogConfirmButton

--- a/frontend/app/src/modules/shell/components/dialogs/BigDialog.vue
+++ b/frontend/app/src/modules/shell/components/dialogs/BigDialog.vue
@@ -202,7 +202,7 @@ function promptClose() {
             <RuiTooltip
               v-if="!actionHidden"
               :disabled="!actionTooltip"
-              :popper="{ placement: 'top' }"
+              :options="{ placement: 'top' }"
               tooltip-class="max-w-80"
             >
               <template #activator>

--- a/frontend/app/src/modules/shell/components/display/AccountDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/AccountDisplay.vue
@@ -43,7 +43,7 @@ const aliasName = computed<string | null>(() => {
     :open-delay="400"
     :disabled="noTruncate && !aliasName"
     class="flex items-center flex-nowrap gap-2"
-    tooltip-class="[&_*]:font-mono"
+    :class-names="{ tooltip: '[&_*]:font-mono' }"
   >
     <template #activator>
       <div

--- a/frontend/app/src/modules/shell/components/display/AccountDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/AccountDisplay.vue
@@ -39,7 +39,7 @@ const aliasName = computed<string | null>(() => {
 
 <template>
   <RuiTooltip
-    :popper="{ placement: 'top' }"
+    :options="{ placement: 'top' }"
     :open-delay="400"
     :disabled="noTruncate && !aliasName"
     class="flex items-center flex-nowrap gap-2"
@@ -58,7 +58,7 @@ const aliasName = computed<string | null>(() => {
           />
           <RuiTooltip
             v-else
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             :open-delay="400"
           >
             <template #activator>

--- a/frontend/app/src/modules/shell/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/LabeledAddressDisplay.vue
@@ -96,7 +96,7 @@ const truncatedLabelDisplayed = computed(() => {
   <RuiChip
     variant="outlined"
     class="w-full hover:cursor-default max-w-[32rem] min-w-[15rem] !bg-rui-grey-100 dark:!bg-rui-grey-900"
-    content-class="w-full flex items-center px-0"
+    :class-names="{ content: 'w-full flex items-center px-0' }"
     size="sm"
     color="primary"
   >

--- a/frontend/app/src/modules/shell/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/LabeledAddressDisplay.vue
@@ -102,7 +102,7 @@ const truncatedLabelDisplayed = computed(() => {
   >
     <RuiTooltip
       :disabled="!shouldShowAmount"
-      :popper="{ placement: 'top' }"
+      :options="{ placement: 'top' }"
       :open-delay="400"
       class="flex-1"
     >

--- a/frontend/app/src/modules/shell/components/inputs/AssetSelect.vue
+++ b/frontend/app/src/modules/shell/components/inputs/AssetSelect.vue
@@ -104,7 +104,7 @@ function onUpdateModelValue(value: string): void {
     :disabled="disabled"
     :options="visibleAssets"
     class="asset-select w-full [&_.group]:py-1.5"
-    menu-class="!min-w-full"
+    :class-names="{ menu: '!min-w-full' }"
     :hint="hint"
     :label="fieldLabel"
     :clearable="clearable"

--- a/frontend/app/src/modules/shell/components/navigation/NavigationMenuItem.vue
+++ b/frontend/app/src/modules/shell/components/navigation/NavigationMenuItem.vue
@@ -102,7 +102,7 @@ onMounted(() => {
       </DefineImage>
       <RuiTooltip
         v-if="mini"
-        :popper="{ placement: 'right' }"
+        :options="{ placement: 'right' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/modules/shell/components/navigation/PinnedSidebar.vue
+++ b/frontend/app/src/modules/shell/components/navigation/PinnedSidebar.vue
@@ -55,7 +55,7 @@ function collapse(): void {
     <RuiTooltip
       v-for="tab in tabs"
       :key="tab.name"
-      :popper="{ placement: 'left' }"
+      :options="{ placement: 'left' }"
       :open-delay="300"
     >
       <template #activator>

--- a/frontend/app/src/modules/shell/pinned/PinnedDetailSheet.vue
+++ b/frontend/app/src/modules/shell/pinned/PinnedDetailSheet.vue
@@ -136,7 +136,7 @@ watch(open, async (isOpen) => {
       tabindex="-1"
       :style="{ height }"
       class="absolute bottom-0 left-0 right-0 border-t-2 border-rui-primary flex flex-col shadow-lg !rounded-b-none z-10 overflow-hidden focus:outline-none"
-      content-class="h-full"
+      :class-names="{ content: 'h-full' }"
       data-testid="pinned-detail-sheet"
       v-bind="$attrs"
     >

--- a/frontend/app/src/modules/shell/sync-progress/SyncIndicator.vue
+++ b/frontend/app/src/modules/shell/sync-progress/SyncIndicator.vue
@@ -168,7 +168,7 @@ watchImmediate(runCounter, (runCounter) => {
     <RuiMenu
       id="balances-saved-dropdown"
       v-model="visible"
-      menu-class="z-[215]"
+      :class-names="{ menu: 'z-[215]' }"
       :persistent="syncSettingMenuOpen"
     >
       <template #activator="{ attrs }">

--- a/frontend/app/src/modules/shell/sync-progress/SyncSettings.vue
+++ b/frontend/app/src/modules/shell/sync-progress/SyncSettings.vue
@@ -15,7 +15,7 @@ const { isMdAndUp } = useBreakpoint();
 <template>
   <RuiMenu
     v-model="model"
-    :popper="{ placement: isMdAndUp ? 'right-start' : 'bottom-end' }"
+    :options="{ placement: isMdAndUp ? 'right-start' : 'bottom-end' }"
     :close-on-content-click="false"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/shell/theme/ThemeControl.vue
+++ b/frontend/app/src/modules/shell/theme/ThemeControl.vue
@@ -55,7 +55,7 @@ async function changeSelectedTheme(selectedTheme: Theme) {
     <RuiMenu
       v-if="!menu"
       menu-class="w-[16rem]"
-      :popper="{ placement: 'bottom-end' }"
+      :options="{ placement: 'bottom-end' }"
     >
       <template #activator="{ attrs }">
         <MenuTooltipButton

--- a/frontend/app/src/modules/shell/theme/ThemeControl.vue
+++ b/frontend/app/src/modules/shell/theme/ThemeControl.vue
@@ -54,7 +54,7 @@ async function changeSelectedTheme(selectedTheme: Theme) {
   <div class="relative">
     <RuiMenu
       v-if="!menu"
-      menu-class="w-[16rem]"
+      :class-names="{ menu: 'w-[16rem]' }"
       :options="{ placement: 'bottom-end' }"
     >
       <template #activator="{ attrs }">
@@ -108,8 +108,10 @@ async function changeSelectedTheme(selectedTheme: Theme) {
             hide-details
             hide-track
             :tick-size="12"
-            slider-class="!bg-rui-grey-200 dark:!bg-rui-grey-800"
-            tick-class="!bg-rui-grey-200 dark:!bg-rui-grey-800"
+            :class-names="{
+              slider: '!bg-rui-grey-200 dark:!bg-rui-grey-800',
+              tick: '!bg-rui-grey-200 dark:!bg-rui-grey-800',
+            }"
             vertical
             @update:model-value="changeSelectedTheme($event)"
           />

--- a/frontend/app/src/modules/staking/eth/ValidatorStatus.vue
+++ b/frontend/app/src/modules/staking/eth/ValidatorStatus.vue
@@ -17,7 +17,7 @@ const { getColor } = useEthValidatorUtils();
   <RuiChip
     size="sm"
     :color="getColor(validator.status)"
-    content-class="text-xs inline-flex gap-1 items-center"
+    :class-names="{ content: 'text-xs inline-flex gap-1 items-center' }"
     class="uppercase font-semibold"
   >
     {{ validator.status }}

--- a/frontend/app/src/modules/staking/kraken/KrakenStakingOverview.vue
+++ b/frontend/app/src/modules/staking/kraken/KrakenStakingOverview.vue
@@ -28,7 +28,7 @@ const { t } = useI18n({ useScope: 'global' });
         <div class="flex items-center text-rui-text-secondary gap-2 font-light">
           {{ t('kraken_staking_overview.historical') }}
           <RuiTooltip
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             :open-delay="400"
           >
             <template #activator>
@@ -53,7 +53,7 @@ const { t } = useI18n({ useScope: 'global' });
         <div class="flex items-center text-rui-text-secondary gap-2 font-light">
           {{ t('kraken_staking_overview.current') }}
           <RuiTooltip
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             :open-delay="400"
           >
             <template #activator>

--- a/frontend/app/src/modules/staking/lido-csm/LidoCsmAddDialog.vue
+++ b/frontend/app/src/modules/staking/lido-csm/LidoCsmAddDialog.vue
@@ -113,7 +113,7 @@ async function submitForm(): Promise<void> {
     <RuiCard
       divide
       no-padding
-      content-class="overflow-hidden"
+      :class-names="{ content: 'overflow-hidden' }"
     >
       <template #header>
         {{ t('staking_page.lido_csm.form.title') }}

--- a/frontend/app/src/modules/staking/liquity/LiquityPnlRow.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityPnlRow.vue
@@ -18,7 +18,7 @@ const { t } = useI18n({ useScope: 'global' });
         <RuiTooltip
           :options="{ placement: 'top' }"
           :open-delay="400"
-          tooltip-class="max-w-[10rem]"
+          :class-names="{ tooltip: 'max-w-[10rem]' }"
         >
           <template #activator>
             <RuiIcon name="lu-info" />

--- a/frontend/app/src/modules/staking/liquity/LiquityPnlRow.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityPnlRow.vue
@@ -16,7 +16,7 @@ const { t } = useI18n({ useScope: 'global' });
     <template #label>
       <div class="flex items-center justify-end gap-2">
         <RuiTooltip
-          :popper="{ placement: 'top' }"
+          :options="{ placement: 'top' }"
           :open-delay="400"
           tooltip-class="max-w-[10rem]"
         >

--- a/frontend/app/src/modules/staking/liquity/LiquityProxyInformation.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityProxyInformation.vue
@@ -11,7 +11,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <RuiMenu
     :options="{ placement: 'right-start' }"
-    menu-class="max-w-[25rem]"
+    :class-names="{ menu: 'max-w-[25rem]' }"
   >
     <template #activator="{ attrs }">
       <RuiButton

--- a/frontend/app/src/modules/staking/liquity/LiquityProxyInformation.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityProxyInformation.vue
@@ -10,7 +10,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 <template>
   <RuiMenu
-    :popper="{ placement: 'right-start' }"
+    :options="{ placement: 'right-start' }"
     menu-class="max-w-[25rem]"
   >
     <template #activator="{ attrs }">

--- a/frontend/app/src/modules/staking/liquity/LiquityStatistics.vue
+++ b/frontend/app/src/modules/staking/liquity/LiquityStatistics.vue
@@ -85,7 +85,7 @@ const {
 
       <RuiAccordions class="pt-4">
         <RuiAccordion
-          header-class="pt-4 pb-4 -mb-4 border-t border-default justify-center w-full"
+          :class-names="{ header: 'pt-4 pb-4 -mb-4 border-t border-default justify-center w-full' }"
           class="flex-col-reverse"
         >
           <div class="grid md:grid-cols-2 md:gap-12">

--- a/frontend/app/src/modules/statistics/AssetAmountAndValuePlaceholder.vue
+++ b/frontend/app/src/modules/statistics/AssetAmountAndValuePlaceholder.vue
@@ -10,7 +10,7 @@ const { minimumTier } = useFeatureAccess(PremiumFeature.GRAPHS_VIEW);
 </script>
 
 <template>
-  <RuiCard content-class="-mx-3 !pt-0">
+  <RuiCard :class-names="{ content: '-mx-3 !pt-0' }">
     <template #header>
       <div class="pt-2">
         {{ t('premium_components.statistics.asset_amount_and_value_over_time') }}

--- a/frontend/app/src/modules/statistics/wrapped/components/WrappedCard.vue
+++ b/frontend/app/src/modules/statistics/wrapped/components/WrappedCard.vue
@@ -33,7 +33,7 @@ const itemsToUse = computed<T[]>(() => {
     no-padding
     variant="outlined"
     class="overflow-hidden"
-    content-class="divide-y divide-rui-grey-300 dark:divide-rui-grey-800 bg-rui-grey-50 dark:bg-rui-grey-900"
+    :class-names="{ content: 'divide-y divide-rui-grey-300 dark:divide-rui-grey-800 bg-rui-grey-50 dark:bg-rui-grey-900' }"
   >
     <div class="flex px-4 py-3 gap-2 items-center bg-gradient-to-b from-transparent to-rui-primary/[0.05]">
       <div class="flex items-center justify-center size-6 shrink-0 bg-rui-primary-lighter/[0.2] dark:bg-rui-primary-darker/[0.2] rounded-full overflow-hidden">

--- a/frontend/app/src/modules/tags/TagForm.vue
+++ b/frontend/app/src/modules/tags/TagForm.vue
@@ -49,7 +49,7 @@ defineExpose({
     <RuiCard
       variant="outlined"
       class="overflow-hidden mb-2"
-      content-class="flex justify-between items-center"
+      :class-names="{ content: 'flex justify-between items-center' }"
     >
       <template #custom-header>
         <div class="bg-rui-grey-100 dark:bg-rui-grey-800 text-rui-text-secondary px-4 py-2 font-medium text-sm">

--- a/frontend/app/src/modules/tags/TagIcon.vue
+++ b/frontend/app/src/modules/tags/TagIcon.vue
@@ -24,7 +24,7 @@ const shouldShowAmount = useSetting('shouldShowAmount');
       class="font-medium !rounded-md shrink-0"
       data-testid="tag"
       tile
-      content-class="flex font-mono"
+      :class-names="{ content: 'flex font-mono' }"
       :size="small ? 'sm' : 'md'"
       :bg-color="`#${tag.backgroundColor}`"
       :text-color="`#${tag.foregroundColor}`"

--- a/frontend/app/src/modules/tags/TagManager.vue
+++ b/frontend/app/src/modules/tags/TagManager.vue
@@ -104,7 +104,7 @@ onMounted(async () => {
       </RuiButton>
     </template>
 
-    <RuiCard content-class="flex flex-col gap-4">
+    <RuiCard :class-names="{ content: 'flex flex-col gap-4' }">
       <RuiTextField
         v-model="search"
         variant="outlined"

--- a/frontend/app/src/modules/user-data/GroupedImport.vue
+++ b/frontend/app/src/modules/user-data/GroupedImport.vue
@@ -125,7 +125,7 @@ const [DefineDisplay, ReuseDisplay] = createReusableTemplate<{
 </script>
 
 <template>
-  <RuiCard content-class="p-4">
+  <RuiCard :class-names="{ content: 'p-4' }">
     <DefineDisplay #default="{ logo, icon, label }">
       <div class="flex items-center gap-3">
         <AppImage

--- a/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
+++ b/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
@@ -206,7 +206,7 @@ function redetectTokens(): void {
     <RuiCard
       divide
       no-padding
-      content-class="overflow-hidden"
+      :class-names="{ content: 'overflow-hidden' }"
     >
       <template #header>
         {{ t('trade.select_asset.select_token') }}

--- a/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
+++ b/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
@@ -242,7 +242,7 @@ function redetectTokens(): void {
           />
           <RuiTooltip
             :open-delay="400"
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
           >
             <template #activator>
               <RuiButton

--- a/frontend/app/src/modules/wallet/send/TradeHistoryItem.vue
+++ b/frontend/app/src/modules/wallet/send/TradeHistoryItem.vue
@@ -47,7 +47,7 @@ const dot = '•';
         <RuiChip
           size="sm"
           :color="color"
-          content-class="!text-[9px]"
+          :class-names="{ content: '!text-[9px]' }"
           class="leading-3 uppercase !p-0.5"
         >
           {{ item.status }}

--- a/frontend/app/src/modules/wallet/send/TradeHistoryView.vue
+++ b/frontend/app/src/modules/wallet/send/TradeHistoryView.vue
@@ -75,7 +75,7 @@ const tabs = computed<{ label: string; transactions: RecentTransaction[] }[]>(()
       <RuiCard
         divide
         no-padding
-        content-class="overflow-hidden"
+        :class-names="{ content: 'overflow-hidden' }"
       >
         <template #header>
           {{ t('trade.recent_transactions.title') }}

--- a/frontend/app/src/modules/wallet/send/TradeRecipientAddress.vue
+++ b/frontend/app/src/modules/wallet/send/TradeRecipientAddress.vue
@@ -56,7 +56,7 @@ const { containerProps: addressBookContainerProps, list: addressBookList, wrappe
 <template>
   <RuiMenu
     v-model="modelOpenSuggestionsMenu"
-    wrapper-class="w-full"
+    :class-names="{ wrapper: 'w-full' }"
   >
     <template #activator>
       <div
@@ -162,7 +162,7 @@ const { containerProps: addressBookContainerProps, list: addressBookList, wrappe
     <RuiCard
       divide
       no-padding
-      content-class="overflow-hidden pb-2"
+      :class-names="{ content: 'overflow-hidden pb-2' }"
     >
       <template #header>
         {{ t('trade.recipient.select_recipient_address') }}

--- a/frontend/app/src/pages/airdrops/index.vue
+++ b/frontend/app/src/pages/airdrops/index.vue
@@ -111,7 +111,7 @@ const {
         <template #item.claimed="{ row: { claimed, cutoffTime, hasDecoder } }">
           <RuiTooltip
             v-if="!hasDecoder"
-            :popper="{ placement: 'top' }"
+            :options="{ placement: 'top' }"
             :open-delay="400"
             tooltip-class="max-w-[12rem]"
           >

--- a/frontend/app/src/pages/airdrops/index.vue
+++ b/frontend/app/src/pages/airdrops/index.vue
@@ -113,7 +113,7 @@ const {
             v-if="!hasDecoder"
             :options="{ placement: 'top' }"
             :open-delay="400"
-            tooltip-class="max-w-[12rem]"
+            :class-names="{ tooltip: 'max-w-[12rem]' }"
           >
             <template #activator>
               <RuiChip

--- a/frontend/app/src/pages/import/index.vue
+++ b/frontend/app/src/pages/import/index.vue
@@ -20,7 +20,7 @@ const { t } = useI18n({ useScope: 'global' });
 <template>
   <TablePageLayout :title="[t('import_data.title')]">
     <template #buttons>
-      <HintMenuIcon :popper="{ placement: 'left-start' }">
+      <HintMenuIcon :options="{ placement: 'left-start' }">
         {{ t('import_data.description') }}
       </HintMenuIcon>
     </template>

--- a/frontend/app/src/pages/price-manager/oracle/index.vue
+++ b/frontend/app/src/pages/price-manager/oracle/index.vue
@@ -24,7 +24,7 @@ const oracleSettingsRoute: RouteLocationRaw = { name: '/settings/oracle/' };
   >
     <template #buttons>
       <RuiTooltip
-        :popper="{ placement: 'top' }"
+        :options="{ placement: 'top' }"
         :open-delay="400"
       >
         <template #activator>

--- a/frontend/app/src/pages/statistics/snapshots/index.vue
+++ b/frontend/app/src/pages/statistics/snapshots/index.vue
@@ -66,7 +66,7 @@ const {
 
       <RuiTooltip
         :open-delay="400"
-        tooltip-class="max-w-[16rem]"
+        :class-names="{ tooltip: 'max-w-[16rem]' }"
       >
         <template #activator>
           <RuiButton


### PR DESCRIPTION
Removes every deprecated `@rotki/ui-library` prop from the app: 330 sites across
238 files, in three mechanical commits that are best reviewed one at a time.

| Commit | What | Sites | Files |
|---|---|---|---|
| 1 | `popper` → `options`, the `placement`-only sites | 176 | 130 |
| 2 | `popper` → `options`, the sites passing offset/autoUpdate keys | 18 | 17 |
| 3 | `*-class` → `class-names`, plus one inert `exact-path` | 137 | 119 |

Nothing here was scheduled for removal before the next major, so this is not
urgent work. The reason to do it anyway is behavioural rather than tidiness:
`classNames.*` is the channel that feeds twMerge in the fixed components, so
migrating buys correct override behaviour.

## ⚠️ One deliberate visual change: overlays move 6px closer

**This is the part worth a reviewer's attention.** The `popper` → `options`
rename is *not* behaviour-neutral, and it is not obvious why.

The components pick one path or the other, with no merge:

```js
useFloating(() => props.popper ? toFloatingOptions(props.popper) : props.options ?? {})
```

Every unset key therefore falls back to a default — and the two paths disagree on
exactly one. `toFloatingOptions` maps an absent `offsetDistance` to `mainAxis: 8`,
while `DEFAULT_FLOATING_OPTIONS.offset` is `2`. So every migrated tooltip and menu
now sits **6px closer to its activator**.

That is the intended outcome: adopt the library default rather than pin
`offset: 8` on 176 call sites. Flagging it because it is an app-wide spacing
change that no individual line of the diff shows. Say the word if you would
rather keep the old spacing and I will pin it instead.

Everything else matches across both paths (flip, shiftPadding, strategy,
placement), so nothing but the gap moves. The three sites that set
`offsetDistance: 0` are unaffected, since they pin the offset themselves.

## `autoUpdate: false` would have been wrong

Twelve sites pass `scroll: false, resize: false` to stop the tooltip reflowing
while a virtualized list scrolls. The tempting translation is `autoUpdate: false`.
It is a different behaviour, not a synonym: in `startAutoUpdate`, `false` returns
early and registers **no** observer, whereas the object form still passes
`elementResize: true` and leaves floating-ui's `layoutShift` at its default. These
sites want the object form, key for key:

```diff
- :popper="{ placement: 'top', scroll: false, resize: false }"
+ :options="{ autoUpdate: { resize: false, scroll: false }, placement: 'top' }"
```

Whether they would be *better* off with a flat `autoUpdate: false` is a fair
question for the virtualized lists, but that is a performance change rather than a
deprecation migration, so it is out of scope here.

## The `*Class` half is behaviour-neutral

Each component reads `classNames?.x ?? xClass`, a clean either/or, so the rename
picks the same value. Where the left side is wrapped as `cn(classNames?.x) ?? xClass`
(RuiCard, RuiMenu) the fallback still fired, because `cn` returns `undefined`
rather than `''` for empty input — the deprecated props were live, not already
dead.

Three tags carried two deprecated props each and merge into one object: two
`RuiSlider`s (slider + tick) and one `RuiMenu` (menu + wrapper).

`exact-path` on `RuiTab` is deleted rather than translated. It has no successor —
vue-router's `useLink` matches routes internally — and the single call site passed
`false`, which is what the component already does.

## Nothing to fix in ui-library

An earlier revision of this description claimed two library gaps. Both were wrong,
and are retracted:

- `toFloatingOptions` is faithful **by design**. Its job is to reproduce the old
  `popper` semantics, and `offsetDistance ?? 8` is exactly what the old API did.
  The 2px default on `FloatingOptions` is a deliberate new default on a new API.
  The adapter preserves; the new API changes. That divergence is the point of the
  deprecation, not a defect in it.
- `FloatingOptions` not being exported blocks nothing. `AssetIcon`'s computed
  infers fine, and `vue-tsc` still checks the object literal against the
  component's prop type at the call site.

## Testing

- 8 local CI gates green: eslint, stylelint, typecheck, knip, linked-keys,
  dev-proxy, typos, and the full vitest suite (**4,526 tests, 419 files**).
- `LocationLabelSelector.spec.ts` went red on commit 3 and is fixed in it: its
  `RuiAutoComplete` stub declared `menuClass`, so it caught the moved binding
  exactly as intended. Its assertion is unchanged.
- Checked in the running app: `AboutButton` (an `offset: 0` site) measures a
  **0px** gap between tooltip and activator, confirming the migrated binding is
  live and that the explicit-offset sites are preserved exactly.

## Checklist

- [x] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.
      No user-guide change needed: no feature, flow, or screen changes.
