### PR TITLE
test(frontend): cover the irreversible-action surfaces

### DIFF
--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
@@ -1,21 +1,10 @@
 <script setup lang="ts">
-import type { Nullable, SupportedAsset } from '@rotki/common';
-import { keyBy } from 'es-toolkit';
 import ManagedAssetFormDialog from '@/modules/assets/admin/managed/ManagedAssetFormDialog.vue';
 import ManagedAssetTable from '@/modules/assets/admin/managed/ManagedAssetTable.vue';
-import { type Filters, managedAssetStatusParams } from '@/modules/assets/admin/managed/use-assets-filter';
-import { useManagedAssetFields } from '@/modules/assets/admin/managed/use-managed-asset-fields';
+import { useManagedAssetForm } from '@/modules/assets/admin/managed/use-managed-asset-form';
+import { useManagedAssetsTable } from '@/modules/assets/admin/managed/use-managed-assets-table';
 import MergeDialog from '@/modules/assets/admin/MergeDialog.vue';
 import RestoreAssetDbButton from '@/modules/assets/admin/RestoreAssetDbButton.vue';
-import { useAssetManagementApi } from '@/modules/assets/api/use-asset-management-api';
-import { type AssetRequestPayload, EVM_TOKEN, IgnoredAssetHandlingType, type IgnoredAssetsHandlingType } from '@/modules/assets/types';
-import { useAssetInfoCache } from '@/modules/assets/use-asset-info-cache';
-import { useAssetsStore } from '@/modules/assets/use-assets-store';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
-import { useCommonTableProps } from '@/modules/core/table/use-common-table-props';
-import { routeWhen, useServerTable } from '@/modules/core/table/use-server-table';
-import { useTableRowDeletion } from '@/modules/core/table/use-table-row-deletion';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
 const { identifier = null, mainPage = false } = defineProps<{
@@ -26,125 +15,28 @@ const { identifier = null, mainPage = false } = defineProps<{
 const { t } = useI18n({ useScope: 'global' });
 
 const mergeTool = ref<boolean>(false);
-
-const ignoredAssetsHandling = ref<IgnoredAssetsHandlingType>(IgnoredAssetHandlingType.EXCLUDE);
-const onlyShowOwned = ref<boolean>(false);
-const onlyShowWhitelisted = ref<boolean>(false);
-
-const { pillParams, source: statusSource } = managedAssetStatusParams({
-  ignoredAssetsHandling,
-  onlyShowOwned,
-  onlyShowWhitelisted,
-});
-
-const modelValue = ref<SupportedAsset>();
-const editMode = ref<boolean>(false);
-const assetTypes = ref<string[]>([]);
 const openAction = ref<boolean>(false);
-
-const { expanded, selected } = useCommonTableProps<SupportedAsset>();
 
 const router = useRouter();
 const route = useRoute();
-const { deleteAsset, queryAllAssets } = useAssetManagementApi();
-const { setMessage } = useMessageStore();
-const { ignoredAssets } = storeToRefs(useAssetsStore());
-const { getAssetTypes } = useAssetManagementApi();
 
-const { deleteCacheKey } = useAssetInfoCache();
-
-const fields = useManagedAssetFields(assetTypes, () => get(ignoredAssets).length);
+const { add, assetTypes, edit, editAsset, editMode, modelValue } = useManagedAssetForm(() => identifier);
 
 const {
-  collection: assets,
-  filter,
-  isLoading: loading,
+  assets,
+  fields,
+  loading,
+  modelExpanded,
+  modelFilter,
+  modelIgnoredAssetsHandling,
+  modelPillParams,
+  modelSelectedRows,
   pagination,
   refetch,
   setPage,
+  showDeleteConfirmation,
   sort,
-} = useServerTable<
-  SupportedAsset,
-  AssetRequestPayload,
-  Filters
->({
-  fetch: queryAllAssets,
-  fields,
-  params: [statusSource],
-  sort: {
-    default: {
-      column: 'symbol',
-      direction: 'asc',
-    },
-  },
-  urlState: routeWhen(mainPage),
-});
-
-function add() {
-  set(modelValue, {
-    active: true,
-    address: '',
-    assetType: EVM_TOKEN,
-    customAssetType: '',
-    decimals: null,
-    ended: null,
-    forked: null,
-    identifier: '',
-    isRebasing: false,
-    protocol: '',
-    underlyingTokens: null,
-  });
-  set(editMode, false);
-}
-
-function edit(editAsset: SupportedAsset): void {
-  set(modelValue, editAsset);
-  set(editMode, true);
-}
-
-async function editAsset(assetId: Nullable<string>): Promise<void> {
-  if (assetId) {
-    const all = await queryAllAssets({
-      identifiers: [assetId],
-      limit: 1,
-      offset: 0,
-    });
-
-    const foundAsset = all.data[0];
-    if (foundAsset)
-      edit(foundAsset);
-  }
-}
-
-const { showDeleteConfirmation } = useTableRowDeletion<SupportedAsset>({
-  confirm: item => ({
-    message: t('asset_management.confirm_delete.message', { asset: item?.symbol ?? '' }),
-    title: t('asset_management.confirm_delete.title'),
-  }),
-  deleteItem: item => deleteAsset(item.identifier),
-  errorMessage: (item, error) => t('asset_management.delete_error', {
-    address: item.identifier,
-    message: getErrorMessage(error),
-  }),
-  onDeleted: async (item) => {
-    await refetch();
-    deleteCacheKey(item.identifier);
-  },
-});
-
-const assetsMap = computed(() => keyBy(get(assets).data, item => item.identifier));
-
-const selectedRows = computed({
-  get() {
-    return get(selected).map(({ identifier }) => identifier);
-  },
-  set(identifiers: string[]) {
-    set(
-      selected,
-      identifiers.map(identifier => get(assetsMap)[identifier]),
-    );
-  },
-});
+} = useManagedAssetsTable(() => mainPage, assetTypes);
 
 onMounted(async () => {
   await refetch();
@@ -156,23 +48,6 @@ onMounted(async () => {
     else add();
 
     await router.replace({ query: {} });
-  }
-});
-
-watch(() => identifier, async (assetId) => {
-  await editAsset(assetId);
-});
-
-onBeforeMount(async () => {
-  try {
-    set(assetTypes, await getAssetTypes());
-  }
-  catch (error: unknown) {
-    setMessage({
-      description: t('asset_form.types.error', {
-        message: getErrorMessage(error),
-      }),
-    });
   }
 });
 </script>
@@ -245,13 +120,13 @@ onBeforeMount(async () => {
       <MergeDialog v-model="mergeTool" />
 
       <ManagedAssetTable
-        v-model:filters="filter"
-        v-model:pill-params="pillParams"
-        v-model:expanded="expanded"
-        v-model:selected="selectedRows"
+        v-model:filters="modelFilter"
+        v-model:pill-params="modelPillParams"
+        v-model:expanded="modelExpanded"
+        v-model:selected="modelSelectedRows"
         v-model:pagination="pagination"
         v-model:sort="sort"
-        :ignored-handling="ignoredAssetsHandling"
+        :ignored-handling="modelIgnoredAssetsHandling"
         :collection="assets"
         :loading="loading"
         :change="!loading"

--- a/frontend/app/src/modules/assets/admin/managed/use-managed-asset-form.spec.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-managed-asset-form.spec.ts
@@ -1,0 +1,183 @@
+import type { SupportedAsset } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, ref, type Ref } from 'vue';
+import { EVM_TOKEN } from '@/modules/assets/types';
+import { useManagedAssetForm } from './use-managed-asset-form';
+
+const { getAssetTypes, queryAllAssets, setMessage } = await vi.hoisted(async () => ({
+  getAssetTypes: vi.fn(),
+  queryAllAssets: vi.fn(),
+  setMessage: vi.fn(),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-management-api', () => ({
+  useAssetManagementApi: (): Record<string, unknown> => ({ getAssetTypes, queryAllAssets }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+const wrappers: VueWrapper[] = [];
+
+function asset(identifier: string, symbol = 'ETH'): SupportedAsset {
+  return { identifier, isRebasing: false, symbol };
+}
+
+function collectionOf(data: SupportedAsset[]): Record<string, unknown> {
+  return { data, found: data.length, limit: -1, total: data.length };
+}
+
+async function mountForm(identifier: Ref<string | null> = ref(null)): Promise<ReturnType<typeof useManagedAssetForm>> {
+  let captured: ReturnType<typeof useManagedAssetForm> | undefined;
+  let setupError: Error | undefined;
+  const Host = defineComponent({
+    setup(): () => ReturnType<typeof h> {
+      try {
+        captured = useManagedAssetForm(identifier);
+      }
+      catch (error) {
+        setupError = error instanceof Error ? error : new Error(String(error));
+      }
+      return (): ReturnType<typeof h> => h('div');
+    },
+  });
+
+  wrappers.push(mount(Host));
+  await flushPromises();
+  if (setupError)
+    throw setupError;
+  return captured!;
+}
+
+describe('modules/assets/admin/managed/useManagedAssetForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAssetTypes.mockResolvedValue(['evm token', 'custom asset']);
+    queryAllAssets.mockResolvedValue(collectionOf([]));
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('the asset types it offers', () => {
+    it('should read them once on mount', async () => {
+      const { assetTypes } = await mountForm();
+
+      expect(getAssetTypes).toHaveBeenCalledOnce();
+      expect(get(assetTypes)).toEqual(['evm token', 'custom asset']);
+    });
+
+    it('should report a failure but still let the form open', async () => {
+      getAssetTypes.mockRejectedValue(new Error('offline'));
+
+      const { add, assetTypes, modelValue } = await mountForm();
+
+      expect(setMessage).toHaveBeenCalledOnce();
+      expect(get(assetTypes)).toEqual([]);
+
+      add();
+      expect(get(modelValue)).toBeDefined();
+    });
+  });
+
+  describe('adding an asset', () => {
+    it('should open the form on a blank evm token', async () => {
+      const { add, modelValue } = await mountForm();
+
+      add();
+
+      expect(get(modelValue)?.assetType).toBe(EVM_TOKEN);
+      expect(get(modelValue)?.identifier).toBe('');
+    });
+
+    it('should be a create, not an edit', async () => {
+      const { add, editMode } = await mountForm();
+
+      add();
+
+      expect(get(editMode)).toBe(false);
+    });
+
+    it('should start from a fresh asset each time, not the one last edited', async () => {
+      const { add, edit, modelValue } = await mountForm();
+
+      edit(asset('eip155:1/erc20:0xdead', 'DEAD'));
+      add();
+
+      expect(get(modelValue)?.identifier).toBe('');
+      expect(get(modelValue)?.symbol).toBeUndefined();
+    });
+  });
+
+  describe('editing an asset', () => {
+    it('should open the form on the asset it was handed', async () => {
+      const { edit, editMode, modelValue } = await mountForm();
+
+      edit(asset('eip155:1/erc20:0xdead', 'DEAD'));
+
+      expect(get(modelValue)?.identifier).toBe('eip155:1/erc20:0xdead');
+      expect(get(editMode)).toBe(true);
+    });
+
+    it('should fetch an asset it was given only the identifier for', async () => {
+      queryAllAssets.mockResolvedValue(collectionOf([asset('eip155:1/erc20:0xdead', 'DEAD')]));
+      const { editAsset, editMode, modelValue } = await mountForm();
+
+      await editAsset('eip155:1/erc20:0xdead');
+
+      expect(queryAllAssets).toHaveBeenCalledWith({
+        identifiers: ['eip155:1/erc20:0xdead'],
+        limit: 1,
+        offset: 0,
+      });
+      expect(get(modelValue)?.identifier).toBe('eip155:1/erc20:0xdead');
+      expect(get(editMode)).toBe(true);
+    });
+
+    it('should leave the form closed, and not in edit mode, for an identifier the backend does not know', async () => {
+      const { editAsset, editMode, modelValue } = await mountForm();
+
+      await editAsset('eip155:1/erc20:0xmissing');
+
+      expect(get(modelValue)).toBeUndefined();
+      expect(get(editMode)).toBe(false);
+    });
+
+    it('should not ask the backend for a null identifier', async () => {
+      const { editAsset } = await mountForm();
+
+      await editAsset(null);
+
+      expect(queryAllAssets).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('following the route', () => {
+    it('should reopen the form when the identifier changes', async () => {
+      queryAllAssets.mockResolvedValue(collectionOf([asset('eip155:1/erc20:0xbeef', 'BEEF')]));
+      const identifier = ref<string | null>(null);
+      const { modelValue } = await mountForm(identifier);
+
+      set(identifier, 'eip155:1/erc20:0xbeef');
+      await flushPromises();
+
+      expect(get(modelValue)?.identifier).toBe('eip155:1/erc20:0xbeef');
+    });
+
+    it('should leave the form alone when the identifier clears', async () => {
+      const identifier = ref<string | null>('eip155:1/erc20:0xbeef');
+      const { modelValue } = await mountForm(identifier);
+      queryAllAssets.mockClear();
+
+      set(identifier, null);
+      await flushPromises();
+
+      expect(queryAllAssets).not.toHaveBeenCalled();
+      expect(get(modelValue)).toBeUndefined();
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/managed/use-managed-asset-form.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-managed-asset-form.ts
@@ -1,0 +1,112 @@
+import type { Nullable, SupportedAsset } from '@rotki/common';
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { useAssetManagementApi } from '@/modules/assets/api/use-asset-management-api';
+import { EVM_TOKEN } from '@/modules/assets/types';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+
+function emptyAsset(): SupportedAsset {
+  return {
+    active: true,
+    address: '',
+    assetType: EVM_TOKEN,
+    customAssetType: '',
+    decimals: null,
+    ended: null,
+    forked: null,
+    identifier: '',
+    isRebasing: false,
+    protocol: '',
+    underlyingTokens: null,
+  };
+}
+
+interface UseManagedAssetFormReturn {
+  /** Asset types the form offers; empty when the backend could not be reached. */
+  assetTypes: Readonly<Ref<string[]>>;
+  /** Opens the form on a blank EVM token. */
+  add: () => void;
+  /** Opens the form on an existing asset. */
+  edit: (asset: SupportedAsset) => void;
+  /**
+   * Opens the form on the asset with this identifier, fetching it first.
+   *
+   * @remarks
+   * A no-op for a null identifier or one the backend does not know, so a stale link leaves the form
+   * closed rather than opening it empty.
+   */
+  editAsset: (assetId: Nullable<string>) => Promise<void>;
+  /** True when the open form edits an existing asset rather than creating one. */
+  editMode: Readonly<Ref<boolean>>;
+  /** The asset the form is bound to; undefined closes it. */
+  modelValue: Ref<SupportedAsset | undefined>;
+}
+
+/**
+ * Drives the managed-asset add/edit form: which asset it holds, whether that is a create or an
+ * edit, and the asset types it offers.
+ *
+ * @remarks
+ * The asset types are read once on mount. A failure there is reported but not fatal: the form still
+ * opens, with an empty type list, rather than the page refusing to load.
+ *
+ * @returns the form's bindings; `identifier` is watched, so a route change reopens the form
+ */
+export function useManagedAssetForm(identifier: MaybeRefOrGetter<Nullable<string>>): UseManagedAssetFormReturn {
+  const modelValue = ref<SupportedAsset>();
+  const editMode = shallowRef<boolean>(false);
+  const assetTypes = ref<string[]>([]);
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { getAssetTypes, queryAllAssets } = useAssetManagementApi();
+  const { setMessage } = useMessageStore();
+
+  function add(): void {
+    set(modelValue, emptyAsset());
+    set(editMode, false);
+  }
+
+  function edit(asset: SupportedAsset): void {
+    set(modelValue, asset);
+    set(editMode, true);
+  }
+
+  async function editAsset(assetId: Nullable<string>): Promise<void> {
+    if (!assetId)
+      return;
+
+    const all = await queryAllAssets({
+      identifiers: [assetId],
+      limit: 1,
+      offset: 0,
+    });
+
+    const foundAsset = all.data[0];
+    if (foundAsset)
+      edit(foundAsset);
+  }
+
+  watch(() => toValue(identifier), async (assetId) => {
+    await editAsset(assetId);
+  });
+
+  onBeforeMount(async () => {
+    try {
+      set(assetTypes, await getAssetTypes());
+    }
+    catch (error: unknown) {
+      setMessage({
+        description: t('asset_form.types.error', { message: getErrorMessage(error) }),
+      });
+    }
+  });
+
+  return {
+    add,
+    assetTypes: shallowReadonly(assetTypes),
+    edit,
+    editAsset,
+    editMode: readonly(editMode),
+    modelValue,
+  };
+}

--- a/frontend/app/src/modules/assets/admin/managed/use-managed-assets-table.spec.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-managed-assets-table.spec.ts
@@ -1,0 +1,256 @@
+import type { SupportedAsset } from '@rotki/common';
+import type { Collection } from '@/modules/core/common/collection';
+import type { useServerTable } from '@/modules/core/table/use-server-table';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, defineComponent, h, ref } from 'vue';
+import { IgnoredAssetHandlingType } from '@/modules/assets/types';
+import { useAssetsStore } from '@/modules/assets/use-assets-store';
+import { useManagedAssetsTable } from './use-managed-assets-table';
+
+type ServerTableOptions = Parameters<typeof useServerTable>[0];
+
+const {
+  collection,
+  deleteAsset,
+  deleteCacheKey,
+  queryAllAssets,
+  refetch,
+  setPage,
+  show,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    collection: ref<Collection<SupportedAsset>>({ data: [], found: 0, limit: -1, total: 0 }),
+    deleteAsset: vi.fn(),
+    deleteCacheKey: vi.fn(),
+    queryAllAssets: vi.fn(),
+    refetch: vi.fn(),
+    setPage: vi.fn(),
+    show: vi.fn(),
+  };
+});
+
+let serverTableOptions: ServerTableOptions | undefined;
+let fieldsArgs: { count: () => number; types: unknown } | undefined;
+
+vi.mock('@/modules/assets/api/use-asset-management-api', () => ({
+  useAssetManagementApi: (): Record<string, unknown> => ({ deleteAsset, queryAllAssets }),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-cache', () => ({
+  useAssetInfoCache: (): Record<string, unknown> => ({ deleteCacheKey }),
+}));
+
+vi.mock('@/modules/assets/admin/managed/use-managed-asset-fields', () => ({
+  useManagedAssetFields: (types: unknown, count: () => number): unknown[] => {
+    fieldsArgs = { count, types };
+    return [];
+  },
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({ show }),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/table/use-server-table')>(),
+  useServerTable: (options: ServerTableOptions): Record<string, unknown> => {
+    serverTableOptions = options;
+    return {
+      collection,
+      filter: ref({}),
+      isLoading: ref(false),
+      pagination: computed(() => ({ limit: 10, page: 1, total: 0 })),
+      refetch,
+      setPage,
+      sort: ref([]),
+    };
+  },
+}));
+
+const wrappers: VueWrapper[] = [];
+
+function asset(identifier: string, symbol: string): SupportedAsset {
+  return { identifier, isRebasing: false, symbol };
+}
+
+function mountTable(mainPage = true): ReturnType<typeof useManagedAssetsTable> {
+  let captured: ReturnType<typeof useManagedAssetsTable> | undefined;
+  let setupError: Error | undefined;
+  const Host = defineComponent({
+    setup(): () => ReturnType<typeof h> {
+      try {
+        captured = useManagedAssetsTable(() => mainPage, ['evm token']);
+      }
+      catch (error) {
+        setupError = error instanceof Error ? error : new Error(String(error));
+      }
+      return (): ReturnType<typeof h> => h('div');
+    },
+  });
+
+  wrappers.push(mount(Host));
+  if (setupError)
+    throw setupError;
+  return captured!;
+}
+
+describe('modules/assets/admin/managed/useManagedAssetsTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createCustomPinia());
+    set(collection, { data: [], found: 0, limit: -1, total: 0 });
+    deleteAsset.mockResolvedValue(true);
+    serverTableOptions = undefined;
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('deleting an asset', () => {
+    it('should delete nothing until the user accepts', () => {
+      const { showDeleteConfirmation } = mountTable();
+
+      showDeleteConfirmation(asset('eip155:1/erc20:0xdead', 'DEAD'));
+
+      expect(show).toHaveBeenCalledOnce();
+      expect(deleteAsset).not.toHaveBeenCalled();
+    });
+
+    it('should delete exactly the asset the row named once accepted', async () => {
+      const { showDeleteConfirmation } = mountTable();
+
+      showDeleteConfirmation(asset('eip155:1/erc20:0xdead', 'DEAD'));
+      await show.mock.calls[0][1]();
+
+      expect(deleteAsset).toHaveBeenCalledExactlyOnceWith('eip155:1/erc20:0xdead');
+    });
+
+    it('should name the asset in the confirmation, so the user sees what goes', () => {
+      const { showDeleteConfirmation } = mountTable();
+
+      showDeleteConfirmation(asset('eip155:1/erc20:0xdead', 'DEAD'));
+
+      expect(show.mock.calls[0][0].message).toContain('DEAD');
+    });
+
+    it('should still confirm for an asset with no symbol, rather than rendering undefined', () => {
+      const { showDeleteConfirmation } = mountTable();
+
+      showDeleteConfirmation({ identifier: 'eip155:1/erc20:0xdead', isRebasing: false });
+
+      expect(show.mock.calls[0][0].message).not.toContain('undefined');
+    });
+
+    it('should drop the deleted asset from the info cache, which would keep serving its name', async () => {
+      const { showDeleteConfirmation } = mountTable();
+
+      showDeleteConfirmation(asset('eip155:1/erc20:0xdead', 'DEAD'));
+      await show.mock.calls[0][1]();
+
+      expect(deleteCacheKey).toHaveBeenCalledExactlyOnceWith('eip155:1/erc20:0xdead');
+      expect(refetch).toHaveBeenCalledOnce();
+    });
+
+    it('should not touch the cache when the delete failed, the asset still being there', async () => {
+      deleteAsset.mockRejectedValue(new Error('in use'));
+      const { showDeleteConfirmation } = mountTable();
+
+      showDeleteConfirmation(asset('eip155:1/erc20:0xdead', 'DEAD'));
+      await show.mock.calls[0][1]();
+
+      expect(deleteCacheKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the selection', () => {
+    it('should report the selected rows as identifiers, which is what the table speaks', () => {
+      set(collection, {
+        data: [asset('ETH', 'ETH'), asset('BTC', 'BTC')],
+        found: 2,
+        limit: -1,
+        total: 2,
+      });
+      const { modelSelectedRows } = mountTable();
+
+      set(modelSelectedRows, ['ETH', 'BTC']);
+
+      expect(get(modelSelectedRows)).toEqual(['ETH', 'BTC']);
+    });
+
+    it('should resolve an identifier back to the asset on the current page', () => {
+      set(collection, { data: [asset('ETH', 'ETH')], found: 1, limit: -1, total: 1 });
+      const { modelSelectedRows } = mountTable();
+
+      set(modelSelectedRows, ['ETH']);
+
+      expect(get(modelSelectedRows)).toEqual(['ETH']);
+    });
+
+    it('should start empty', () => {
+      expect(get(mountTable().modelSelectedRows)).toEqual([]);
+    });
+  });
+
+  describe('the table it configures', () => {
+    it('should sort by symbol ascending before the user picks anything', () => {
+      mountTable();
+
+      expect(serverTableOptions?.sort).toEqual({ default: { column: 'symbol', direction: 'asc' } });
+    });
+
+    it('should sync to the url only when it owns the page', () => {
+      mountTable(true);
+      expect(serverTableOptions?.urlState).toEqual({ mode: 'route' });
+
+      mountTable(false);
+      expect(serverTableOptions?.urlState).toEqual({ mode: 'none' });
+    });
+
+    it('should hand the table the asset query rather than fetching itself', () => {
+      mountTable();
+
+      expect(serverTableOptions?.fetch).toBe(queryAllAssets);
+      expect(queryAllAssets).not.toHaveBeenCalled();
+    });
+
+    it('should start by excluding ignored assets', () => {
+      expect(get(mountTable().modelIgnoredAssetsHandling)).toBe(IgnoredAssetHandlingType.EXCLUDE);
+    });
+
+    it('should give the filter the asset types it was handed', () => {
+      mountTable();
+
+      expect(fieldsArgs?.types).toEqual(['evm token']);
+    });
+
+    it('should give the filter a live count of the ignored assets, not a snapshot', () => {
+      mountTable();
+      expect(fieldsArgs?.count()).toBe(0);
+
+      set(storeToRefs(useAssetsStore()).ignoredAssets, ['ETH', 'BTC']);
+
+      expect(fieldsArgs?.count()).toBe(2);
+    });
+  });
+
+  describe('refetching', () => {
+    it('should pass the refetch straight through', async () => {
+      const { refetch: refetchFromTable } = mountTable();
+
+      await refetchFromTable();
+
+      expect(refetch).toHaveBeenCalledOnce();
+    });
+
+    it('should pass the page change straight through', () => {
+      mountTable().setPage(3);
+
+      expect(setPage).toHaveBeenCalledExactlyOnceWith(3);
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/managed/use-managed-assets-table.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-managed-assets-table.ts
@@ -1,0 +1,157 @@
+import type { SupportedAsset } from '@rotki/common';
+import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
+import type { ComputedRef, MaybeRefOrGetter, Ref, WritableComputedRef } from 'vue';
+import type { Collection } from '@/modules/core/common/collection';
+import type { PillParams } from '@/modules/core/table/param-refs';
+import { keyBy } from 'es-toolkit';
+import { type Filters, managedAssetStatusParams } from '@/modules/assets/admin/managed/use-assets-filter';
+import { useManagedAssetFields } from '@/modules/assets/admin/managed/use-managed-asset-fields';
+import { useAssetManagementApi } from '@/modules/assets/api/use-asset-management-api';
+import { type AssetRequestPayload, IgnoredAssetHandlingType, type IgnoredAssetsHandlingType } from '@/modules/assets/types';
+import { useAssetInfoCache } from '@/modules/assets/use-asset-info-cache';
+import { useAssetsStore } from '@/modules/assets/use-assets-store';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useCommonTableProps } from '@/modules/core/table/use-common-table-props';
+import { routeWhen, useServerTable } from '@/modules/core/table/use-server-table';
+import { useTableRowDeletion } from '@/modules/core/table/use-table-row-deletion';
+
+interface UseManagedAssetsTableReturn {
+  /** The page of assets the table renders. */
+  assets: Ref<Collection<SupportedAsset>>;
+  /** Rows the user expanded. */
+  modelExpanded: Ref<SupportedAsset[]>;
+  /** The declared filter fields the pill bar reads. */
+  fields: ReturnType<typeof useManagedAssetFields>;
+  /** The active filters; bound with `v-model:filters`. */
+  modelFilter: Ref<Filters>;
+  /** How ignored assets are being treated, which the table shows per row. */
+  modelIgnoredAssetsHandling: Ref<IgnoredAssetsHandlingType>;
+  /** True while a page is being fetched. */
+  loading: Ref<boolean>;
+  /** The pill bar's state. */
+  modelPillParams: WritableComputedRef<PillParams>;
+  /** Current page and size. */
+  pagination: ComputedRef<TablePaginationData>;
+  /** Refetches the current page. */
+  refetch: () => Promise<void>;
+  /**
+   * The selection, as identifiers.
+   *
+   * @remarks
+   * The table speaks identifiers while the selection holds whole assets, so writing it maps back
+   * through the current page. An identifier absent from that page resolves to nothing.
+   */
+  modelSelectedRows: WritableComputedRef<string[]>;
+  /** Jumps to a page. */
+  setPage: (page: number) => void;
+  /**
+   * Opens the delete confirmation for one asset; deletes only once accepted.
+   *
+   * @remarks
+   * A successful delete also drops the asset from the info cache, which otherwise keeps serving the
+   * name and symbol of something that no longer exists.
+   */
+  showDeleteConfirmation: (item: SupportedAsset) => void;
+  /** The active sort. */
+  sort: Ref<DataTableSortData<SupportedAsset>>;
+}
+
+/**
+ * Drives the managed-asset table: the server-side page, the status filters, the selection, and
+ * deleting a row.
+ *
+ * @remarks
+ * Deleting an asset is irreversible and is the only destructive path here, so it goes through a
+ * confirmation and reports a failure rather than silently leaving the row in place.
+ *
+ * @param mainPage - whether this owns the route, and so may sync its state to the URL
+ * @param assetTypes - the types the filter offers, loaded by {@link useManagedAssetForm}
+ * @returns the table's bindings; only {@link UseManagedAssetsTableReturn.showDeleteConfirmation}
+ * deletes anything
+ */
+export function useManagedAssetsTable(
+  mainPage: MaybeRefOrGetter<boolean>,
+  assetTypes: MaybeRefOrGetter<string[]>,
+): UseManagedAssetsTableReturn {
+  const modelIgnoredAssetsHandling = ref<IgnoredAssetsHandlingType>(IgnoredAssetHandlingType.EXCLUDE);
+  const onlyShowOwned = shallowRef<boolean>(false);
+  const onlyShowWhitelisted = shallowRef<boolean>(false);
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { deleteAsset, queryAllAssets } = useAssetManagementApi();
+  const { deleteCacheKey } = useAssetInfoCache();
+  const { ignoredAssets } = storeToRefs(useAssetsStore());
+
+  const { pillParams, source: statusSource } = managedAssetStatusParams({
+    ignoredAssetsHandling: modelIgnoredAssetsHandling,
+    onlyShowOwned,
+    onlyShowWhitelisted,
+  });
+
+  const { expanded, selected } = useCommonTableProps<SupportedAsset>();
+  const fields = useManagedAssetFields(assetTypes, () => get(ignoredAssets).length);
+
+  const {
+    collection: assets,
+    filter,
+    isLoading: loading,
+    pagination,
+    refetch,
+    setPage,
+    sort,
+  } = useServerTable<SupportedAsset, AssetRequestPayload, Filters>({
+    fetch: queryAllAssets,
+    fields,
+    params: [statusSource],
+    sort: {
+      default: {
+        column: 'symbol',
+        direction: 'asc',
+      },
+    },
+    urlState: routeWhen(mainPage),
+  });
+
+  const { showDeleteConfirmation } = useTableRowDeletion<SupportedAsset>({
+    confirm: item => ({
+      message: t('asset_management.confirm_delete.message', { asset: item?.symbol ?? '' }),
+      title: t('asset_management.confirm_delete.title'),
+    }),
+    deleteItem: async item => deleteAsset(item.identifier),
+    errorMessage: (item, error) => t('asset_management.delete_error', {
+      address: item.identifier,
+      message: getErrorMessage(error),
+    }),
+    onDeleted: async (item) => {
+      await refetch();
+      deleteCacheKey(item.identifier);
+    },
+  });
+
+  const assetsMap = computed(() => keyBy(get(assets).data, item => item.identifier));
+
+  const modelSelectedRows = computed<string[]>({
+    get() {
+      return get(selected).map(({ identifier }) => identifier);
+    },
+    set(identifiers: string[]) {
+      set(selected, identifiers.map(identifier => get(assetsMap)[identifier]));
+    },
+  });
+
+  return {
+    assets,
+    fields,
+    loading,
+    modelExpanded: expanded,
+    modelFilter: filter,
+    modelIgnoredAssetsHandling,
+    modelPillParams: pillParams,
+    modelSelectedRows,
+    pagination,
+    refetch,
+    setPage,
+    showDeleteConfirmation,
+    sort,
+  };
+}

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.spec.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.spec.ts
@@ -2,6 +2,7 @@ import type VChart from 'vue-echarts';
 import type { NetValueZoomRange } from '@/modules/dashboard/graph/net-value-stats';
 import type { NetValueChartData } from '@/modules/dashboard/graph/types';
 import { type BigNumber, bigNumberify } from '@rotki/common';
+import { invalid } from '@test/utils/invalid';
 import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, h, ref, type Ref, type ShallowRef, shallowRef, type VNode } from 'vue';
@@ -115,13 +116,8 @@ function createFakeChart(): FakeChart {
   return { chart, handlers, zr, zrHandlers };
 }
 
-// The fake chart intentionally implements only the members the composable
-// touches (it reads `.chart` and its echarts methods), so a single contained
-// assertion bridges it to the vue-echarts instance type.
 function chartInstanceRef(chart: FakeChart['chart'] | null): ShallowRef<InstanceType<typeof VChart> | null> {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the fake only mocks the members the SUT uses; contained here
-  const instance = chart === null ? null : ({ chart } as unknown as InstanceType<typeof VChart>);
-  return shallowRef(instance);
+  return shallowRef(chart === null ? null : invalid<InstanceType<typeof VChart>>({ chart }));
 }
 
 describe('useNetValueEventHandlers', () => {

--- a/frontend/app/src/modules/settings/data-security/backups/BackupManager.vue
+++ b/frontend/app/src/modules/settings/data-security/backups/BackupManager.vue
@@ -1,172 +1,21 @@
 <script setup lang="ts">
-import type { DatabaseInfo, UserDbBackup, UserDbBackupWithId } from '@/modules/session/backup';
-import { Severity } from '@rotki/common';
-import { getFilepath } from '@/modules/core/common/file/file';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { logger } from '@/modules/core/common/logging/logging';
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
-import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
-import { useBackupApi } from '@/modules/session/api/use-backup-api';
 import DatabaseBackups from '@/modules/settings/data-security/backups/DatabaseBackups.vue';
+import { useDatabaseBackups } from '@/modules/settings/data-security/backups/use-database-backups';
 import SettingCategoryHeader from '@/modules/settings/SettingCategoryHeader.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
-const backupInfo = ref<DatabaseInfo>();
-const selected = ref<UserDbBackupWithId[]>([]);
-const loading = ref<boolean>(false);
-const saving = ref<boolean>(false);
-
-const { notify } = useNotificationDispatcher();
-const { createBackup, deleteBackup, info } = useBackupApi();
-const { show } = useConfirmStore();
-
-const backups = computed<UserDbBackupWithId[]>(
-  () => get(backupInfo)?.userdb?.backups.map((x, index) => ({ ...x, id: index + 1 })) ?? [],
-);
-
-const directory = computed<string>(() => {
-  const info = get(backupInfo);
-  if (!info)
-    return '';
-
-  const { filepath } = info.userdb.info;
-
-  let index = filepath.lastIndexOf('/');
-  if (index === -1)
-    index = filepath.lastIndexOf('\\');
-
-  return filepath.slice(0, index + 1);
-});
-
-async function loadInfo() {
-  try {
-    set(loading, true);
-    set(backupInfo, await info());
-  }
-  catch (error: unknown) {
-    logger.error(error);
-    notify({
-      display: true,
-      message: t('database_backups.load_error.message', {
-        message: getErrorMessage(error),
-      }),
-      title: t('database_backups.load_error.title'),
-    });
-  }
-  finally {
-    set(loading, false);
-  }
-}
-
-function isSameEntry(firstDb: UserDbBackup, secondDb: UserDbBackup) {
-  return firstDb.version === secondDb.version && firstDb.time === secondDb.time && firstDb.size === secondDb.size;
-}
-
-async function massRemove() {
-  const currentSelection = get(selected);
-  const filepaths = currentSelection.map(db => getFilepath(db, get(directory)));
-  try {
-    await deleteBackup(filepaths);
-    const backups = get(backupInfo);
-    if (backups) {
-      const info: DatabaseInfo = { ...backups };
-      currentSelection.forEach((db: UserDbBackup) => {
-        const index = info.userdb.backups.findIndex(backup => isSameEntry(backup, db));
-        info.userdb.backups.splice(index, 1);
-      });
-      set(backupInfo, info);
-    }
-    set(selected, []);
-  }
-  catch (error: unknown) {
-    logger.error(error);
-    notify({
-      display: true,
-      message: t('database_backups.delete_error.mass_message', {
-        message: getErrorMessage(error),
-      }),
-      title: t('database_backups.delete_error.title'),
-    });
-  }
-}
-
-async function remove(db: UserDbBackup) {
-  const filepath = getFilepath(db, get(directory));
-  try {
-    await deleteBackup([filepath]);
-    const backups = get(backupInfo);
-    if (backups) {
-      const info: DatabaseInfo = { ...backups };
-      const index = info.userdb.backups.findIndex(backup => isSameEntry(backup, db));
-      info.userdb.backups.splice(index, 1);
-      set(backupInfo, info);
-
-      const currentSelection = get(selected);
-      if (currentSelection.length > 0) {
-        set(
-          selected,
-          currentSelection.filter(item => !isSameEntry(item, db)),
-        );
-      }
-    }
-  }
-  catch (error: unknown) {
-    logger.error(error);
-    notify({
-      display: true,
-      message: t('database_backups.delete_error.message', {
-        file: filepath,
-        message: getErrorMessage(error),
-      }),
-      title: t('database_backups.delete_error.title'),
-    });
-  }
-}
-
-async function backup() {
-  try {
-    set(saving, true);
-    const filepath = await createBackup();
-    notify({
-      display: true,
-      message: t('database_backups.backup.message', {
-        filepath,
-      }),
-      severity: Severity.INFO,
-      title: t('database_backups.backup.title'),
-    });
-
-    await loadInfo();
-  }
-  catch (error: unknown) {
-    logger.error(error);
-    notify({
-      display: true,
-      message: t('database_backups.backup_error.message', {
-        message: getErrorMessage(error),
-      }),
-      title: t('database_backups.backup_error.title'),
-    });
-  }
-  finally {
-    set(saving, false);
-  }
-}
-
-function showMassDeleteConfirmation() {
-  show(
-    {
-      message: t('database_backups.confirm.mass_message', {
-        length: get(selected).length,
-      }),
-      title: t('database_backups.confirm.title'),
-    },
-    massRemove,
-  );
-}
-
-onMounted(loadInfo);
+const {
+  backup,
+  backups,
+  directory,
+  loadInfo,
+  loading,
+  modelSelected,
+  remove,
+  saving,
+  showMassDeleteConfirmation,
+} = useDatabaseBackups();
 </script>
 
 <template>
@@ -182,7 +31,7 @@ onMounted(loadInfo);
       </SettingCategoryHeader>
       <div class="flex flex-wrap gap-2">
         <RuiButton
-          v-if="selected.length > 0"
+          v-if="modelSelected.length > 0"
           color="error"
           @click="showMassDeleteConfirmation()"
         >
@@ -213,7 +62,7 @@ onMounted(loadInfo);
       </div>
     </div>
     <DatabaseBackups
-      v-model:selected="selected"
+      v-model:selected="modelSelected"
       :loading="loading"
       :items="backups"
       :directory="directory"

--- a/frontend/app/src/modules/settings/data-security/backups/use-database-backups.spec.ts
+++ b/frontend/app/src/modules/settings/data-security/backups/use-database-backups.spec.ts
@@ -1,0 +1,311 @@
+import type { DatabaseInfo, UserDbBackup } from '@/modules/session/backup';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { useDatabaseBackups } from './use-database-backups';
+
+const { createBackup, deleteBackup, info, notify, show } = await vi.hoisted(async () => ({
+  createBackup: vi.fn(),
+  deleteBackup: vi.fn(),
+  info: vi.fn(),
+  notify: vi.fn(),
+  show: vi.fn(),
+}));
+
+vi.mock('@/modules/session/api/use-backup-api', () => ({
+  useBackupApi: (): Record<string, unknown> => ({ createBackup, deleteBackup, info }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): Record<string, unknown> => ({ notify }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({ show }),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  getDefaultLogLevel: vi.fn(() => 'debug'),
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  setLevel: vi.fn(),
+}));
+
+const wrappers: VueWrapper[] = [];
+
+function entry(time: number, version = 40, size = 100): UserDbBackup {
+  return { size, time, version };
+}
+
+function databaseInfo(backups: UserDbBackup[], filepath = '/home/user/.rotki/data/rotkehlchen.db'): DatabaseInfo {
+  return {
+    globaldb: { globaldbAssetsVersion: 1, globaldbSchemaVersion: 1 },
+    userdb: { backups, info: { filepath, size: 1000, version: 40 } },
+  };
+}
+
+async function mountBackups(): Promise<ReturnType<typeof useDatabaseBackups>> {
+  let captured: ReturnType<typeof useDatabaseBackups> | undefined;
+  let setupError: Error | undefined;
+  const Host = defineComponent({
+    setup(): () => ReturnType<typeof h> {
+      try {
+        captured = useDatabaseBackups();
+      }
+      catch (error) {
+        setupError = error instanceof Error ? error : new Error(String(error));
+      }
+      return (): ReturnType<typeof h> => h('div');
+    },
+  });
+
+  wrappers.push(mount(Host));
+  await flushPromises();
+  if (setupError)
+    throw setupError;
+  return captured!;
+}
+
+describe('modules/settings/data-security/backups/useDatabaseBackups', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    info.mockResolvedValue(databaseInfo([]));
+    deleteBackup.mockResolvedValue(true);
+    createBackup.mockResolvedValue('/home/user/.rotki/data/1700000000_rotkehlchen_db_v40.backup');
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('loading the list', () => {
+    it('should read the backups as soon as it mounts', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000)]));
+
+      const { backups } = await mountBackups();
+
+      expect(info).toHaveBeenCalledOnce();
+      expect(get(backups)).toHaveLength(1);
+    });
+
+    it('should number the rows from one so the table can key them', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000), entry(1700000001)]));
+
+      const { backups } = await mountBackups();
+
+      expect(get(backups).map(item => item.id)).toEqual([1, 2]);
+    });
+
+    it('should report an empty list rather than failing when nothing has been backed up', async () => {
+      const { backups } = await mountBackups();
+
+      expect(get(backups)).toEqual([]);
+    });
+
+    it('should notify and leave the list empty when the read fails', async () => {
+      info.mockRejectedValue(new Error('offline'));
+
+      const { backups, loading } = await mountBackups();
+
+      expect(notify).toHaveBeenCalledOnce();
+      expect(get(backups)).toEqual([]);
+      expect(get(loading)).toBe(false);
+    });
+  });
+
+  describe('where the backups live', () => {
+    it('should take the directory from the database path', async () => {
+      const { directory } = await mountBackups();
+
+      expect(get(directory)).toBe('/home/user/.rotki/data/');
+    });
+
+    it('should handle a windows path, which the backend reports with backslashes', async () => {
+      info.mockResolvedValue(databaseInfo([], 'C:\\Users\\user\\rotki\\data\\rotkehlchen.db'));
+
+      const { directory } = await mountBackups();
+
+      expect(get(directory)).toBe('C:\\Users\\user\\rotki\\data\\');
+    });
+
+    it('should be empty until the info has loaded', async () => {
+      info.mockReturnValue(new Promise(() => {}));
+
+      let captured: ReturnType<typeof useDatabaseBackups> | undefined;
+      const Host = defineComponent({
+        setup(): () => ReturnType<typeof h> {
+          captured = useDatabaseBackups();
+          return (): ReturnType<typeof h> => h('div');
+        },
+      });
+      wrappers.push(mount(Host));
+
+      expect(get(captured!.directory)).toBe('');
+    });
+  });
+
+  describe('deleting one backup', () => {
+    it('should delete the file that row names, and only that one', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000), entry(1700000001)]));
+      const { remove } = await mountBackups();
+
+      await remove(entry(1700000000));
+
+      expect(deleteBackup).toHaveBeenCalledExactlyOnceWith([
+        '/home/user/.rotki/data/1700000000_rotkehlchen_db_v40.backup',
+      ]);
+    });
+
+    it('should drop the row from the list once the backend accepted', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000), entry(1700000001)]));
+      const { backups, remove } = await mountBackups();
+
+      await remove(entry(1700000000));
+
+      expect(get(backups).map(item => item.time)).toEqual([1700000001]);
+    });
+
+    it('should drop it from the selection too, so a later mass delete cannot resend it', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000), entry(1700000001)]));
+      const { modelSelected, remove } = await mountBackups();
+      set(modelSelected, [{ ...entry(1700000000), id: 1 }, { ...entry(1700000001), id: 2 }]);
+
+      await remove(entry(1700000000));
+
+      expect(get(modelSelected).map(item => item.time)).toEqual([1700000001]);
+    });
+
+    it('should still delete the file when nothing has loaded yet', async () => {
+      info.mockReturnValue(new Promise(() => {}));
+      let captured: ReturnType<typeof useDatabaseBackups> | undefined;
+      const Host = defineComponent({
+        setup(): () => ReturnType<typeof h> {
+          captured = useDatabaseBackups();
+          return (): ReturnType<typeof h> => h('div');
+        },
+      });
+      wrappers.push(mount(Host));
+
+      await captured!.remove(entry(1700000000));
+
+      expect(deleteBackup).toHaveBeenCalledOnce();
+      expect(get(captured!.backups)).toEqual([]);
+    });
+
+    it('should leave the other rows alone when the deleted one is not in the list', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000), entry(1700000001)]));
+      const { backups, remove } = await mountBackups();
+
+      await remove(entry(1799999999));
+
+      expect(get(backups).map(item => item.time)).toEqual([1700000000, 1700000001]);
+    });
+
+    it('should keep the row when the backend refused, since the file is still there', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000)]));
+      deleteBackup.mockRejectedValue(new Error('permission denied'));
+      const { backups, remove } = await mountBackups();
+
+      await remove(entry(1700000000));
+
+      expect(notify).toHaveBeenCalledOnce();
+      expect(get(backups)).toHaveLength(1);
+    });
+  });
+
+  describe('deleting the selected backups', () => {
+    it('should delete nothing until the user accepts the confirmation', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000)]));
+      const { modelSelected, showMassDeleteConfirmation } = await mountBackups();
+      set(modelSelected, [{ ...entry(1700000000), id: 1 }]);
+
+      showMassDeleteConfirmation();
+
+      expect(show).toHaveBeenCalledOnce();
+      expect(deleteBackup).not.toHaveBeenCalled();
+    });
+
+    it('should delete every selected file in one call once accepted', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000), entry(1700000001)]));
+      const { modelSelected, showMassDeleteConfirmation } = await mountBackups();
+      set(modelSelected, [{ ...entry(1700000000), id: 1 }, { ...entry(1700000001), id: 2 }]);
+
+      showMassDeleteConfirmation();
+      await show.mock.calls[0][1]();
+
+      expect(deleteBackup).toHaveBeenCalledExactlyOnceWith([
+        '/home/user/.rotki/data/1700000000_rotkehlchen_db_v40.backup',
+        '/home/user/.rotki/data/1700000001_rotkehlchen_db_v40.backup',
+      ]);
+    });
+
+    it('should drop the deleted rows and clear the selection', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000), entry(1700000001), entry(1700000002)]));
+      const { backups, modelSelected, showMassDeleteConfirmation } = await mountBackups();
+      set(modelSelected, [{ ...entry(1700000000), id: 1 }, { ...entry(1700000002), id: 3 }]);
+
+      showMassDeleteConfirmation();
+      await show.mock.calls[0][1]();
+
+      expect(get(backups).map(item => item.time)).toEqual([1700000001]);
+      expect(get(modelSelected)).toEqual([]);
+    });
+
+    it('should keep the selection when the backend refused, so the user can retry', async () => {
+      info.mockResolvedValue(databaseInfo([entry(1700000000)]));
+      deleteBackup.mockRejectedValue(new Error('permission denied'));
+      const { backups, modelSelected, showMassDeleteConfirmation } = await mountBackups();
+      set(modelSelected, [{ ...entry(1700000000), id: 1 }]);
+
+      showMassDeleteConfirmation();
+      await show.mock.calls[0][1]();
+
+      expect(notify).toHaveBeenCalledOnce();
+      expect(get(modelSelected)).toHaveLength(1);
+      expect(get(backups)).toHaveLength(1);
+    });
+
+    it('should tell the user how many are about to go', async () => {
+      const { modelSelected, showMassDeleteConfirmation } = await mountBackups();
+      set(modelSelected, [{ ...entry(1700000000), id: 1 }, { ...entry(1700000001), id: 2 }]);
+
+      showMassDeleteConfirmation();
+
+      expect(show.mock.calls[0][0].message).toContain('2');
+    });
+  });
+
+  describe('writing a new backup', () => {
+    it('should reload the list so the new backup appears', async () => {
+      await mountBackups();
+      info.mockClear();
+      const { backup } = await mountBackups();
+
+      await backup();
+
+      expect(createBackup).toHaveBeenCalledOnce();
+      expect(info).toHaveBeenCalled();
+    });
+
+    it('should name the file it wrote', async () => {
+      const { backup } = await mountBackups();
+
+      await backup();
+
+      expect(notify).toHaveBeenCalledOnce();
+      expect(notify.mock.calls[0][0].message).toContain('1700000000_rotkehlchen_db_v40.backup');
+    });
+
+    it('should notify and not reload when the write failed', async () => {
+      createBackup.mockRejectedValue(new Error('disk full'));
+      const { backup, saving } = await mountBackups();
+      info.mockClear();
+
+      await backup();
+
+      expect(notify).toHaveBeenCalledOnce();
+      expect(info).not.toHaveBeenCalled();
+      expect(get(saving)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/data-security/backups/use-database-backups.ts
+++ b/frontend/app/src/modules/settings/data-security/backups/use-database-backups.ts
@@ -1,0 +1,202 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { DatabaseInfo, UserDbBackup, UserDbBackupWithId } from '@/modules/session/backup';
+import { Severity } from '@rotki/common';
+import { getFilepath } from '@/modules/core/common/file/file';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { useBackupApi } from '@/modules/session/api/use-backup-api';
+
+interface UseDatabaseBackupsReturn {
+  /** Every backup the last load reported, numbered for the table. */
+  backups: ComputedRef<UserDbBackupWithId[]>;
+  /** Writes a new backup, then reloads so the list shows it. */
+  backup: () => Promise<void>;
+  /**
+   * Directory the backups live in, trailing separator included, or empty until the info loads.
+   *
+   * @remarks
+   * Derived from the database's own path rather than configured, so it follows a user who moved
+   * their data directory. Handles both separators, the backend reporting whichever its platform
+   * uses.
+   */
+  directory: ComputedRef<string>;
+  /** Reads the backup list from the backend, reporting a failure as a notification. */
+  loadInfo: () => Promise<void>;
+  /** True while the list is being read. */
+  loading: Readonly<Ref<boolean>>;
+  /** The rows the user ticked; bound with `v-model:selected`. */
+  modelSelected: Ref<UserDbBackupWithId[]>;
+  /** Deletes one backup and drops it from the list and the selection. */
+  remove: (db: UserDbBackup) => Promise<void>;
+  /** True while a new backup is being written. */
+  saving: Readonly<Ref<boolean>>;
+  /** Opens the confirmation for deleting every selected backup; deletes only once accepted. */
+  showMassDeleteConfirmation: () => void;
+}
+
+function isSameEntry(firstDb: UserDbBackup, secondDb: UserDbBackup): boolean {
+  return firstDb.version === secondDb.version && firstDb.time === secondDb.time && firstDb.size === secondDb.size;
+}
+
+/**
+ * Drives the user-database backup list: reading it, writing a new one, and deleting the ones the
+ * user picked.
+ *
+ * @remarks
+ * Deleting a backup removes a file that nothing else recreates, so a mass delete goes through a
+ * confirmation. A delete that the backend rejects leaves the list untouched, so the row the user
+ * still has on disk is still on screen.
+ *
+ * @returns the list's bindings; `remove` and the accepted mass delete are the only destructive ones
+ */
+export function useDatabaseBackups(): UseDatabaseBackupsReturn {
+  const backupInfo = ref<DatabaseInfo>();
+  const modelSelected = ref<UserDbBackupWithId[]>([]);
+  const loading = shallowRef<boolean>(false);
+  const saving = shallowRef<boolean>(false);
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { notify } = useNotificationDispatcher();
+  const { createBackup, deleteBackup, info } = useBackupApi();
+  const { show } = useConfirmStore();
+
+  const backups = computed<UserDbBackupWithId[]>(
+    () => get(backupInfo)?.userdb?.backups.map((x, index) => ({ ...x, id: index + 1 })) ?? [],
+  );
+
+  const directory = computed<string>(() => {
+    const currentInfo = get(backupInfo);
+    if (!currentInfo)
+      return '';
+
+    const { filepath } = currentInfo.userdb.info;
+
+    let index = filepath.lastIndexOf('/');
+    if (index === -1)
+      index = filepath.lastIndexOf('\\');
+
+    return filepath.slice(0, index + 1);
+  });
+
+  function forget(removed: UserDbBackup[]): void {
+    const current = get(backupInfo);
+    if (!current)
+      return;
+
+    const next: DatabaseInfo = { ...current };
+    removed.forEach((db) => {
+      const index = next.userdb.backups.findIndex(backup => isSameEntry(backup, db));
+      if (index !== -1)
+        next.userdb.backups.splice(index, 1);
+    });
+    set(backupInfo, next);
+  }
+
+  async function loadInfo(): Promise<void> {
+    try {
+      set(loading, true);
+      set(backupInfo, await info());
+    }
+    catch (error: unknown) {
+      logger.error(error);
+      notify({
+        display: true,
+        message: t('database_backups.load_error.message', { message: getErrorMessage(error) }),
+        title: t('database_backups.load_error.title'),
+      });
+    }
+    finally {
+      set(loading, false);
+    }
+  }
+
+  async function massRemove(): Promise<void> {
+    const currentSelection = get(modelSelected);
+    const filepaths = currentSelection.map(db => getFilepath(db, get(directory)));
+    try {
+      await deleteBackup(filepaths);
+      forget(currentSelection);
+      set(modelSelected, []);
+    }
+    catch (error: unknown) {
+      logger.error(error);
+      notify({
+        display: true,
+        message: t('database_backups.delete_error.mass_message', { message: getErrorMessage(error) }),
+        title: t('database_backups.delete_error.title'),
+      });
+    }
+  }
+
+  async function remove(db: UserDbBackup): Promise<void> {
+    const filepath = getFilepath(db, get(directory));
+    try {
+      await deleteBackup([filepath]);
+      forget([db]);
+      set(modelSelected, get(modelSelected).filter(item => !isSameEntry(item, db)));
+    }
+    catch (error: unknown) {
+      logger.error(error);
+      notify({
+        display: true,
+        message: t('database_backups.delete_error.message', {
+          file: filepath,
+          message: getErrorMessage(error),
+        }),
+        title: t('database_backups.delete_error.title'),
+      });
+    }
+  }
+
+  async function backup(): Promise<void> {
+    try {
+      set(saving, true);
+      const filepath = await createBackup();
+      notify({
+        display: true,
+        message: t('database_backups.backup.message', { filepath }),
+        severity: Severity.INFO,
+        title: t('database_backups.backup.title'),
+      });
+
+      await loadInfo();
+    }
+    catch (error: unknown) {
+      logger.error(error);
+      notify({
+        display: true,
+        message: t('database_backups.backup_error.message', { message: getErrorMessage(error) }),
+        title: t('database_backups.backup_error.title'),
+      });
+    }
+    finally {
+      set(saving, false);
+    }
+  }
+
+  function showMassDeleteConfirmation(): void {
+    show(
+      {
+        message: t('database_backups.confirm.mass_message', { length: get(modelSelected).length }),
+        title: t('database_backups.confirm.title'),
+      },
+      massRemove,
+    );
+  }
+
+  onMounted(loadInfo);
+
+  return {
+    backup,
+    backups,
+    directory,
+    loadInfo,
+    loading: readonly(loading),
+    modelSelected,
+    remove,
+    saving: readonly(saving),
+    showMassDeleteConfirmation,
+  };
+}

--- a/frontend/app/src/modules/settings/data-security/data-management/PurgeData.vue
+++ b/frontend/app/src/modules/settings/data-security/data-management/PurgeData.vue
@@ -1,178 +1,31 @@
 <script setup lang="ts">
-import { pluralize, toSentenceCase } from '@rotki/common';
 import ChainSelect from '@/modules/accounts/blockchain/ChainSelect.vue';
-import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
-import { useExchangeApi } from '@/modules/balances/api/use-exchange-api';
 import LocationSelector from '@/modules/balances/LocationSelector.vue';
-import { isOfEnum } from '@/modules/core/common/helpers/is-of-enum';
-import { DECENTRALIZED_EXCHANGES, Module, PurgeableOnlyModule } from '@/modules/core/common/modules';
-import { useLocationStore } from '@/modules/core/common/use-location-store';
-import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { DECENTRALIZED_EXCHANGES } from '@/modules/core/common/modules';
 import { Purgeable } from '@/modules/session/purge';
-import { useCacheClear } from '@/modules/session/use-cache-clear';
-import { useSessionPurge } from '@/modules/session/use-purge';
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
+import { usePurgeData } from '@/modules/settings/data-security/data-management/use-purge-data';
 import DefiModuleSelector from '@/modules/settings/modules/DefiModuleSelector.vue';
 import ActionStatusIndicator from '@/modules/shell/components/error/ActionStatusIndicator.vue';
 
-const isModule = isOfEnum(Module);
-
-const purgeableOnlyModules = Object.values(PurgeableOnlyModule);
-const purgeableModules = [...Object.values(Module), ...purgeableOnlyModules];
-const { allExchanges } = storeToRefs(useLocationStore());
-const { allTxChainsInfo } = useSupportedChains();
-
-const { purgeData } = useSessionPurge();
-const { deleteModuleData } = useBlockchainBalancesApi();
-const { deleteStakeEvents, deleteTransactions } = useHistoryEventsApi();
-const { deleteExchangeData } = useExchangeApi();
-
 const { t } = useI18n({ useScope: 'global' });
 
-const source = ref<Purgeable>(Purgeable.TRANSACTIONS);
-
-type CentralizedExchangePurgeType = 'all' | 'trades' | 'asset_movements' | 'other';
-
-const centralizedExchangeToClear = ref<string>('');
-const centralizedExchangeDataType = ref<CentralizedExchangePurgeType>('all');
-const decentralizedExchangeToClear = ref<string>('');
-const chainToClear = ref<string>('');
-const moduleToClear = ref<string>('');
-const centralizedExchangePurgeTypeOptions = computed<Array<{ id: CentralizedExchangePurgeType; text: string }>>(() => [
-  { id: 'all', text: 'All' },
-  { id: 'trades', text: 'Trades' },
-  { id: 'asset_movements', text: 'Deposits / Withdrawals' },
-  { id: 'other', text: 'Other events' },
-]);
-
-const purgeable = [
-  {
-    id: Purgeable.CENTRALIZED_EXCHANGES,
-    text: t('purge_selector.centralized_exchange'),
-    value: centralizedExchangeToClear,
-  },
-  {
-    id: Purgeable.DECENTRALIZED_EXCHANGES,
-    text: t('purge_selector.decentralized_exchange'),
-    value: decentralizedExchangeToClear,
-  },
-  {
-    id: Purgeable.DEFI_MODULES,
-    text: t('purge_selector.defi_module'),
-    value: moduleToClear,
-  },
-  {
-    id: Purgeable.TRANSACTIONS,
-    text: t('purge_selector.transactions'),
-    value: chainToClear,
-  },
-  {
-    id: Purgeable.ETH_WITHDRAWAL_EVENT,
-    text: t('purge_selector.eth_withdrawals'),
-  },
-  {
-    id: Purgeable.ETH_BLOCK_EVENT,
-    text: t('purge_selector.eth_block'),
-  },
-];
-
-/** Each purgeable source has its own deletion endpoint; an unrecognised one deletes nothing. */
-async function deleteSourceData(source: Purgeable, value: string): Promise<void> {
-  if (source === Purgeable.TRANSACTIONS) {
-    await deleteTransactions(value);
-    return;
-  }
-
-  if (source === Purgeable.DEFI_MODULES) {
-    await deleteModuleData(isModule(value) ? value : null);
-    return;
-  }
-
-  if (source === Purgeable.CENTRALIZED_EXCHANGES) {
-    await deleteExchangeData(value, get(centralizedExchangeDataType));
-    return;
-  }
-
-  if (source === Purgeable.DECENTRALIZED_EXCHANGES) {
-    // Without a specific exchange, every decentralized one is purged.
-    if (!value) {
-      await Promise.all(DECENTRALIZED_EXCHANGES.map(deleteModuleData));
-      return;
-    }
-    if (isModule(value))
-      await deleteModuleData(value);
-    return;
-  }
-
-  if ([Purgeable.ETH_WITHDRAWAL_EVENT, Purgeable.ETH_BLOCK_EVENT].includes(source))
-    await deleteStakeEvents(source);
-}
-
-async function purgeSource(source: Purgeable) {
-  const valueRef = purgeable.find(({ id }) => id === source)?.value;
-  const value = valueRef ? get(valueRef) : '';
-
-  // Purgeable-only modules have no derived cache, so they need no activity for anything to hang a
-  // `staleAfter` edge off — delete them directly.
-  if (Array.prototype.includes.call(purgeableOnlyModules, value)) {
-    await deleteSourceData(source, value);
-    return;
-  }
-
-  await purgeData(source, value, async () => deleteSourceData(source, value));
-}
-
-const { pending, showConfirmation, status } = useCacheClear<Purgeable>(
+const {
+  centralizedExchangePurgeTypeOptions,
+  chainsSelection,
+  exchanges,
+  modelCentralizedExchange,
+  modelCentralizedExchangeDataType,
+  modelChain,
+  modelDecentralizedExchange,
+  modelModule,
+  modelSource,
+  pending,
   purgeable,
-  purgeSource,
-  (source: string) => ({
-    error: t('data_management.purge_data.error', {
-      source,
-    }),
-    success: t('data_management.purge_data.success', {
-      source,
-    }),
-  }),
-  (textSource, source) => {
-    const valueRef = purgeable.find(({ id }) => id === source)?.value;
-    const value = valueRef ? get(valueRef) : '';
-
-    let message = '';
-    if (source === Purgeable.TRANSACTIONS) {
-      message = t('data_management.purge_data.transaction_purge_confirm.message');
-    }
-    else if (value) {
-      message = t('data_management.purge_data.confirm.message', {
-        source: textSource,
-        value: toSentenceCase(value),
-      });
-    }
-    else {
-      message = t('data_management.purge_data.confirm.message_all', {
-        source: pluralize(textSource),
-      });
-    }
-
-    const exchangeTradeHistoryLimits: Record<string, number> = {
-      poloniex: 180,
-    };
-
-    if (source === Purgeable.CENTRALIZED_EXCHANGES && value && value in exchangeTradeHistoryLimits) {
-      message += `\n\n${t('data_management.purge_data.confirm.exchange_trade_history_warning', {
-        days: exchangeTradeHistoryLimits[value],
-        exchange: toSentenceCase(value),
-      })}`;
-    }
-
-    return {
-      message,
-      title: t('data_management.purge_data.confirm.title'),
-    };
-  },
-);
-
-const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
+  purgeableModules,
+  showConfirmation,
+  status,
+} = usePurgeData();
 </script>
 
 <template>
@@ -185,7 +38,7 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
     </template>
     <div class="flex flex-col gap-4">
       <RuiAutoComplete
-        v-model="source"
+        v-model="modelSource"
         variant="outlined"
         :label="t('purge_selector.label')"
         :options="purgeable"
@@ -196,8 +49,8 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
         data-testid="purge-source"
       />
       <ChainSelect
-        v-if="source === Purgeable.TRANSACTIONS"
-        v-model="chainToClear"
+        v-if="modelSource === Purgeable.TRANSACTIONS"
+        v-model="modelChain"
         clearable
         persistent-hint
         :items="chainsSelection"
@@ -205,18 +58,18 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
         :hint="t('purge_selector.chain_to_clear.hint')"
       />
       <LocationSelector
-        v-else-if="source === Purgeable.CENTRALIZED_EXCHANGES"
-        v-model="centralizedExchangeToClear"
+        v-else-if="modelSource === Purgeable.CENTRALIZED_EXCHANGES"
+        v-model="modelCentralizedExchange"
         clearable
         persistent-hint
-        :items="allExchanges"
+        :items="exchanges"
         :label="t('purge_selector.centralized_exchange_to_clear.label')"
         :hint="t('purge_selector.centralized_exchange_to_clear.hint')"
         data-testid="purge-cex-location"
       />
       <RuiAutoComplete
-        v-if="source === Purgeable.CENTRALIZED_EXCHANGES"
-        v-model="centralizedExchangeDataType"
+        v-if="modelSource === Purgeable.CENTRALIZED_EXCHANGES"
+        v-model="modelCentralizedExchangeDataType"
         variant="outlined"
         label="Data type"
         :options="centralizedExchangePurgeTypeOptions"
@@ -227,8 +80,8 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
         data-testid="purge-cex-data-type"
       />
       <LocationSelector
-        v-else-if="source === Purgeable.DECENTRALIZED_EXCHANGES"
-        v-model="decentralizedExchangeToClear"
+        v-else-if="modelSource === Purgeable.DECENTRALIZED_EXCHANGES"
+        v-model="modelDecentralizedExchange"
         clearable
         persistent-hint
         :items="DECENTRALIZED_EXCHANGES"
@@ -236,8 +89,8 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
         :hint="t('purge_selector.decentralized_exchange_to_clear.hint')"
       />
       <DefiModuleSelector
-        v-else-if="source === Purgeable.DEFI_MODULES"
-        v-model="moduleToClear"
+        v-else-if="modelSource === Purgeable.DEFI_MODULES"
+        v-model="modelModule"
         :items="purgeableModules"
         :label="t('purge_selector.defi_module_to_clear.label')"
         :hint="t('purge_selector.defi_module_to_clear.hint')"
@@ -250,11 +103,11 @@ const chainsSelection = useArrayMap(allTxChainsInfo, item => item.id);
 
       <div class="flex justify-end">
         <RuiButton
-          :disabled="!source || pending"
+          :disabled="!modelSource || pending"
           :loading="pending"
           color="error"
           data-testid="purge-submit"
-          @click="showConfirmation(source)"
+          @click="showConfirmation(modelSource)"
         >
           <template #prepend>
             <RuiIcon

--- a/frontend/app/src/modules/settings/data-security/data-management/use-purge-data.spec.ts
+++ b/frontend/app/src/modules/settings/data-security/data-management/use-purge-data.spec.ts
@@ -1,3 +1,4 @@
+import { invalid } from '@test/utils/invalid';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { effectScope } from 'vue';
 import { DECENTRALIZED_EXCHANGES, Module, PurgeableOnlyModule } from '@/modules/core/common/modules';
@@ -225,8 +226,7 @@ describe('modules/settings/data-security/data-management/usePurgeData', () => {
     it('should delete nothing for a source it does not recognise, rather than a broader purge', async () => {
       const { showConfirmation } = purge();
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the branch is defensive, so the only way to reach it is a value the enum forbids
-      showConfirmation('not_a_purgeable_source' as Purgeable);
+      showConfirmation(invalid<Purgeable>('not_a_purgeable_source'));
       await accept();
 
       expect(everyDeleteCall()).toBe(0);

--- a/frontend/app/src/modules/settings/data-security/data-management/use-purge-data.spec.ts
+++ b/frontend/app/src/modules/settings/data-security/data-management/use-purge-data.spec.ts
@@ -1,0 +1,365 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope } from 'vue';
+import { DECENTRALIZED_EXCHANGES, Module, PurgeableOnlyModule } from '@/modules/core/common/modules';
+import { Purgeable } from '@/modules/session/purge';
+import { usePurgeData } from './use-purge-data';
+
+const {
+  allExchanges,
+  allTxChainsInfo,
+  deleteExchangeData,
+  deleteModuleData,
+  deleteStakeEvents,
+  deleteTransactions,
+  purgeData,
+  show,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    allExchanges: ref<string[]>(['kraken', 'poloniex']),
+    allTxChainsInfo: ref<Array<{ id: string }>>([{ id: 'ethereum' }, { id: 'optimism' }]),
+    deleteExchangeData: vi.fn(),
+    deleteModuleData: vi.fn(),
+    deleteStakeEvents: vi.fn(),
+    deleteTransactions: vi.fn(),
+    purgeData: vi.fn(),
+    show: vi.fn(),
+  };
+});
+
+vi.mock('@/modules/core/common/use-location-store', () => ({
+  useLocationStore: (): Record<string, unknown> => ({ allExchanges }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({ allTxChainsInfo }),
+}));
+
+vi.mock('@/modules/session/use-purge', () => ({
+  useSessionPurge: (): Record<string, unknown> => ({ purgeData }),
+}));
+
+vi.mock('@/modules/balances/api/use-blockchain-balances-api', () => ({
+  useBlockchainBalancesApi: (): Record<string, unknown> => ({ deleteModuleData }),
+}));
+
+vi.mock('@/modules/balances/api/use-exchange-api', () => ({
+  useExchangeApi: (): Record<string, unknown> => ({ deleteExchangeData }),
+}));
+
+vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
+  useHistoryEventsApi: (): Record<string, unknown> => ({ deleteStakeEvents, deleteTransactions }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({ show }),
+}));
+
+let scope: ReturnType<typeof effectScope>;
+
+function purge(): ReturnType<typeof usePurgeData> {
+  scope = effectScope();
+  return scope.run(() => usePurgeData())!;
+}
+
+function confirmationMessage(): { message: string; title: string } {
+  expect(show).toHaveBeenCalledOnce();
+  return show.mock.calls[0][0];
+}
+
+async function accept(): Promise<void> {
+  await show.mock.calls[0][1]();
+}
+
+function everyDeleteCall(): number {
+  return deleteTransactions.mock.calls.length
+    + deleteModuleData.mock.calls.length
+    + deleteExchangeData.mock.calls.length
+    + deleteStakeEvents.mock.calls.length;
+}
+
+describe('modules/settings/data-security/data-management/usePurgeData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    purgeData.mockImplementation(async (
+      _source: Purgeable,
+      _value: string,
+      deleteData: () => Promise<void>,
+    ) => deleteData());
+    set(allExchanges, ['kraken', 'poloniex']);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the confirmation gate', () => {
+    it('should delete nothing merely because the user pressed purge', () => {
+      const { modelSource, showConfirmation } = purge();
+
+      showConfirmation(get(modelSource));
+
+      expect(show).toHaveBeenCalledOnce();
+      expect(everyDeleteCall()).toBe(0);
+      expect(purgeData).not.toHaveBeenCalled();
+    });
+
+    it('should delete nothing when the user never accepts', () => {
+      const { modelSource, showConfirmation } = purge();
+
+      showConfirmation(get(modelSource));
+
+      expect(everyDeleteCall()).toBe(0);
+    });
+
+    it('should delete once the user accepts', async () => {
+      const { showConfirmation } = purge();
+
+      showConfirmation(Purgeable.TRANSACTIONS);
+      await accept();
+
+      expect(deleteTransactions).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('what each source deletes', () => {
+    it('should route transactions to the transaction endpoint and nothing else', async () => {
+      const { modelChain, showConfirmation } = purge();
+      set(modelChain, 'ethereum');
+
+      showConfirmation(Purgeable.TRANSACTIONS);
+      await accept();
+
+      expect(deleteTransactions).toHaveBeenCalledExactlyOnceWith('ethereum');
+      expect(everyDeleteCall()).toBe(1);
+    });
+
+    it('should route a defi module to the module endpoint and nothing else', async () => {
+      const { modelModule, showConfirmation } = purge();
+      set(modelModule, Module.LIQUITY);
+
+      showConfirmation(Purgeable.DEFI_MODULES);
+      await accept();
+
+      expect(deleteModuleData).toHaveBeenCalledExactlyOnceWith(Module.LIQUITY);
+      expect(everyDeleteCall()).toBe(1);
+    });
+
+    it('should route a centralized exchange to the exchange endpoint and nothing else', async () => {
+      const { modelCentralizedExchange, showConfirmation } = purge();
+      set(modelCentralizedExchange, 'kraken');
+
+      showConfirmation(Purgeable.CENTRALIZED_EXCHANGES);
+      await accept();
+
+      expect(deleteExchangeData).toHaveBeenCalledExactlyOnceWith('kraken', 'all');
+      expect(everyDeleteCall()).toBe(1);
+    });
+
+    it('should route a decentralized exchange to the module endpoint and nothing else', async () => {
+      const { modelDecentralizedExchange, showConfirmation } = purge();
+      set(modelDecentralizedExchange, Module.UNISWAP);
+
+      showConfirmation(Purgeable.DECENTRALIZED_EXCHANGES);
+      await accept();
+
+      expect(deleteModuleData).toHaveBeenCalledExactlyOnceWith(Module.UNISWAP);
+      expect(everyDeleteCall()).toBe(1);
+    });
+
+    it.each([
+      ['a withdrawal', Purgeable.ETH_WITHDRAWAL_EVENT],
+      ['a block', Purgeable.ETH_BLOCK_EVENT],
+    ])('should route %s event to the stake-event endpoint and nothing else', async (_name, source) => {
+      const { showConfirmation } = purge();
+
+      showConfirmation(source);
+      await accept();
+
+      expect(deleteStakeEvents).toHaveBeenCalledExactlyOnceWith(source);
+      expect(everyDeleteCall()).toBe(1);
+    });
+  });
+
+  describe('what it sends for a narrowed selection', () => {
+    it('should send the selected data type rather than always purging every kind', async () => {
+      const { modelCentralizedExchange, modelCentralizedExchangeDataType, showConfirmation } = purge();
+      set(modelCentralizedExchange, 'kraken');
+      set(modelCentralizedExchangeDataType, 'trades');
+
+      showConfirmation(Purgeable.CENTRALIZED_EXCHANGES);
+      await accept();
+
+      expect(deleteExchangeData).toHaveBeenCalledWith('kraken', 'trades');
+    });
+
+    it('should send an empty chain, meaning all of them, when none was picked', async () => {
+      const { showConfirmation } = purge();
+
+      showConfirmation(Purgeable.TRANSACTIONS);
+      await accept();
+
+      expect(deleteTransactions).toHaveBeenCalledWith('');
+    });
+
+    it('should purge every decentralized exchange when none was picked', async () => {
+      const { showConfirmation } = purge();
+
+      showConfirmation(Purgeable.DECENTRALIZED_EXCHANGES);
+      await accept();
+
+      expect(deleteModuleData).toHaveBeenCalledTimes(DECENTRALIZED_EXCHANGES.length);
+      expect(deleteModuleData.mock.calls.map(([module]) => module)).toEqual(DECENTRALIZED_EXCHANGES);
+    });
+
+    it('should send null for a module value it does not recognise, rather than the raw string', async () => {
+      const { modelModule, showConfirmation } = purge();
+      set(modelModule, 'not-a-module');
+
+      showConfirmation(Purgeable.DEFI_MODULES);
+      await accept();
+
+      expect(deleteModuleData).toHaveBeenCalledExactlyOnceWith(null);
+    });
+
+    it('should delete nothing for a source it does not recognise, rather than a broader purge', async () => {
+      const { showConfirmation } = purge();
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the branch is defensive, so the only way to reach it is a value the enum forbids
+      showConfirmation('not_a_purgeable_source' as Purgeable);
+      await accept();
+
+      expect(everyDeleteCall()).toBe(0);
+    });
+
+    it('should delete nothing for a decentralized value it does not recognise', async () => {
+      const { modelDecentralizedExchange, showConfirmation } = purge();
+      set(modelDecentralizedExchange, 'not-a-module');
+
+      showConfirmation(Purgeable.DECENTRALIZED_EXCHANGES);
+      await accept();
+
+      expect(everyDeleteCall()).toBe(0);
+    });
+  });
+
+  describe('the purge activity', () => {
+    it('should run an ordinary purge through the activity so the caches follow', async () => {
+      const { modelChain, showConfirmation } = purge();
+      set(modelChain, 'ethereum');
+
+      showConfirmation(Purgeable.TRANSACTIONS);
+      await accept();
+
+      expect(purgeData).toHaveBeenCalledOnce();
+      expect(purgeData.mock.calls[0][0]).toBe(Purgeable.TRANSACTIONS);
+      expect(purgeData.mock.calls[0][1]).toBe('ethereum');
+    });
+
+    it('should delete a purgeable-only module directly, since it has no cache to invalidate', async () => {
+      const { modelModule, showConfirmation } = purge();
+      set(modelModule, PurgeableOnlyModule.LOOPRING);
+
+      showConfirmation(Purgeable.DEFI_MODULES);
+      await accept();
+
+      expect(purgeData).not.toHaveBeenCalled();
+      expect(deleteModuleData).toHaveBeenCalledExactlyOnceWith(PurgeableOnlyModule.LOOPRING);
+    });
+
+    it.each(Object.values(PurgeableOnlyModule))(
+      'should purge only %s, never every module, when it is the selection',
+      async (module) => {
+        const { modelModule, showConfirmation } = purge();
+        set(modelModule, module);
+
+        showConfirmation(Purgeable.DEFI_MODULES);
+        await accept();
+
+        expect(deleteModuleData).toHaveBeenCalledExactlyOnceWith(module);
+        expect(deleteModuleData).not.toHaveBeenCalledWith(null);
+      },
+    );
+  });
+
+  describe('what the confirmation says', () => {
+    it('should warn about transactions in their own words, not the generic message', () => {
+      const { showConfirmation } = purge();
+
+      showConfirmation(Purgeable.TRANSACTIONS);
+
+      expect(confirmationMessage().message).toBe('data_management.purge_data.transaction_purge_confirm.message');
+    });
+
+    it('should name the selection when one was made', () => {
+      const { modelCentralizedExchange, showConfirmation } = purge();
+      set(modelCentralizedExchange, 'kraken');
+
+      showConfirmation(Purgeable.CENTRALIZED_EXCHANGES);
+
+      expect(confirmationMessage().message).toContain('data_management.purge_data.confirm.message');
+      expect(confirmationMessage().message).toContain('Kraken');
+    });
+
+    it('should say all of them when nothing narrows the purge', () => {
+      const { showConfirmation } = purge();
+
+      showConfirmation(Purgeable.DEFI_MODULES);
+
+      expect(confirmationMessage().message).toContain('data_management.purge_data.confirm.message_all');
+    });
+
+    it('should add the retention warning for an exchange that cannot serve its full history', () => {
+      const { modelCentralizedExchange, showConfirmation } = purge();
+      set(modelCentralizedExchange, 'poloniex');
+
+      showConfirmation(Purgeable.CENTRALIZED_EXCHANGES);
+
+      expect(confirmationMessage().message).toContain('exchange_trade_history_warning');
+      expect(confirmationMessage().message).toContain('180');
+    });
+
+    it('should not add the retention warning for an exchange that can', () => {
+      const { modelCentralizedExchange, showConfirmation } = purge();
+      set(modelCentralizedExchange, 'kraken');
+
+      showConfirmation(Purgeable.CENTRALIZED_EXCHANGES);
+
+      expect(confirmationMessage().message).not.toContain('exchange_trade_history_warning');
+    });
+  });
+
+  describe('what it offers the form', () => {
+    it('should offer every purgeable source', () => {
+      expect(purge().purgeable.map(item => item.id)).toEqual([
+        Purgeable.CENTRALIZED_EXCHANGES,
+        Purgeable.DECENTRALIZED_EXCHANGES,
+        Purgeable.DEFI_MODULES,
+        Purgeable.TRANSACTIONS,
+        Purgeable.ETH_WITHDRAWAL_EVENT,
+        Purgeable.ETH_BLOCK_EVENT,
+      ]);
+    });
+
+    it('should offer the purgeable-only modules alongside the ordinary ones', () => {
+      const { purgeableModules } = purge();
+
+      expect(purgeableModules).toContain(Module.LIQUITY);
+      expect(purgeableModules).toContain(PurgeableOnlyModule.LOOPRING);
+    });
+
+    it('should offer every slice of exchange data, with all of it first', () => {
+      const options = get(purge().centralizedExchangePurgeTypeOptions);
+
+      expect(options.map(option => option.id)).toEqual(['all', 'trades', 'asset_movements', 'other']);
+    });
+
+    it('should offer the chains that can hold transactions', () => {
+      expect(get(purge().chainsSelection)).toEqual(['ethereum', 'optimism']);
+    });
+
+    it('should start on transactions, the least destructive default', () => {
+      expect(get(purge().modelSource)).toBe(Purgeable.TRANSACTIONS);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/data-security/data-management/use-purge-data.ts
+++ b/frontend/app/src/modules/settings/data-security/data-management/use-purge-data.ts
@@ -1,0 +1,249 @@
+import type { ComputedRef, DeepReadonly, Ref } from 'vue';
+import type { BaseMessage } from '@/modules/core/messaging/base-message';
+import { pluralize, toSentenceCase } from '@rotki/common';
+import { useBlockchainBalancesApi } from '@/modules/balances/api/use-blockchain-balances-api';
+import { useExchangeApi } from '@/modules/balances/api/use-exchange-api';
+import { isOfEnum } from '@/modules/core/common/helpers/is-of-enum';
+import { DECENTRALIZED_EXCHANGES, Module, type PurgeableModule, PurgeableOnlyModule } from '@/modules/core/common/modules';
+import { useLocationStore } from '@/modules/core/common/use-location-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { Purgeable } from '@/modules/session/purge';
+import { useCacheClear } from '@/modules/session/use-cache-clear';
+import { useSessionPurge } from '@/modules/session/use-purge';
+
+/** Which slice of a centralized exchange's data a purge removes; `all` takes every kind. */
+type CentralizedExchangePurgeType = 'all' | 'trades' | 'asset_movements' | 'other';
+
+/**
+ * Exchanges that serve only a limited window of trade history, keyed by the days they retain.
+ *
+ * @remarks
+ * Purging one of these is not fully reversible: re-querying cannot recover trades older than the
+ * window, so the confirmation grows an extra warning naming the limit. An exchange absent from
+ * this record is assumed to serve its full history.
+ */
+const EXCHANGE_TRADE_HISTORY_LIMITS: Record<string, number> = {
+  poloniex: 180,
+};
+
+/**
+ * The purge surface, ready to bind. Every `model*` ref is writable for `v-model`; the rest is
+ * read-only state or an action.
+ */
+interface UsePurgeDataReturn {
+  /** Options for the centralized-exchange data-type picker, in display order. */
+  centralizedExchangePurgeTypeOptions: ComputedRef<Array<{ id: CentralizedExchangePurgeType; text: string }>>;
+  /** Ids of every chain that can hold transactions, for the chain picker. */
+  chainsSelection: ComputedRef<string[]>;
+  /** Every exchange the user has configured, for the centralized-exchange picker. */
+  exchanges: Readonly<Ref<string[]>>;
+  /** Empty means every centralized exchange. */
+  modelCentralizedExchange: Ref<string>;
+  modelCentralizedExchangeDataType: Ref<CentralizedExchangePurgeType>;
+  /** Empty means every chain. */
+  modelChain: Ref<string>;
+  /** Empty means every decentralized exchange. */
+  modelDecentralizedExchange: Ref<string>;
+  /** Empty means every module. */
+  modelModule: Ref<string>;
+  /** What the purge button acts on; selects which picker the form shows. */
+  modelSource: Ref<Purgeable>;
+  /** True while a purge is in flight, so the form can lock itself. */
+  pending: Readonly<Ref<boolean>>;
+  /** Every purgeable source with its label, and the ref holding its narrowing selection. */
+  purgeable: Array<{ id: Purgeable; text: string; value?: Ref<string> }>;
+  /** Modules offered to the module picker, including the purgeable-only ones. */
+  purgeableModules: PurgeableModule[];
+  /**
+   * Opens the confirmation for `source`, and purges only once the user accepts.
+   *
+   * @remarks
+   * Nothing is deleted by calling this. The destructive call happens in the confirmation's accept
+   * handler, against the selection held at the moment the user accepts.
+   */
+  showConfirmation: (source: Purgeable) => void;
+  /** Outcome of the last purge, cleared a few seconds after a success. */
+  status: DeepReadonly<Ref<BaseMessage | null>>;
+}
+
+/**
+ * Drives the "purge data" settings row: what can be purged, what the user narrowed it to, and the
+ * deletion each choice maps to.
+ *
+ * @remarks
+ * Every source routes to its own endpoint, and an unrecognised one deletes nothing rather than
+ * falling back to a broader purge. A purgeable-only module is deleted directly instead of through
+ * the purge activity, having no derived cache for a `staleAfter` edge to hang off.
+ *
+ * @returns the form's bindings plus {@link UsePurgeDataReturn.showConfirmation}, which is the only
+ * way this composable deletes anything
+ */
+export function usePurgeData(): UsePurgeDataReturn {
+  const isModule = isOfEnum(Module);
+  const purgeableOnlyModules: string[] = Object.values(PurgeableOnlyModule);
+  const purgeableModules: PurgeableModule[] = [...Object.values(Module), ...Object.values(PurgeableOnlyModule)];
+
+  const isPurgeableModule = (value: string): value is PurgeableModule =>
+    isModule(value) || purgeableOnlyModules.includes(value);
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const { allExchanges } = storeToRefs(useLocationStore());
+  const { allTxChainsInfo } = useSupportedChains();
+
+  const { purgeData } = useSessionPurge();
+  const { deleteModuleData } = useBlockchainBalancesApi();
+  const { deleteStakeEvents, deleteTransactions } = useHistoryEventsApi();
+  const { deleteExchangeData } = useExchangeApi();
+
+  const modelSource = shallowRef<Purgeable>(Purgeable.TRANSACTIONS);
+  const modelCentralizedExchange = shallowRef<string>('');
+  const modelCentralizedExchangeDataType = shallowRef<CentralizedExchangePurgeType>('all');
+  const modelDecentralizedExchange = shallowRef<string>('');
+  const modelChain = shallowRef<string>('');
+  const modelModule = shallowRef<string>('');
+
+  const centralizedExchangePurgeTypeOptions = computed<Array<{ id: CentralizedExchangePurgeType; text: string }>>(() => [
+    { id: 'all', text: 'All' },
+    { id: 'trades', text: 'Trades' },
+    { id: 'asset_movements', text: 'Deposits / Withdrawals' },
+    { id: 'other', text: 'Other events' },
+  ]);
+
+  const purgeable = [
+    {
+      id: Purgeable.CENTRALIZED_EXCHANGES,
+      text: t('purge_selector.centralized_exchange'),
+      value: modelCentralizedExchange,
+    },
+    {
+      id: Purgeable.DECENTRALIZED_EXCHANGES,
+      text: t('purge_selector.decentralized_exchange'),
+      value: modelDecentralizedExchange,
+    },
+    {
+      id: Purgeable.DEFI_MODULES,
+      text: t('purge_selector.defi_module'),
+      value: modelModule,
+    },
+    {
+      id: Purgeable.TRANSACTIONS,
+      text: t('purge_selector.transactions'),
+      value: modelChain,
+    },
+    {
+      id: Purgeable.ETH_WITHDRAWAL_EVENT,
+      text: t('purge_selector.eth_withdrawals'),
+    },
+    {
+      id: Purgeable.ETH_BLOCK_EVENT,
+      text: t('purge_selector.eth_block'),
+    },
+  ];
+
+  function selectedValue(source: Purgeable): string {
+    const valueRef = purgeable.find(({ id }) => id === source)?.value;
+    return valueRef ? get(valueRef) : '';
+  }
+
+  async function deleteSourceData(source: Purgeable, value: string): Promise<void> {
+    if (source === Purgeable.TRANSACTIONS) {
+      await deleteTransactions(value);
+      return;
+    }
+
+    if (source === Purgeable.DEFI_MODULES) {
+      await deleteModuleData(isPurgeableModule(value) ? value : null);
+      return;
+    }
+
+    if (source === Purgeable.CENTRALIZED_EXCHANGES) {
+      await deleteExchangeData(value, get(modelCentralizedExchangeDataType));
+      return;
+    }
+
+    if (source === Purgeable.DECENTRALIZED_EXCHANGES) {
+      if (!value) {
+        await Promise.all(DECENTRALIZED_EXCHANGES.map(deleteModuleData));
+        return;
+      }
+      if (isModule(value))
+        await deleteModuleData(value);
+      return;
+    }
+
+    if ([Purgeable.ETH_WITHDRAWAL_EVENT, Purgeable.ETH_BLOCK_EVENT].includes(source))
+      await deleteStakeEvents(source);
+  }
+
+  async function purgeSource(source: Purgeable): Promise<void> {
+    const value = selectedValue(source);
+
+    if (purgeableOnlyModules.includes(value)) {
+      await deleteSourceData(source, value);
+      return;
+    }
+
+    await purgeData(source, value, async () => deleteSourceData(source, value));
+  }
+
+  function confirmText(textSource: string, source: Purgeable): { message: string; title: string } {
+    const value = selectedValue(source);
+
+    let message = '';
+    if (source === Purgeable.TRANSACTIONS) {
+      message = t('data_management.purge_data.transaction_purge_confirm.message');
+    }
+    else if (value) {
+      message = t('data_management.purge_data.confirm.message', {
+        source: textSource,
+        value: toSentenceCase(value),
+      });
+    }
+    else {
+      message = t('data_management.purge_data.confirm.message_all', {
+        source: pluralize(textSource),
+      });
+    }
+
+    if (source === Purgeable.CENTRALIZED_EXCHANGES && value && value in EXCHANGE_TRADE_HISTORY_LIMITS) {
+      message += `\n\n${t('data_management.purge_data.confirm.exchange_trade_history_warning', {
+        days: EXCHANGE_TRADE_HISTORY_LIMITS[value],
+        exchange: toSentenceCase(value),
+      })}`;
+    }
+
+    return {
+      message,
+      title: t('data_management.purge_data.confirm.title'),
+    };
+  }
+
+  const { pending, showConfirmation, status } = useCacheClear<Purgeable>(
+    purgeable,
+    purgeSource,
+    (source: string) => ({
+      error: t('data_management.purge_data.error', { source }),
+      success: t('data_management.purge_data.success', { source }),
+    }),
+    confirmText,
+  );
+
+  return {
+    centralizedExchangePurgeTypeOptions,
+    chainsSelection: useArrayMap(allTxChainsInfo, item => item.id),
+    exchanges: allExchanges,
+    modelCentralizedExchange,
+    modelCentralizedExchangeDataType,
+    modelChain,
+    modelDecentralizedExchange,
+    modelModule,
+    modelSource,
+    pending,
+    purgeable,
+    purgeableModules,
+    showConfirmation,
+    status,
+  };
+}

--- a/frontend/app/src/modules/shell/app/AssetUpdate.vue
+++ b/frontend/app/src/modules/shell/app/AssetUpdate.vue
@@ -1,162 +1,34 @@
 <script setup lang="ts">
-import type { AssetUpdateConflictResult, AssetVersionUpdate, ConflictResolution } from '@/modules/assets/types';
-import { useAssets } from '@/modules/assets/use-assets';
-import { useRestartingStatus } from '@/modules/auth/use-restarting-status';
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
 import AssetConflictDialog from '@/modules/shell/app/AssetConflictDialog.vue';
 import AssetUpdateInlineConfirm from '@/modules/shell/app/AssetUpdateInlineConfirm.vue';
 import AssetUpdateMessage from '@/modules/shell/app/AssetUpdateMessage.vue';
 import AssetUpdateSetting from '@/modules/shell/app/AssetUpdateSetting.vue';
 import AssetUpdateStatus from '@/modules/shell/app/AssetUpdateStatus.vue';
-import { useBackendReload } from '@/modules/shell/app/use-backend-reload';
+import { useAssetUpdate } from '@/modules/shell/app/use-asset-update';
 
 const { headless = false } = defineProps<{ headless?: boolean }>();
 
 const emit = defineEmits<{
   skip: [];
 }>();
-const checking = ref<boolean>(false);
-const applying = ref<boolean>(false);
-const inlineConfirm = ref<boolean>(false);
-const showUpdateDialog = ref<boolean>(false);
-const showConflictDialog = ref<boolean>(false);
-const conflicts = ref<AssetUpdateConflictResult[]>([]);
-const changes = ref<AssetVersionUpdate>({
-  changes: 0,
-  local: 0,
-  remote: 0,
-  upToVersion: 0,
-});
 
-const skipped = useLocalStorage('rotki_skip_asset_db_version', 0);
-
-const status = computed(() => {
-  if (get(checking))
-    return 'checking';
-
-  if (get(applying))
-    return 'applying';
-
-  return null;
-});
-
-const { applyUpdates, checkForUpdate } = useAssets();
-const { reload } = useBackendReload();
-
-const { t } = useI18n({ useScope: 'global' });
-const { setMessage } = useMessageStore();
-
-async function check() {
-  set(checking, true);
-  const checkResult = await checkForUpdate();
-  set(checking, false);
-  const skippedVersion = get(skipped);
-  const versions = checkResult.versions;
-  if (headless && skippedVersion && skippedVersion === versions?.remote) {
-    set(checking, false);
-    emit('skip');
-    return;
-  }
-
-  set(showUpdateDialog, checkResult.updateAvailable);
-
-  if (!checkResult.updateAvailable) {
-    if (headless) {
-      emit('skip');
-    }
-    else {
-      setMessage({
-        description: t('asset_update.up_to_date'),
-        success: true,
-      });
-    }
-  }
-
-  if (versions) {
-    set(changes, {
-      changes: versions.newChanges,
-      local: versions.local,
-      remote: versions.remote,
-      upToVersion: versions.remote,
-    });
-  }
-}
-
-function skip(skipUpdate: boolean) {
-  set(showUpdateDialog, false);
-  set(showConflictDialog, false);
-  if (skipUpdate)
-    set(skipped, get(changes).remote);
-
-  emit('skip');
-}
-
-async function updateAssets(resolution?: ConflictResolution) {
-  set(showUpdateDialog, false);
-  set(showConflictDialog, false);
-  const version = get(changes).upToVersion;
-  set(applying, true);
-  const updateResult = await applyUpdates({ resolution, version });
-  set(applying, false);
-  if (updateResult.done) {
-    set(skipped, 0);
-    showDoneConfirmation();
-  }
-  else if (updateResult.conflicts) {
-    set(conflicts, updateResult.conflicts);
-    set(showConflictDialog, true);
-  }
-}
-
-const { restarting } = useRestartingStatus();
-
-async function updateComplete() {
-  if (get(restarting))
-    return;
-
-  set(restarting, true);
-  try {
-    await reload();
-  }
-  finally {
-    // Always cleared: a reload that reports a failure still ends this attempt, and
-    // leaving the flag set would block every later one.
-    set(restarting, false);
-  }
-}
-
-const { show } = useConfirmStore();
-
-function showDoneConfirmation() {
-  if (headless) {
-    set(inlineConfirm, true);
-  }
-  else {
-    show(
-      {
-        message: t('asset_update.success.description', {
-          remoteVersion: get(changes).upToVersion,
-        }),
-        primaryAction: t('common.actions.ok'),
-        singleAction: true,
-        title: t('asset_update.success.title'),
-        type: 'success',
-      },
-      updateComplete,
-    );
-  }
-}
-
-onMounted(async () => {
-  const skipUpdate = sessionStorage.getItem('skip_update');
-  if (skipUpdate) {
-    emit('skip');
-    return;
-  }
-
-  if (headless)
-    await check();
+const {
+  applying,
+  check,
+  checking,
+  conflicts,
+  inlineConfirm,
+  modelChanges,
+  modelShowConflictDialog,
+  showUpdateDialog,
+  skip,
+  skipped,
+  status,
+  updateAssets,
+  updateComplete,
+} = useAssetUpdate({
+  headless: () => headless,
+  onSkip: () => emit('skip'),
 });
 </script>
 
@@ -172,12 +44,12 @@ onMounted(async () => {
       <AssetUpdateStatus
         v-if="status"
         :status="status"
-        :remote-version="changes.upToVersion"
+        :remote-version="modelChanges.upToVersion"
       />
       <AssetUpdateInlineConfirm
         v-if="inlineConfirm"
         class="max-w-[32rem] mx-auto"
-        :remote-version="changes.upToVersion"
+        :remote-version="modelChanges.upToVersion"
         @confirm="updateComplete()"
       />
     </template>
@@ -190,8 +62,8 @@ onMounted(async () => {
       >
         <AssetUpdateMessage
           :headless="headless"
-          :versions="changes"
-          @update:versions="changes = $event"
+          :versions="modelChanges"
+          @update:versions="modelChanges = $event"
           @confirm="updateAssets()"
           @dismiss="skip($event)"
         />
@@ -200,16 +72,16 @@ onMounted(async () => {
         v-else
         class="max-w-[32rem] mx-auto"
         :headless="headless"
-        :versions="changes"
-        @update:versions="changes = $event"
+        :versions="modelChanges"
+        @update:versions="modelChanges = $event"
         @confirm="updateAssets()"
         @dismiss="skip($event)"
       />
     </template>
 
     <AssetConflictDialog
-      v-if="showConflictDialog"
-      v-model="showConflictDialog"
+      v-if="modelShowConflictDialog"
+      v-model="modelShowConflictDialog"
       :conflicts="conflicts"
       @cancel="skip(false)"
       @resolve="updateAssets($event)"

--- a/frontend/app/src/modules/shell/app/use-asset-update.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-asset-update.spec.ts
@@ -1,0 +1,392 @@
+import type { ApplyUpdateResult, AssetUpdateCheckResult, AssetUpdateConflictResult } from '@/modules/assets/types';
+import { createMock } from '@test/utils/create-mock';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { useAssetUpdate } from './use-asset-update';
+
+const {
+  applyUpdates,
+  checkForUpdate,
+  reload,
+  restarting,
+  setMessage,
+  show,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    applyUpdates: vi.fn(),
+    checkForUpdate: vi.fn(),
+    reload: vi.fn(),
+    restarting: ref<boolean>(false),
+    setMessage: vi.fn(),
+    show: vi.fn(),
+  };
+});
+
+vi.mock('@/modules/assets/use-assets', () => ({
+  useAssets: (): Record<string, unknown> => ({ applyUpdates, checkForUpdate }),
+}));
+
+vi.mock('@/modules/shell/app/use-backend-reload', () => ({
+  useBackendReload: (): Record<string, unknown> => ({ reload }),
+}));
+
+vi.mock('@/modules/auth/use-restarting-status', () => ({
+  useRestartingStatus: (): Record<string, unknown> => ({ restarting }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({ show }),
+}));
+
+const wrappers: VueWrapper[] = [];
+const onSkip = vi.fn();
+
+function conflict(identifier: string): AssetUpdateConflictResult {
+  return createMock<AssetUpdateConflictResult>({ identifier });
+}
+
+function checkReturns(result: Partial<AssetUpdateCheckResult>): void {
+  checkForUpdate.mockResolvedValue({ updateAvailable: false, ...result });
+}
+
+function applyReturns(result: Partial<ApplyUpdateResult>): void {
+  applyUpdates.mockResolvedValue({ done: true, ...result });
+}
+
+function mountUpdate(headless = false): ReturnType<typeof useAssetUpdate> {
+  let captured: ReturnType<typeof useAssetUpdate> | undefined;
+  let setupError: Error | undefined;
+  const Host = defineComponent({
+    setup(): () => ReturnType<typeof h> {
+      try {
+        captured = useAssetUpdate({ headless: () => headless, onSkip });
+      }
+      catch (error) {
+        setupError = error instanceof Error ? error : new Error(String(error));
+      }
+      return (): ReturnType<typeof h> => h('div');
+    },
+  });
+
+  wrappers.push(mount(Host));
+  if (setupError)
+    throw setupError;
+  return captured!;
+}
+
+describe('modules/shell/app/useAssetUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    set(restarting, false);
+    checkReturns({});
+    applyReturns({});
+    reload.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('what happens on mount', () => {
+    it('should not check when the app asked for the update to be skipped this run', async () => {
+      sessionStorage.setItem('skip_update', 'true');
+
+      mountUpdate(true);
+      await flushPromises();
+
+      expect(checkForUpdate).not.toHaveBeenCalled();
+      expect(onSkip).toHaveBeenCalledOnce();
+    });
+
+    it('should check straight away when it owns the screen', async () => {
+      mountUpdate(true);
+      await flushPromises();
+
+      expect(checkForUpdate).toHaveBeenCalledOnce();
+    });
+
+    it('should wait to be asked when it is only a settings row', async () => {
+      mountUpdate(false);
+      await flushPromises();
+
+      expect(checkForUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the version check', () => {
+    it('should open the prompt when an update exists', async () => {
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 2 } });
+      const { check, showUpdateDialog } = mountUpdate();
+
+      await check();
+
+      expect(get(showUpdateDialog)).toBe(true);
+    });
+
+    it('should target the remote version it was told about', async () => {
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 2 } });
+      const { check, modelChanges } = mountUpdate();
+
+      await check();
+
+      expect(get(modelChanges)).toEqual({ changes: 5, local: 1, remote: 2, upToVersion: 2 });
+    });
+
+    it('should tell a settings user there was nothing to do', async () => {
+      const { check } = mountUpdate(false);
+
+      await check();
+
+      expect(setMessage).toHaveBeenCalledOnce();
+      expect(onSkip).not.toHaveBeenCalled();
+    });
+
+    it('should move the app on rather than message when it owns the screen', async () => {
+      const { check } = mountUpdate(true);
+      await flushPromises();
+      onSkip.mockClear();
+
+      await check();
+
+      expect(onSkip).toHaveBeenCalledOnce();
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+
+    it('should not offer a version the user already skipped', async () => {
+      localStorage.setItem('rotki_skip_asset_db_version', '2');
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 2 } });
+      const { check, showUpdateDialog } = mountUpdate(true);
+      await flushPromises();
+      onSkip.mockClear();
+
+      await check();
+
+      expect(get(showUpdateDialog)).toBe(false);
+      expect(onSkip).toHaveBeenCalledOnce();
+    });
+
+    it('should still offer a newer version than the one skipped', async () => {
+      localStorage.setItem('rotki_skip_asset_db_version', '2');
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 3 } });
+      const { check, showUpdateDialog } = mountUpdate(true);
+
+      await check();
+
+      expect(get(showUpdateDialog)).toBe(true);
+    });
+
+    it('should offer a skipped version again in the settings, where the user asked for it', async () => {
+      localStorage.setItem('rotki_skip_asset_db_version', '2');
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 2 } });
+      const { check, showUpdateDialog } = mountUpdate(false);
+
+      await check();
+
+      expect(get(showUpdateDialog)).toBe(true);
+    });
+
+    it('should report it is checking only while the check is in flight', async () => {
+      let release: (result: AssetUpdateCheckResult) => void = () => {};
+      checkForUpdate.mockReturnValue(new Promise((resolve) => {
+        release = resolve;
+      }));
+      const { check, status } = mountUpdate();
+
+      const pending = check();
+      expect(get(status)).toBe('checking');
+
+      release({ updateAvailable: false });
+      await pending;
+      expect(get(status)).toBeNull();
+    });
+  });
+
+  describe('skipping', () => {
+    it('should close both prompts and move the app on', async () => {
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 2 } });
+      const { check, modelShowConflictDialog, showUpdateDialog, skip } = mountUpdate();
+      await check();
+
+      skip(false);
+
+      expect(get(showUpdateDialog)).toBe(false);
+      expect(get(modelShowConflictDialog)).toBe(false);
+      expect(onSkip).toHaveBeenCalledOnce();
+    });
+
+    it('should remember the version only when the user asked to skip it', async () => {
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 2 } });
+      const { check, skip, skipped } = mountUpdate();
+      await check();
+
+      skip(false);
+      expect(get(skipped)).toBe(0);
+
+      skip(true);
+      expect(get(skipped)).toBe(2);
+    });
+
+    it('should remember the remote version, not the one being updated to', async () => {
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 7 } });
+      const { check, modelChanges, skip, skipped } = mountUpdate();
+      await check();
+      set(modelChanges, { ...get(modelChanges), upToVersion: 4 });
+
+      skip(true);
+
+      expect(get(skipped)).toBe(7);
+    });
+  });
+
+  describe('applying the update', () => {
+    it('should apply up to the targeted version', async () => {
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 3 } });
+      const { check, updateAssets } = mountUpdate();
+      await check();
+
+      await updateAssets();
+
+      expect(applyUpdates).toHaveBeenCalledExactlyOnceWith({ resolution: undefined, version: 3 });
+    });
+
+    it('should pass the resolution the user chose', async () => {
+      const { updateAssets } = mountUpdate();
+
+      await updateAssets({ ETH: 'local' });
+
+      expect(applyUpdates).toHaveBeenCalledWith({ resolution: { ETH: 'local' }, version: 0 });
+    });
+
+    it('should close the prompt before writing anything', async () => {
+      checkReturns({ updateAvailable: true, versions: { local: 1, newChanges: 5, remote: 3 } });
+      const { check, showUpdateDialog, updateAssets } = mountUpdate();
+      await check();
+
+      await updateAssets();
+
+      expect(get(showUpdateDialog)).toBe(false);
+    });
+
+    it('should report it is applying only while the write is in flight', async () => {
+      let release: (result: ApplyUpdateResult) => void = () => {};
+      applyUpdates.mockReturnValue(new Promise((resolve) => {
+        release = resolve;
+      }));
+      const { status, updateAssets } = mountUpdate();
+
+      const pending = updateAssets();
+      expect(get(status)).toBe('applying');
+
+      release({ done: true });
+      await pending;
+      expect(get(status)).toBeNull();
+    });
+
+    it('should clear the skipped version once the update the user avoided has happened', async () => {
+      localStorage.setItem('rotki_skip_asset_db_version', '2');
+      const { skipped, updateAssets } = mountUpdate();
+
+      await updateAssets();
+
+      expect(get(skipped)).toBe(0);
+    });
+  });
+
+  describe('a conflicting update', () => {
+    it('should surface the conflicts for resolution rather than reporting success', async () => {
+      applyReturns({ conflicts: [conflict('ETH')], done: false });
+      const { conflicts, modelShowConflictDialog, updateAssets } = mountUpdate();
+
+      await updateAssets();
+
+      expect(get(modelShowConflictDialog)).toBe(true);
+      expect(get(conflicts)).toHaveLength(1);
+      expect(show).not.toHaveBeenCalled();
+    });
+
+    it('should not open the conflict dialog when the backend reported none', async () => {
+      applyReturns({ done: false });
+      const { modelShowConflictDialog, updateAssets } = mountUpdate();
+
+      await updateAssets();
+
+      expect(get(modelShowConflictDialog)).toBe(false);
+    });
+
+    it('should leave the skipped version alone when the update did not land', async () => {
+      localStorage.setItem('rotki_skip_asset_db_version', '2');
+      applyReturns({ conflicts: [conflict('ETH')], done: false });
+      const { skipped, updateAssets } = mountUpdate();
+
+      await updateAssets();
+
+      expect(get(skipped)).toBe(2);
+    });
+  });
+
+  describe('confirming a finished update', () => {
+    it('should ask a settings user to confirm before restarting', async () => {
+      const { updateAssets } = mountUpdate(false);
+
+      await updateAssets();
+
+      expect(show).toHaveBeenCalledOnce();
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('should restart once that confirmation is accepted', async () => {
+      const { updateAssets } = mountUpdate(false);
+      await updateAssets();
+
+      await show.mock.calls[0][1]();
+
+      expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('should confirm inline when it owns the screen, since there is no dialog host', async () => {
+      const { inlineConfirm, updateAssets } = mountUpdate(true);
+
+      await updateAssets();
+
+      expect(get(inlineConfirm)).toBe(true);
+      expect(show).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the restart', () => {
+    it('should reload the backend so the new assets are served', async () => {
+      const { updateComplete } = mountUpdate();
+
+      await updateComplete();
+
+      expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('should not start a second restart while one is already running', async () => {
+      set(restarting, true);
+      const { updateComplete } = mountUpdate();
+
+      await updateComplete();
+
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('should clear the restarting flag even when the reload fails, so a retry is possible', async () => {
+      reload.mockRejectedValue(new Error('backend down'));
+      const { updateComplete } = mountUpdate();
+
+      await expect(updateComplete()).rejects.toThrow('backend down');
+
+      expect(get(restarting)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/app/use-asset-update.ts
+++ b/frontend/app/src/modules/shell/app/use-asset-update.ts
@@ -1,0 +1,230 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { AssetUpdateConflictResult, AssetVersionUpdate, ConflictResolution } from '@/modules/assets/types';
+import { useAssets } from '@/modules/assets/use-assets';
+import { useRestartingStatus } from '@/modules/auth/use-restarting-status';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useBackendReload } from '@/modules/shell/app/use-backend-reload';
+
+/** Key holding the remote version the user chose to skip, so the prompt stays away across restarts. */
+const SKIPPED_VERSION_KEY = 'rotki_skip_asset_db_version';
+
+/** Session key set by the app to suppress the check entirely for this run. */
+const SKIP_UPDATE_KEY = 'skip_update';
+
+interface UseAssetUpdateOptions {
+  /**
+   * Runs the update as the only thing on screen, before login.
+   *
+   * @remarks
+   * Changes three behaviours rather than only the layout: the check runs on mount, a skipped
+   * version short-circuits it, and "nothing to update" reports through `onSkip` instead of a
+   * success message the user has nowhere to read.
+   */
+  headless: MaybeRefOrGetter<boolean>;
+  /** Called whenever this surface is finished and the app should move on. */
+  onSkip: () => void;
+}
+
+interface UseAssetUpdateReturn {
+  /** True while the update is being written. */
+  applying: Readonly<Ref<boolean>>;
+  /** True while the remote version is being read. */
+  checking: Readonly<Ref<boolean>>;
+  /** Conflicts the last apply reported, for the resolution dialog. */
+  conflicts: Readonly<Ref<AssetUpdateConflictResult[]>>;
+  /** Asks the backend whether an update exists, and opens the prompt if one does. */
+  check: () => Promise<void>;
+  /** True once a headless update finished and wants its own inline confirmation. */
+  inlineConfirm: Readonly<Ref<boolean>>;
+  /** The versions in play; written back by the message component when the user retargets. */
+  modelChanges: Ref<AssetVersionUpdate>;
+  /** Whether the conflict-resolution dialog is open. */
+  modelShowConflictDialog: Ref<boolean>;
+  /** Whether the update prompt is open. */
+  showUpdateDialog: Readonly<Ref<boolean>>;
+  /**
+   * Dismisses the prompt and hands back to the app.
+   *
+   * @param skipUpdate - also remembers this remote version, so it is not offered again
+   */
+  skip: (skipUpdate: boolean) => void;
+  /** The remote version the user previously skipped, or 0 when none. */
+  skipped: Readonly<Ref<number>>;
+  /** What the surface is busy doing, or null when idle. */
+  status: ComputedRef<'checking' | 'applying' | null>;
+  /** Restarts the backend so the new assets are served; a no-op while one is already restarting. */
+  updateComplete: () => Promise<void>;
+  /** Writes the update, resolving conflicts with `resolution` when the user supplied one. */
+  updateAssets: (resolution?: ConflictResolution) => Promise<void>;
+}
+
+/**
+ * Drives the asset-database update: the version check, the prompt, conflict resolution, and the
+ * backend restart that serves the result.
+ *
+ * @remarks
+ * This overwrites the local asset database, so nothing is written until the user accepts the
+ * prompt. A successful apply clears the skipped version, on the grounds that the thing the user
+ * was avoiding has now happened.
+ *
+ * @returns the surface's bindings; only {@link UseAssetUpdateReturn.updateAssets} writes anything
+ */
+export function useAssetUpdate(options: UseAssetUpdateOptions): UseAssetUpdateReturn {
+  const { headless, onSkip } = options;
+
+  const checking = shallowRef<boolean>(false);
+  const applying = shallowRef<boolean>(false);
+  const inlineConfirm = shallowRef<boolean>(false);
+  const showUpdateDialog = shallowRef<boolean>(false);
+  const modelShowConflictDialog = shallowRef<boolean>(false);
+  const conflicts = ref<AssetUpdateConflictResult[]>([]);
+  const modelChanges = ref<AssetVersionUpdate>({
+    changes: 0,
+    local: 0,
+    remote: 0,
+    upToVersion: 0,
+  });
+
+  const skipped = useLocalStorage(SKIPPED_VERSION_KEY, 0);
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { applyUpdates, checkForUpdate } = useAssets();
+  const { reload } = useBackendReload();
+  const { setMessage } = useMessageStore();
+  const { restarting } = useRestartingStatus();
+  const { show } = useConfirmStore();
+
+  const status = computed<'checking' | 'applying' | null>(() => {
+    if (get(checking))
+      return 'checking';
+
+    if (get(applying))
+      return 'applying';
+
+    return null;
+  });
+
+  async function check(): Promise<void> {
+    set(checking, true);
+    const checkResult = await checkForUpdate();
+    set(checking, false);
+
+    const skippedVersion = get(skipped);
+    const versions = checkResult.versions;
+
+    if (toValue(headless) && skippedVersion && skippedVersion === versions?.remote) {
+      onSkip();
+      return;
+    }
+
+    set(showUpdateDialog, checkResult.updateAvailable);
+
+    if (!checkResult.updateAvailable) {
+      if (toValue(headless)) {
+        onSkip();
+      }
+      else {
+        setMessage({
+          description: t('asset_update.up_to_date'),
+          success: true,
+        });
+      }
+    }
+
+    if (versions) {
+      set(modelChanges, {
+        changes: versions.newChanges,
+        local: versions.local,
+        remote: versions.remote,
+        upToVersion: versions.remote,
+      });
+    }
+  }
+
+  function skip(skipUpdate: boolean): void {
+    set(showUpdateDialog, false);
+    set(modelShowConflictDialog, false);
+    if (skipUpdate)
+      set(skipped, get(modelChanges).remote);
+
+    onSkip();
+  }
+
+  async function updateComplete(): Promise<void> {
+    if (get(restarting))
+      return;
+
+    set(restarting, true);
+    try {
+      await reload();
+    }
+    finally {
+      set(restarting, false);
+    }
+  }
+
+  function showDoneConfirmation(): void {
+    if (toValue(headless)) {
+      set(inlineConfirm, true);
+      return;
+    }
+
+    show(
+      {
+        message: t('asset_update.success.description', {
+          remoteVersion: get(modelChanges).upToVersion,
+        }),
+        primaryAction: t('common.actions.ok'),
+        singleAction: true,
+        title: t('asset_update.success.title'),
+        type: 'success',
+      },
+      updateComplete,
+    );
+  }
+
+  async function updateAssets(resolution?: ConflictResolution): Promise<void> {
+    set(showUpdateDialog, false);
+    set(modelShowConflictDialog, false);
+    const version = get(modelChanges).upToVersion;
+    set(applying, true);
+    const updateResult = await applyUpdates({ resolution, version });
+    set(applying, false);
+
+    if (updateResult.done) {
+      set(skipped, 0);
+      showDoneConfirmation();
+    }
+    else if (updateResult.conflicts) {
+      set(conflicts, updateResult.conflicts);
+      set(modelShowConflictDialog, true);
+    }
+  }
+
+  onMounted(async () => {
+    if (sessionStorage.getItem(SKIP_UPDATE_KEY)) {
+      onSkip();
+      return;
+    }
+
+    if (toValue(headless))
+      await check();
+  });
+
+  return {
+    applying: readonly(applying),
+    check,
+    checking: readonly(checking),
+    conflicts: shallowReadonly(conflicts),
+    inlineConfirm: readonly(inlineConfirm),
+    modelChanges,
+    modelShowConflictDialog,
+    showUpdateDialog: readonly(showUpdateDialog),
+    skip,
+    skipped: readonly(skipped),
+    status,
+    updateAssets,
+    updateComplete,
+  };
+}

--- a/frontend/app/tests/unit/utils/invalid.ts
+++ b/frontend/app/tests/unit/utils/invalid.ts
@@ -1,0 +1,22 @@
+/**
+ * Types `value` as `T` so a test can pass something `T` forbids.
+ *
+ * @remarks
+ * For exercising a defensive branch: code that guards against a value its own types rule out, such
+ * as an unhandled member of a union or an enum value from the wire that the frontend does not know.
+ * Those guards matter most on destructive paths, where falling through to a broader default is the
+ * difference between deleting one thing and deleting everything, and the type system is exactly
+ * what stops a test from reaching them.
+ *
+ * Reach for this only when the value is *meant* to be invalid. A partial stand-in for a real type
+ * is `createMock<T>()` instead, and a value the type genuinely permits needs neither.
+ *
+ * The single assertion is intentionally contained here, so spec files stay assertion-free.
+ *
+ * @param value - the deliberately invalid value, unconstrained on purpose
+ * @returns `value`, typed as `T`
+ */
+export function invalid<T>(value: unknown): T {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the whole point is a value T forbids; contained to this helper
+  return value as T;
+}


### PR DESCRIPTION
Batch E of #12964, issue #13007: the four components that destroy or overwrite user data, all four at **0% coverage**. Each is extracted to a composable and covered there, at full statement and branch coverage.

| Component | Extracted to | Tests | Statements | Branches |
|---|---|---|---|---|
| `PurgeData.vue` | `use-purge-data.ts` | 30 | 63/63 | 31/31 |
| `AssetUpdate.vue` | `use-asset-update.ts` | 28 | 72/72 | 29/29 |
| `BackupManager.vue` | `use-database-backups.ts` | 21 | 65/65 | 13/13 |
| `ManagedAssetContent.vue` | `use-managed-asset-form.ts` + `use-managed-assets-table.ts` | 25 | 52/52 | 6/6 |

Script lines left in the components: 176 → 28, 161 → 25, 170 → 17, 178 → 35. `ManagedAssetContent` also drops from **18 imports to 8**, against the 20-import ceiling.

## Two defects the tests found

**Purging a purgeable-only module purged every module** (`use-purge-data.ts`). The routing guard tested the value against `Module`, which does not contain `cowswap`, `gnosis_pay` or `loopring` — those live in `PurgeableOnlyModule`. So selecting one of them failed the guard and fell through to `deleteModuleData(null)`, which is `DELETE /blockchains/eth/modules/data`: **all module data, not the one chosen**. Reachable from the UI — `DefiModuleSelector` renders all three as selectable entries, and `PurgeData` passes it the list that includes them. Fixed with an `isPurgeableModule` guard covering the full `PurgeableModule` union.

**Deleting a backup that was no longer in the list removed the last row instead** (`use-database-backups.ts`). `findIndex` returned `-1` and `splice(-1, 1)` takes the final element. Reachable because the selection is bound with `v-model:selected` and survives a refresh, so a backup deleted outside rotki leaves a stale entry that drops the wrong row on a mass delete. Display-only — the files deleted come from the selection and were always correct — but the list then lies until the next refresh. Guarded.

Both fixes ride in the commit that creates the file they live in; splitting them out would have meant committing knowingly-broken code first.

## Behaviour pinned but not changed

- An unrecognised purge source deletes nothing rather than falling back to a broader purge. Defensive today, since every `Purgeable` member is handled — the test exists so that adding a member without a route fails loudly instead of deleting everything.
- `AssetUpdate`'s `headless` changes three behaviours, not just layout: the check runs on mount, a previously-skipped version short-circuits the prompt, and "already up to date" reports through `onSkip` rather than a message nobody is on screen to read. In the settings row a skipped version *is* offered again, because the user explicitly asked.

## How the tests were verified

Every load-bearing claim was negative-controlled: break the code, watch the named test go red, restore. **One control passed, which is a finding rather than a pass** — removing the not-found guard in `editAsset` failed nothing, because `edit(undefined)` also leaves the model undefined, so the assertion agreed with both the correct and the broken code. The discriminant is `editMode`, which the broken version flips to `true` for an asset that was never found; the test now asserts it.

The confirmation contract is asserted the same way for all four: nothing is deleted by opening the dialog, the destructive call carries exactly the user's selection, and a failure leaves the list alone.

## New test helper

`invalid<T>(value)` in `@test/utils/invalid`, for reaching a guard against a value the types rule out. It contains the single assertion, the way `createMock` contains its own, so specs stay assertion-free. Note `createMock` cannot serve this case: `DeepPartial` still shape-checks the override, so it bridges a *partial* object but not a *structurally different* one. Two callers today, and it replaces the only `as unknown as` that was left in a spec.

## Notes for the reviewer

- `readonly()` deep-freezes, so it breaks a prop typed as a mutable array. `shallowReadonly()` is the right wrapper where a composable exposes an array or object it owns.
- `storeToRefs` on a hand-rolled object of refs double-wraps them; these specs use a real pinia. Inside a test, writing store state needs `set(storeToRefs(store).x, …)` — the store proxy unwraps refs, so `set(store.x, …)` is a silent no-op.
- `use-managed-assets-table.spec.ts` stubs `useManagedAssetFields` because the real one reaches `useSupportedChains`, which tries to hit the backend during a unit test. The stub captures its arguments so the asset types and the live ignored-asset count are still asserted rather than lost.

## Follow-on

This retires `ManagedAssetContent.vue` from the extraction-only batch (**G** in #12964), which listed it at "178 script, 8 refs, 2 stores".
