### PR TITLE
test(frontend): cover seven modules that were at zero

### DIFF
--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-api.spec.ts
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-api.spec.ts
@@ -74,7 +74,7 @@ describe('useCounterpartyMappingApi', () => {
       await fetchAllCounterpartyMapping({
         limit: 10,
         offset: 0,
-        orderByAttributes: ['counterpartySymbol'],
+        orderByAttributes: ['counterparty_symbol'],
         ascending: [true],
       });
 

--- a/frontend/app/src/modules/assets/admin/use-asset-display-helpers.spec.ts
+++ b/frontend/app/src/modules/assets/admin/use-asset-display-helpers.spec.ts
@@ -1,0 +1,145 @@
+import type { SupportedAsset } from '@rotki/common';
+import type { Collection } from '@/modules/core/common/collection';
+import { describe, expect, it } from 'vitest';
+import { CUSTOM_ASSET } from '@/modules/assets/types';
+import { useAssetDisplayHelpers } from './use-asset-display-helpers';
+
+const EVM_IDENTIFIER = 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F';
+
+function asset(overrides: Partial<SupportedAsset> = {}): SupportedAsset {
+  return { identifier: 'ETH', isRebasing: false, ...overrides };
+}
+
+function collection(data: SupportedAsset[]): Collection<SupportedAsset> {
+  return { data, found: data.length, limit: -1, total: data.length };
+}
+
+const nothingWhitelisted = (): boolean => false;
+
+function helpers(
+  data: SupportedAsset[] = [],
+  isAssetWhitelisted: (identifier: string) => boolean = nothingWhitelisted,
+): ReturnType<typeof useAssetDisplayHelpers> {
+  return useAssetDisplayHelpers(collection(data), isAssetWhitelisted);
+}
+
+describe('modules/assets/admin/useAssetDisplayHelpers', () => {
+  describe('formatType', () => {
+    it('should sentence-case the given type', () => {
+      expect(helpers().formatType('evm token')).toBe('Evm token');
+    });
+
+    it('should fall back to an EVM token for a missing type', () => {
+      expect(helpers().formatType()).toBe('EVM token');
+      expect(helpers().formatType(null)).toBe('EVM token');
+    });
+
+    it('should leave an empty type empty, unlike a null one, so the column renders blank', () => {
+      expect(helpers().formatType('')).toBe('');
+    });
+  });
+
+  describe('the display name', () => {
+    it('should prefer the name', () => {
+      const display = helpers().getAsset(asset({ name: 'Dai', symbol: 'DAI' }));
+
+      expect(display.name).toBe('Dai');
+    });
+
+    it('should fall back to the symbol when there is no name', () => {
+      const display = helpers().getAsset(asset({ name: null, symbol: 'DAI' }));
+
+      expect(display.name).toBe('DAI');
+    });
+
+    it('should fall back to the contract address for an evm asset with neither', () => {
+      const display = helpers().getAsset(asset({ identifier: EVM_IDENTIFIER, name: null, symbol: null }));
+
+      expect(display.name).toBe('0x6B175474E89094C44Da98b954EedeAC495271d0F');
+    });
+
+    it('should fall back to the identifier when it is not an evm asset', () => {
+      const display = helpers().getAsset(asset({ identifier: 'BTC', name: null, symbol: null }));
+
+      expect(display.name).toBe('BTC');
+    });
+  });
+
+  describe('getAsset', () => {
+    it('should carry the identifier, chain and protocol through', () => {
+      const display = helpers().getAsset(asset({
+        evmChain: 'ethereum',
+        identifier: EVM_IDENTIFIER,
+        protocol: 'spam',
+      }));
+
+      expect(display.identifier).toBe(EVM_IDENTIFIER);
+      expect(display.evmChain).toBe('ethereum');
+      expect(display.protocol).toBe('spam');
+    });
+
+    it('should default an absent symbol and custom type to empty strings', () => {
+      const display = helpers().getAsset(asset({ customAssetType: null, symbol: null }));
+
+      expect(display.symbol).toBe('');
+      expect(display.customAssetType).toBe('');
+    });
+
+    it('should flag a custom asset', () => {
+      expect(helpers().getAsset(asset({ assetType: CUSTOM_ASSET })).isCustomAsset).toBe(true);
+      expect(helpers().getAsset(asset({ assetType: 'evm token' })).isCustomAsset).toBe(false);
+    });
+  });
+
+  describe('what a row allows', () => {
+    it('should allow editing and ignoring a regular asset', () => {
+      const regular = asset({ assetType: 'evm token' });
+
+      expect(helpers().canBeEdited(regular)).toBe(true);
+      expect(helpers().canBeIgnored(regular)).toBe(true);
+    });
+
+    it('should allow neither for a custom asset', () => {
+      const custom = asset({ assetType: CUSTOM_ASSET });
+
+      expect(helpers().canBeEdited(custom)).toBe(false);
+      expect(helpers().canBeIgnored(custom)).toBe(false);
+    });
+  });
+
+  describe('the disabled rows', () => {
+    it('should disable a spam asset', () => {
+      const rows = [asset({ identifier: 'SPAM', protocol: 'spam' }), asset({ identifier: 'ETH' })];
+
+      expect(get(helpers(rows).disabledRows).map(item => item.identifier)).toEqual(['SPAM']);
+    });
+
+    it('should disable a whitelisted asset', () => {
+      const rows = [asset({ identifier: 'SAFE' }), asset({ identifier: 'ETH' })];
+
+      const disabled = get(helpers(rows, identifier => identifier === 'SAFE').disabledRows);
+
+      expect(disabled.map(item => item.identifier)).toEqual(['SAFE']);
+    });
+
+    it('should disable a row that is both, listing it once', () => {
+      const rows = [asset({ identifier: 'SAFE', protocol: 'spam' })];
+
+      const disabled = get(helpers(rows, identifier => identifier === 'SAFE').disabledRows);
+
+      expect(disabled).toHaveLength(1);
+    });
+
+    it('should disable nothing when neither applies', () => {
+      const rows = [asset({ identifier: 'ETH' }), asset({ identifier: 'BTC' })];
+
+      expect(get(helpers(rows).disabledRows)).toEqual([]);
+    });
+
+    it('should not treat another protocol as spam', () => {
+      const rows = [asset({ identifier: 'AAVE', protocol: 'aave' })];
+
+      expect(get(helpers(rows).disabledRows)).toEqual([]);
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/detection/use-newly-detected-tokens-db.spec.ts
+++ b/frontend/app/src/modules/assets/detection/use-newly-detected-tokens-db.spec.ts
@@ -260,7 +260,7 @@ describe('useNewlyDetectedTokensDb', () => {
       const payload: NewDetectedTokensRequestPayload = {
         limit: 2,
         offset: 0,
-        orderByAttributes: ['detectedAt'],
+        orderByAttributes: ['detected_at'],
         ascending: [false],
       };
 

--- a/frontend/app/src/modules/assets/detection/use-newly-detected-tokens.spec.ts
+++ b/frontend/app/src/modules/assets/detection/use-newly-detected-tokens.spec.ts
@@ -183,7 +183,7 @@ describe('useNewlyDetectedTokens', () => {
       const payload: NewDetectedTokensRequestPayload = {
         limit: 10,
         offset: 0,
-        orderByAttributes: ['detectedAt'],
+        orderByAttributes: ['detected_at'],
         ascending: [false],
       };
       const result = await getData(payload);

--- a/frontend/app/src/modules/assets/prices/use-historic-price-manager.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-historic-price-manager.spec.ts
@@ -1,0 +1,327 @@
+import type { HistoricalPrice, HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
+import { bigNumberify } from '@rotki/common';
+import { mockTranslate } from '@test/i18n';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { PriceOracle } from '@/modules/settings/types/price-oracle';
+import { useHistoricPrices } from './use-historic-price-manager';
+
+const addHistoricalPrice = vi.fn<() => Promise<boolean>>(async () => true);
+const editHistoricalPrice = vi.fn<() => Promise<boolean>>(async () => true);
+const deleteHistoricalPrice = vi.fn<() => Promise<boolean>>(async () => true);
+const fetchHistoricalPrices = vi.fn<() => Promise<HistoricalPrice[]>>(async () => []);
+const resetHistoricalPricesData = vi.fn();
+const notifyError = vi.fn();
+const showErrorMessage = vi.fn();
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: (): Record<string, unknown> => ({
+    addHistoricalPrice,
+    deleteHistoricalPrice,
+    editHistoricalPrice,
+    fetchHistoricalPrices,
+  }),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: (): Record<string, unknown> => ({ resetHistoricalPricesData }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): Record<string, unknown> => ({ notifyError, showErrorMessage }),
+}));
+
+const wrappers: VueWrapper[] = [];
+
+function price(overrides: Partial<HistoricalPrice> = {}): HistoricalPrice {
+  return {
+    fromAsset: 'ETH',
+    price: bigNumberify(1500),
+    timestamp: 1700000000,
+    toAsset: 'USD',
+    ...overrides,
+  };
+}
+
+function formPayload(overrides: Partial<HistoricalPriceFormPayload> = {}): HistoricalPriceFormPayload {
+  return {
+    fromAsset: 'ETH',
+    price: '1500',
+    sourceType: PriceOracle.MANUAL,
+    timestamp: 1700000000,
+    toAsset: 'USD',
+    ...overrides,
+  };
+}
+
+function mountManager(
+  filter?: { fromAsset?: string; toAsset?: string },
+): ReturnType<typeof useHistoricPrices> {
+  let captured: ReturnType<typeof useHistoricPrices> | undefined;
+  let setupError: Error | undefined;
+  const filterRef = ref<{ fromAsset?: string; toAsset?: string }>(filter ?? {});
+
+  const Host = defineComponent({
+    setup(): () => ReturnType<typeof h> {
+      try {
+        captured = useHistoricPrices(mockTranslate, filter ? filterRef : undefined);
+      }
+      catch (error) {
+        setupError = error instanceof Error ? error : new Error(String(error));
+      }
+      return (): ReturnType<typeof h> => h('div');
+    },
+  });
+
+  wrappers.push(mount(Host));
+  if (setupError)
+    throw setupError;
+  return captured!;
+}
+
+describe('modules/assets/prices/useHistoricPrices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchHistoricalPrices.mockResolvedValue([]);
+    addHistoricalPrice.mockResolvedValue(true);
+    editHistoricalPrice.mockResolvedValue(true);
+    deleteHistoricalPrice.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('the initial load', () => {
+    it('should fetch as soon as it mounts, without waiting for a caller', async () => {
+      const rows = [price()];
+      fetchHistoricalPrices.mockResolvedValue(rows);
+
+      const { items } = mountManager();
+      await flushPromises();
+
+      expect(fetchHistoricalPrices).toHaveBeenCalledOnce();
+      expect(get(items)).toEqual(rows);
+    });
+
+    it('should narrow the fetch to the filter it was given', async () => {
+      mountManager({ fromAsset: 'ETH', toAsset: 'USD' });
+      await flushPromises();
+
+      expect(fetchHistoricalPrices).toHaveBeenCalledWith({ fromAsset: 'ETH', toAsset: 'USD' });
+    });
+
+    it('should ask for everything when no filter is given', async () => {
+      mountManager();
+      await flushPromises();
+
+      expect(fetchHistoricalPrices).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('the loading flag', () => {
+    it('should be raised for the duration of the fetch and lowered after it', async () => {
+      let release: (rows: HistoricalPrice[]) => void = () => {};
+      fetchHistoricalPrices.mockReturnValue(new Promise((resolve) => {
+        release = resolve;
+      }));
+
+      const { loading } = mountManager();
+
+      expect(get(loading)).toBe(true);
+      release([]);
+      await flushPromises();
+      expect(get(loading)).toBe(false);
+    });
+
+    it('should be lowered again even when the fetch rejects', async () => {
+      fetchHistoricalPrices.mockRejectedValue(new Error('offline'));
+
+      const { loading } = mountManager();
+      await flushPromises();
+
+      expect(get(loading)).toBe(false);
+    });
+  });
+
+  describe('a failed fetch', () => {
+    it('should notify and leave the previous rows in place', async () => {
+      const rows = [price()];
+      fetchHistoricalPrices.mockResolvedValue(rows);
+      const { items, refresh } = mountManager();
+      await flushPromises();
+
+      fetchHistoricalPrices.mockRejectedValue(new Error('offline'));
+      await refresh();
+
+      expect(notifyError).toHaveBeenCalledOnce();
+      expect(get(items)).toEqual(rows);
+    });
+  });
+
+  describe('refreshing', () => {
+    it('should not touch the price cache for a plain refresh', async () => {
+      const { refresh } = mountManager();
+      await flushPromises();
+
+      await refresh();
+
+      expect(resetHistoricalPricesData).not.toHaveBeenCalled();
+    });
+
+    it('should invalidate the cache for the rows it just fetched when they changed', async () => {
+      const rows = [price()];
+      fetchHistoricalPrices.mockResolvedValue(rows);
+      const { refresh } = mountManager();
+      await flushPromises();
+
+      await refresh({ modified: true });
+
+      expect(resetHistoricalPricesData).toHaveBeenCalledWith(rows);
+    });
+
+    it('should also invalidate an entry that is no longer among the fetched rows', async () => {
+      const removed = price({ fromAsset: 'BTC', timestamp: 1600000000 });
+      const remaining = price();
+      fetchHistoricalPrices.mockResolvedValue([remaining]);
+      const { refresh } = mountManager();
+      await flushPromises();
+
+      await refresh({ additionalEntry: removed, modified: true });
+
+      expect(resetHistoricalPricesData).toHaveBeenCalledWith([remaining, removed]);
+    });
+
+    it('should ignore an additional entry when nothing was modified', async () => {
+      const { refresh } = mountManager();
+      await flushPromises();
+
+      await refresh({ additionalEntry: price() });
+
+      expect(resetHistoricalPricesData).not.toHaveBeenCalled();
+    });
+
+    it('should refetch when the filter changes', async () => {
+      const filter = ref({ fromAsset: 'ETH', toAsset: 'USD' });
+      let captured: ReturnType<typeof useHistoricPrices> | undefined;
+      const Host = defineComponent({
+        setup(): () => ReturnType<typeof h> {
+          captured = useHistoricPrices(mockTranslate, filter);
+          return (): ReturnType<typeof h> => h('div');
+        },
+      });
+      wrappers.push(mount(Host));
+      await flushPromises();
+      expect(captured).toBeDefined();
+
+      set(filter, { fromAsset: 'BTC', toAsset: 'USD' });
+      await flushPromises();
+
+      expect(fetchHistoricalPrices).toHaveBeenLastCalledWith({ fromAsset: 'BTC', toAsset: 'USD' });
+      expect(fetchHistoricalPrices).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('saving', () => {
+    it('should add when it is not an update', async () => {
+      const { save } = mountManager();
+      await flushPromises();
+
+      const saved = await save(formPayload(), false);
+
+      expect(addHistoricalPrice).toHaveBeenCalledWith(formPayload());
+      expect(editHistoricalPrice).not.toHaveBeenCalled();
+      expect(saved).toBe(true);
+    });
+
+    it('should edit when it is an update', async () => {
+      const { save } = mountManager();
+      await flushPromises();
+
+      const saved = await save(formPayload(), true);
+
+      expect(editHistoricalPrice).toHaveBeenCalledWith(formPayload());
+      expect(addHistoricalPrice).not.toHaveBeenCalled();
+      expect(saved).toBe(true);
+    });
+
+    it('should pass a refusal from the backend straight back to the caller', async () => {
+      addHistoricalPrice.mockResolvedValue(false);
+      const { save } = mountManager();
+      await flushPromises();
+
+      expect(await save(formPayload(), false)).toBe(false);
+      expect(showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it('should report a failed add as a message rather than a notification', async () => {
+      addHistoricalPrice.mockRejectedValue(new Error('rejected'));
+      const { save } = mountManager();
+      await flushPromises();
+
+      const saved = await save(formPayload(), false);
+
+      expect(saved).toBe(false);
+      expect(showErrorMessage).toHaveBeenCalledWith(
+        'price_management.add.error.title',
+        'price_management.add.error.description::rejected',
+      );
+      expect(notifyError).not.toHaveBeenCalled();
+    });
+
+    it('should name the edit, not the add, when an update fails', async () => {
+      editHistoricalPrice.mockRejectedValue(new Error('rejected'));
+      const { save } = mountManager();
+      await flushPromises();
+
+      await save(formPayload(), true);
+
+      expect(showErrorMessage).toHaveBeenCalledWith(
+        'price_management.edit.error.title',
+        'price_management.edit.error.description::rejected',
+      );
+    });
+  });
+
+  describe('deleting', () => {
+    it('should send the pair and timestamp as a manual price, without the price itself', async () => {
+      const { deletePrice } = mountManager();
+      await flushPromises();
+
+      await deletePrice(price());
+
+      expect(deleteHistoricalPrice).toHaveBeenCalledWith({
+        fromAsset: 'ETH',
+        sourceType: PriceOracle.MANUAL,
+        timestamp: 1700000000,
+        toAsset: 'USD',
+      });
+    });
+
+    it('should invalidate the deleted entry, which the refetch can no longer report', async () => {
+      const deleted = price();
+      const { deletePrice } = mountManager();
+      await flushPromises();
+      fetchHistoricalPrices.mockResolvedValue([]);
+
+      await deletePrice(deleted);
+
+      expect(resetHistoricalPricesData).toHaveBeenCalledWith([deleted]);
+    });
+
+    it('should notify and not refetch when the delete fails', async () => {
+      deleteHistoricalPrice.mockRejectedValue(new Error('locked'));
+      const { deletePrice } = mountManager();
+      await flushPromises();
+      fetchHistoricalPrices.mockClear();
+
+      await deletePrice(price());
+
+      expect(notifyError).toHaveBeenCalledOnce();
+      expect(fetchHistoricalPrices).not.toHaveBeenCalled();
+      expect(resetHistoricalPricesData).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/prices/use-historical-price-fetcher.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-historical-price-fetcher.spec.ts
@@ -1,0 +1,298 @@
+import type { FailedHistoricalAssetPriceResponse, HistoricalAssetPricePayload } from '@rotki/common';
+import type { ActivityContext, NativeActivitySpec } from '@/modules/task-center/use-native-task';
+import { createMock } from '@test/utils/create-mock';
+import { err, ok, type Result } from 'plainfp/result';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackendCancelled, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { useHistoricalPriceFetcher } from './use-historical-price-fetcher';
+
+const {
+  failedDailyPrices,
+  getAssetField,
+  notifyError,
+  queryHistoricalAssetPrices,
+  resolvedFailedDailyPrices,
+  runTask,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    failedDailyPrices: ref<Record<string, FailedHistoricalAssetPriceResponse>>({}),
+    getAssetField: vi.fn(() => 'Ethereum'),
+    notifyError: vi.fn(),
+    queryHistoricalAssetPrices: vi.fn(),
+    resolvedFailedDailyPrices: ref<Record<string, number[]>>({}),
+    runTask: vi.fn(),
+  };
+});
+
+let submitted: NativeActivitySpec<unknown> | undefined;
+
+vi.mock('@/modules/task-center/use-native-task', () => ({
+  useNativeTask: (): Record<string, unknown> => ({
+    submitTask: async <T>(spec: NativeActivitySpec<T>): Promise<Result<T, TaskError>> => {
+      submitted = spec;
+      return spec.run(createMock<ActivityContext>({ runTask }));
+    },
+  }),
+}));
+
+vi.mock('@/modules/statistics/api/use-statistics-api', () => ({
+  useStatisticsApi: (): Record<string, unknown> => ({ queryHistoricalAssetPrices }),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: (): Record<string, unknown> => ({ getAssetField }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): Record<string, unknown> => ({ notifyError }),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: (): Record<string, unknown> => ({ failedDailyPrices, resolvedFailedDailyPrices }),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  getDefaultLogLevel: vi.fn(() => 'debug'),
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  setLevel: vi.fn(),
+}));
+
+const ASSET = 'ETH';
+
+function payload(overrides: Partial<HistoricalAssetPricePayload> = {}): HistoricalAssetPricePayload {
+  return {
+    asset: ASSET,
+    fromTimestamp: 1600000000,
+    interval: 86400,
+    toTimestamp: 1700000000,
+    ...overrides,
+  };
+}
+
+function backendReturns(response: {
+  noPricesTimestamps?: number[];
+  prices?: Record<string, string>;
+  rateLimitedPricesTimestamps?: number[];
+}): void {
+  queryHistoricalAssetPrices.mockResolvedValue({
+    noPricesTimestamps: [],
+    prices: {},
+    rateLimitedPricesTimestamps: [],
+    ...response,
+  });
+  runTask.mockImplementation(async (run: () => Promise<unknown>) => ok(await run()));
+}
+
+describe('modules/assets/prices/useHistoricalPriceFetcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(failedDailyPrices, {});
+    set(resolvedFailedDailyPrices, {});
+    submitted = undefined;
+    backendReturns({});
+  });
+
+  describe('the activity it submits', () => {
+    it('should key the activity on the range as well as the asset, so two ranges cannot dedup onto one', async () => {
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(submitted?.id).toBe(makeActivityId(
+        ActivityKind.PRICES,
+        ActivityPart.DAILY,
+        ASSET,
+        86400,
+        1600000000,
+        1700000000,
+      ));
+    });
+
+    it('should give two ranges of one asset different ids', async () => {
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+      const first = submitted?.id;
+      await fetchHistoricalAssetPrice(payload({ toTimestamp: 1650000000 }));
+
+      expect(submitted?.id).not.toBe(first);
+    });
+
+    it('should file the activity under prices and allow a re-run', async () => {
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(submitted?.kind).toBe(ActivityKind.PRICES);
+      expect(submitted?.rerunnable).toBe(true);
+    });
+
+    it('should name the asset in the subtitle rather than showing its identifier', async () => {
+      getAssetField.mockReturnValue('Ethereum');
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(getAssetField).toHaveBeenCalledWith(ASSET, 'name');
+      expect(submitted?.subtitle).toMatchObject({ params: { asset: 'Ethereum' } });
+    });
+  });
+
+  describe('the timestamps it asks the backend to skip', () => {
+    it('should skip nothing on a first fetch', async () => {
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(queryHistoricalAssetPrices).toHaveBeenCalledWith({ ...payload(), excludeTimestamps: [] });
+    });
+
+    it('should skip the timestamps already known to have no price', async () => {
+      set(failedDailyPrices, {
+        [ASSET]: { noPricesTimestamps: [111, 222], rateLimitedPricesTimestamps: [] },
+      });
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(queryHistoricalAssetPrices).toHaveBeenCalledWith({ ...payload(), excludeTimestamps: [111, 222] });
+    });
+
+    it('should stop skipping a timestamp the user has since resolved by hand', async () => {
+      set(failedDailyPrices, {
+        [ASSET]: { noPricesTimestamps: [111, 222], rateLimitedPricesTimestamps: [] },
+      });
+      set(resolvedFailedDailyPrices, { [ASSET]: [111] });
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(queryHistoricalAssetPrices).toHaveBeenCalledWith({ ...payload(), excludeTimestamps: [222] });
+    });
+
+    it('should not skip another asset\'s failures', async () => {
+      set(failedDailyPrices, {
+        BTC: { noPricesTimestamps: [111], rateLimitedPricesTimestamps: [] },
+      });
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(queryHistoricalAssetPrices).toHaveBeenCalledWith({ ...payload(), excludeTimestamps: [] });
+    });
+  });
+
+  describe('what it records after a fetch', () => {
+    it('should record the timestamps the backend could not price', async () => {
+      backendReturns({ noPricesTimestamps: [333] });
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(get(failedDailyPrices)[ASSET]).toEqual({
+        noPricesTimestamps: [333],
+        rateLimitedPricesTimestamps: [],
+      });
+    });
+
+    it('should record a rate limit separately from a missing price', async () => {
+      backendReturns({ rateLimitedPricesTimestamps: [444] });
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(get(failedDailyPrices)[ASSET]).toEqual({
+        noPricesTimestamps: [],
+        rateLimitedPricesTimestamps: [444],
+      });
+    });
+
+    it('should keep skipping the excluded timestamps the backend was never asked about', async () => {
+      set(failedDailyPrices, {
+        [ASSET]: { noPricesTimestamps: [111], rateLimitedPricesTimestamps: [] },
+      });
+      backendReturns({});
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(get(failedDailyPrices)[ASSET]).toEqual({
+        noPricesTimestamps: [111],
+        rateLimitedPricesTimestamps: [],
+      });
+    });
+
+    it('should clear the asset once nothing failed and nothing was skipped', async () => {
+      set(failedDailyPrices, {
+        BTC: { noPricesTimestamps: [999], rateLimitedPricesTimestamps: [] },
+        [ASSET]: { noPricesTimestamps: [], rateLimitedPricesTimestamps: [] },
+      });
+      set(resolvedFailedDailyPrices, { [ASSET]: [111] });
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(get(failedDailyPrices)).not.toHaveProperty(ASSET);
+      expect(get(resolvedFailedDailyPrices)).not.toHaveProperty(ASSET);
+      expect(get(failedDailyPrices).BTC).toBeDefined();
+    });
+  });
+
+  describe('the value it returns', () => {
+    it('should return the parsed prices', async () => {
+      backendReturns({ prices: { 1600000000: '1500.5' } });
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      const result = await fetchHistoricalAssetPrice(payload());
+
+      expect(result.prices[1600000000].toString()).toBe('1500.5');
+    });
+
+    it('should return an empty response when the task fails, rather than throwing', async () => {
+      runTask.mockResolvedValue(err(TaskFailed({ message: 'boom' })));
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      const result = await fetchHistoricalAssetPrice(payload());
+
+      expect(result).toEqual({ noPricesTimestamps: [], prices: {}, rateLimitedPricesTimestamps: [] });
+    });
+  });
+
+  describe('how it reports a failure', () => {
+    it('should notify the user when the task actually failed', async () => {
+      runTask.mockResolvedValue(err(TaskFailed({ message: 'boom' })));
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(notifyError).toHaveBeenCalledOnce();
+    });
+
+    it('should stay quiet when the task was cancelled rather than failed', async () => {
+      runTask.mockResolvedValue(err(BackendCancelled({ message: 'stopped' })));
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      const result = await fetchHistoricalAssetPrice(payload());
+
+      expect(notifyError).not.toHaveBeenCalled();
+      expect(result).toEqual({ noPricesTimestamps: [], prices: {}, rateLimitedPricesTimestamps: [] });
+    });
+
+    it('should leave the recorded failures untouched when the task fails', async () => {
+      set(failedDailyPrices, {
+        [ASSET]: { noPricesTimestamps: [111], rateLimitedPricesTimestamps: [] },
+      });
+      runTask.mockResolvedValue(err(TaskFailed({ message: 'boom' })));
+      const { fetchHistoricalAssetPrice } = useHistoricalPriceFetcher();
+
+      await fetchHistoricalAssetPrice(payload());
+
+      expect(get(failedDailyPrices)[ASSET]).toEqual({
+        noPricesTimestamps: [111],
+        rateLimitedPricesTimestamps: [],
+      });
+    });
+  });
+});

--- a/frontend/app/src/modules/balances/manual-balances.spec.ts
+++ b/frontend/app/src/modules/balances/manual-balances.spec.ts
@@ -1,0 +1,292 @@
+import type { ManualBalanceRequestPayload, ManualBalanceWithValue } from '@/modules/balances/types/manual-balances';
+import { type BigNumber, bigNumberify } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { BalanceType } from '@/modules/balances/types/balances';
+import { sortAndFilterManualBalance } from './manual-balances';
+
+let nextId = 1;
+
+function balance(overrides: Partial<ManualBalanceWithValue> = {}): ManualBalanceWithValue {
+  return {
+    amount: bigNumberify(1),
+    asset: 'ETH',
+    balanceType: BalanceType.ASSET,
+    identifier: nextId++,
+    label: 'a label',
+    location: 'external',
+    tags: null,
+    value: bigNumberify(1),
+    ...overrides,
+  };
+}
+
+function payload(overrides: Partial<ManualBalanceRequestPayload> = {}): ManualBalanceRequestPayload {
+  return { limit: 10, offset: 0, ...overrides };
+}
+
+function pricesOf(prices: Record<string, number>): { resolveAssetPrice: (asset: string) => BigNumber | undefined } {
+  return {
+    resolveAssetPrice: (asset: string) => asset in prices ? bigNumberify(prices[asset]) : undefined,
+  };
+}
+
+const noPrices = pricesOf({});
+
+describe('modules/balances/sortAndFilterManualBalance', () => {
+  describe('the collection it returns', () => {
+    it('should report the unfiltered count as the total and the filtered count as found', () => {
+      const balances = [balance({ label: 'keep' }), balance({ label: 'drop' }), balance({ label: 'drop' })];
+
+      const result = sortAndFilterManualBalance(balances, payload({ label: 'keep' }), noPrices);
+
+      expect(result.found).toBe(1);
+      expect(result.total).toBe(3);
+    });
+
+    it('should always report a limit of -1, since it paginates in memory', () => {
+      const result = sortAndFilterManualBalance([balance()], payload(), noPrices);
+
+      expect(result.limit).toBe(-1);
+    });
+
+    it('should attach the price to each row', () => {
+      const balances = [balance({ asset: 'ETH' }), balance({ asset: 'UNKNOWN' })];
+
+      const result = sortAndFilterManualBalance(balances, payload(), pricesOf({ ETH: 3000 }));
+
+      expect(result.data[0].price?.toNumber()).toBe(3000);
+      expect(result.data[1].price).toBeUndefined();
+    });
+  });
+
+  describe('pagination', () => {
+    it('should return the requested page', () => {
+      const balances = [balance({ label: 'a' }), balance({ label: 'b' }), balance({ label: 'c' })];
+
+      const result = sortAndFilterManualBalance(balances, payload({ limit: 2, offset: 1 }), noPrices);
+
+      expect(result.data.map(item => item.label)).toEqual(['b', 'c']);
+    });
+
+    it('should report the full count even when a page is returned', () => {
+      const balances = [balance(), balance(), balance()];
+
+      const result = sortAndFilterManualBalance(balances, payload({ limit: 1, offset: 0 }), noPrices);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.found).toBe(3);
+    });
+  });
+
+  describe('the total value', () => {
+    it('should sum price times amount over every filtered row, not just the page', () => {
+      const balances = [
+        balance({ amount: bigNumberify(2), asset: 'ETH' }),
+        balance({ amount: bigNumberify(3), asset: 'ETH' }),
+      ];
+
+      const result = sortAndFilterManualBalance(balances, payload({ limit: 1 }), pricesOf({ ETH: 100 }));
+
+      expect(result.data).toHaveLength(1);
+      expect(result.totalValue?.toNumber()).toBe(500);
+    });
+
+    it('should skip an unpriced asset rather than counting its amount', () => {
+      const balances = [
+        balance({ amount: bigNumberify(2), asset: 'ETH' }),
+        balance({ amount: bigNumberify(99), asset: 'UNKNOWN' }),
+      ];
+
+      const result = sortAndFilterManualBalance(balances, payload(), pricesOf({ ETH: 100 }));
+
+      expect(result.totalValue?.toNumber()).toBe(200);
+    });
+
+    it('should skip an asset priced at zero', () => {
+      const balances = [balance({ amount: bigNumberify(2), asset: 'ETH' })];
+
+      const result = sortAndFilterManualBalance(balances, payload(), pricesOf({ ETH: 0 }));
+
+      expect(result.totalValue?.toNumber()).toBe(0);
+    });
+
+    it('should count only what survives the filter', () => {
+      const balances = [
+        balance({ amount: bigNumberify(2), asset: 'ETH', label: 'keep' }),
+        balance({ amount: bigNumberify(5), asset: 'ETH', label: 'drop' }),
+      ];
+
+      const result = sortAndFilterManualBalance(balances, payload({ label: 'keep' }), pricesOf({ ETH: 100 }));
+
+      expect(result.totalValue?.toNumber()).toBe(200);
+    });
+  });
+
+  describe('filtering', () => {
+    it('should return everything when no filter is given', () => {
+      const balances = [balance(), balance()];
+
+      expect(sortAndFilterManualBalance(balances, payload(), noPrices).found).toBe(2);
+    });
+
+    it('should treat an empty tag list as no filter at all', () => {
+      const balances = [balance({ tags: null }), balance({ tags: ['x'] })];
+
+      expect(sortAndFilterManualBalance(balances, payload({ tags: [] }), noPrices).found).toBe(2);
+    });
+
+    it('should match a label partially', () => {
+      const balances = [balance({ label: 'my savings' }), balance({ label: 'other' })];
+
+      const result = sortAndFilterManualBalance(balances, payload({ label: 'saving' }), noPrices);
+
+      expect(result.data.map(item => item.label)).toEqual(['my savings']);
+    });
+
+    it('should match a location partially', () => {
+      const balances = [balance({ location: 'kraken' }), balance({ location: 'external' })];
+
+      const result = sortAndFilterManualBalance(balances, payload({ location: 'krak' }), noPrices);
+
+      expect(result.data.map(item => item.location)).toEqual(['kraken']);
+    });
+
+    it('should match an asset exactly, not partially', () => {
+      const balances = [balance({ asset: 'ETH' }), balance({ asset: 'ETHW' })];
+
+      const result = sortAndFilterManualBalance(balances, payload({ asset: 'ETH' }), noPrices);
+
+      expect(result.data.map(item => item.asset)).toEqual(['ETH']);
+    });
+
+    it('should ignore surrounding whitespace when matching an asset', () => {
+      const balances = [balance({ asset: ' ETH ' })];
+
+      expect(sortAndFilterManualBalance(balances, payload({ asset: 'ETH' }), noPrices).found).toBe(1);
+    });
+
+    it('should keep a row carrying any one of the requested tags', () => {
+      const balances = [balance({ tags: ['b'] }), balance({ tags: ['c'] })];
+
+      const result = sortAndFilterManualBalance(balances, payload({ tags: ['a', 'b'] }), noPrices);
+
+      expect(result.data.map(item => item.tags)).toEqual([['b']]);
+    });
+
+    it('should drop a row with no tags when a tag is required', () => {
+      const balances = [balance({ tags: null })];
+
+      expect(sortAndFilterManualBalance(balances, payload({ tags: ['a'] }), noPrices).found).toBe(0);
+    });
+
+    it('should require every given filter to match, not any', () => {
+      const balances = [
+        balance({ asset: 'ETH', label: 'keep' }),
+        balance({ asset: 'BTC', label: 'keep' }),
+      ];
+
+      const result = sortAndFilterManualBalance(balances, payload({ asset: 'ETH', label: 'keep' }), noPrices);
+
+      expect(result.found).toBe(1);
+    });
+  });
+
+  describe('sorting', () => {
+    it('should leave the order alone when no attribute is given', () => {
+      const balances = [balance({ label: 'b' }), balance({ label: 'a' })];
+
+      const result = sortAndFilterManualBalance(balances, payload(), noPrices);
+
+      expect(result.data.map(item => item.label)).toEqual(['b', 'a']);
+    });
+
+    it('should sort a text column ascending', () => {
+      const balances = [balance({ label: 'b' }), balance({ label: 'a' })];
+
+      const result = sortAndFilterManualBalance(
+        balances,
+        payload({ ascending: [true], orderByAttributes: ['label'] }),
+        noPrices,
+      );
+
+      expect(result.data.map(item => item.label)).toEqual(['a', 'b']);
+    });
+
+    it('should sort a text column descending', () => {
+      const balances = [balance({ label: 'a' }), balance({ label: 'b' })];
+
+      const result = sortAndFilterManualBalance(
+        balances,
+        payload({ ascending: [false], orderByAttributes: ['label'] }),
+        noPrices,
+      );
+
+      expect(result.data.map(item => item.label)).toEqual(['b', 'a']);
+    });
+
+    it('should sort a numeric column by magnitude rather than as text', () => {
+      const balances = [
+        balance({ amount: bigNumberify(9), label: 'nine' }),
+        balance({ amount: bigNumberify(10), label: 'ten' }),
+      ];
+
+      const result = sortAndFilterManualBalance(
+        balances,
+        payload({ ascending: [true], orderByAttributes: ['amount'] }),
+        noPrices,
+      );
+
+      expect(result.data.map(item => item.label)).toEqual(['nine', 'ten']);
+    });
+
+    it('should accept the snake_case attribute getApiSortingParams produces, not the camelCase key', () => {
+      const balances = [
+        balance({ balanceType: BalanceType.LIABILITY, label: 'liability' }),
+        balance({ balanceType: BalanceType.ASSET, label: 'asset' }),
+      ];
+
+      const result = sortAndFilterManualBalance(
+        balances,
+        payload({ ascending: [true], orderByAttributes: ['balance_type'] }),
+        noPrices,
+      );
+
+      expect(result.data.map(item => item.label)).toEqual(['asset', 'liability']);
+    });
+
+    it('should ignore an optional attribute that is absent from the rows', () => {
+      const balances = [balance({ label: 'b' }), balance({ label: 'a' })];
+
+      const result = sortAndFilterManualBalance(
+        balances,
+        payload({ ascending: [true], orderByAttributes: ['asset_is_missing'] }),
+        noPrices,
+      );
+
+      expect(result.data.map(item => item.label)).toEqual(['b', 'a']);
+    });
+
+    it('should fall through to the second attribute when the first ties', () => {
+      const balances = [
+        balance({ label: 'b', location: 'same' }),
+        balance({ label: 'a', location: 'same' }),
+      ];
+
+      const result = sortAndFilterManualBalance(
+        balances,
+        payload({ ascending: [true, true], orderByAttributes: ['location', 'label'] }),
+        noPrices,
+      );
+
+      expect(result.data.map(item => item.label)).toEqual(['a', 'b']);
+    });
+
+    it('should not reorder the caller\'s array when no filter narrows it first', () => {
+      const balances = [balance({ label: 'b' }), balance({ label: 'a' })];
+
+      sortAndFilterManualBalance(balances, payload({ ascending: [true], orderByAttributes: ['label'] }), noPrices);
+
+      expect(balances.map(item => item.label)).toEqual(['b', 'a']);
+    });
+  });
+});

--- a/frontend/app/src/modules/balances/manual-balances.ts
+++ b/frontend/app/src/modules/balances/manual-balances.ts
@@ -48,6 +48,18 @@ function filterBalance(balance: ManualBalance, filters: Filters): boolean {
   return matches.length > 0 && matches.every(match => match.matches);
 }
 
+/**
+ * Filters, sorts and pages manual balances in memory, standing in for the server-side query the
+ * other tables issue.
+ *
+ * @remarks
+ * `balances` is never reordered. With no filter active the working set *is* the array passed in,
+ * and callers take that straight from the store, so sorting in place would reorder the store for
+ * every other consumer.
+ *
+ * @returns a collection whose `limit` is always -1, since the paging has already happened here and
+ * there is no server page size to report
+ */
 export function sortAndFilterManualBalance(
   balances: ManualBalanceWithValue[],
   params: ManualBalanceRequestPayload,
@@ -73,7 +85,7 @@ export function sortAndFilterManualBalance(
   const sorted
     = orderByAttributes.length === 0
       ? filtered
-      : filtered.sort((a, b) => {
+      : [...filtered].sort((a, b) => {
           for (const [i, attr] of orderByAttributes.entries()) {
             // The table sends snake_case attributes, so match the converted name against the row's keys.
             const converted = camelCase(attr);

--- a/frontend/app/src/modules/balances/non-fungible/use-nft-data.spec.ts
+++ b/frontend/app/src/modules/balances/non-fungible/use-nft-data.spec.ts
@@ -1,0 +1,287 @@
+import type { NonFungibleBalance } from '@/modules/balances/types/nfbalances';
+import type { Collection } from '@/modules/core/common/collection';
+import type { useServerTable } from '@/modules/core/table/use-server-table';
+import { bigNumberify } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, defineComponent, h, ref } from 'vue';
+import { TableColumn } from '@/modules/core/table/table-column';
+import { TableId } from '@/modules/core/table/use-remember-table-sorting';
+import { DashboardTableType } from '@/modules/settings/types/frontend-settings';
+import { ActivityKind } from '@/modules/task-center/core/types';
+import { useNftData } from './use-nft-data';
+
+type ServerTableOptions = Parameters<typeof useServerTable>[0];
+
+const {
+  collection,
+  currencySymbol,
+  dashboardTablesVisibleColumns,
+  fetchNonFungibleBalances,
+  refreshNonFungibleBalances,
+  sectionActive,
+  setPage,
+  totalNetWorth,
+  useIsActive,
+  useRememberTableSorting,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  const { bigNumberify } = await import('@rotki/common');
+  return {
+    collection: ref<Collection<NonFungibleBalance>>({ data: [], found: 0, limit: -1, total: 0 }),
+    currencySymbol: ref<string>('USD'),
+    dashboardTablesVisibleColumns: ref<Record<string, string[]>>({}),
+    fetchNonFungibleBalances: vi.fn(),
+    refreshNonFungibleBalances: vi.fn(),
+    sectionActive: ref<boolean>(false),
+    setPage: vi.fn(),
+    totalNetWorth: ref(bigNumberify(0)),
+    useIsActive: vi.fn(),
+    useRememberTableSorting: vi.fn(),
+  };
+});
+
+let serverTableOptions: ServerTableOptions | undefined;
+
+function emptyCollection(): Collection<NonFungibleBalance> {
+  return { data: [], found: 0, limit: -1, total: 0 };
+}
+
+vi.mock('@/modules/balances/nft/use-nft-balances', () => ({
+  useNftBalances: (): Record<string, unknown> => ({ fetchNonFungibleBalances, refreshNonFungibleBalances }),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/table/use-server-table')>(),
+  useServerTable: (options: ServerTableOptions): Record<string, unknown> => {
+    serverTableOptions = options;
+    return {
+      collection,
+      isLoading: ref(false),
+      pagination: computed(() => ({ limit: 10, page: 1, total: 0 })),
+      refetch: vi.fn(),
+      setPage,
+      sort: computed(() => []),
+    };
+  },
+}));
+
+vi.mock('@/modules/core/table/use-remember-table-sorting', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/table/use-remember-table-sorting')>(),
+  useRememberTableSorting,
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (key: string): unknown => key === 'currencySymbol' ? currencySymbol : dashboardTablesVisibleColumns,
+}));
+
+vi.mock('@/modules/statistics/use-statistics-store', () => ({
+  useStatisticsStore: (): Record<string, unknown> => ({ totalNetWorth }),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', () => ({
+  useTaskCenter: (): Record<string, unknown> => ({ useIsActive }),
+}));
+
+const wrappers: VueWrapper[] = [];
+
+function mountNftData(dashboard = false): ReturnType<typeof useNftData> {
+  let captured: ReturnType<typeof useNftData> | undefined;
+  let setupError: Error | undefined;
+  const Host = defineComponent({
+    setup(): () => ReturnType<typeof h> {
+      try {
+        captured = useNftData({ dashboard });
+      }
+      catch (error) {
+        setupError = error instanceof Error ? error : new Error(String(error));
+      }
+      return (): ReturnType<typeof h> => h('div');
+    },
+  });
+
+  wrappers.push(mount(Host));
+  if (setupError)
+    throw setupError;
+  return captured!;
+}
+
+function columnKeys(dashboard = false): string[] {
+  return get(mountNftData(dashboard).cols).map(col => col.key);
+}
+
+describe('modules/balances/non-fungible/useNftData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useIsActive.mockReturnValue(sectionActive);
+    set(collection, emptyCollection());
+    set(currencySymbol, 'USD');
+    set(dashboardTablesVisibleColumns, { [DashboardTableType.NFT]: [] });
+    set(totalNetWorth, bigNumberify(0));
+    set(sectionActive, false);
+    serverTableOptions = undefined;
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('the share of net worth', () => {
+    it('should report a holding as a percentage of the whole portfolio', () => {
+      set(totalNetWorth, bigNumberify(2000));
+
+      expect(mountNftData().percentageOfTotalNetValue(bigNumberify(500))).toBe('25.00');
+    });
+
+    it('should report zero rather than dividing by an empty portfolio', () => {
+      expect(mountNftData().percentageOfTotalNetValue(bigNumberify(500))).toBe('0.00');
+    });
+
+    it('should always carry two decimals', () => {
+      set(totalNetWorth, bigNumberify(3));
+
+      expect(mountNftData().percentageOfTotalNetValue(bigNumberify(1))).toBe('33.33');
+    });
+  });
+
+  describe('the share of the nft group', () => {
+    it('should divide by the value of the whole filtered group, not the page', () => {
+      set(collection, { ...emptyCollection(), totalValue: bigNumberify(400) });
+
+      expect(mountNftData().percentageOfCurrentGroup(bigNumberify(100))).toBe('25.00');
+    });
+
+    it('should report zero when the group has no value yet', () => {
+      set(collection, { ...emptyCollection(), totalValue: undefined });
+
+      expect(mountNftData().percentageOfCurrentGroup(bigNumberify(100))).toBe('0.00');
+    });
+
+    it('should treat an unknown group value as zero rather than throwing', () => {
+      set(collection, { ...emptyCollection(), totalValue: null });
+
+      expect(mountNftData().percentageOfCurrentGroup(bigNumberify(100))).toBe('0.00');
+    });
+  });
+
+  describe('the columns of the full page', () => {
+    it('should offer the ignore, custom price and action columns a dashboard has no room for', () => {
+      expect(columnKeys()).toEqual(['name', 'ignored', 'priceInAsset', 'price', 'manuallyInput', 'actions']);
+    });
+
+    it('should name the user currency in the price column', () => {
+      set(currencySymbol, 'EUR');
+
+      const price = get(mountNftData().cols).find(col => col.key === 'price');
+
+      expect(price?.label).toBe('common.price_in_symbol::EUR');
+    });
+  });
+
+  describe('the columns of the dashboard widget', () => {
+    it('should show only the three core columns when no percentage is enabled', () => {
+      expect(columnKeys(true)).toEqual(['name', 'priceInAsset', 'price']);
+    });
+
+    it('should add the net-worth percentage when that column is enabled', () => {
+      set(dashboardTablesVisibleColumns, {
+        [DashboardTableType.NFT]: [TableColumn.PERCENTAGE_OF_TOTAL_NET_VALUE],
+      });
+
+      expect(columnKeys(true)).toEqual(['name', 'priceInAsset', 'price', 'percentageOfTotalNetValue']);
+    });
+
+    it('should add the group percentage when that column is enabled', () => {
+      set(dashboardTablesVisibleColumns, {
+        [DashboardTableType.NFT]: [TableColumn.PERCENTAGE_OF_TOTAL_CURRENT_GROUP],
+      });
+
+      expect(columnKeys(true)).toEqual(['name', 'priceInAsset', 'price', 'percentageOfTotalCurrentGroup']);
+    });
+
+    it('should keep net worth ahead of group when both are enabled', () => {
+      set(dashboardTablesVisibleColumns, {
+        [DashboardTableType.NFT]: [
+          TableColumn.PERCENTAGE_OF_TOTAL_CURRENT_GROUP,
+          TableColumn.PERCENTAGE_OF_TOTAL_NET_VALUE,
+        ],
+      });
+
+      expect(columnKeys(true)).toEqual([
+        'name',
+        'priceInAsset',
+        'price',
+        'percentageOfTotalNetValue',
+        'percentageOfTotalCurrentGroup',
+      ]);
+    });
+  });
+
+  describe('the reset to the first page', () => {
+    it('should go back to page one when the ignored-assets filter changes', async () => {
+      const { modelIgnoredAssetsHandling } = mountNftData();
+
+      set(modelIgnoredAssetsHandling, 'show_all');
+      await flushPromises();
+
+      expect(setPage).toHaveBeenCalledWith(1);
+    });
+
+    it('should leave the dashboard widget where it is, since it does not own the page', async () => {
+      const { modelIgnoredAssetsHandling } = mountNftData(true);
+
+      set(modelIgnoredAssetsHandling, 'show_all');
+      await flushPromises();
+
+      expect(setPage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the table it configures', () => {
+    it('should sync the full page to the url and keep the widget out of it', () => {
+      mountNftData();
+      expect(serverTableOptions?.urlState).toEqual({ mode: 'route' });
+
+      mountNftData(true);
+      expect(serverTableOptions?.urlState).toEqual({ mode: 'none' });
+    });
+
+    it('should sort by price, highest first, before the user picks anything', () => {
+      mountNftData();
+
+      expect(serverTableOptions?.sort).toEqual({ default: [{ column: 'price', direction: 'desc' }] });
+    });
+
+    it('should hand the table the nft fetcher rather than fetching itself', () => {
+      mountNftData();
+
+      expect(serverTableOptions?.fetch).toBe(fetchNonFungibleBalances);
+      expect(fetchNonFungibleBalances).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('what it passes straight through', () => {
+    it('should report the section busy while the nft balance activity runs', () => {
+      const { sectionLoading } = mountNftData();
+
+      expect(useIsActive).toHaveBeenCalledWith(ActivityKind.NFT_BALANCES);
+      set(sectionActive, true);
+      expect(get(sectionLoading)).toBe(true);
+    });
+
+    it('should expose the refresh without wrapping it', () => {
+      expect(mountNftData().refreshNonFungibleBalances).toBe(refreshNonFungibleBalances);
+    });
+
+    it('should remember the sorting under the non-fungible table id', () => {
+      mountNftData();
+
+      expect(useRememberTableSorting).toHaveBeenCalledWith(
+        TableId.NON_FUNGIBLE_BALANCES,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/frontend/app/src/modules/core/common/common-types.ts
+++ b/frontend/app/src/modules/core/common/common-types.ts
@@ -12,7 +12,15 @@ export type WritableRef<T> = Ref<T>;
 export interface PaginationRequestPayload<T> {
   readonly limit: number;
   readonly offset: number;
-  readonly orderByAttributes?: (keyof T)[];
+  /**
+   * Column names in the snake_case the wire uses, which is what `getApiSortingParams` produces.
+   *
+   * @remarks
+   * Not `keyof T`: the sorting is run through `transformCase` on the way in, so a camelCase key
+   * never reaches a payload. Typing it as `keyof T` made every consumer convert back and forced a
+   * cast at the one place that builds it.
+   */
+  readonly orderByAttributes?: ToSnakeCase<keyof T & string>[];
   readonly ascending?: boolean[];
   readonly ignoreCache?: boolean;
   readonly onlyCache?: boolean;

--- a/frontend/app/src/modules/settings/api/use-accounting-api.spec.ts
+++ b/frontend/app/src/modules/settings/api/use-accounting-api.spec.ts
@@ -491,7 +491,7 @@ describe('useAccountingApi', () => {
       await fetchAccountingRuleConflicts({
         limit: 10,
         offset: 0,
-        orderByAttributes: ['localId'],
+        orderByAttributes: ['local_id'],
         ascending: [true],
       });
 

--- a/frontend/app/src/modules/shell/app/use-backend-messages.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-messages.spec.ts
@@ -1,0 +1,413 @@
+import type { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { BackendCode, type DebugStateGroup, type Listeners, type OAuthResult, type StartupError } from '@shared/ipc';
+import { createMock } from '@test/utils/create-mock';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { useAreaVisibilityStore } from '@/modules/core/common/use-area-visibility-store';
+import { useMainStore } from '@/modules/core/common/use-main-store';
+
+type BackendMessages = ReturnType<typeof import('./use-backend-messages').useBackendMessages>;
+
+const getStartupError = vi.fn<() => StartupError | null>(() => null);
+const setDataDirectory = vi.fn<(dataDirectory: string) => void>();
+const setupListeners = vi.fn<(listeners: Listeners) => void>();
+const restartBackend = vi.fn<() => Promise<void>>(async () => {});
+const startMonitoring = vi.fn<() => void>();
+const stopMonitoring = vi.fn<() => void>();
+const setWsConnectionEnabled = vi.fn<(enabled: boolean) => void>();
+const stopConnectionAttempts = vi.fn<() => void>();
+const startQuitting = vi.fn<() => void>();
+const stopRequests = vi.fn<() => void>();
+const setMcpServerState = vi.fn<(state: unknown) => void>();
+const resetDebugState = vi.fn<(group: DebugStateGroup) => string[]>(() => []);
+const reload = vi.fn<() => void>();
+
+const development = ref<boolean>(false);
+
+vi.mock('@shared/utils', async importOriginal => ({
+  ...await importOriginal<typeof import('@shared/utils')>(),
+  checkIfDevelopment: (): boolean => get(development),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): ReturnType<typeof useInterop> => createMock<ReturnType<typeof useInterop>>({
+    getStartupError,
+    setDataDirectory,
+    setupListeners,
+  }),
+}));
+
+vi.mock('@/modules/shell/app/use-backend-management', () => ({
+  useBackendManagement: (): { restartBackend: typeof restartBackend } => ({ restartBackend }),
+}));
+
+vi.mock('@/modules/shell/app/use-monitor-service', () => ({
+  useMonitorService: (): { start: typeof startMonitoring; stop: typeof stopMonitoring } => ({
+    start: startMonitoring,
+    stop: stopMonitoring,
+  }),
+}));
+
+vi.mock('@/modules/shell/app/use-websocket-connection', () => ({
+  useWebsocketConnection: (): { setConnectionEnabled: typeof setWsConnectionEnabled } => ({
+    setConnectionEnabled: setWsConnectionEnabled,
+  }),
+}));
+
+vi.mock('@/modules/shell/app/use-backend-connection', () => ({
+  useBackendConnection: (): { stopConnectionAttempts: typeof stopConnectionAttempts } => ({
+    stopConnectionAttempts,
+  }),
+}));
+
+vi.mock('@/modules/shell/app/use-app-quitting', () => ({
+  useAppQuitting: (): { startQuitting: typeof startQuitting } => ({ startQuitting }),
+}));
+
+vi.mock('@/modules/settings/backend/use-mcp-server-state', () => ({ setMcpServerState }));
+
+vi.mock('@/modules/shell/app/debug-state-reset', () => ({ resetDebugState }));
+
+vi.mock('@/modules/core/api', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/api')>(),
+  api: { stopRequests },
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  getDefaultLogLevel: vi.fn(() => 'debug'),
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  setLevel: vi.fn(),
+}));
+
+const wrappers: VueWrapper[] = [];
+
+async function mountHost(): Promise<BackendMessages> {
+  vi.doUnmock('@/modules/shell/app/use-backend-messages');
+  vi.resetModules();
+  const { useBackendMessages } = await import('./use-backend-messages');
+
+  let captured: BackendMessages | undefined;
+  let setupError: Error | undefined;
+  const Host = defineComponent({
+    setup(): () => ReturnType<typeof h> {
+      try {
+        captured = useBackendMessages();
+      }
+      catch (error) {
+        setupError = error instanceof Error ? error : new Error(String(error));
+      }
+      return (): ReturnType<typeof h> => h('div');
+    },
+  });
+
+  wrappers.push(mount(Host));
+  if (setupError)
+    throw setupError;
+  return captured!;
+}
+
+function listeners(): Listeners {
+  expect(setupListeners).toHaveBeenCalledOnce();
+  return setupListeners.mock.calls[0][0];
+}
+
+function oAuthSuccess(service: string): OAuthResult {
+  return { accessToken: 'token', service, success: true };
+}
+
+describe('modules/shell/app/useBackendMessages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getStartupError.mockReturnValue(null);
+    resetDebugState.mockReturnValue([]);
+    set(development, false);
+    vi.stubGlobal('location', { reload });
+    setActivePinia(createCustomPinia());
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+    vi.unstubAllGlobals();
+  });
+
+  describe('an error that happened before the app mounted', () => {
+    it('should surface a terminated backend as the startup message', async () => {
+      getStartupError.mockReturnValue({ code: BackendCode.TERMINATED, message: 'backend died' });
+
+      const { isMacOsVersionUnsupported, isWinVersionUnsupported, startupErrorMessage } = await mountHost();
+
+      expect(get(startupErrorMessage)).toBe('backend died');
+      expect(get(isMacOsVersionUnsupported)).toBe(false);
+      expect(get(isWinVersionUnsupported)).toBe(false);
+    });
+
+    it('should flag an unsupported macos without also showing the raw message', async () => {
+      getStartupError.mockReturnValue({ code: BackendCode.MACOS_VERSION, message: 'too old' });
+
+      const { isMacOsVersionUnsupported, startupErrorMessage } = await mountHost();
+
+      expect(get(isMacOsVersionUnsupported)).toBe(true);
+      expect(get(startupErrorMessage)).toBe('');
+    });
+
+    it('should flag an unsupported windows without also showing the raw message', async () => {
+      getStartupError.mockReturnValue({ code: BackendCode.WIN_VERSION, message: 'too old' });
+
+      const { isWinVersionUnsupported, startupErrorMessage } = await mountHost();
+
+      expect(get(isWinVersionUnsupported)).toBe(true);
+      expect(get(startupErrorMessage)).toBe('');
+    });
+
+    it('should still halt the backend for a code it does not recognise, showing nothing', async () => {
+      getStartupError.mockReturnValue({ code: 99, message: 'something new' });
+
+      const { isMacOsVersionUnsupported, isWinVersionUnsupported, startupErrorMessage } = await mountHost();
+
+      expect(stopConnectionAttempts).toHaveBeenCalledOnce();
+      expect(get(startupErrorMessage)).toBe('');
+      expect(get(isMacOsVersionUnsupported)).toBe(false);
+      expect(get(isWinVersionUnsupported)).toBe(false);
+    });
+
+    it('should halt every outbound channel, not just the one that failed', async () => {
+      getStartupError.mockReturnValue({ code: BackendCode.TERMINATED, message: 'backend died' });
+
+      await mountHost();
+
+      expect(stopConnectionAttempts).toHaveBeenCalledOnce();
+      expect(stopMonitoring).toHaveBeenCalledOnce();
+      expect(setWsConnectionEnabled).toHaveBeenCalledWith(false);
+    });
+
+    it('should leave the app untouched when the backend started cleanly', async () => {
+      const { isMacOsVersionUnsupported, isWinVersionUnsupported, startupErrorMessage } = await mountHost();
+
+      expect(get(startupErrorMessage)).toBe('');
+      expect(get(isMacOsVersionUnsupported)).toBe(false);
+      expect(get(isWinVersionUnsupported)).toBe(false);
+      expect(stopConnectionAttempts).not.toHaveBeenCalled();
+      expect(stopMonitoring).not.toHaveBeenCalled();
+      expect(setWsConnectionEnabled).not.toHaveBeenCalled();
+    });
+
+    it('should read the pending error before registering the listeners that would report a later one', async () => {
+      await mountHost();
+
+      expect(getStartupError.mock.invocationCallOrder[0])
+        .toBeLessThan(setupListeners.mock.invocationCallOrder[0]);
+    });
+  });
+
+  describe('an error reported after the app mounted', () => {
+    it('should handle a late error exactly as one pending at mount', async () => {
+      const { startupErrorMessage } = await mountHost();
+
+      listeners().onError('backend died later', BackendCode.TERMINATED);
+
+      expect(get(startupErrorMessage)).toBe('backend died later');
+      expect(stopConnectionAttempts).toHaveBeenCalledOnce();
+      expect(stopMonitoring).toHaveBeenCalledOnce();
+      expect(setWsConnectionEnabled).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('the quit sequence', () => {
+    it('should show the shutdown screen before anything can error against the dying backend', async () => {
+      await mountHost();
+
+      listeners().onAppClosing?.();
+
+      const [quitting] = startQuitting.mock.invocationCallOrder;
+      expect(quitting).toBeLessThan(stopConnectionAttempts.mock.invocationCallOrder[0]);
+      expect(quitting).toBeLessThan(stopMonitoring.mock.invocationCallOrder[0]);
+      expect(quitting).toBeLessThan(stopRequests.mock.invocationCallOrder[0]);
+    });
+
+    it('should stop in-flight requests once the backend is no longer being talked to', async () => {
+      await mountHost();
+
+      listeners().onAppClosing?.();
+
+      expect(stopRequests).toHaveBeenCalledOnce();
+      expect(stopRequests.mock.invocationCallOrder[0])
+        .toBeGreaterThan(setWsConnectionEnabled.mock.invocationCallOrder[0]);
+    });
+  });
+
+  describe('a debug state reset', () => {
+    it('should reload so the wiped keys stop being served from memory', async () => {
+      resetDebugState.mockReturnValue(['rotki.first_run']);
+      await mountHost();
+
+      listeners().onResetDebugState?.('firstRun');
+
+      expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('should not reload when the group cleared nothing', async () => {
+      await mountHost();
+
+      listeners().onResetDebugState?.('firstRun');
+
+      expect(resetDebugState).toHaveBeenCalledWith('firstRun');
+      expect(reload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a restart', () => {
+    it('should clear the error and re-arm both connections before asking for the restart', async () => {
+      getStartupError.mockReturnValue({ code: BackendCode.TERMINATED, message: 'backend died' });
+      const { startupErrorMessage } = await mountHost();
+      const { connectionEnabled } = storeToRefs(useMainStore());
+      set(connectionEnabled, false);
+
+      listeners().onRestart();
+
+      expect(get(startupErrorMessage)).toBe('');
+      expect(get(connectionEnabled)).toBe(true);
+      expect(setWsConnectionEnabled).toHaveBeenLastCalledWith(true);
+      expect(restartBackend).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('the menu-driven messages', () => {
+    it('should open the about dialog', async () => {
+      await mountHost();
+      const { showAbout } = storeToRefs(useAreaVisibilityStore());
+
+      listeners().onAbout();
+
+      expect(get(showAbout)).toBe(true);
+    });
+
+    it('should forward an mcp server state straight through', async () => {
+      await mountHost();
+
+      listeners().onMcpState?.('Ready');
+
+      expect(setMcpServerState).toHaveBeenCalledWith('Ready');
+    });
+  });
+
+  describe('the oauth callback handlers', () => {
+    it('should fan a result out to every registered handler', async () => {
+      const { registerOAuthCallbackHandler } = await mountHost();
+      const first = vi.fn();
+      const second = vi.fn();
+      registerOAuthCallbackHandler(first);
+      registerOAuthCallbackHandler(second);
+
+      listeners().onOAuthCallback?.(oAuthSuccess('google'));
+
+      expect(first).toHaveBeenCalledWith(oAuthSuccess('google'));
+      expect(second).toHaveBeenCalledWith(oAuthSuccess('google'));
+    });
+
+    it('should stop calling a handler that unregistered, and keep calling the rest', async () => {
+      const { registerOAuthCallbackHandler, unregisterOAuthCallbackHandler } = await mountHost();
+      const leaving = vi.fn();
+      const staying = vi.fn();
+      registerOAuthCallbackHandler(leaving);
+      registerOAuthCallbackHandler(staying);
+
+      unregisterOAuthCallbackHandler(leaving);
+      listeners().onOAuthCallback?.(oAuthSuccess('monerium'));
+
+      expect(leaving).not.toHaveBeenCalled();
+      expect(staying).toHaveBeenCalledOnce();
+    });
+
+    it('should ignore an unregister for a handler that was never registered', async () => {
+      const { registerOAuthCallbackHandler, unregisterOAuthCallbackHandler } = await mountHost();
+      const registered = vi.fn();
+      registerOAuthCallbackHandler(registered);
+
+      unregisterOAuthCallbackHandler(vi.fn());
+      listeners().onOAuthCallback?.(oAuthSuccess('google'));
+
+      expect(registered).toHaveBeenCalledOnce();
+    });
+
+    it('should drop only one registration when the same handler registered twice', async () => {
+      const { registerOAuthCallbackHandler, unregisterOAuthCallbackHandler } = await mountHost();
+      const twice = vi.fn();
+      registerOAuthCallbackHandler(twice);
+      registerOAuthCallbackHandler(twice);
+
+      unregisterOAuthCallbackHandler(twice);
+      listeners().onOAuthCallback?.(oAuthSuccess('google'));
+
+      expect(twice).toHaveBeenCalledOnce();
+    });
+
+    it('should reach a handler registered after the callback was already delivered once', async () => {
+      const { registerOAuthCallbackHandler } = await mountHost();
+      const late = vi.fn();
+
+      listeners().onOAuthCallback?.(oAuthSuccess('google'));
+      registerOAuthCallbackHandler(late);
+      listeners().onOAuthCallback?.(oAuthSuccess('monerium'));
+
+      expect(late).toHaveBeenCalledExactlyOnceWith(oAuthSuccess('monerium'));
+    });
+  });
+
+  describe('the data directory menu entry', () => {
+    it('should disarm it when the backend goes away', async () => {
+      await mountHost();
+      const { setConnected } = useMainStore();
+
+      setConnected(true);
+      await nextTick();
+      expect(setDataDirectory).not.toHaveBeenCalled();
+
+      setConnected(false);
+      await nextTick();
+
+      expect(setDataDirectory).toHaveBeenCalledExactlyOnceWith('');
+    });
+
+    it('should leave it alone when the backend connects', async () => {
+      await mountHost();
+      const { setConnected } = useMainStore();
+
+      setConnected(true);
+      await nextTick();
+
+      expect(setDataDirectory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the development-only monitoring', () => {
+    it('should start monitoring when a development build mounts logged in', async () => {
+      set(development, true);
+      setActivePinia(createCustomPinia());
+      set(storeToRefs(useSessionAuthStore()).logged, true);
+
+      await mountHost();
+
+      expect(startMonitoring).toHaveBeenCalledOnce();
+    });
+
+    it('should not start monitoring in a production build', async () => {
+      set(storeToRefs(useSessionAuthStore()).logged, true);
+
+      await mountHost();
+
+      expect(startMonitoring).not.toHaveBeenCalled();
+    });
+
+    it('should not start monitoring before anyone has logged in', async () => {
+      set(development, true);
+
+      await mountHost();
+
+      expect(startMonitoring).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/wallet/transaction-helpers.spec.ts
+++ b/frontend/app/src/modules/wallet/transaction-helpers.spec.ts
@@ -1,0 +1,198 @@
+import type {
+  PrepareERC20TransferResponse,
+  PrepareNativeTransferResponse,
+  TransactionParams,
+} from '@/modules/wallet/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  handleTransactionError,
+  prepareTransactionPayload,
+  validateTransactionRequirements,
+} from './transaction-helpers';
+
+const FROM = '0xaaa';
+const TO = '0xbbb';
+const TOKEN = 'eip155:1/erc20:0xtoken';
+
+function params(overrides: Partial<TransactionParams> = {}): TransactionParams {
+  return { amount: '1.5', chain: 'ethereum', native: true, to: TO, ...overrides };
+}
+
+const namesEveryChain = (chain: string): string => chain;
+
+describe('modules/wallet/validateTransactionRequirements', () => {
+  it('should return the chain id, evm chain and sender when all are known', () => {
+    const result = validateTransactionRequirements({
+      connectedAddress: FROM,
+      connectedChainId: 1,
+      getEvmChainName: namesEveryChain,
+      params: params(),
+    });
+
+    expect(result).toEqual({ chainId: 1, evmChain: 'ethereum', fromAddress: FROM });
+  });
+
+  it('should refuse when the wallet reports no chain', () => {
+    expect(() => validateTransactionRequirements({
+      connectedAddress: FROM,
+      connectedChainId: undefined,
+      getEvmChainName: namesEveryChain,
+      params: params(),
+    })).toThrow('No chain ID available');
+  });
+
+  it('should refuse when the chain is not a known evm chain', () => {
+    expect(() => validateTransactionRequirements({
+      connectedAddress: FROM,
+      connectedChainId: 1,
+      getEvmChainName: () => undefined,
+      params: params({ chain: 'nonsense' }),
+    })).toThrow('No chain ID available');
+  });
+
+  it('should refuse a chain id of zero rather than treating it as valid', () => {
+    expect(() => validateTransactionRequirements({
+      connectedAddress: FROM,
+      connectedChainId: 0,
+      getEvmChainName: namesEveryChain,
+      params: params(),
+    })).toThrow('No chain ID available');
+  });
+
+  it('should refuse when no wallet address is connected, past the chain guard', () => {
+    expect(() => validateTransactionRequirements({
+      connectedAddress: undefined,
+      connectedChainId: 1,
+      getEvmChainName: namesEveryChain,
+      params: params(),
+    })).toThrow('AssertionError');
+  });
+});
+
+describe('modules/wallet/prepareTransactionPayload', () => {
+  const prepareERC20Transfer = vi.fn(async (): Promise<PrepareERC20TransferResponse> => ({
+    chainId: 1,
+    data: '0xerc20data',
+    from: FROM,
+    nonce: 7,
+    to: TOKEN,
+    value: BigInt(0),
+  }));
+
+  const prepareNativeTransfer = vi.fn(async (): Promise<PrepareNativeTransferResponse> => ({
+    from: FROM,
+    nonce: 7,
+    to: TO,
+    value: BigInt('1500000000000000000'),
+  }));
+
+  const deps = { prepareERC20Transfer, prepareNativeTransfer };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('a native transfer', () => {
+    it('should send the amount, the recipient and the evm chain', async () => {
+      await prepareTransactionPayload(params({ native: true }), FROM, 'ethereum', deps);
+
+      expect(prepareNativeTransfer).toHaveBeenCalledWith({
+        amount: '1.5',
+        chain: 'ethereum',
+        fromAddress: FROM,
+        toAddress: TO,
+      });
+      expect(prepareERC20Transfer).not.toHaveBeenCalled();
+    });
+
+    it('should add empty call data, which a native transfer carries', async () => {
+      const result = await prepareTransactionPayload(params({ native: true }), FROM, 'ethereum', deps);
+
+      expect(result.data).toBe('0x');
+    });
+  });
+
+  describe('a token transfer', () => {
+    it('should send the token rather than the chain', async () => {
+      await prepareTransactionPayload(
+        params({ assetIdentifier: TOKEN, native: false }),
+        FROM,
+        'ethereum',
+        deps,
+      );
+
+      expect(prepareERC20Transfer).toHaveBeenCalledWith({
+        amount: '1.5',
+        fromAddress: FROM,
+        toAddress: TO,
+        token: TOKEN,
+      });
+      expect(prepareNativeTransfer).not.toHaveBeenCalled();
+    });
+
+    it('should return the prepared call data untouched', async () => {
+      const result = await prepareTransactionPayload(
+        params({ assetIdentifier: TOKEN, native: false }),
+        FROM,
+        'ethereum',
+        deps,
+      );
+
+      expect(result.data).toBe('0xerc20data');
+    });
+
+    it('should refuse a token transfer that names no token', async () => {
+      await expect(prepareTransactionPayload(
+        params({ assetIdentifier: undefined, native: false }),
+        FROM,
+        'ethereum',
+        deps,
+      )).rejects.toThrow('AssertionError');
+
+      expect(prepareERC20Transfer).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('modules/wallet/handleTransactionError', () => {
+  const setPreparing = vi.fn();
+  const setWaitingForWalletConfirmation = vi.fn();
+  const updateTransactionStatus = vi.fn();
+
+  const handlers = { setPreparing, setWaitingForWalletConfirmation, updateTransactionStatus };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('should clear both in-flight flags', () => {
+    handleTransactionError(new Error('boom'), handlers);
+
+    expect(setPreparing).toHaveBeenCalledWith(false);
+    expect(setWaitingForWalletConfirmation).toHaveBeenCalledWith(false);
+  });
+
+  it('should mark the transaction failed when the error names one', () => {
+    handleTransactionError({ transaction: { hash: '0xdead' } }, handlers);
+
+    expect(updateTransactionStatus).toHaveBeenCalledWith('0xdead', 'failed');
+  });
+
+  it.each([
+    ['a plain error', new Error('boom')],
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'boom'],
+    ['no transaction', { message: 'boom' }],
+    ['a transaction with no hash', { transaction: {} }],
+    ['a hash that is not a string', { transaction: { hash: 12345 } }],
+    ['an empty hash', { transaction: { hash: '' } }],
+  ])('should mark nothing failed for %s, while still clearing the flags', (_name, error) => {
+    handleTransactionError(error, handlers);
+
+    expect(updateTransactionStatus).not.toHaveBeenCalled();
+    expect(setPreparing).toHaveBeenCalledWith(false);
+    expect(setWaitingForWalletConfirmation).toHaveBeenCalledWith(false);
+  });
+});

--- a/frontend/app/src/modules/wallet/transaction-helpers.ts
+++ b/frontend/app/src/modules/wallet/transaction-helpers.ts
@@ -1,4 +1,5 @@
 import type {
+  PreparedTransaction,
   PrepareERC20TransferPayload,
   PrepareERC20TransferResponse,
   PrepareNativeTransferPayload,
@@ -59,7 +60,7 @@ export async function prepareTransactionPayload(
   fromAddress: string,
   evmChain: string,
   deps: TransactionDependencies,
-): Promise<PrepareERC20TransferResponse | PrepareNativeTransferResponse> {
+): Promise<PreparedTransaction> {
   const { prepareERC20Transfer, prepareNativeTransfer } = deps;
 
   if (!params.native) {

--- a/frontend/app/src/modules/wallet/types.ts
+++ b/frontend/app/src/modules/wallet/types.ts
@@ -69,6 +69,18 @@ export const PrepareNativeTransferResponse = z.object({
 
 export type PrepareNativeTransferResponse = z.infer<typeof PrepareNativeTransferResponse>;
 
+/**
+ * A transfer the backend has prepared, ready to hand to the wallet.
+ *
+ * @remarks
+ * Both arms carry `data`: the ERC20 response brings its own, and a native transfer is given the
+ * empty `0x` by `prepareTransactionPayload`. The native response alone does not declare it, which
+ * is why this alias exists rather than the bare union.
+ */
+export type PreparedTransaction =
+  | PrepareERC20TransferResponse
+  | (PrepareNativeTransferResponse & { data: string });
+
 export interface GetAssetBalancePayload {
   evmChain: string;
   address: string;

--- a/frontend/app/src/modules/wallet/use-wallet-store.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.ts
@@ -1,7 +1,6 @@
 import type {
   GasFeeEstimation,
-  PrepareERC20TransferResponse,
-  PrepareNativeTransferResponse,
+  PreparedTransaction,
   RecentTransaction,
   TransactionParams,
 } from '@/modules/wallet/types';
@@ -268,9 +267,9 @@ export const useWalletStore = defineStore(STORE_ID, () => {
     }
   };
 
-  const executeTransaction = async (client: ViemWalletClient, backendPayload: PrepareERC20TransferResponse | PrepareNativeTransferResponse): Promise<Hash> => {
+  const executeTransaction = async (client: ViemWalletClient, backendPayload: PreparedTransaction): Promise<Hash> => {
     set(waitingForWalletConfirmation, true);
-    const data = 'data' in backendPayload ? backendPayload.data : '0x';
+    const { data } = backendPayload;
     if (!isHex(data)) {
       throw new Error('Invalid transaction data');
     }


### PR DESCRIPTION
Batch F of #12964, issue #13008: seven `.ts` modules that were at **0% coverage**. Each is now at full statement coverage, 149 tests total.

| Module | Tests | Statements | Branches |
|---|---|---|---|
| `balances/manual-balances.ts` | 26 | 26/26 | |
| `wallet/transaction-helpers.ts` | 20 | 20/20 | |
| `assets/admin/use-asset-display-helpers.ts` | 17 | 17/17 | |
| `shell/app/use-backend-messages.ts` | 25 | 59/59 | 18/18 |
| `assets/prices/use-historic-price-manager.ts` | 19 | 41/41 | 12/12 |
| `balances/non-fungible/use-nft-data.ts` | 20 | 31/31 | 12/12 |
| `assets/prices/use-historical-price-fetcher.ts` | 17 | 39/39 | 15/15 |

`history/events/use-unmatched-movement-rows.ts` was in the batch's original scope but left it: `da657112ef` shipped its own spec.

## Defects the tests found

**`sortAndFilterManualBalance` sorted in place** (`fix(balances): sort a copy of the manual balances`). With no filter active the working set *is* the array the caller passed in, and the caller hands it `get(manualBalances)` — the store's own array. Sorting the table permanently reordered the store for every other consumer. Found by writing the non-mutation assertion; this is the second batch in a row where a function that sorts something it was handed mutated its input.

## Behaviour pinned but deliberately not changed

- `formatType('')` returns empty rather than the `EVM token` fallback: the guard is `??`, which catches null and undefined but not an empty string, so an empty `assetType` renders as a blank column. Asserted as current behaviour — changing it needs evidence it is wanted.
- `unregisterOAuthCallbackHandler` drops only the first registration when the same handler registered twice (`indexOf` + `splice`). Asserted, not changed.

## Two type corrections, committed separately

1. **`orderByAttributes` was typed `(keyof T)[]`**, i.e. camelCase, but nothing ever puts a camelCase key in a payload — `getApiSortingParams` runs every column through `transformCase`. Retyped `ToSnakeCase<keyof T & string>[]`. Blast radius was 6 errors, all in specs, none in production code, which is itself the evidence the old type was wrong.
2. **`prepareTransactionPayload` always sets `data`, but its return type did not admit it.** The one consumer narrowed with `'data' in payload` *and* repeated the `'0x'` default. Added a `PreparedTransaction` alias.

## How the tests were verified

Every load-bearing claim was negative-controlled: break the code, watch the named test go red, restore. 13 controls run. Two **passed**, which is a finding rather than a pass, and both assertions were re-aimed until the break was caught:

- the data-directory test drove connect→disconnect and asserted "called exactly once with `''`", which the inverted guard also satisfies. It now asserts nothing was called between the two transitions.
- the first attempt at breaking `fetchPrices`' `finally` was a no-op, because the `catch` swallows the error so control still reached the line. Re-done by moving the reset inside the `try`.

Ordering claims are pinned with `mock.invocationCallOrder` rather than prose — notably `onAppClosing`, where the source documents the order as load-bearing: `startQuitting` swaps in the shutdown screen before anything can error against the dying backend.

## Notes for the reviewer

- `tests/unit/setup-files/setup.ts` globally mocks `use-backend-messages`, so its spec calls `vi.doUnmock` before `vi.resetModules()` and the dynamic import — the same shape `use-monitor-service.spec.ts` already uses. Without it the spec silently tests the stub.
- The composables with `onBeforeMount` are acquired inside a mounted host component, because `createGlobalState` registers the hook on whichever component's `setup` calls it first.
- Each host rethrows a `setup()` throw after mount. Vue routes those to a console warning that vitest suppresses, so without the rethrow a broken harness reads as an assertion failure in the source.
- `useServerTable` is stubbed in the nft-data spec and the configuration passed to it is asserted, per the testing guidance on stubbing what happy-dom cannot run faithfully.
- No spec contains a comment; `pnpm run audit:comments` flags none of the seven.
