### PR TITLE
test(frontend): coverage batch I, the history/events cluster

### DIFF
--- a/frontend/app/src/modules/core/notifications/PendingTask.vue
+++ b/frontend/app/src/modules/core/notifications/PendingTask.vue
@@ -35,7 +35,7 @@ const { scrambleAddress } = useScramble();
  * separators put back verbatim. `scrambleAddress` returns its input unchanged while privacy mode
  * is off, so this needs no condition of its own.
  *
- * @param value a subtitle param, which is only rewritten when it is a string
+ * @param value - a subtitle param, which is only rewritten when it is a string
  * @returns the value with each address replaced
  */
 function scrambleAddresses(value: unknown): unknown {

--- a/frontend/app/src/modules/history/events/HistoryEventsDecodingStatus.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventsDecodingStatus.spec.ts
@@ -1,0 +1,149 @@
+import type { EvmUnDecodedTransactionsData, ProtocolCacheUpdatesData } from '@/modules/core/messaging/types';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import HistoryEventsDecodingStatus from '@/modules/history/events/HistoryEventsDecodingStatus.vue';
+import { useProtocolCacheStatusStore } from '@/modules/history/use-protocol-cache-status-store';
+
+const { checkMissingEventsAndRedecode, isActive } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    checkMissingEventsAndRedecode: vi.fn(),
+    isActive: ref<boolean>(false),
+  };
+});
+
+vi.mock('@/modules/task-center/use-task-center', () => ({
+  useTaskCenter: (): Record<string, unknown> => ({
+    useIsActive: (): typeof isActive => isActive,
+  }),
+}));
+
+vi.mock('@/modules/history/events/tx/use-history-transaction-decoding', () => ({
+  useHistoryTransactionDecoding: (): Record<string, unknown> => ({ checkMissingEventsAndRedecode }),
+}));
+
+const wrappers: VueWrapper[] = [];
+
+function undecoded(evmChain: string, processed: number, total: number): EvmUnDecodedTransactionsData {
+  return { chain: evmChain, processed, total };
+}
+
+function cacheUpdate(): ProtocolCacheUpdatesData {
+  return { chain: 'ethereum', processed: 3, protocol: 'curve', total: 9 };
+}
+
+async function mountStatus(decodingStatus: EvmUnDecodedTransactionsData[] = []): Promise<VueWrapper> {
+  const wrapper = mount(HistoryEventsDecodingStatus, {
+    global: { provide: libraryDefaults },
+    props: { decodingStatus, refreshing: false },
+  });
+  wrappers.push(wrapper);
+  await flushPromises();
+  return wrapper;
+}
+
+function rowsOf(wrapper: VueWrapper): Array<Record<string, unknown>> {
+  return wrapper.findComponent({ name: 'RuiDataTable' }).props('rows');
+}
+
+describe('modules/history/events/HistoryEventsDecodingStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createCustomPinia());
+    set(isActive, false);
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('what it asks its parent to do', () => {
+    it('should ask for a reset on mount when there is nothing left undecoded', async () => {
+      const wrapper = await mountStatus([]);
+
+      expect(wrapper.emitted('reset-undecoded-transactions')).toHaveLength(1);
+    });
+
+    it('should not ask for a reset while transactions are still undecoded', async () => {
+      const wrapper = await mountStatus([undecoded('ethereum', 1, 4)]);
+
+      expect(wrapper.emitted('reset-undecoded-transactions')).toBeUndefined();
+    });
+
+    it('should ask for a redecode rather than decoding anything itself', async () => {
+      const wrapper = await mountStatus([undecoded('ethereum', 1, 4)]);
+
+      await wrapper.find('[data-testid="redecode-all"]').trigger('click');
+
+      expect(wrapper.emitted('redecode-all-events')).toHaveLength(1);
+      expect(checkMissingEventsAndRedecode).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when decoding finishes', () => {
+    it('should ask for a reset, so the parent stops showing stale progress', async () => {
+      set(isActive, true);
+      const wrapper = await mountStatus([undecoded('ethereum', 1, 4)]);
+
+      set(isActive, false);
+      await flushPromises();
+
+      expect(wrapper.emitted('reset-undecoded-transactions')).toHaveLength(1);
+    });
+
+    it('should ask twice when the list is already empty, refresh having asked once too', async () => {
+      set(isActive, true);
+      const wrapper = await mountStatus([]);
+      const onMount = wrapper.emitted('reset-undecoded-transactions')?.length ?? 0;
+
+      set(isActive, false);
+      await flushPromises();
+
+      expect((wrapper.emitted('reset-undecoded-transactions')?.length ?? 0) - onMount).toBe(2);
+    });
+
+    it('should ask for nothing while decoding is still running', async () => {
+      const wrapper = await mountStatus([undecoded('ethereum', 1, 4)]);
+
+      set(isActive, true);
+      await flushPromises();
+
+      expect(wrapper.emitted('reset-undecoded-transactions')).toBeUndefined();
+    });
+  });
+
+  describe('the rows it renders', () => {
+    it('should show the most recent chain first', async () => {
+      const wrapper = await mountStatus([
+        undecoded('ethereum', 1, 4),
+        undecoded('optimism', 2, 5),
+      ]);
+
+      expect(rowsOf(wrapper).map(row => row.chain)).toEqual(['optimism', 'ethereum']);
+    });
+
+    it('should render no table at all when nothing is undecoded', async () => {
+      const wrapper = await mountStatus([]);
+
+      expect(wrapper.findComponent({ name: 'RuiDataTable' }).exists()).toBe(false);
+    });
+
+    it('should put a protocol cache refresh above the chains while one is running', async () => {
+      useProtocolCacheStatusStore().setProtocolCacheStatus(cacheUpdate());
+
+      const wrapper = await mountStatus([undecoded('optimism', 2, 5)]);
+
+      expect(rowsOf(wrapper)[0]).toMatchObject({ chain: 'ethereum', processed: 0, total: 0 });
+      expect(rowsOf(wrapper)).toHaveLength(2);
+    });
+
+    it('should leave the chains alone when no cache refresh is running', async () => {
+      const wrapper = await mountStatus([undecoded('optimism', 2, 5)]);
+
+      expect(rowsOf(wrapper)).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/HistoryEventsDecodingStatus.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsDecodingStatus.vue
@@ -266,6 +266,7 @@ onMounted(() => refresh());
       <RuiButton
         color="error"
         :disabled="refreshing || isDecoding"
+        data-testid="redecode-all"
         @click="redecodeAllEvents()"
       >
         <template #prepend>

--- a/frontend/app/src/modules/history/events/HistoryEventsIdentifier.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsIdentifier.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
-import { Blockchain, HistoryEventEntryType, toSentenceCase } from '@rotki/common';
-import { type MessageKey, msg } from '@/message-key';
-import {
-  isAssetMovementEventRef,
-  isEthBlockEventRef,
-  isWithdrawalEventRef,
-} from '@/modules/history/event-utils';
+import { Blockchain, toSentenceCase } from '@rotki/common';
+import { useHistoryEventsIdentifier } from '@/modules/history/events/use-history-events-identifier';
 import HashLink from '@/modules/shell/components/HashLink.vue';
 
 const { event, groupEvents } = defineProps<{
@@ -14,116 +9,22 @@ const { event, groupEvents } = defineProps<{
   groupEvents?: HistoryEventEntry[];
 }>();
 
-/**
- * Header message per entry type. Exhaustive on purpose: deriving the key with
- * `toSnakeCase(entryType)` meant a new entry type produced a key nobody had written, and `i18n-t`
- * renders a missing keypath verbatim, so bitcoin and solana events displayed the raw
- * `transactions.events.headers.*` string. Spelling the map out fails the build instead, and the
- * branded values are checked against the locale messages.
- */
-const HEADER_KEYS: Record<HistoryEventEntryType, MessageKey> = {
-  [HistoryEventEntryType.ASSET_MOVEMENT_EVENT]: msg.$t('transactions.events.headers.asset_movement_event'),
-  [HistoryEventEntryType.BITCOIN_EVENT]: msg.$t('transactions.events.headers.bitcoin_event'),
-  [HistoryEventEntryType.ETH_BLOCK_EVENT]: msg.$t('transactions.events.headers.eth_block_event'),
-  [HistoryEventEntryType.ETH_DEPOSIT_EVENT]: msg.$t('transactions.events.headers.eth_deposit_event'),
-  [HistoryEventEntryType.ETH_WITHDRAWAL_EVENT]: msg.$t('transactions.events.headers.eth_withdrawal_event'),
-  [HistoryEventEntryType.EVM_EVENT]: msg.$t('transactions.events.headers.evm_event'),
-  [HistoryEventEntryType.EVM_SWAP_EVENT]: msg.$t('transactions.events.headers.evm_swap_event'),
-  [HistoryEventEntryType.HISTORY_EVENT]: msg.$t('transactions.events.headers.history_event'),
-  [HistoryEventEntryType.SOLANA_EVENT]: msg.$t('transactions.events.headers.solana_event'),
-  [HistoryEventEntryType.SOLANA_SWAP_EVENT]: msg.$t('transactions.events.headers.solana_swap_event'),
-  [HistoryEventEntryType.SWAP_EVENT]: msg.$t('transactions.events.headers.swap_event'),
-};
-
 const { t } = useI18n({ useScope: 'global' });
-
-const { is2xlAndUp, isMd } = useBreakpoint();
-
-const truncateLength = computed<number>(() => {
-  if (get(is2xlAndUp)) {
-    return 12;
-  }
-
-  if (get(isMd)) {
-    return 6;
-  }
-
-  return 8;
-});
-
-const blockEvent = isEthBlockEventRef(() => event);
-const withdrawEvent = isWithdrawalEventRef(() => event);
-const assetMovementEvent = isAssetMovementEventRef(() => event);
-
-const eventWithTxRef = computed<{ location: string; txRef: string } | undefined>(() => {
-  if ('txRef' in event && event.txRef) {
-    return {
-      location: event.location,
-      txRef: event.txRef,
-    };
-  }
-  return undefined;
-});
-
-const allTxRefs = computed<{ location: string; txRef: string }[]>(() => {
-  if (!get(assetMovementEvent) || !groupEvents)
-    return [];
-
-  const seen = new Set<string>();
-  const result: { location: string; txRef: string }[] = [];
-
-  for (const child of groupEvents) {
-    if (!('txRef' in child) || !child.txRef || seen.has(child.txRef))
-      continue;
-
-    seen.add(child.txRef);
-    result.push({
-      location: child.location,
-      txRef: child.txRef,
-    });
-  }
-
-  return result;
-});
-
-const extraHashCount = computed<number>(() => Math.max(get(allTxRefs).length - 1, 0));
 
 const hashMenuOpen = ref<boolean>(false);
 
-const translationKey = computed<MessageKey>(() => {
-  // consider an evm swap event as a case of evm event
-  // as they are both evm events and have the same header
-  let entryType = event.entryType;
-  const specialTypesWithTxRef: HistoryEventEntryType[] = [
-    HistoryEventEntryType.ETH_DEPOSIT_EVENT,
-    HistoryEventEntryType.ASSET_MOVEMENT_EVENT,
-  ];
-
-  if (get(eventWithTxRef) && !specialTypesWithTxRef.includes(entryType)) {
-    entryType = HistoryEventEntryType.EVM_EVENT;
-  }
-
-  return HEADER_KEYS[entryType];
-});
-
-const assetMovementTransactionId = computed<string | undefined>(() => get(assetMovementEvent)?.extraData?.transactionId ?? undefined);
-
-/**
- * The key is used to avoid an issue where the block event identifier would be reused
- * to display a hash event identifier resulting in a numerical display instead.
- */
-const key = computed(() => {
-  if (get(eventWithTxRef))
-    return 'tx_hash';
-  else if (get(blockEvent))
-    return 'block';
-  else if (get(withdrawEvent))
-    return 'withdraw';
-  else if (get(assetMovementEvent))
-    return 'asset_movement';
-  else
-    return undefined;
-});
+const {
+  allTxRefs,
+  assetMovementEvent,
+  assetMovementTransactionId,
+  blockEvent,
+  eventWithTxRef,
+  extraHashCount,
+  key,
+  translationKey,
+  truncateLength,
+  withdrawEvent,
+} = useHistoryEventsIdentifier(() => event, () => groupEvents);
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/events/HistoryEventsSkippedExternalEvents.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsSkippedExternalEvents.vue
@@ -1,38 +1,14 @@
 <script setup lang="ts">
-import type { Message } from '@rotki/common';
 import type { DataTableColumn } from '@rotki/ui-library';
-import type { SkippedHistoryEventsSummary } from '@/modules/history/events/event-payloads';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { logger } from '@/modules/core/common/logging/logging';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
-import { useSkippedHistoryEventsApi } from '@/modules/history/api/events/use-skipped-history-events-api';
+import { type SkippedEventsLocation, useSkippedEventsActions } from '@/modules/history/events/use-skipped-events-actions';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
-import { useInterop } from '@/modules/shell/app/use-electron-interop';
-
-interface Location {
-  location: string;
-  number: number;
-}
-
-const { getSkippedEventsSummary } = useSkippedHistoryEventsApi();
-
-const { execute: refreshSkippedEvents, state: skippedEvents } = useAsyncState<SkippedHistoryEventsSummary>(
-  getSkippedEventsSummary,
-  {
-    locations: {},
-    total: 0,
-  },
-  {
-    delay: 0,
-    immediate: true,
-    resetOnExecute: false,
-  },
-);
 
 const { t } = useI18n({ useScope: 'global' });
 
-const headers: DataTableColumn<Location>[] = [
+const { exportCSV, loading, locationsData, reProcessSkippedEvents, skippedEvents } = useSkippedEventsActions();
+
+const headers: DataTableColumn<SkippedEventsLocation>[] = [
   {
     align: 'center',
     cellClass: 'py-3',
@@ -47,115 +23,6 @@ const headers: DataTableColumn<Location>[] = [
     label: t('transactions.events.skipped.headers.number'),
   },
 ];
-
-const locationsData = computed<Location[]>(() =>
-  Object.entries(get(skippedEvents).locations).map(([location, number]) => ({
-    location,
-    number,
-  })),
-);
-
-const { appSession, openDirectory } = useInterop();
-
-const { downloadSkippedEventsCSV, exportSkippedEventsCSV } = useSkippedHistoryEventsApi();
-
-const { setMessage } = useMessageStore();
-
-function showExportCSVError(description: string) {
-  setMessage({
-    description,
-    success: false,
-    title: t('transactions.events.skipped.csv_export_error'),
-  });
-}
-
-async function createCsv(path: string): Promise<void> {
-  let message: Message;
-  try {
-    const success = await exportSkippedEventsCSV(path);
-    message = {
-      description: success
-        ? t('actions.online_events.skipped.csv_export.message.success')
-        : t('actions.online_events.skipped.csv_export.message.failure'),
-      success,
-      title: t('actions.online_events.skipped.csv_export.title'),
-    };
-  }
-  catch (error: unknown) {
-    message = {
-      description: getErrorMessage(error),
-      success: false,
-      title: t('actions.online_events.skipped.csv_export.title'),
-    };
-  }
-  setMessage(message);
-}
-
-async function exportCSV() {
-  try {
-    if (appSession) {
-      const directory = await openDirectory(t('common.select_directory'));
-      if (!directory)
-        return;
-
-      await createCsv(directory);
-    }
-    else {
-      const result = await downloadSkippedEventsCSV();
-      if (!result.success)
-        showExportCSVError(result.message ?? t('transactions.events.skipped.download_failed'));
-    }
-  }
-  catch (error: unknown) {
-    showExportCSVError(getErrorMessage(error));
-  }
-}
-
-const { reProcessSkippedEvents: reProcessSkippedEventsCaller } = useSkippedHistoryEventsApi();
-
-const loading = ref<boolean>(false);
-
-async function reProcessSkippedEvents() {
-  set(loading, true);
-  let message: Message;
-  try {
-    const { successful, total } = await reProcessSkippedEventsCaller();
-    if (successful === 0) {
-      message = {
-        description: t('transactions.events.skipped.reprocess.failed.no_processed_events'),
-        success: false,
-        title: t('transactions.events.skipped.reprocess.failed.title'),
-      };
-    }
-    else {
-      message = {
-        description:
-          successful < total
-            ? t('transactions.events.skipped.reprocess.success.some', {
-                successful,
-                total,
-              })
-            : t('transactions.events.skipped.reprocess.success.all'),
-        success: true,
-        title: t('transactions.events.skipped.reprocess.success.title'),
-      };
-    }
-  }
-  catch (error: unknown) {
-    logger.error(error);
-    message = {
-      description: getErrorMessage(error),
-      success: false,
-      title: t('transactions.events.skipped.reprocess.failed.title'),
-    };
-  }
-  finally {
-    set(loading, false);
-  }
-
-  setMessage(message);
-  await refreshSkippedEvents();
-}
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsContent.spec.ts
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsContent.spec.ts
@@ -1,0 +1,275 @@
+import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
+import { createMock } from '@test/utils/create-mock';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import MatchAssetMovementsContent from '@/modules/history/events/MatchAssetMovementsContent.vue';
+import { UNMATCHED_ACTIONS } from '@/modules/history/events/unmatched-actions';
+
+const movementsApi = {
+  autoMatchLoading: ref<boolean>(false),
+  autoMatchMinimumTier: ref<string>('premium'),
+  ignoredLoading: ref<boolean>(false),
+  ignoredMovements: ref<UnmatchedAssetMovement[]>([]),
+  isAutoMatchAllowed: ref<boolean>(true),
+  loading: ref<boolean>(false),
+  refreshUnmatchedAssetMovements: vi.fn(async () => Promise.resolve()),
+  triggerAssetMovementAutoMatching: vi.fn(),
+  unmatchedMovements: ref<UnmatchedAssetMovement[]>([]),
+};
+
+const actionsApi = {
+  confirmIgnoreAllFiat: vi.fn(),
+  confirmIgnoreSelected: vi.fn(),
+  confirmRestoreSelected: vi.fn(),
+  dismissResolution: vi.fn(),
+  fiatMovements: ref<UnmatchedAssetMovement[]>([]),
+  ignoreLoading: ref<boolean>(false),
+  ignoreMovement: vi.fn(async () => Promise.resolve()),
+  markExternal: vi.fn(async () => Promise.resolve()),
+  modelSelectedIgnored: ref<UnmatchedAssetMovement[]>([]),
+  modelSelectedUnmatched: ref<UnmatchedAssetMovement[]>([]),
+  resolutionNotice: ref<{ message: string } | undefined>(),
+  restoreMovement: vi.fn(async () => Promise.resolve()),
+  undoResolution: vi.fn(async () => Promise.resolve()),
+};
+
+vi.mock('@/modules/history/events/use-unmatched-asset-movements', () => ({
+  useUnmatchedAssetMovements: (): typeof movementsApi => movementsApi,
+}));
+
+vi.mock('@/modules/history/events/use-asset-movement-actions', () => ({
+  useAssetMovementActions: (): typeof actionsApi => actionsApi,
+}));
+
+const UnmatchedMovementsListStub = defineComponent({
+  emits: ['action', 'pin'],
+  name: 'UnmatchedMovementsList',
+  props: { movements: { default: () => [], type: Array } },
+  setup(_, { emit }): () => VNode {
+    return (): VNode => h('div', {
+      'data-testid': 'movements-list',
+      'onClick': () => emit('pin'),
+    });
+  },
+});
+
+const stubs = {
+  AssetMovementMatchingSettingsMenu: true,
+  UnmatchedMovementsList: UnmatchedMovementsListStub,
+  UnmatchedResolutionStrip: true,
+};
+
+const wrappers: VueWrapper[] = [];
+
+const movements = new Map<number, UnmatchedAssetMovement>();
+
+function movement(identifier: number): UnmatchedAssetMovement {
+  const existing = movements.get(identifier);
+  if (existing)
+    return existing;
+
+  const created = createMock<UnmatchedAssetMovement>({ identifier });
+  movements.set(identifier, created);
+  return created;
+}
+
+async function mountContent(props: Record<string, unknown> = {}): Promise<VueWrapper> {
+  const wrapper = mount(MatchAssetMovementsContent, { global: { stubs }, props });
+  wrappers.push(wrapper);
+  await flushPromises();
+  return wrapper;
+}
+
+function triggerAction(wrapper: VueWrapper, action: string, item: UnmatchedAssetMovement): void {
+  wrapper.findComponent(UnmatchedMovementsListStub).vm.$emit('action', { action, item });
+}
+
+describe('modules/history/events/MatchAssetMovementsContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(movementsApi.unmatchedMovements, []);
+    set(movementsApi.ignoredMovements, []);
+    set(actionsApi.resolutionNotice, undefined);
+    set(actionsApi.modelSelectedUnmatched, []);
+    set(actionsApi.modelSelectedIgnored, []);
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('what it does on mount', () => {
+    it('should refresh the unmatched movements, so the pane is never empty by default', async () => {
+      await mountContent();
+
+      expect(movementsApi.refreshUnmatchedAssetMovements).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('where each row action goes', () => {
+    it('should ask the parent to open the matcher rather than matching itself', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.FIND_MATCH, movement(1));
+
+      expect(wrapper.emitted('select')?.[0]).toEqual([movement(1)]);
+      expect(actionsApi.ignoreMovement).not.toHaveBeenCalled();
+    });
+
+    it('should ask the parent to show the row in events', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.SHOW_IN_EVENTS, movement(2));
+
+      expect(wrapper.emitted('show-in-events')?.[0]).toEqual([movement(2)]);
+    });
+
+    it('should ignore exactly the row the action carried', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.IGNORE, movement(3));
+
+      expect(actionsApi.ignoreMovement).toHaveBeenCalledExactlyOnceWith(movement(3));
+      expect(actionsApi.restoreMovement).not.toHaveBeenCalled();
+    });
+
+    it('should restore exactly the row the action carried', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.RESTORE, movement(4));
+
+      expect(actionsApi.restoreMovement).toHaveBeenCalledExactlyOnceWith(movement(4));
+      expect(actionsApi.ignoreMovement).not.toHaveBeenCalled();
+    });
+
+    it('should mark exactly the row the action carried as external', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.MARK_EXTERNAL, movement(5));
+
+      expect(actionsApi.markExternal).toHaveBeenCalledExactlyOnceWith(movement(5));
+    });
+
+    it('should do nothing for an action this pane does not offer', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.CREATE_COUNTERPART, movement(6));
+
+      expect(actionsApi.ignoreMovement).not.toHaveBeenCalled();
+      expect(actionsApi.restoreMovement).not.toHaveBeenCalled();
+      expect(actionsApi.markExternal).not.toHaveBeenCalled();
+      expect(wrapper.emitted('select')).toBeUndefined();
+      expect(wrapper.emitted('show-in-events')).toBeUndefined();
+    });
+  });
+
+  describe('what it forwards to its parent', () => {
+    it('should pass a pin request straight up', async () => {
+      const wrapper = await mountContent();
+
+      await wrapper.find('[data-testid="movements-list"]').trigger('click');
+
+      expect(wrapper.emitted('pin')).toHaveLength(1);
+    });
+  });
+
+  describe('the bulk actions', () => {
+    it('should confirm before ignoring the selection, rather than ignoring it outright', async () => {
+      set(actionsApi.modelSelectedUnmatched, [movement(1)]);
+      const wrapper = await mountContent();
+
+      await wrapper.find('[data-testid="ignore-selected"]').trigger('click');
+
+      expect(actionsApi.confirmIgnoreSelected).toHaveBeenCalledOnce();
+      expect(actionsApi.ignoreMovement).not.toHaveBeenCalled();
+    });
+
+    it('should offer nothing to ignore when the selection is empty', async () => {
+      const wrapper = await mountContent();
+
+      expect(wrapper.find('[data-testid="ignore-selected"]').attributes('disabled')).toBeDefined();
+    });
+
+    it('should offer nothing to ignore while auto-match is not allowed', async () => {
+      set(actionsApi.modelSelectedUnmatched, [movement(1)]);
+      set(movementsApi.isAutoMatchAllowed, false);
+      const wrapper = await mountContent();
+
+      expect(wrapper.find('[data-testid="ignore-selected"]').attributes('disabled')).toBeDefined();
+
+      set(movementsApi.isAutoMatchAllowed, true);
+    });
+
+    it('should confirm before ignoring every fiat movement', async () => {
+      set(actionsApi.fiatMovements, [movement(1)]);
+      const wrapper = await mountContent();
+
+      await wrapper.find('[data-testid="ignore-fiat"]').trigger('click');
+
+      expect(actionsApi.confirmIgnoreAllFiat).toHaveBeenCalledOnce();
+
+      set(actionsApi.fiatMovements, []);
+    });
+
+    it('should start auto-matching only when there is something to match', async () => {
+      const wrapper = await mountContent();
+      expect(wrapper.find('[data-testid="auto-match"]').attributes('disabled')).toBeDefined();
+
+      set(movementsApi.unmatchedMovements, [movement(1)]);
+      await nextTick();
+
+      await wrapper.find('[data-testid="auto-match"]').trigger('click');
+      expect(movementsApi.triggerAssetMovementAutoMatching).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('the ignored tab', () => {
+    it('should confirm before restoring the selection', async () => {
+      set(movementsApi.ignoredMovements, [movement(1)]);
+      set(actionsApi.modelSelectedIgnored, [movement(1)]);
+      const wrapper = await mountContent();
+
+      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:model-value', 1);
+      await nextTick();
+
+      await wrapper.find('[data-testid="restore-selected"]').trigger('click');
+
+      expect(actionsApi.confirmRestoreSelected).toHaveBeenCalledOnce();
+      expect(actionsApi.restoreMovement).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the pinned variant', () => {
+    it('should not offer a close button, having no dialog to close', async () => {
+      const wrapper = await mountContent({ isPinned: true });
+
+      expect(wrapper.find('[data-testid="close"]').exists()).toBe(false);
+    });
+
+    it('should offer one in the dialog', async () => {
+      const wrapper = await mountContent();
+
+      await wrapper.find('[data-testid="close"]').trigger('click');
+
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+  });
+
+  describe('the resolution notice', () => {
+    it('should stay hidden until something has been resolved', async () => {
+      const wrapper = await mountContent();
+
+      expect(wrapper.findComponent({ name: 'UnmatchedResolutionStrip' }).exists()).toBe(false);
+    });
+
+    it('should appear once a resolution is pending an undo', async () => {
+      set(actionsApi.resolutionNotice, { message: 'ignored 2 movements' });
+
+      const wrapper = await mountContent();
+
+      expect(wrapper.findComponent({ name: 'UnmatchedResolutionStrip' }).exists()).toBe(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsContent.vue
@@ -203,6 +203,7 @@ onBeforeMount(async () => {
         :class="{ 'h-[30px]': isPinned }"
         :disabled="!isAutoMatchAllowed || modelSelectedUnmatched.length === 0 || ignoreLoading"
         :loading="ignoreLoading"
+        data-testid="ignore-selected"
         @click="confirmIgnoreSelected()"
       >
         {{ t('asset_movement_matching.actions.ignore_selected') }}
@@ -229,6 +230,7 @@ onBeforeMount(async () => {
             :class="{ 'h-[30px]': isPinned }"
             :disabled="!isAutoMatchAllowed || fiatMovements.length === 0 || ignoreLoading"
             :loading="ignoreLoading"
+            data-testid="ignore-fiat"
             @click="confirmIgnoreAllFiat()"
           >
             {{ t('asset_movement_matching.actions.ignore_fiat') }}
@@ -254,6 +256,7 @@ onBeforeMount(async () => {
               :class="{ 'h-[30px] !px-3': isPinned }"
               :disabled="!isAutoMatchAllowed || unmatchedMovements.length === 0 || autoMatchLoading"
               :loading="autoMatchLoading"
+              data-testid="auto-match"
               @click="triggerAssetMovementAutoMatching()"
             >
               {{ t('asset_movement_matching.actions.auto_match') }}
@@ -278,6 +281,7 @@ onBeforeMount(async () => {
         :size="buttonSize"
         :disabled="!isAutoMatchAllowed || modelSelectedIgnored.length === 0 || ignoreLoading"
         :loading="ignoreLoading"
+        data-testid="restore-selected"
         @click="confirmRestoreSelected()"
       >
         {{ t('asset_movement_matching.actions.restore_selected') }}
@@ -294,6 +298,7 @@ onBeforeMount(async () => {
     <RuiButton
       v-if="!isPinned"
       variant="text"
+      data-testid="close"
       @click="emit('close')"
     >
       {{ t('common.actions.close') }}

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.spec.ts
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.spec.ts
@@ -1,0 +1,226 @@
+import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
+import { createMock } from '@test/utils/create-mock';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import MatchBridgeTransactionsContent from '@/modules/history/events/MatchBridgeTransactionsContent.vue';
+import { UNMATCHED_ACTIONS } from '@/modules/history/events/unmatched-actions';
+
+const transactionsApi = {
+  autoMatchLoading: ref<boolean>(false),
+  autoMatchMinimumTier: ref<string>('premium'),
+  ignoredLoading: ref<boolean>(false),
+  ignoredTransactions: ref<UnmatchedBridgeTransaction[]>([]),
+  isAutoMatchAllowed: ref<boolean>(true),
+  loading: ref<boolean>(false),
+  refreshUnmatchedBridgeTransactions: vi.fn(async () => Promise.resolve()),
+  triggerBridgeAutoMatching: vi.fn(),
+  unmatchedTransactions: ref<UnmatchedBridgeTransaction[]>([]),
+};
+
+const actionsApi = {
+  confirmCreateCounterpart: vi.fn(),
+  confirmIgnoreSelected: vi.fn(),
+  confirmRestoreSelected: vi.fn(),
+  dismissResolution: vi.fn(),
+  ignoreLoading: ref<boolean>(false),
+  ignoreTransaction: vi.fn(async () => Promise.resolve()),
+  markExternal: vi.fn(async () => Promise.resolve()),
+  modelSelectedIgnored: ref<UnmatchedBridgeTransaction[]>([]),
+  modelSelectedUnmatched: ref<UnmatchedBridgeTransaction[]>([]),
+  resolutionNotice: ref<{ message: string } | undefined>(),
+  restoreTransaction: vi.fn(async () => Promise.resolve()),
+  undoResolution: vi.fn(async () => Promise.resolve()),
+};
+
+vi.mock('@/modules/history/events/use-unmatched-bridge-transactions', () => ({
+  useUnmatchedBridgeTransactions: (): typeof transactionsApi => transactionsApi,
+}));
+
+vi.mock('@/modules/history/events/use-bridge-transaction-actions', () => ({
+  useBridgeTransactionActions: (): typeof actionsApi => actionsApi,
+}));
+
+const UnmatchedBridgesListStub = defineComponent({
+  emits: ['action', 'pin'],
+  name: 'UnmatchedBridgesList',
+  props: { transactions: { default: () => [], type: Array } },
+  setup(_, { emit }): () => VNode {
+    return (): VNode => h('div', {
+      'data-testid': 'bridges-list',
+      'onClick': () => emit('pin'),
+    });
+  },
+});
+
+const stubs = {
+  AssetMovementMatchingSettingsMenu: true,
+  UnmatchedBridgesList: UnmatchedBridgesListStub,
+  UnmatchedResolutionStrip: true,
+};
+
+const wrappers: VueWrapper[] = [];
+const transactions = new Map<number, UnmatchedBridgeTransaction>();
+
+function transaction(identifier: number): UnmatchedBridgeTransaction {
+  const existing = transactions.get(identifier);
+  if (existing)
+    return existing;
+
+  const created = createMock<UnmatchedBridgeTransaction>({ identifier });
+  transactions.set(identifier, created);
+  return created;
+}
+
+async function mountContent(props: Record<string, unknown> = {}): Promise<VueWrapper> {
+  const wrapper = mount(MatchBridgeTransactionsContent, { global: { stubs }, props });
+  wrappers.push(wrapper);
+  await flushPromises();
+  return wrapper;
+}
+
+function triggerAction(wrapper: VueWrapper, action: string, item: UnmatchedBridgeTransaction): void {
+  wrapper.findComponent(UnmatchedBridgesListStub).vm.$emit('action', { action, item });
+}
+
+describe('modules/history/events/MatchBridgeTransactionsContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(transactionsApi.unmatchedTransactions, []);
+    set(transactionsApi.ignoredTransactions, []);
+    set(transactionsApi.isAutoMatchAllowed, true);
+    set(actionsApi.resolutionNotice, undefined);
+    set(actionsApi.modelSelectedUnmatched, []);
+    set(actionsApi.modelSelectedIgnored, []);
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('what it does on mount', () => {
+    it('should refresh the unmatched transactions', async () => {
+      await mountContent();
+
+      expect(transactionsApi.refreshUnmatchedBridgeTransactions).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('where each row action goes', () => {
+    it('should ask the parent to open the matcher rather than matching itself', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.FIND_MATCH, transaction(1));
+
+      expect(wrapper.emitted('select')?.[0]).toEqual([transaction(1)]);
+    });
+
+    it('should ask the parent to show the row in events', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.SHOW_IN_EVENTS, transaction(2));
+
+      expect(wrapper.emitted('show-in-events')?.[0]).toEqual([transaction(2)]);
+    });
+
+    it('should ignore exactly the row the action carried', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.IGNORE, transaction(3));
+
+      expect(actionsApi.ignoreTransaction).toHaveBeenCalledExactlyOnceWith(transaction(3));
+      expect(actionsApi.restoreTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should restore exactly the row the action carried', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.RESTORE, transaction(4));
+
+      expect(actionsApi.restoreTransaction).toHaveBeenCalledExactlyOnceWith(transaction(4));
+      expect(actionsApi.ignoreTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should mark exactly the row the action carried as external', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.MARK_EXTERNAL, transaction(5));
+
+      expect(actionsApi.markExternal).toHaveBeenCalledExactlyOnceWith(transaction(5));
+    });
+
+    it('should confirm before creating a counterpart, unlike the asset movements pane', async () => {
+      const wrapper = await mountContent();
+
+      triggerAction(wrapper, UNMATCHED_ACTIONS.CREATE_COUNTERPART, transaction(6));
+
+      expect(actionsApi.confirmCreateCounterpart).toHaveBeenCalledExactlyOnceWith(transaction(6));
+    });
+  });
+
+  describe('the bulk actions', () => {
+    it('should confirm before ignoring the selection', async () => {
+      set(actionsApi.modelSelectedUnmatched, [transaction(1)]);
+      const wrapper = await mountContent();
+
+      await wrapper.find('[data-testid="ignore-selected"]').trigger('click');
+
+      expect(actionsApi.confirmIgnoreSelected).toHaveBeenCalledOnce();
+      expect(actionsApi.ignoreTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should hide the ignore button entirely when nothing is selected', async () => {
+      const wrapper = await mountContent();
+      expect(wrapper.find('[data-testid="ignore-selected"]').exists()).toBe(false);
+
+      set(actionsApi.modelSelectedUnmatched, [transaction(1)]);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid="ignore-selected"]').exists()).toBe(true);
+    });
+
+    it('should hide the restore button entirely when nothing is selected', async () => {
+      set(transactionsApi.ignoredTransactions, [transaction(1)]);
+      const wrapper = await mountContent();
+      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:model-value', 1);
+      await nextTick();
+      expect(wrapper.find('[data-testid="restore-selected"]').exists()).toBe(false);
+
+      set(actionsApi.modelSelectedIgnored, [transaction(1)]);
+      await nextTick();
+
+      expect(wrapper.find('[data-testid="restore-selected"]').exists()).toBe(true);
+    });
+
+    it('should start auto-matching only when there is something to match', async () => {
+      const wrapper = await mountContent();
+      expect(wrapper.find('[data-testid="auto-match"]').attributes('disabled')).toBeDefined();
+
+      set(transactionsApi.unmatchedTransactions, [transaction(1)]);
+      await nextTick();
+
+      await wrapper.find('[data-testid="auto-match"]').trigger('click');
+      expect(transactionsApi.triggerBridgeAutoMatching).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('what it forwards to its parent', () => {
+    it('should pass a pin request straight up', async () => {
+      const wrapper = await mountContent();
+
+      await wrapper.find('[data-testid="bridges-list"]').trigger('click');
+
+      expect(wrapper.emitted('pin')).toHaveLength(1);
+    });
+
+    it('should offer a close button only in the dialog', async () => {
+      const pinned = await mountContent({ isPinned: true });
+      expect(pinned.find('[data-testid="close"]').exists()).toBe(false);
+
+      const dialog = await mountContent();
+      await dialog.find('[data-testid="close"]').trigger('click');
+      expect(dialog.emitted('close')).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.vue
@@ -207,6 +207,7 @@ onBeforeMount(async () => {
         :class="{ 'h-[30px]': isPinned }"
         :disabled="ignoreLoading"
         :loading="ignoreLoading"
+        data-testid="ignore-selected"
         @click="confirmIgnoreSelected()"
       >
         {{ t('asset_movement_matching.actions.ignore_selected') }}
@@ -238,6 +239,7 @@ onBeforeMount(async () => {
               :class="{ 'h-[30px] !px-3': isPinned }"
               :disabled="!isAutoMatchAllowed || unmatchedTransactions.length === 0 || autoMatchLoading"
               :loading="autoMatchLoading"
+              data-testid="auto-match"
               @click="triggerBridgeAutoMatching()"
             >
               {{ t('asset_movement_matching.actions.auto_match') }}
@@ -263,6 +265,7 @@ onBeforeMount(async () => {
         :size="buttonSize"
         :disabled="ignoreLoading"
         :loading="ignoreLoading"
+        data-testid="restore-selected"
         @click="confirmRestoreSelected()"
       >
         {{ t('asset_movement_matching.actions.restore_selected') }}
@@ -279,6 +282,7 @@ onBeforeMount(async () => {
     <RuiButton
       v-if="!isPinned"
       variant="text"
+      data-testid="close"
       @click="emit('close')"
     >
       {{ t('common.actions.close') }}

--- a/frontend/app/src/modules/history/events/PotentialMatchesContent.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesContent.vue
@@ -1,16 +1,7 @@
 <script setup lang="ts">
-import type { MatchingFlow, MatchSuggestions, PotentialMatchRow, UnmatchedEventGroup } from '@/modules/history/events/matching/types';
-import type { HistoryEventCollectionRow } from '@/modules/history/events/schemas';
-import { bigNumberify } from '@rotki/common';
-import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
-import { logger } from '@/modules/core/common/logging/logging';
-import { getErrorMessage } from '@/modules/core/notifications/use-notifications';
-import { useAssetMovementMatchingApi } from '@/modules/history/api/events/use-asset-movement-matching-api';
-import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
-import { getEventEntryFromCollection } from '@/modules/history/event-utils';
+import type { MatchingFlow, UnmatchedEventGroup } from '@/modules/history/events/matching/types';
+import { usePotentialMatches } from '@/modules/history/events/matching/use-potential-matches';
 import PotentialMatchesList from '@/modules/history/events/PotentialMatchesList.vue';
-import { useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
-import { useAssetMovementSettings } from '@/modules/settings/use-asset-movement-settings';
 
 const { flow, isPinned, movement } = defineProps<{
   movement: UnmatchedEventGroup;
@@ -37,142 +28,28 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 const {
-  matchAssetMovement,
-  refreshUnmatchedAssetMovements,
-} = useUnmatchedAssetMovements();
+  confirmMatch,
+  matchingLoading,
+  modelOnlyExpectedAssets: onlyExpectedAssets,
+  modelSearchTimeRange: searchTimeRange,
+  modelSelectedMatchIds: selectedMatchIds,
+  modelTolerancePercentage: tolerancePercentage,
+  potentialMatches,
+  searchError,
+  searchLoading,
+  searchPotentialMatches,
+} = usePotentialMatches(() => movement, () => flow);
 
-const { fetchHistoryEvents } = useHistoryEventsApi();
-const { getAssetMovementMatches } = useAssetMovementMatchingApi();
-
-const { assetMovementAmountTolerance, assetMovementTimeRange } = useAssetMovementSettings();
-
-function getDefaultHourRange(): number {
-  return (flow?.defaultTimeRangeSeconds ?? get(assetMovementTimeRange)) / 3600;
-}
-
-function getDefaultTolerancePercentage(): string {
-  return bigNumberify(flow?.defaultTolerance ?? get(assetMovementAmountTolerance)).multipliedBy(100).toString();
-}
-
-const searchLoading = ref<boolean>(false);
-const matchingLoading = ref<boolean>(false);
-const searchError = ref<string>();
-const potentialMatches = ref<PotentialMatchRow[]>([]);
-const selectedMatchIds = ref<number[]>([]);
-const searchTimeRange = ref<string>(getDefaultHourRange().toString());
-const onlyExpectedAssets = ref<boolean>(true);
-const tolerancePercentage = ref<string>(getDefaultTolerancePercentage());
-
-// The tolerance is a free-text field, so a search started before it holds a number searches on the
-// default rather than on a parse that throws.
-function percentageToDecimal(percentage: string): string {
-  const value = parseNumericInput(percentage, bigNumberify(getDefaultTolerancePercentage()));
-  return value.dividedBy(100).toString();
-}
 const buttonSize = computed<'sm' | undefined>(() => isPinned ? 'sm' : undefined);
-
-function transformToMatchRow(row: HistoryEventCollectionRow, isCloseMatch: boolean): PotentialMatchRow {
-  const { entry, ...meta } = getEventEntryFromCollection(row);
-  const eventEntry = { ...entry, ...meta };
-  return {
-    entry: eventEntry,
-    identifier: eventEntry.identifier,
-    isCloseMatch,
-  };
-}
-
-async function searchPotentialMatches(): Promise<void> {
-  set(searchError, undefined);
-  set(potentialMatches, []);
-  set(searchLoading, true);
-
-  try {
-    const hours = Number.parseInt(get(searchTimeRange), 10) || getDefaultHourRange();
-    const timeRangeInSeconds = hours * 60 * 60;
-
-    const getSuggestions = flow?.getSuggestions
-      ?? (async (m: UnmatchedEventGroup, timeRange: number, onlyExpected: boolean, tolerance: string): Promise<MatchSuggestions> =>
-        getAssetMovementMatches(m.groupIdentifier, timeRange, onlyExpected, tolerance));
-    const suggestions = await getSuggestions(movement, timeRangeInSeconds, get(onlyExpectedAssets), percentageToDecimal(get(tolerancePercentage)));
-    const allIdentifiers = [...suggestions.closeMatches, ...suggestions.otherEvents];
-
-    if (allIdentifiers.length === 0) {
-      set(potentialMatches, []);
-      return;
-    }
-
-    const response = await fetchHistoryEvents({
-      aggregateByGroupIds: false,
-      identifiers: allIdentifiers.map(String),
-      limit: -1,
-      offset: 0,
-    });
-
-    const closeMatchSet = new Set(suggestions.closeMatches);
-    const matches = response.entries
-      .map(row => transformToMatchRow(row, closeMatchSet.has(getEventEntryFromCollection(row).entry.identifier)));
-
-    const identifierOrderMap = new Map(allIdentifiers.map((id, index) => [id, index]));
-    matches.sort((a, b) => {
-      const orderA = identifierOrderMap.get(a.entry.identifier) ?? Number.MAX_SAFE_INTEGER;
-      const orderB = identifierOrderMap.get(b.entry.identifier) ?? Number.MAX_SAFE_INTEGER;
-      return orderA - orderB;
-    });
-
-    set(potentialMatches, matches);
-  }
-  catch (error) {
-    logger.error('Failed to search potential matches:', error);
-    set(searchError, t('asset_movement_matching.dialog.search_error', { error: getErrorMessage(error) }));
-  }
-  finally {
-    set(searchLoading, false);
-  }
-}
-
-async function confirmMatch(): Promise<void> {
-  const matchIds = get(selectedMatchIds);
-
-  if (matchIds.length === 0)
-    return;
-
-  set(matchingLoading, true);
-
-  try {
-    const unmatchedId = movement.identifier ?? getEventEntryFromCollection(movement.events).entry.identifier;
-
-    if (!unmatchedId)
-      return;
-
-    const result = flow
-      ? await flow.match(unmatchedId, matchIds)
-      : await matchAssetMovement(unmatchedId, matchIds);
-
-    if (result.success) {
-      if (flow)
-        await flow.refresh(true);
-      else
-        await refreshUnmatchedAssetMovements(true);
-      emit('matched');
-    }
-  }
-  finally {
-    set(matchingLoading, false);
-  }
-}
 
 function close(): void {
   emit('close');
 }
 
-watchImmediate(() => movement, async () => {
-  set(potentialMatches, []);
-  set(selectedMatchIds, []);
-  set(searchTimeRange, getDefaultHourRange().toString());
-  set(onlyExpectedAssets, true);
-  set(tolerancePercentage, getDefaultTolerancePercentage());
-  await searchPotentialMatches();
-});
+async function onConfirm(): Promise<void> {
+  if (await confirmMatch())
+    emit('matched');
+}
 </script>
 
 <template>
@@ -216,7 +93,7 @@ watchImmediate(() => movement, async () => {
         :size="buttonSize"
         :disabled="selectedMatchIds.length === 0"
         :loading="matchingLoading"
-        @click="confirmMatch()"
+        @click="onConfirm()"
       >
         {{ t('asset_movement_matching.dialog.confirm_match') }}
         <RuiChip

--- a/frontend/app/src/modules/history/events/matching/use-potential-matches.spec.ts
+++ b/frontend/app/src/modules/history/events/matching/use-potential-matches.spec.ts
@@ -1,0 +1,360 @@
+import type { MatchingFlow, MatchSuggestions, UnmatchedEventGroup } from './types';
+import { createOnlineHistoryEvent } from '@test/utils/history-events';
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, ref } from 'vue';
+import { HistoryEventAccountingRuleStatus, type HistoryEventEntryWithMeta } from '@/modules/history/events/schemas';
+import { usePotentialMatches } from './use-potential-matches';
+
+const {
+  assetMovementAmountTolerance,
+  assetMovementTimeRange,
+  fetchHistoryEvents,
+  getAssetMovementMatches,
+  matchAssetMovement,
+  refreshUnmatchedAssetMovements,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    assetMovementAmountTolerance: ref<string>('0.05'),
+    assetMovementTimeRange: ref<number>(7200),
+    fetchHistoryEvents: vi.fn(),
+    getAssetMovementMatches: vi.fn(),
+    matchAssetMovement: vi.fn(),
+    refreshUnmatchedAssetMovements: vi.fn(),
+  };
+});
+
+vi.mock('@/modules/history/events/use-unmatched-asset-movements', () => ({
+  useUnmatchedAssetMovements: (): Record<string, unknown> => ({
+    matchAssetMovement,
+    refreshUnmatchedAssetMovements,
+  }),
+}));
+
+vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
+  useHistoryEventsApi: (): Record<string, unknown> => ({ fetchHistoryEvents }),
+}));
+
+vi.mock('@/modules/history/api/events/use-asset-movement-matching-api', () => ({
+  useAssetMovementMatchingApi: (): Record<string, unknown> => ({ getAssetMovementMatches }),
+}));
+
+vi.mock('@/modules/settings/use-asset-movement-settings', () => ({
+  useAssetMovementSettings: (): Record<string, unknown> => ({
+    assetMovementAmountTolerance,
+    assetMovementTimeRange,
+  }),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  getDefaultLogLevel: vi.fn(() => 'debug'),
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  setLevel: vi.fn(),
+}));
+
+let scope: ReturnType<typeof effectScope>;
+
+function withMeta(identifier: number): HistoryEventEntryWithMeta {
+  return {
+    entry: createOnlineHistoryEvent({ identifier }),
+    eventAccountingRuleStatus: HistoryEventAccountingRuleStatus.PROCESSED,
+    ignoredInAccounting: false,
+  };
+}
+
+function group(overrides: Partial<UnmatchedEventGroup> = {}): UnmatchedEventGroup {
+  return {
+    asset: 'ETH',
+    events: withMeta(10),
+    groupIdentifier: 'group-a',
+    identifier: 42,
+    ...overrides,
+  };
+}
+
+function suggestions(closeMatches: number[], otherEvents: number[] = []): MatchSuggestions {
+  return { closeMatches, otherEvents };
+}
+
+function matchingFlow(overrides: Partial<MatchingFlow> = {}): MatchingFlow {
+  return {
+    getSuggestions: vi.fn<MatchingFlow['getSuggestions']>(async () => Promise.resolve(suggestions([]))),
+    match: vi.fn<MatchingFlow['match']>(async () => Promise.resolve({ success: true })),
+    refresh: vi.fn<MatchingFlow['refresh']>(async () => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+async function matches(
+  movement: UnmatchedEventGroup | (() => UnmatchedEventGroup) = group(),
+  flow?: MatchingFlow,
+): Promise<ReturnType<typeof usePotentialMatches>> {
+  scope = effectScope();
+  const api = scope.run(() => usePotentialMatches(movement, flow))!;
+  await flushPromises();
+  return api;
+}
+
+describe('modules/history/events/matching/usePotentialMatches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAssetMovementMatches.mockResolvedValue(suggestions([]));
+    fetchHistoryEvents.mockResolvedValue({ entries: [], entriesFound: 0, entriesLimit: -1, entriesTotal: 0 });
+    matchAssetMovement.mockResolvedValue({ success: true });
+    refreshUnmatchedAssetMovements.mockResolvedValue(undefined);
+    set(assetMovementTimeRange, 7200);
+    set(assetMovementAmountTolerance, '0.05');
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the filters it starts from', () => {
+    it('should pre-fill the settings when no flow overrides them', async () => {
+      const { modelSearchTimeRange, modelTolerancePercentage } = await matches();
+
+      expect(get(modelSearchTimeRange)).toBe('2');
+      expect(get(modelTolerancePercentage)).toBe('5');
+    });
+
+    it('should prefer the flow defaults, so a bridge does not search on movement settings', async () => {
+      const flow = matchingFlow({ defaultTimeRangeSeconds: 86400, defaultTolerance: '0.1' });
+
+      const { modelSearchTimeRange, modelTolerancePercentage } = await matches(group(), flow);
+
+      expect(get(modelSearchTimeRange)).toBe('24');
+      expect(get(modelTolerancePercentage)).toBe('10');
+    });
+  });
+
+  describe('searching', () => {
+    it('should search as soon as it is given a group', async () => {
+      await matches();
+
+      expect(getAssetMovementMatches).toHaveBeenCalledExactlyOnceWith('group-a', 7200, true, '0.05');
+    });
+
+    it('should send the flow the group itself, not just its identifier', async () => {
+      const flow = matchingFlow();
+      const movement = group();
+
+      await matches(movement, flow);
+
+      expect(flow.getSuggestions).toHaveBeenCalledExactlyOnceWith(movement, 7200, true, '0.05');
+      expect(getAssetMovementMatches).not.toHaveBeenCalled();
+    });
+
+    it('should convert the typed hours and percentage to the units the backend takes', async () => {
+      const { modelSearchTimeRange, modelTolerancePercentage, searchPotentialMatches } = await matches();
+      getAssetMovementMatches.mockClear();
+
+      set(modelSearchTimeRange, '3');
+      set(modelTolerancePercentage, '2.5');
+      await searchPotentialMatches();
+
+      expect(getAssetMovementMatches).toHaveBeenCalledWith('group-a', 10800, true, '0.025');
+    });
+
+    it('should fall back to the default window when the range is not a number', async () => {
+      const { modelSearchTimeRange, searchPotentialMatches } = await matches();
+      getAssetMovementMatches.mockClear();
+
+      set(modelSearchTimeRange, '');
+      await searchPotentialMatches();
+
+      expect(getAssetMovementMatches).toHaveBeenCalledWith('group-a', 7200, true, '0.05');
+    });
+
+    it('should fall back to the default tolerance when it is not a number', async () => {
+      const { modelTolerancePercentage, searchPotentialMatches } = await matches();
+      getAssetMovementMatches.mockClear();
+
+      set(modelTolerancePercentage, 'abc');
+      await searchPotentialMatches();
+
+      expect(getAssetMovementMatches).toHaveBeenCalledWith('group-a', 7200, true, '0.05');
+    });
+
+    it('should fetch nothing further when there is nothing to match against', async () => {
+      const { potentialMatches } = await matches();
+
+      expect(fetchHistoryEvents).not.toHaveBeenCalled();
+      expect(get(potentialMatches)).toEqual([]);
+    });
+
+    it('should fetch every suggested event in one request', async () => {
+      getAssetMovementMatches.mockResolvedValue(suggestions([2], [3, 4]));
+
+      await matches();
+
+      expect(fetchHistoryEvents).toHaveBeenCalledExactlyOnceWith({
+        aggregateByGroupIds: false,
+        identifiers: ['2', '3', '4'],
+        limit: -1,
+        offset: 0,
+      });
+    });
+
+    it('should mark only the close matches as such', async () => {
+      getAssetMovementMatches.mockResolvedValue(suggestions([2], [3]));
+      fetchHistoryEvents.mockResolvedValue({ entries: [withMeta(2), withMeta(3)] });
+
+      const { potentialMatches } = await matches();
+
+      expect(get(potentialMatches).map(row => [row.identifier, row.isCloseMatch])).toEqual([[2, true], [3, false]]);
+    });
+
+    it('should keep the suggested order, which the fetch does not preserve', async () => {
+      getAssetMovementMatches.mockResolvedValue(suggestions([7], [3, 5]));
+      fetchHistoryEvents.mockResolvedValue({ entries: [withMeta(5), withMeta(3), withMeta(7)] });
+
+      const { potentialMatches } = await matches();
+
+      expect(get(potentialMatches).map(row => row.identifier)).toEqual([7, 3, 5]);
+    });
+
+    it('should push an event the backend returned unasked to the end, rather than dropping it', async () => {
+      getAssetMovementMatches.mockResolvedValue(suggestions([7], [3]));
+      fetchHistoryEvents.mockResolvedValue({ entries: [withMeta(99), withMeta(98), withMeta(3), withMeta(7)] });
+
+      const { potentialMatches } = await matches();
+
+      expect(get(potentialMatches).map(row => row.identifier)).toEqual([7, 3, 99, 98]);
+    });
+
+    it('should report the failure instead of leaving the pane spinning', async () => {
+      getAssetMovementMatches.mockRejectedValue(new Error('backend down'));
+
+      const { potentialMatches, searchError, searchLoading } = await matches();
+
+      expect(get(searchError)).toContain('asset_movement_matching.dialog.search_error');
+      expect(get(potentialMatches)).toEqual([]);
+      expect(get(searchLoading)).toBe(false);
+    });
+
+    it('should clear a previous failure when searching again', async () => {
+      getAssetMovementMatches.mockRejectedValueOnce(new Error('backend down'));
+      const { searchError, searchPotentialMatches } = await matches();
+
+      await searchPotentialMatches();
+
+      expect(get(searchError)).toBeUndefined();
+    });
+  });
+
+  describe('when the group changes', () => {
+    it('should search the new group and drop the previous selection', async () => {
+      const movement = ref<UnmatchedEventGroup>(group());
+      const { modelSelectedMatchIds } = await matches(() => get(movement));
+      set(modelSelectedMatchIds, [2]);
+
+      set(movement, group({ groupIdentifier: 'group-b' }));
+      await flushPromises();
+
+      expect(get(modelSelectedMatchIds)).toEqual([]);
+      expect(getAssetMovementMatches).toHaveBeenLastCalledWith('group-b', 7200, true, '0.05');
+    });
+
+    it('should drop the previous candidates, so one group never shows another\'s', async () => {
+      getAssetMovementMatches.mockResolvedValueOnce(suggestions([2]));
+      fetchHistoryEvents.mockResolvedValueOnce({ entries: [withMeta(2)] });
+      const movement = ref<UnmatchedEventGroup>(group());
+      const { potentialMatches } = await matches(() => get(movement));
+
+      set(movement, group({ groupIdentifier: 'group-b' }));
+      await flushPromises();
+
+      expect(get(potentialMatches)).toEqual([]);
+    });
+
+    it('should reset filters the user had narrowed', async () => {
+      const movement = ref<UnmatchedEventGroup>(group());
+      const { modelOnlyExpectedAssets, modelSearchTimeRange } = await matches(() => get(movement));
+      set(modelSearchTimeRange, '48');
+      set(modelOnlyExpectedAssets, false);
+
+      set(movement, group({ groupIdentifier: 'group-b' }));
+      await flushPromises();
+
+      expect(get(modelSearchTimeRange)).toBe('2');
+      expect(get(modelOnlyExpectedAssets)).toBe(true);
+    });
+  });
+
+  describe('confirming a match', () => {
+    it('should match the selected events against the group', async () => {
+      const { confirmMatch, modelSelectedMatchIds } = await matches();
+      set(modelSelectedMatchIds, [2, 3]);
+
+      const matched = await confirmMatch();
+
+      expect(matchAssetMovement).toHaveBeenCalledExactlyOnceWith(42, [2, 3]);
+      expect(refreshUnmatchedAssetMovements).toHaveBeenCalledExactlyOnceWith(true);
+      expect(matched).toBe(true);
+    });
+
+    it('should route through the flow when there is one', async () => {
+      const flow = matchingFlow();
+      const { confirmMatch, modelSelectedMatchIds } = await matches(group(), flow);
+      set(modelSelectedMatchIds, [2]);
+
+      await confirmMatch();
+
+      expect(flow.match).toHaveBeenCalledExactlyOnceWith(42, [2]);
+      expect(flow.refresh).toHaveBeenCalledExactlyOnceWith(true);
+      expect(matchAssetMovement).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the first event when the group names no identifier', async () => {
+      const { confirmMatch, modelSelectedMatchIds } = await matches(group({ identifier: undefined }));
+      set(modelSelectedMatchIds, [2]);
+
+      await confirmMatch();
+
+      expect(matchAssetMovement).toHaveBeenCalledWith(10, [2]);
+    });
+
+    it('should refuse to match a group whose event has no identifier yet', async () => {
+      const events = { ...withMeta(0), entry: createOnlineHistoryEvent({ identifier: 0 }) };
+      const { confirmMatch, modelSelectedMatchIds } = await matches(group({ events, identifier: undefined }));
+      set(modelSelectedMatchIds, [2]);
+
+      const matched = await confirmMatch();
+
+      expect(matchAssetMovement).not.toHaveBeenCalled();
+      expect(matched).toBe(false);
+    });
+
+    it('should do nothing when nothing is selected', async () => {
+      const { confirmMatch } = await matches();
+
+      const matched = await confirmMatch();
+
+      expect(matchAssetMovement).not.toHaveBeenCalled();
+      expect(matched).toBe(false);
+    });
+
+    it('should not refresh when the backend rejected the match', async () => {
+      matchAssetMovement.mockResolvedValue({ message: 'nope', success: false });
+      const { confirmMatch, modelSelectedMatchIds } = await matches();
+      set(modelSelectedMatchIds, [2]);
+
+      const matched = await confirmMatch();
+
+      expect(refreshUnmatchedAssetMovements).not.toHaveBeenCalled();
+      expect(matched).toBe(false);
+    });
+
+    it('should stop showing progress even when the match throws', async () => {
+      matchAssetMovement.mockRejectedValue(new Error('boom'));
+      const { confirmMatch, matchingLoading, modelSelectedMatchIds } = await matches();
+      set(modelSelectedMatchIds, [2]);
+
+      await expect(confirmMatch()).rejects.toThrow('boom');
+
+      expect(get(matchingLoading)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/matching/use-potential-matches.ts
+++ b/frontend/app/src/modules/history/events/matching/use-potential-matches.ts
@@ -1,0 +1,207 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { MatchingFlow, MatchSuggestions, PotentialMatchRow, UnmatchedEventGroup } from './types';
+import type { HistoryEventCollectionRow } from '@/modules/history/events/schemas';
+import { bigNumberify } from '@rotki/common';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
+import { logger } from '@/modules/core/common/logging/logging';
+import { getErrorMessage } from '@/modules/core/notifications/use-notifications';
+import { useAssetMovementMatchingApi } from '@/modules/history/api/events/use-asset-movement-matching-api';
+import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { getEventEntryFromCollection } from '@/modules/history/event-utils';
+import { useUnmatchedAssetMovements } from '@/modules/history/events/use-unmatched-asset-movements';
+import { useAssetMovementSettings } from '@/modules/settings/use-asset-movement-settings';
+
+interface UsePotentialMatchesReturn {
+  /**
+   * Runs the match, then refreshes the unmatched list.
+   *
+   * @returns whether events were matched, so the caller only announces a real change
+   */
+  confirmMatch: () => Promise<boolean>;
+  /** True while a match is being written. */
+  matchingLoading: Readonly<Ref<boolean>>;
+  /** Restrict the search to assets the unmatched entry could plausibly pair with. */
+  modelOnlyExpectedAssets: Ref<boolean>;
+  /** The identifiers the user picked to match against. */
+  modelSelectedMatchIds: Ref<number[]>;
+  /** The search window in hours, as typed. */
+  modelSearchTimeRange: Ref<string>;
+  /** The amount tolerance as a percentage, as typed. */
+  modelTolerancePercentage: Ref<string>;
+  /** Candidate events for the current search, close matches first. */
+  potentialMatches: Readonly<Ref<PotentialMatchRow[]>>;
+  /** Message describing why the last search failed, if it did. */
+  searchError: Readonly<Ref<string | undefined>>;
+  /** True while candidates are being fetched. */
+  searchLoading: Readonly<Ref<boolean>>;
+  /** Fetches candidates for the current filters. */
+  searchPotentialMatches: () => Promise<void>;
+}
+
+/**
+ * Drives the potential-matches pane: the search filters, the candidates they return, and writing
+ * the chosen match.
+ *
+ * @remarks
+ * Searches whenever the group changes, resetting the filters to the flow's defaults first, so the
+ * pane never shows one group's candidates against another's filters.
+ *
+ * @param movement - the unmatched group being matched
+ * @param flow - the backend calls and defaults to use; omitted means asset movements
+ * @returns the pane's bindings; the `model`-prefixed refs are the filter inputs
+ */
+export function usePotentialMatches(
+  movement: MaybeRefOrGetter<UnmatchedEventGroup>,
+  flow?: MaybeRefOrGetter<MatchingFlow | undefined>,
+): UsePotentialMatchesReturn {
+  const searchLoading = shallowRef<boolean>(false);
+  const matchingLoading = shallowRef<boolean>(false);
+  const searchError = ref<string>();
+  const potentialMatches = ref<PotentialMatchRow[]>([]);
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { matchAssetMovement, refreshUnmatchedAssetMovements } = useUnmatchedAssetMovements();
+  const { fetchHistoryEvents } = useHistoryEventsApi();
+  const { getAssetMovementMatches } = useAssetMovementMatchingApi();
+  const { assetMovementAmountTolerance, assetMovementTimeRange } = useAssetMovementSettings();
+
+  function getDefaultHourRange(): number {
+    return (toValue(flow)?.defaultTimeRangeSeconds ?? get(assetMovementTimeRange)) / 3600;
+  }
+
+  function getDefaultTolerancePercentage(): string {
+    return bigNumberify(toValue(flow)?.defaultTolerance ?? get(assetMovementAmountTolerance))
+      .multipliedBy(100)
+      .toString();
+  }
+
+  const modelSelectedMatchIds = ref<number[]>([]);
+  const modelSearchTimeRange = ref<string>(getDefaultHourRange().toString());
+  const modelOnlyExpectedAssets = shallowRef<boolean>(true);
+  const modelTolerancePercentage = ref<string>(getDefaultTolerancePercentage());
+
+  function percentageToDecimal(percentage: string): string {
+    const value = parseNumericInput(percentage, bigNumberify(getDefaultTolerancePercentage()));
+    return value.dividedBy(100).toString();
+  }
+
+  function transformToMatchRow(row: HistoryEventCollectionRow, isCloseMatch: boolean): PotentialMatchRow {
+    const { entry, ...meta } = getEventEntryFromCollection(row);
+    const eventEntry = { ...entry, ...meta };
+    return {
+      entry: eventEntry,
+      identifier: eventEntry.identifier,
+      isCloseMatch,
+    };
+  }
+
+  async function searchPotentialMatches(): Promise<void> {
+    set(searchError, undefined);
+    set(potentialMatches, []);
+    set(searchLoading, true);
+
+    try {
+      const hours = Number.parseInt(get(modelSearchTimeRange), 10) || getDefaultHourRange();
+      const timeRangeInSeconds = hours * 60 * 60;
+
+      const group = toValue(movement);
+      const getSuggestions = toValue(flow)?.getSuggestions
+        ?? (async (m: UnmatchedEventGroup, timeRange: number, onlyExpected: boolean, tolerance: string): Promise<MatchSuggestions> =>
+          getAssetMovementMatches(m.groupIdentifier, timeRange, onlyExpected, tolerance));
+      const suggestions = await getSuggestions(
+        group,
+        timeRangeInSeconds,
+        get(modelOnlyExpectedAssets),
+        percentageToDecimal(get(modelTolerancePercentage)),
+      );
+      const allIdentifiers = [...suggestions.closeMatches, ...suggestions.otherEvents];
+
+      if (allIdentifiers.length === 0)
+        return;
+
+      const response = await fetchHistoryEvents({
+        aggregateByGroupIds: false,
+        identifiers: allIdentifiers.map(String),
+        limit: -1,
+        offset: 0,
+      });
+
+      const closeMatchSet = new Set(suggestions.closeMatches);
+      const matches = response.entries
+        .map(row => transformToMatchRow(row, closeMatchSet.has(getEventEntryFromCollection(row).entry.identifier)));
+
+      const identifierOrderMap = new Map(allIdentifiers.map((id, index) => [id, index]));
+      matches.sort((a, b) => {
+        const orderA = identifierOrderMap.get(a.entry.identifier) ?? Number.MAX_SAFE_INTEGER;
+        const orderB = identifierOrderMap.get(b.entry.identifier) ?? Number.MAX_SAFE_INTEGER;
+        return orderA - orderB;
+      });
+
+      set(potentialMatches, matches);
+    }
+    catch (error) {
+      logger.error('Failed to search potential matches:', error);
+      set(searchError, t('asset_movement_matching.dialog.search_error', { error: getErrorMessage(error) }));
+    }
+    finally {
+      set(searchLoading, false);
+    }
+  }
+
+  async function confirmMatch(): Promise<boolean> {
+    const matchIds = get(modelSelectedMatchIds);
+
+    if (matchIds.length === 0)
+      return false;
+
+    set(matchingLoading, true);
+
+    try {
+      const group = toValue(movement);
+      const unmatchedId = group.identifier ?? getEventEntryFromCollection(group.events).entry.identifier;
+
+      if (!unmatchedId)
+        return false;
+
+      const selectedFlow = toValue(flow);
+      const result = selectedFlow
+        ? await selectedFlow.match(unmatchedId, matchIds)
+        : await matchAssetMovement(unmatchedId, matchIds);
+
+      if (!result.success)
+        return false;
+
+      if (selectedFlow)
+        await selectedFlow.refresh(true);
+      else
+        await refreshUnmatchedAssetMovements(true);
+
+      return true;
+    }
+    finally {
+      set(matchingLoading, false);
+    }
+  }
+
+  watchImmediate(() => toValue(movement), async () => {
+    set(potentialMatches, []);
+    set(modelSelectedMatchIds, []);
+    set(modelSearchTimeRange, getDefaultHourRange().toString());
+    set(modelOnlyExpectedAssets, true);
+    set(modelTolerancePercentage, getDefaultTolerancePercentage());
+    await searchPotentialMatches();
+  });
+
+  return {
+    confirmMatch,
+    matchingLoading: readonly(matchingLoading),
+    modelOnlyExpectedAssets,
+    modelSearchTimeRange,
+    modelSelectedMatchIds,
+    modelTolerancePercentage,
+    potentialMatches: shallowReadonly(potentialMatches),
+    searchError: readonly(searchError),
+    searchLoading: readonly(searchLoading),
+    searchPotentialMatches,
+  };
+}

--- a/frontend/app/src/modules/history/events/prices/EventAssetPriceUpdateDialog.vue
+++ b/frontend/app/src/modules/history/events/prices/EventAssetPriceUpdateDialog.vue
@@ -1,15 +1,8 @@
 <script setup lang="ts">
-import type { OraclePriceEntry } from '@/modules/assets/prices/price-types';
 import type { EventPriceUpdatePayload } from '@/modules/history/events/prices/use-event-price-update-trigger';
-import { type BigNumber, toSentenceCase } from '@rotki/common';
-import { startPromise } from '@shared/utils';
+import { toSentenceCase } from '@rotki/common';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
-import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { logger } from '@/modules/core/common/logging/logging';
-import { useNotifications } from '@/modules/core/notifications/use-notifications';
-import { type EventPriceUpdateMode, useEventPriceUpdate } from '@/modules/history/events/prices/use-event-price-update';
-import { PriceOracle } from '@/modules/settings/types/price-oracle';
+import { useEventPriceUpdateDialog } from '@/modules/history/events/prices/use-event-price-update-dialog';
 import { useSetting } from '@/modules/settings/use-setting';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
@@ -18,119 +11,21 @@ import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 const modelValue = defineModel<EventPriceUpdatePayload | undefined>({ required: true });
 
 const { t } = useI18n({ useScope: 'global' });
-const { notifyError, notifyInfo } = useNotifications();
 const currencySymbol = useSetting('currencySymbol');
-const { fetchExistingEntry, updatePrice } = useEventPriceUpdate();
 
-const price = ref<string>('');
-const mode = ref<EventPriceUpdateMode>('manual');
-const existingEntry = ref<OraclePriceEntry>();
-const loading = ref<boolean>(false);
-const saving = ref<boolean>(false);
-
-const open = computed<boolean>(() => modelValue.value !== undefined);
-
-function close(): void {
-  set(modelValue, undefined);
-}
-
-const existingIsManual = computed<boolean>(() => get(existingEntry)?.sourceType === PriceOracle.MANUAL);
-const showModeChoice = computed<boolean>(() => Boolean(get(existingEntry)) && !get(existingIsManual));
-
-const parsedPrice = computed<BigNumber | undefined>(() => parseNumericInput(get(price).trim()));
-
-const priceValid = computed<boolean>(() => {
-  const parsed = get(parsedPrice);
-  return parsed !== undefined && parsed.isGreaterThan(0);
-});
-
-const priceErrors = computed<string[]>(() => {
-  const value = get(price).trim();
-  if (!value || get(priceValid))
-    return [];
-  return [t('event_asset_price_update.price_error')];
-});
-
-async function load(payload: EventPriceUpdatePayload): Promise<void> {
-  set(loading, true);
-  set(existingEntry, undefined);
-  set(price, '');
-  try {
-    const quote = get(currencySymbol);
-    const entry = await fetchExistingEntry(payload.asset, quote, payload.timestamp);
-    set(existingEntry, entry);
-    if (entry) {
-      set(price, entry.price.toFixed());
-      set(mode, entry.sourceType === PriceOracle.MANUAL ? 'manual' : 'oracle');
-    }
-    else {
-      set(mode, 'manual');
-    }
-  }
-  catch (error: unknown) {
-    logger.error('Failed to load existing oracle price entry:', error);
-    notifyError(
-      t('event_asset_price_update.fetch_error.title'),
-      t('event_asset_price_update.fetch_error.description', { error: getErrorMessage(error) }),
-    );
-  }
-  finally {
-    set(loading, false);
-  }
-}
-
-async function save(): Promise<void> {
-  const payload = get(modelValue);
-  if (!payload)
-    return;
-
-  const parsed = get(parsedPrice);
-  if (!parsed)
-    return;
-
-  const entry = get(existingEntry);
-  const nextPrice = get(price).trim();
-  const selectedMode = get(mode);
-  const unchanged = entry
-    && parsed.isEqualTo(entry.price)
-    && (selectedMode === 'oracle' || entry.sourceType === PriceOracle.MANUAL);
-  if (unchanged) {
-    close();
-    return;
-  }
-
-  set(saving, true);
-  try {
-    await updatePrice({
-      existingEntry: entry,
-      fromAsset: payload.asset,
-      mode: selectedMode,
-      price: nextPrice,
-      timestampMs: payload.timestamp,
-      toAsset: get(currencySymbol),
-    });
-    notifyInfo(
-      t('event_asset_price_update.success.title'),
-      t('event_asset_price_update.success.description'),
-    );
-    set(modelValue, undefined);
-  }
-  catch (error: unknown) {
-    logger.error('Failed to update event price:', error);
-    notifyError(
-      t('event_asset_price_update.save_error.title'),
-      t('event_asset_price_update.save_error.description', { error: getErrorMessage(error) }),
-    );
-  }
-  finally {
-    set(saving, false);
-  }
-}
-
-watch(modelValue, (payload) => {
-  if (payload)
-    startPromise(load(payload));
-}, { immediate: true });
+const {
+  close,
+  existingEntry,
+  loading,
+  modelMode: mode,
+  modelPrice: price,
+  open,
+  priceErrors,
+  priceValid,
+  save,
+  saving,
+  showModeChoice,
+} = useEventPriceUpdateDialog(modelValue);
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/events/prices/use-event-price-update-dialog.spec.ts
+++ b/frontend/app/src/modules/history/events/prices/use-event-price-update-dialog.spec.ts
@@ -1,0 +1,266 @@
+import type { OraclePriceEntry } from '@/modules/assets/prices/price-types';
+import type { EventPriceUpdatePayload } from '@/modules/history/events/prices/use-event-price-update-trigger';
+import { bigNumberify } from '@rotki/common';
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, ref, type Ref } from 'vue';
+import { PriceOracle } from '@/modules/settings/types/price-oracle';
+import { useEventPriceUpdateDialog } from './use-event-price-update-dialog';
+
+const { currencySymbol, fetchExistingEntry, notifyError, notifyInfo, updatePrice } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    currencySymbol: ref<string>('USD'),
+    fetchExistingEntry: vi.fn(),
+    notifyError: vi.fn(),
+    notifyInfo: vi.fn(),
+    updatePrice: vi.fn(),
+  };
+});
+
+vi.mock('@/modules/history/events/prices/use-event-price-update', () => ({
+  useEventPriceUpdate: (): Record<string, unknown> => ({ fetchExistingEntry, updatePrice }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notifications', () => ({
+  useNotifications: (): Record<string, unknown> => ({ notifyError, notifyInfo }),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (): typeof currencySymbol => currencySymbol,
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  getDefaultLogLevel: vi.fn(() => 'debug'),
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  setLevel: vi.fn(),
+}));
+
+let scope: ReturnType<typeof effectScope>;
+
+function oracleEntry(overrides: Partial<OraclePriceEntry> = {}): OraclePriceEntry {
+  return {
+    fromAsset: 'ETH',
+    price: bigNumberify(1500),
+    sourceType: 'cryptocompare',
+    timestamp: 1700000000,
+    toAsset: 'USD',
+    ...overrides,
+  };
+}
+
+function payload(): EventPriceUpdatePayload {
+  return { asset: 'ETH', timestamp: 1700000000 };
+}
+
+async function dialog(
+  model: Ref<EventPriceUpdatePayload | undefined>,
+): Promise<ReturnType<typeof useEventPriceUpdateDialog>> {
+  scope = effectScope();
+  const api = scope.run(() => useEventPriceUpdateDialog(model))!;
+  await flushPromises();
+  return api;
+}
+
+describe('modules/history/events/prices/useEventPriceUpdateDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchExistingEntry.mockResolvedValue(undefined);
+    updatePrice.mockResolvedValue(undefined);
+    set(currencySymbol, 'USD');
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('opening on an event', () => {
+    it('should read whatever price is already recorded', async () => {
+      fetchExistingEntry.mockResolvedValue(oracleEntry());
+
+      const { existingEntry, modelPrice } = await dialog(ref(payload()));
+
+      expect(fetchExistingEntry).toHaveBeenCalledExactlyOnceWith('ETH', 'USD', 1700000000);
+      expect(get(existingEntry)?.sourceType).toBe('cryptocompare');
+      expect(get(modelPrice)).toBe('1500');
+    });
+
+    it('should default to overwriting the oracle when the recorded price came from one', async () => {
+      fetchExistingEntry.mockResolvedValue(oracleEntry());
+
+      const { modelMode, showModeChoice } = await dialog(ref(payload()));
+
+      expect(get(modelMode)).toBe('oracle');
+      expect(get(showModeChoice)).toBe(true);
+    });
+
+    it('should default to manual, offering no choice, when the recorded price was already manual', async () => {
+      fetchExistingEntry.mockResolvedValue(oracleEntry({ sourceType: PriceOracle.MANUAL }));
+
+      const { modelMode, showModeChoice } = await dialog(ref(payload()));
+
+      expect(get(modelMode)).toBe('manual');
+      expect(get(showModeChoice)).toBe(false);
+    });
+
+    it('should start empty and manual when nothing is recorded yet', async () => {
+      const { modelMode, modelPrice, showModeChoice } = await dialog(ref(payload()));
+
+      expect(get(modelPrice)).toBe('');
+      expect(get(modelMode)).toBe('manual');
+      expect(get(showModeChoice)).toBe(false);
+    });
+
+    it('should notify and stay usable when the read fails', async () => {
+      fetchExistingEntry.mockRejectedValue(new Error('offline'));
+
+      const { existingEntry, loading } = await dialog(ref(payload()));
+
+      expect(notifyError).toHaveBeenCalledOnce();
+      expect(get(existingEntry)).toBeUndefined();
+      expect(get(loading)).toBe(false);
+    });
+
+    it('should read nothing while no event is being priced', async () => {
+      const { open } = await dialog(ref(undefined));
+
+      expect(fetchExistingEntry).not.toHaveBeenCalled();
+      expect(get(open)).toBe(false);
+    });
+  });
+
+  describe('the price field', () => {
+    it.each([
+      ['0', false],
+      ['-1', false],
+      ['abc', false],
+      ['0.5', true],
+      ['1500', true],
+    ])('should treat %s as valid=%s', async (value, valid) => {
+      const { modelPrice, priceValid } = await dialog(ref(payload()));
+
+      set(modelPrice, value);
+
+      expect(get(priceValid)).toBe(valid);
+    });
+
+    it('should stay quiet until something has been typed', async () => {
+      const { priceErrors } = await dialog(ref(payload()));
+
+      expect(get(priceErrors)).toEqual([]);
+    });
+
+    it('should complain once an unusable price is typed', async () => {
+      const { modelPrice, priceErrors } = await dialog(ref(payload()));
+
+      set(modelPrice, '0');
+
+      expect(get(priceErrors)).toEqual(['event_asset_price_update.price_error']);
+    });
+  });
+
+  describe('saving', () => {
+    it('should write the typed price against the event and close', async () => {
+      const model = ref<EventPriceUpdatePayload | undefined>(payload());
+      const { modelPrice, save } = await dialog(model);
+      set(modelPrice, '1600');
+
+      await save();
+
+      expect(updatePrice).toHaveBeenCalledExactlyOnceWith({
+        existingEntry: undefined,
+        fromAsset: 'ETH',
+        mode: 'manual',
+        price: '1600',
+        timestampMs: 1700000000,
+        toAsset: 'USD',
+      });
+      expect(notifyInfo).toHaveBeenCalledOnce();
+      expect(get(model)).toBeUndefined();
+    });
+
+    it('should write nothing when no event is being priced', async () => {
+      const { save } = await dialog(ref(undefined));
+
+      await save();
+
+      expect(updatePrice).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing when the price does not parse', async () => {
+      const { modelPrice, save } = await dialog(ref(payload()));
+      set(modelPrice, 'abc');
+
+      await save();
+
+      expect(updatePrice).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing when the manual price is unchanged, avoiding a duplicate entry', async () => {
+      fetchExistingEntry.mockResolvedValue(oracleEntry({ sourceType: PriceOracle.MANUAL }));
+      const model = ref<EventPriceUpdatePayload | undefined>(payload());
+      const { save } = await dialog(model);
+
+      await save();
+
+      expect(updatePrice).not.toHaveBeenCalled();
+      expect(get(model)).toBeUndefined();
+    });
+
+    it('should write nothing when keeping the oracle price as it is', async () => {
+      fetchExistingEntry.mockResolvedValue(oracleEntry());
+      const { save } = await dialog(ref(payload()));
+
+      await save();
+
+      expect(updatePrice).not.toHaveBeenCalled();
+    });
+
+    it('should still write when the oracle price is being converted to a manual one', async () => {
+      fetchExistingEntry.mockResolvedValue(oracleEntry());
+      const { modelMode, save } = await dialog(ref(payload()));
+
+      set(modelMode, 'manual');
+      await save();
+
+      expect(updatePrice).toHaveBeenCalledOnce();
+      expect(updatePrice.mock.calls[0][0]).toMatchObject({ mode: 'manual', price: '1500' });
+    });
+
+    it('should write when the price itself changed', async () => {
+      fetchExistingEntry.mockResolvedValue(oracleEntry({ sourceType: PriceOracle.MANUAL }));
+      const { modelPrice, save } = await dialog(ref(payload()));
+
+      set(modelPrice, '1600');
+      await save();
+
+      expect(updatePrice).toHaveBeenCalledOnce();
+    });
+
+    it('should notify and stay open when the write fails', async () => {
+      updatePrice.mockRejectedValue(new Error('rejected'));
+      const model = ref<EventPriceUpdatePayload | undefined>(payload());
+      const { modelPrice, save, saving } = await dialog(model);
+      set(modelPrice, '1600');
+
+      await save();
+
+      expect(notifyError).toHaveBeenCalledOnce();
+      expect(get(model)).toBeDefined();
+      expect(get(saving)).toBe(false);
+    });
+  });
+
+  describe('closing', () => {
+    it('should drop the event without writing anything', async () => {
+      const model = ref<EventPriceUpdatePayload | undefined>(payload());
+      const { close, open } = await dialog(model);
+
+      close();
+
+      expect(get(model)).toBeUndefined();
+      expect(get(open)).toBe(false);
+      expect(updatePrice).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/prices/use-event-price-update-dialog.ts
+++ b/frontend/app/src/modules/history/events/prices/use-event-price-update-dialog.ts
@@ -1,0 +1,185 @@
+import type { BigNumber } from '@rotki/common';
+import type { ComputedRef, Ref } from 'vue';
+import type { OraclePriceEntry } from '@/modules/assets/prices/price-types';
+import type { EventPriceUpdatePayload } from '@/modules/history/events/prices/use-event-price-update-trigger';
+import { startPromise } from '@shared/utils';
+import { parseNumericInput } from '@/modules/core/common/data/bignumbers';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useNotifications } from '@/modules/core/notifications/use-notifications';
+import { type EventPriceUpdateMode, useEventPriceUpdate } from '@/modules/history/events/prices/use-event-price-update';
+import { PriceOracle } from '@/modules/settings/types/price-oracle';
+import { useSetting } from '@/modules/settings/use-setting';
+
+interface UseEventPriceUpdateDialogReturn {
+  /** Closes the dialog without writing anything. */
+  close: () => void;
+  /** The price already recorded for this asset and moment, when one exists. */
+  existingEntry: Readonly<Ref<OraclePriceEntry | undefined>>;
+  /** True when the recorded price is one the user set by hand rather than an oracle's. */
+  existingIsManual: ComputedRef<boolean>;
+  /** True while the existing price is being read. */
+  loading: Readonly<Ref<boolean>>;
+  /** Whether the dialog is showing, derived from the payload it was handed. */
+  open: ComputedRef<boolean>;
+  /** Whether the new price is written as a manual entry or against the oracle. */
+  modelMode: Ref<EventPriceUpdateMode>;
+  /** The price as typed, before parsing. */
+  modelPrice: Ref<string>;
+  /** Validation messages for the price field; empty while it is untouched. */
+  priceErrors: ComputedRef<string[]>;
+  /** True when the typed price parses and is above zero. */
+  priceValid: ComputedRef<boolean>;
+  /**
+   * Writes the price, then closes.
+   *
+   * @remarks
+   * Writes nothing when the price has not actually changed, so re-opening a dialog and pressing
+   * save cannot create a duplicate manual entry.
+   */
+  save: () => Promise<void>;
+  /** True while the price is being written. */
+  saving: Readonly<Ref<boolean>>;
+  /** True when the user gets to choose between overwriting the oracle or adding a manual price. */
+  showModeChoice: ComputedRef<boolean>;
+}
+
+/**
+ * Drives the dialog that sets a historical price for one event's asset.
+ *
+ * @remarks
+ * Reads whatever price is already recorded whenever the payload changes, so the field opens
+ * pre-filled and the mode defaults to whichever kind that entry was.
+ *
+ * @param modelValue - the event being priced; undefined closes the dialog
+ * @returns the dialog's bindings; only {@link UseEventPriceUpdateDialogReturn.save} writes
+ */
+export function useEventPriceUpdateDialog(
+  modelValue: Ref<EventPriceUpdatePayload | undefined>,
+): UseEventPriceUpdateDialogReturn {
+  const modelPrice = shallowRef<string>('');
+  const modelMode = shallowRef<EventPriceUpdateMode>('manual');
+  const existingEntry = ref<OraclePriceEntry>();
+  const loading = shallowRef<boolean>(false);
+  const saving = shallowRef<boolean>(false);
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { notifyError, notifyInfo } = useNotifications();
+  const currencySymbol = useSetting('currencySymbol');
+  const { fetchExistingEntry, updatePrice } = useEventPriceUpdate();
+
+  const open = computed<boolean>(() => get(modelValue) !== undefined);
+
+  function close(): void {
+    set(modelValue, undefined);
+  }
+
+  const existingIsManual = computed<boolean>(() => get(existingEntry)?.sourceType === PriceOracle.MANUAL);
+  const showModeChoice = computed<boolean>(() => Boolean(get(existingEntry)) && !get(existingIsManual));
+
+  const parsedPrice = computed<BigNumber | undefined>(() => parseNumericInput(get(modelPrice).trim()));
+
+  const priceValid = computed<boolean>(() => get(parsedPrice)?.isGreaterThan(0) ?? false);
+
+  const priceErrors = computed<string[]>(() => {
+    const value = get(modelPrice).trim();
+    if (!value || get(priceValid))
+      return [];
+    return [t('event_asset_price_update.price_error')];
+  });
+
+  async function load(payload: EventPriceUpdatePayload): Promise<void> {
+    set(loading, true);
+    set(existingEntry, undefined);
+    set(modelPrice, '');
+    try {
+      const entry = await fetchExistingEntry(payload.asset, get(currencySymbol), payload.timestamp);
+      set(existingEntry, entry);
+      if (entry) {
+        set(modelPrice, entry.price.toFixed());
+        set(modelMode, entry.sourceType === PriceOracle.MANUAL ? 'manual' : 'oracle');
+      }
+      else {
+        set(modelMode, 'manual');
+      }
+    }
+    catch (error: unknown) {
+      logger.error('Failed to load existing oracle price entry:', error);
+      notifyError(
+        t('event_asset_price_update.fetch_error.title'),
+        t('event_asset_price_update.fetch_error.description', { error: getErrorMessage(error) }),
+      );
+    }
+    finally {
+      set(loading, false);
+    }
+  }
+
+  async function save(): Promise<void> {
+    const payload = get(modelValue);
+    if (!payload)
+      return;
+
+    const parsed = get(parsedPrice);
+    if (!parsed)
+      return;
+
+    const entry = get(existingEntry);
+    const nextPrice = get(modelPrice).trim();
+    const selectedMode = get(modelMode);
+    const unchanged = entry
+      && parsed.isEqualTo(entry.price)
+      && (selectedMode === 'oracle' || entry.sourceType === PriceOracle.MANUAL);
+    if (unchanged) {
+      close();
+      return;
+    }
+
+    set(saving, true);
+    try {
+      await updatePrice({
+        existingEntry: entry,
+        fromAsset: payload.asset,
+        mode: selectedMode,
+        price: nextPrice,
+        timestampMs: payload.timestamp,
+        toAsset: get(currencySymbol),
+      });
+      notifyInfo(
+        t('event_asset_price_update.success.title'),
+        t('event_asset_price_update.success.description'),
+      );
+      close();
+    }
+    catch (error: unknown) {
+      logger.error('Failed to update event price:', error);
+      notifyError(
+        t('event_asset_price_update.save_error.title'),
+        t('event_asset_price_update.save_error.description', { error: getErrorMessage(error) }),
+      );
+    }
+    finally {
+      set(saving, false);
+    }
+  }
+
+  watch(modelValue, (payload) => {
+    if (payload)
+      startPromise(load(payload));
+  }, { immediate: true });
+
+  return {
+    close,
+    existingEntry: shallowReadonly(existingEntry),
+    existingIsManual,
+    loading: readonly(loading),
+    modelMode,
+    modelPrice,
+    open,
+    priceErrors,
+    priceValid,
+    save,
+    saving: readonly(saving),
+    showModeChoice,
+  };
+}

--- a/frontend/app/src/modules/history/events/tx/RepullingTransactionFormDialog.vue
+++ b/frontend/app/src/modules/history/events/tx/RepullingTransactionFormDialog.vue
@@ -1,18 +1,9 @@
 <script lang="ts" setup>
 import type { Exchange } from '@/modules/balances/types/exchanges';
-import type { RepullingEthStakingPayload, RepullingExchangeEventsPayload, RepullingTransactionPayload } from '@/modules/history/events/event-payloads';
-import dayjs from 'dayjs';
+import type { RepullingTransactionResult } from '@/modules/history/events/tx/use-history-transactions';
 import { useTemplateRef } from 'vue';
-import { ApiValidationError } from '@/modules/core/api/types/errors';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { logger } from '@/modules/core/common/logging/logging';
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
-import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
-import RepullingTransactionForm, { type AccountType } from '@/modules/history/events/tx/RepullingTransactionForm.vue';
-import { type RepullingTransactionResult, useHistoryTransactions } from '@/modules/history/events/tx/use-history-transactions';
-import { useRepullingTransactionForm } from '@/modules/history/events/tx/use-repulling-transaction-form';
-import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
+import RepullingTransactionForm from '@/modules/history/events/tx/RepullingTransactionForm.vue';
+import { useRepullingTransactionSubmission } from '@/modules/history/events/tx/use-repulling-transaction-submission';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 import { ActivityKind, useTaskCenter } from '@/modules/task-center/use-task-center';
 
@@ -26,147 +17,26 @@ const { repullExchangeEvents, repullTransactions } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const accountType = ref<AccountType>('blockchain');
-
-const submitting = ref<boolean>(false);
-const errorMessages = ref<Record<string, string[]>>({});
 const form = useTemplateRef<InstanceType<typeof RepullingTransactionForm>>('form');
 const stateUpdated = ref<boolean>(false);
 
-const { setMessage } = useMessageStore();
-const { show } = useConfirmStore();
-const { repullingEthStakingEvents, repullingExchangeEvents, repullingTransactions } = useHistoryTransactions();
 const { useIsActive } = useTaskCenter();
-const { createDefaultFormData, shouldShowConfirmation } = useRepullingTransactionForm();
-const { resetUndecodedTransactionsStatus } = useDecodingStatusStore();
 
 const taskRunning = useIsActive(ActivityKind.REPULLING);
 
-const formData = ref(createDefaultFormData());
-
-function createDefaultEthStakingData(): RepullingEthStakingPayload {
-  return {
-    entryType: OnlineHistoryEventsQueryType.ETH_WITHDRAWALS,
-    fromTimestamp: dayjs().subtract(1, 'year').unix(),
-    toTimestamp: dayjs().unix(),
-  };
-}
-
-const ethStakingData = ref<RepullingEthStakingPayload>(createDefaultEthStakingData());
-
-function resetForm(): void {
-  set(formData, createDefaultFormData());
-  set(ethStakingData, createDefaultEthStakingData());
-  set(accountType, 'blockchain');
-}
-
-async function handleSubmissionError(
-  error: unknown,
-  data: RepullingTransactionPayload,
-  formRef: InstanceType<typeof RepullingTransactionForm> | null,
-): Promise<void> {
-  let message: string | Record<string, string[] | string> = getErrorMessage(error);
-
-  if (error instanceof ApiValidationError)
-    message = error.getValidationErrors(data);
-
-  if (typeof message === 'string') {
-    setMessage({
-      description: message,
-    });
-  }
-  else {
-    set(errorMessages, message);
-    await formRef?.validate();
-  }
-}
-
-async function handleExchangeSubmission(
-  data: RepullingTransactionPayload,
-  formRef: InstanceType<typeof RepullingTransactionForm> | null,
-): Promise<void> {
-  const exchange = formRef?.getExchangeData();
-  const exchangePayload: RepullingExchangeEventsPayload = {
-    fromTimestamp: data.fromTimestamp,
-    location: exchange?.location || '',
-    name: exchange?.name || '',
-    toTimestamp: data.toTimestamp,
-  };
-
-  const newEventsDetected = await repullingExchangeEvents(exchangePayload);
-  if (newEventsDetected && exchange) {
-    repullExchangeEvents?.([exchange]);
-    logger.debug('New exchange events detected');
-  }
-}
-
-async function handleBlockchainSubmission(data: RepullingTransactionPayload): Promise<void> {
-  const chain = data.chain === 'all' ? undefined : data.chain;
-  const blockchainPayload: RepullingTransactionPayload = {
-    address: data.address,
-    chain,
-    fromTimestamp: data.fromTimestamp,
-    toTimestamp: data.toTimestamp,
-  };
-
-  resetUndecodedTransactionsStatus();
-  const result = await repullingTransactions(blockchainPayload);
-  if (result) {
-    repullTransactions?.(result);
-    logger.debug(`New transactions detected${chain ? ` for chain ${chain}` : ' for all chains'}`);
-  }
-}
-
-async function handleEthStakingSubmission(): Promise<void> {
-  await repullingEthStakingEvents(get(ethStakingData));
-}
-
-async function performSubmission(): Promise<void> {
-  const formRef = get(form);
-  const data = get(formData);
-  const type = get(accountType);
-
-  try {
-    set(submitting, true);
-    set(modelValue, false);
-
-    if (type === 'exchange')
-      await handleExchangeSubmission(data, formRef);
-    else if (type === 'eth_staking')
-      await handleEthStakingSubmission();
-    else
-      await handleBlockchainSubmission(data);
-
-    resetForm();
-  }
-  catch (error: unknown) {
-    await handleSubmissionError(error, data, formRef);
-  }
-  finally {
-    set(submitting, false);
-  }
-}
-
-async function submit(): Promise<void> {
-  const formRef = get(form);
-  const valid = await formRef?.validate();
-  if (!valid)
-    return;
-
-  const data = get(formData);
-  const type = get(accountType);
-
-  if (type === 'blockchain' && shouldShowConfirmation(data)) {
-    show({
-      message: t('transactions.repulling.confirmation.message'),
-      title: t('transactions.repulling.confirmation.title'),
-      type: 'info',
-    }, performSubmission);
-  }
-  else {
-    await performSubmission();
-  }
-}
+const {
+  modelAccountType: accountType,
+  modelErrorMessages: errorMessages,
+  modelEthStakingData: ethStakingData,
+  modelFormData: formData,
+  submit,
+  submitting,
+} = useRepullingTransactionSubmission({
+  form,
+  onExchangeEvents: repullExchangeEvents,
+  onTransactions: repullTransactions,
+  open: modelValue,
+});
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/events/tx/use-repulling-transaction-submission.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-repulling-transaction-submission.spec.ts
@@ -1,0 +1,349 @@
+import type { Exchange } from '@/modules/balances/types/exchanges';
+import type { RepullingTransactionPayload } from '@/modules/history/events/event-payloads';
+import type { RepullingTransactionResult } from '@/modules/history/events/tx/use-history-transactions';
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, ref } from 'vue';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import { type RepullingFormHandle, useRepullingTransactionSubmission } from './use-repulling-transaction-submission';
+
+const {
+  createDefaultFormData,
+  repullingEthStakingEvents,
+  repullingExchangeEvents,
+  repullingTransactions,
+  resetUndecodedTransactionsStatus,
+  setMessage,
+  shouldShowConfirmation,
+  show,
+} = vi.hoisted(() => ({
+  createDefaultFormData: vi.fn(),
+  repullingEthStakingEvents: vi.fn(),
+  repullingExchangeEvents: vi.fn(),
+  repullingTransactions: vi.fn(),
+  resetUndecodedTransactionsStatus: vi.fn(),
+  setMessage: vi.fn(),
+  shouldShowConfirmation: vi.fn(),
+  show: vi.fn<(message: unknown, onConfirm: () => void) => void>(),
+}));
+
+vi.mock('@/modules/history/events/tx/use-history-transactions', () => ({
+  useHistoryTransactions: (): Record<string, unknown> => ({
+    repullingEthStakingEvents,
+    repullingExchangeEvents,
+    repullingTransactions,
+  }),
+}));
+
+vi.mock('@/modules/history/events/tx/use-repulling-transaction-form', () => ({
+  useRepullingTransactionForm: (): Record<string, unknown> => ({
+    createDefaultFormData,
+    shouldShowConfirmation,
+  }),
+}));
+
+vi.mock('@/modules/history/use-decoding-status-store', () => ({
+  useDecodingStatusStore: (): Record<string, unknown> => ({ resetUndecodedTransactionsStatus }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({ show }),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  getDefaultLogLevel: vi.fn(() => 'debug'),
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  setLevel: vi.fn(),
+}));
+
+let scope: ReturnType<typeof effectScope>;
+
+const exchange: Exchange = { location: 'kraken', name: 'Kraken 1' };
+
+function defaultFormData(): RepullingTransactionPayload {
+  return { address: '', chain: 'all', fromTimestamp: 100, toTimestamp: 200 };
+}
+
+function formHandle(overrides: Partial<RepullingFormHandle> = {}): RepullingFormHandle {
+  return {
+    getExchangeData: vi.fn<RepullingFormHandle['getExchangeData']>(() => exchange),
+    validate: vi.fn<RepullingFormHandle['validate']>(async () => Promise.resolve(true)),
+    ...overrides,
+  };
+}
+
+function submission(
+  form: RepullingFormHandle | null = formHandle(),
+  callbacks: {
+    onExchangeEvents?: (exchanges: Exchange[]) => void;
+    onTransactions?: (result: RepullingTransactionResult) => void;
+  } = {},
+): ReturnType<typeof useRepullingTransactionSubmission> & { open: ReturnType<typeof ref<boolean>> } {
+  const open = ref<boolean>(true);
+  scope = effectScope();
+  const api = scope.run(() => useRepullingTransactionSubmission({ form, open, ...callbacks }))!;
+  return { ...api, open };
+}
+
+describe('modules/history/events/tx/useRepullingTransactionSubmission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createDefaultFormData.mockImplementation(defaultFormData);
+    shouldShowConfirmation.mockReturnValue(false);
+    repullingTransactions.mockResolvedValue(undefined);
+    repullingExchangeEvents.mockResolvedValue(false);
+    repullingEthStakingEvents.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('before anything is sent', () => {
+    it('should not submit a form that does not validate', async () => {
+      const form = formHandle({ validate: vi.fn(async () => Promise.resolve(false)) });
+      const { open, submit } = submission(form);
+
+      await submit();
+
+      expect(repullingTransactions).not.toHaveBeenCalled();
+      expect(get(open)).toBe(true);
+    });
+
+    it('should not submit when there is no form to validate', async () => {
+      const { submit } = submission(null);
+
+      await submit();
+
+      expect(repullingTransactions).not.toHaveBeenCalled();
+    });
+
+    it('should ask for confirmation before a wide blockchain repull', async () => {
+      shouldShowConfirmation.mockReturnValue(true);
+      const { submit } = submission();
+
+      await submit();
+
+      expect(show).toHaveBeenCalledOnce();
+      expect(repullingTransactions).not.toHaveBeenCalled();
+    });
+
+    it('should repull once the confirmation is accepted', async () => {
+      shouldShowConfirmation.mockReturnValue(true);
+      const { submit } = submission();
+
+      await submit();
+      show.mock.calls[0][1]();
+      await flushPromises();
+
+      expect(repullingTransactions).toHaveBeenCalledOnce();
+    });
+
+    it.each(['exchange', 'eth_staking'] as const)('should never confirm a %s repull', async (type) => {
+      shouldShowConfirmation.mockReturnValue(true);
+      const { modelAccountType, submit } = submission();
+      set(modelAccountType, type);
+
+      await submit();
+
+      expect(show).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('repulling a chain', () => {
+    it('should send the payload without the all-chains sentinel the backend does not know', async () => {
+      const { modelFormData, submit } = submission();
+      set(modelFormData, { address: '0xabc', chain: 'all', fromTimestamp: 100, toTimestamp: 200 });
+
+      await submit();
+
+      expect(repullingTransactions).toHaveBeenCalledExactlyOnceWith({
+        address: '0xabc',
+        chain: undefined,
+        fromTimestamp: 100,
+        toTimestamp: 200,
+      });
+    });
+
+    it('should send a named chain as it stands', async () => {
+      repullingTransactions.mockResolvedValue({ newTransactionsCount: 1 });
+      const { modelFormData, submit } = submission();
+      set(modelFormData, { address: '0xabc', chain: 'ethereum', fromTimestamp: 100, toTimestamp: 200 });
+
+      await submit();
+
+      expect(repullingTransactions).toHaveBeenCalledWith(expect.objectContaining({ chain: 'ethereum' }));
+    });
+
+    it('should clear the undecoded status first, since the repull invalidates it', async () => {
+      const { submit } = submission();
+
+      await submit();
+
+      expect(resetUndecodedTransactionsStatus).toHaveBeenCalledOnce();
+      expect(resetUndecodedTransactionsStatus.mock.invocationCallOrder[0])
+        .toBeLessThan(repullingTransactions.mock.invocationCallOrder[0]);
+    });
+
+    it('should hand the caller the result when transactions were found', async () => {
+      const onTransactions = vi.fn();
+      repullingTransactions.mockResolvedValue({ newTransactionsCount: 3 });
+      const { submit } = submission(formHandle(), { onTransactions });
+
+      await submit();
+
+      expect(onTransactions).toHaveBeenCalledExactlyOnceWith({ newTransactionsCount: 3 });
+    });
+
+    it('should stay quiet when the repull found nothing', async () => {
+      const onTransactions = vi.fn();
+      const { submit } = submission(formHandle(), { onTransactions });
+
+      await submit();
+
+      expect(onTransactions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('repulling an exchange', () => {
+    it('should send the account the form names, with the form timestamps', async () => {
+      const { modelAccountType, modelFormData, submit } = submission();
+      set(modelAccountType, 'exchange');
+      set(modelFormData, { address: '', chain: 'all', fromTimestamp: 500, toTimestamp: 600 });
+
+      await submit();
+
+      expect(repullingExchangeEvents).toHaveBeenCalledExactlyOnceWith({
+        fromTimestamp: 500,
+        location: 'kraken',
+        name: 'Kraken 1',
+        toTimestamp: 600,
+      });
+      expect(repullingTransactions).not.toHaveBeenCalled();
+    });
+
+    it('should send empty identifiers when the form has no exchange selected', async () => {
+      const form = formHandle({ getExchangeData: vi.fn(() => undefined) });
+      const { modelAccountType, submit } = submission(form);
+      set(modelAccountType, 'exchange');
+
+      await submit();
+
+      expect(repullingExchangeEvents).toHaveBeenCalledWith(expect.objectContaining({ location: '', name: '' }));
+    });
+
+    it('should hand the caller the exchange when new events were found', async () => {
+      const onExchangeEvents = vi.fn();
+      repullingExchangeEvents.mockResolvedValue(true);
+      const { modelAccountType, submit } = submission(formHandle(), { onExchangeEvents });
+      set(modelAccountType, 'exchange');
+
+      await submit();
+
+      expect(onExchangeEvents).toHaveBeenCalledExactlyOnceWith([exchange]);
+    });
+
+    it('should stay quiet when new events were found but no exchange is known', async () => {
+      const onExchangeEvents = vi.fn();
+      repullingExchangeEvents.mockResolvedValue(true);
+      const form = formHandle({ getExchangeData: vi.fn(() => undefined) });
+      const { modelAccountType, submit } = submission(form, { onExchangeEvents });
+      set(modelAccountType, 'exchange');
+
+      await submit();
+
+      expect(onExchangeEvents).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('repulling staking events', () => {
+    it('should send the staking payload, which the other two never carry', async () => {
+      const { modelAccountType, modelEthStakingData, submit } = submission();
+      set(modelAccountType, 'eth_staking');
+      const payload = get(modelEthStakingData);
+
+      await submit();
+
+      expect(repullingEthStakingEvents).toHaveBeenCalledExactlyOnceWith(payload);
+      expect(repullingTransactions).not.toHaveBeenCalled();
+      expect(repullingExchangeEvents).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('what happens around a submission', () => {
+    it('should close the dialog rather than hold it open for a background task', async () => {
+      const { open, submit } = submission();
+
+      await submit();
+
+      expect(get(open)).toBe(false);
+    });
+
+    it('should reset the form so a reopened dialog is not pre-filled', async () => {
+      const { modelAccountType, modelFormData, submit } = submission();
+      set(modelAccountType, 'exchange');
+      set(modelFormData, { address: '0xabc', chain: 'ethereum', fromTimestamp: 1, toTimestamp: 2 });
+
+      await submit();
+
+      expect(get(modelAccountType)).toBe('blockchain');
+      expect(get(modelFormData)).toEqual(defaultFormData());
+    });
+
+    it('should stop showing progress once the repull is requested', async () => {
+      const { submit, submitting } = submission();
+
+      await submit();
+
+      expect(get(submitting)).toBe(false);
+    });
+  });
+
+  describe('when the repull is rejected', () => {
+    it('should show a plain failure as a message', async () => {
+      repullingTransactions.mockRejectedValue(new Error('backend down'));
+      const { submit } = submission();
+
+      await submit();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith({ description: 'backend down' });
+    });
+
+    it('should keep the form filled in, so the user can correct it', async () => {
+      repullingTransactions.mockRejectedValue(new Error('backend down'));
+      const { modelFormData, submit } = submission();
+      set(modelFormData, { address: '0xabc', chain: 'ethereum', fromTimestamp: 1, toTimestamp: 2 });
+
+      await submit();
+
+      expect(get(modelFormData).address).toBe('0xabc');
+    });
+
+    it('should route field errors back into the form and re-validate it', async () => {
+      repullingTransactions.mockRejectedValue(
+        new ApiValidationError(JSON.stringify({ address: ['not an address'] })),
+      );
+      const form = formHandle();
+      const { modelErrorMessages, submit } = submission(form);
+
+      await submit();
+
+      expect(get(modelErrorMessages)).toEqual({ address: ['not an address'] });
+      expect(form.validate).toHaveBeenCalledTimes(2);
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+
+    it('should stop showing progress', async () => {
+      repullingTransactions.mockRejectedValue(new Error('backend down'));
+      const { submit, submitting } = submission();
+
+      await submit();
+
+      expect(get(submitting)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/tx/use-repulling-transaction-submission.ts
+++ b/frontend/app/src/modules/history/events/tx/use-repulling-transaction-submission.ts
@@ -1,0 +1,202 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { Exchange } from '@/modules/balances/types/exchanges';
+import type { RepullingEthStakingPayload, RepullingExchangeEventsPayload, RepullingTransactionPayload } from '@/modules/history/events/event-payloads';
+import type { AccountType } from '@/modules/history/events/tx/RepullingTransactionForm.vue';
+import dayjs from 'dayjs';
+import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
+import { type RepullingTransactionResult, useHistoryTransactions } from '@/modules/history/events/tx/use-history-transactions';
+import { useRepullingTransactionForm } from '@/modules/history/events/tx/use-repulling-transaction-form';
+import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
+
+/**
+ * The part of `RepullingTransactionForm` this composable drives, kept structural so the submission
+ * flow can be tested without mounting the form.
+ */
+export interface RepullingFormHandle {
+  getExchangeData: () => Exchange | undefined;
+  validate: () => Promise<boolean>;
+}
+
+interface UseRepullingTransactionSubmissionOptions {
+  /** The form whose validation gates the submission. */
+  form: MaybeRefOrGetter<RepullingFormHandle | null | undefined>;
+  /** Whether the dialog is showing; closed as soon as a submission is under way. */
+  open: Ref<boolean>;
+  /** Called with the exchange that turned out to have new events. */
+  onExchangeEvents?: (exchanges: Exchange[]) => void;
+  /** Called with the repull result when new transactions were found. */
+  onTransactions?: (result: RepullingTransactionResult) => void;
+}
+
+interface UseRepullingTransactionSubmissionReturn {
+  /** Which of the three repull kinds the form is on. */
+  modelAccountType: Ref<AccountType>;
+  /** Per-field backend validation errors, fed back into the form. */
+  modelErrorMessages: Ref<ValidationErrors>;
+  /** The eth staking form's own payload, which shares no fields with the other two. */
+  modelEthStakingData: Ref<RepullingEthStakingPayload>;
+  /** The blockchain and exchange payload. */
+  modelFormData: Ref<RepullingTransactionPayload>;
+  /**
+   * Validates, confirms if the repull is a wide one, then submits.
+   *
+   * @remarks
+   * Only a blockchain repull is ever confirmed; an exchange or staking repull is bounded by the
+   * account it names.
+   */
+  submit: () => Promise<void>;
+  /** True while a repull is being requested. */
+  submitting: Readonly<Ref<boolean>>;
+}
+
+function createDefaultEthStakingData(): RepullingEthStakingPayload {
+  return {
+    entryType: OnlineHistoryEventsQueryType.ETH_WITHDRAWALS,
+    fromTimestamp: dayjs().subtract(1, 'year').unix(),
+    toTimestamp: dayjs().unix(),
+  };
+}
+
+/**
+ * Drives the repulling dialog: which kind of repull the form is on, and submitting it.
+ *
+ * @remarks
+ * The dialog closes the moment a submission starts rather than when it finishes, because a repull
+ * runs as a background task and there is nothing further to watch in the dialog.
+ *
+ * @returns the form's bindings; only {@link UseRepullingTransactionSubmissionReturn.submit} calls
+ * the backend
+ */
+export function useRepullingTransactionSubmission(
+  options: UseRepullingTransactionSubmissionOptions,
+): UseRepullingTransactionSubmissionReturn {
+  const { form, onExchangeEvents, onTransactions, open } = options;
+
+  const submitting = shallowRef<boolean>(false);
+  const modelAccountType = shallowRef<AccountType>('blockchain');
+  const modelErrorMessages = ref<ValidationErrors>({});
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { setMessage } = useMessageStore();
+  const { show } = useConfirmStore();
+  const { repullingEthStakingEvents, repullingExchangeEvents, repullingTransactions } = useHistoryTransactions();
+  const { createDefaultFormData, shouldShowConfirmation } = useRepullingTransactionForm();
+  const { resetUndecodedTransactionsStatus } = useDecodingStatusStore();
+
+  const modelFormData = ref<RepullingTransactionPayload>(createDefaultFormData());
+  const modelEthStakingData = ref<RepullingEthStakingPayload>(createDefaultEthStakingData());
+
+  function resetForm(): void {
+    set(modelFormData, createDefaultFormData());
+    set(modelEthStakingData, createDefaultEthStakingData());
+    set(modelAccountType, 'blockchain');
+  }
+
+  async function handleSubmissionError(error: unknown, data: RepullingTransactionPayload): Promise<void> {
+    let message: string | ValidationErrors = getErrorMessage(error);
+
+    if (error instanceof ApiValidationError)
+      message = error.getValidationErrors(data);
+
+    if (typeof message === 'string') {
+      setMessage({
+        description: message,
+      });
+    }
+    else {
+      set(modelErrorMessages, message);
+      await toValue(form)?.validate();
+    }
+  }
+
+  async function handleExchangeSubmission(data: RepullingTransactionPayload): Promise<void> {
+    const exchange = toValue(form)?.getExchangeData();
+    const exchangePayload: RepullingExchangeEventsPayload = {
+      fromTimestamp: data.fromTimestamp,
+      location: exchange?.location ?? '',
+      name: exchange?.name ?? '',
+      toTimestamp: data.toTimestamp,
+    };
+
+    const newEventsDetected = await repullingExchangeEvents(exchangePayload);
+    if (newEventsDetected && exchange) {
+      onExchangeEvents?.([exchange]);
+      logger.debug('New exchange events detected');
+    }
+  }
+
+  async function handleBlockchainSubmission(data: RepullingTransactionPayload): Promise<void> {
+    const chain = data.chain === 'all' ? undefined : data.chain;
+    const blockchainPayload: RepullingTransactionPayload = {
+      address: data.address,
+      chain,
+      fromTimestamp: data.fromTimestamp,
+      toTimestamp: data.toTimestamp,
+    };
+
+    resetUndecodedTransactionsStatus();
+    const result = await repullingTransactions(blockchainPayload);
+    if (result) {
+      onTransactions?.(result);
+      logger.debug(`New transactions detected${chain ? ` for chain ${chain}` : ' for all chains'}`);
+    }
+  }
+
+  async function performSubmission(): Promise<void> {
+    const data = get(modelFormData);
+    const type = get(modelAccountType);
+
+    try {
+      set(submitting, true);
+      set(open, false);
+
+      if (type === 'exchange')
+        await handleExchangeSubmission(data);
+      else if (type === 'eth_staking')
+        await repullingEthStakingEvents(get(modelEthStakingData));
+      else
+        await handleBlockchainSubmission(data);
+
+      resetForm();
+    }
+    catch (error: unknown) {
+      await handleSubmissionError(error, data);
+    }
+    finally {
+      set(submitting, false);
+    }
+  }
+
+  async function submit(): Promise<void> {
+    const valid = await toValue(form)?.validate();
+    if (!valid)
+      return;
+
+    const data = get(modelFormData);
+
+    if (get(modelAccountType) === 'blockchain' && shouldShowConfirmation(data)) {
+      show({
+        message: t('transactions.repulling.confirmation.message'),
+        title: t('transactions.repulling.confirmation.title'),
+        type: 'info',
+      }, performSubmission);
+    }
+    else {
+      await performSubmission();
+    }
+  }
+
+  return {
+    modelAccountType,
+    modelErrorMessages,
+    modelEthStakingData,
+    modelFormData,
+    submit,
+    submitting: readonly(submitting),
+  };
+}

--- a/frontend/app/src/modules/history/events/use-history-events-identifier.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-identifier.spec.ts
@@ -1,0 +1,180 @@
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import { createAssetMovementEvent, createEthBlockEvent, createEvmEvent, createOnlineHistoryEvent, createWithdrawalEvent } from '@test/utils/history-events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope } from 'vue';
+import { useHistoryEventsIdentifier } from './use-history-events-identifier';
+
+const { is2xlAndUp, isMd } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return { is2xlAndUp: ref<boolean>(false), isMd: ref<boolean>(false) };
+});
+
+vi.mock('@rotki/ui-library', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@rotki/ui-library')>();
+  return {
+    ...actual,
+    useBreakpoint: (): Record<string, unknown> => ({ is2xlAndUp, isMd }),
+  };
+});
+
+let scope: ReturnType<typeof effectScope>;
+
+function identifier(
+  current: HistoryEventEntry,
+  groupEvents?: HistoryEventEntry[],
+): ReturnType<typeof useHistoryEventsIdentifier> {
+  scope = effectScope();
+  return scope.run(() => useHistoryEventsIdentifier(() => current, () => groupEvents))!;
+}
+
+describe('modules/history/events/useHistoryEventsIdentifier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(is2xlAndUp, false);
+    set(isMd, false);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the header message', () => {
+    it('should use the type\'s own header when the event carries no transaction reference', () => {
+      const { translationKey } = identifier(createOnlineHistoryEvent());
+
+      expect(get(translationKey)).toBe('transactions.events.headers.history_event');
+    });
+
+    it('should use the evm header for an event carrying a transaction reference', () => {
+      const { translationKey } = identifier(createEvmEvent({ txRef: '0xdead' }));
+
+      expect(get(translationKey)).toBe('transactions.events.headers.evm_event');
+    });
+
+    it('should keep an asset movement on its own header despite carrying a reference', () => {
+      const movement = { ...createAssetMovementEvent(), txRef: '0xdead' };
+
+      const { translationKey } = identifier(movement);
+
+      expect(get(translationKey)).toBe('transactions.events.headers.asset_movement_event');
+    });
+  });
+
+  describe('the render key', () => {
+    it('should prefer the transaction reference over every other shape', () => {
+      const movement = { ...createAssetMovementEvent(), txRef: '0xdead' };
+
+      expect(get(identifier(movement).key)).toBe('tx_hash');
+    });
+
+    it('should report an asset movement carrying no reference as such', () => {
+      expect(get(identifier(createAssetMovementEvent()).key)).toBe('asset_movement');
+    });
+
+    it('should report a block production event as a block', () => {
+      expect(get(identifier(createEthBlockEvent()).key)).toBe('block');
+    });
+
+    it('should report a validator withdrawal as a withdrawal', () => {
+      expect(get(identifier(createWithdrawalEvent()).key)).toBe('withdraw');
+    });
+
+    it('should report a plain event as having no identifier shape', () => {
+      expect(get(identifier(createOnlineHistoryEvent()).key)).toBeUndefined();
+    });
+  });
+
+  describe('the transaction references of a group', () => {
+    it('should be empty for an event that is not an asset movement', () => {
+      const { allTxRefs } = identifier(createEvmEvent({ txRef: '0xdead' }), [createEvmEvent({ txRef: '0xbeef' })]);
+
+      expect(get(allTxRefs)).toEqual([]);
+    });
+
+    it('should be empty when no group was given', () => {
+      const { allTxRefs } = identifier(createAssetMovementEvent());
+
+      expect(get(allTxRefs)).toEqual([]);
+    });
+
+    it('should collect one entry per distinct reference, in group order', () => {
+      const { allTxRefs } = identifier(createAssetMovementEvent(), [
+        createEvmEvent({ location: 'ethereum', txRef: '0xaaa' }),
+        createEvmEvent({ location: 'optimism', txRef: '0xbbb' }),
+      ]);
+
+      expect(get(allTxRefs)).toEqual([
+        { location: 'ethereum', txRef: '0xaaa' },
+        { location: 'optimism', txRef: '0xbbb' },
+      ]);
+    });
+
+    it('should keep only the first sighting of a repeated reference', () => {
+      const { allTxRefs } = identifier(createAssetMovementEvent(), [
+        createEvmEvent({ location: 'ethereum', txRef: '0xaaa' }),
+        createEvmEvent({ location: 'optimism', txRef: '0xaaa' }),
+      ]);
+
+      expect(get(allTxRefs)).toEqual([{ location: 'ethereum', txRef: '0xaaa' }]);
+    });
+
+    it('should skip group members carrying no reference', () => {
+      const { allTxRefs } = identifier(createAssetMovementEvent(), [
+        createOnlineHistoryEvent(),
+        createEvmEvent({ txRef: '0xaaa' }),
+      ]);
+
+      expect(get(allTxRefs)).toHaveLength(1);
+    });
+  });
+
+  describe('the extra reference count', () => {
+    it('should count everything beyond the one already shown', () => {
+      const { extraHashCount } = identifier(createAssetMovementEvent(), [
+        createEvmEvent({ txRef: '0xaaa' }),
+        createEvmEvent({ txRef: '0xbbb' }),
+        createEvmEvent({ txRef: '0xccc' }),
+      ]);
+
+      expect(get(extraHashCount)).toBe(2);
+    });
+
+    it('should never go negative when there is nothing to show', () => {
+      expect(get(identifier(createOnlineHistoryEvent()).extraHashCount)).toBe(0);
+    });
+  });
+
+  describe('the movement transaction id', () => {
+    it('should read it from the movement extra data', () => {
+      const movement = createAssetMovementEvent({ extraData: { transactionId: 'abc123' } });
+
+      expect(get(identifier(movement).assetMovementTransactionId)).toBe('abc123');
+    });
+
+    it('should be undefined when the movement carries no extra data', () => {
+      expect(get(identifier(createAssetMovementEvent()).assetMovementTransactionId)).toBeUndefined();
+    });
+
+    it('should be undefined for an event that is not a movement at all', () => {
+      expect(get(identifier(createOnlineHistoryEvent()).assetMovementTransactionId)).toBeUndefined();
+    });
+  });
+
+  describe('the truncation width', () => {
+    it('should show most of a hash on the widest viewport', () => {
+      set(is2xlAndUp, true);
+
+      expect(get(identifier(createOnlineHistoryEvent()).truncateLength)).toBe(12);
+    });
+
+    it('should show least at the medium breakpoint, where the column is tightest', () => {
+      set(isMd, true);
+
+      expect(get(identifier(createOnlineHistoryEvent()).truncateLength)).toBe(6);
+    });
+
+    it('should sit between the two elsewhere', () => {
+      expect(get(identifier(createOnlineHistoryEvent()).truncateLength)).toBe(8);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-identifier.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-identifier.ts
@@ -1,0 +1,181 @@
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import { HistoryEventEntryType } from '@rotki/common';
+import { type MessageKey, msg } from '@/message-key';
+import {
+  isAssetMovementEventRef,
+  isEthBlockEventRef,
+  isWithdrawalEventRef,
+} from '@/modules/history/event-utils';
+
+/**
+ * Header message per entry type.
+ *
+ * @remarks
+ * Exhaustive on purpose: deriving the key with `toSnakeCase(entryType)` meant a new entry type
+ * produced a key nobody had written, and `i18n-t` renders a missing keypath verbatim, so bitcoin
+ * and solana events displayed the raw `transactions.events.headers.*` string. Spelling the map out
+ * fails the build instead, and the branded values are checked against the locale messages.
+ */
+const HEADER_KEYS: Record<HistoryEventEntryType, MessageKey> = {
+  [HistoryEventEntryType.ASSET_MOVEMENT_EVENT]: msg.$t('transactions.events.headers.asset_movement_event'),
+  [HistoryEventEntryType.BITCOIN_EVENT]: msg.$t('transactions.events.headers.bitcoin_event'),
+  [HistoryEventEntryType.ETH_BLOCK_EVENT]: msg.$t('transactions.events.headers.eth_block_event'),
+  [HistoryEventEntryType.ETH_DEPOSIT_EVENT]: msg.$t('transactions.events.headers.eth_deposit_event'),
+  [HistoryEventEntryType.ETH_WITHDRAWAL_EVENT]: msg.$t('transactions.events.headers.eth_withdrawal_event'),
+  [HistoryEventEntryType.EVM_EVENT]: msg.$t('transactions.events.headers.evm_event'),
+  [HistoryEventEntryType.EVM_SWAP_EVENT]: msg.$t('transactions.events.headers.evm_swap_event'),
+  [HistoryEventEntryType.HISTORY_EVENT]: msg.$t('transactions.events.headers.history_event'),
+  [HistoryEventEntryType.SOLANA_EVENT]: msg.$t('transactions.events.headers.solana_event'),
+  [HistoryEventEntryType.SOLANA_SWAP_EVENT]: msg.$t('transactions.events.headers.solana_swap_event'),
+  [HistoryEventEntryType.SWAP_EVENT]: msg.$t('transactions.events.headers.swap_event'),
+};
+
+/** Entry types that carry a `txRef` yet keep their own header rather than the generic EVM one. */
+const SPECIAL_TYPES_WITH_TX_REF: HistoryEventEntryType[] = [
+  HistoryEventEntryType.ETH_DEPOSIT_EVENT,
+  HistoryEventEntryType.ASSET_MOVEMENT_EVENT,
+];
+
+/** A transaction reference and the location it belongs to, as the hash links render it. */
+interface LocatedTxRef {
+  location: string;
+  txRef: string;
+}
+
+interface UseHistoryEventsIdentifierReturn {
+  /** Every distinct transaction reference in the group, for an asset movement; empty otherwise. */
+  allTxRefs: ComputedRef<LocatedTxRef[]>;
+  /** The event narrowed to an asset movement, or undefined when it is not one. */
+  assetMovementEvent: ReturnType<typeof isAssetMovementEventRef>;
+  /** The movement's own transaction id from its extra data, when it carries one. */
+  assetMovementTransactionId: ComputedRef<string | undefined>;
+  /** The event narrowed to an eth block event, or undefined when it is not one. */
+  blockEvent: ReturnType<typeof isEthBlockEventRef>;
+  /** How many references beyond the first the group holds, for the "+N" affordance. */
+  extraHashCount: ComputedRef<number>;
+  /** The event's own transaction reference, when it has one. */
+  eventWithTxRef: ComputedRef<LocatedTxRef | undefined>;
+  /**
+   * Which identifier shape is being rendered, or undefined when none applies.
+   *
+   * @remarks
+   * Used as a render key. Without it a block event's identifier could be reused to display a hash
+   * event's, showing a number where a hash belongs.
+   */
+  key: ComputedRef<'tx_hash' | 'block' | 'withdraw' | 'asset_movement' | undefined>;
+  /** Characters of a hash to show before truncating, widening with the viewport. */
+  truncateLength: ComputedRef<number>;
+  /**
+   * The header message for this event.
+   *
+   * @remarks
+   * An event carrying a `txRef` reads as an EVM event unless its own type is listed in
+   * {@link SPECIAL_TYPES_WITH_TX_REF}, which is how an evm swap borrows the evm header.
+   */
+  translationKey: ComputedRef<MessageKey>;
+  /** The event narrowed to a withdrawal, or undefined when it is not one. */
+  withdrawEvent: ReturnType<typeof isWithdrawalEventRef>;
+}
+
+/**
+ * Derives everything the identifier cell renders from one event and, optionally, its group.
+ *
+ * @param event - the event whose identifier is being rendered
+ * @param groupEvents - the events sharing its group, needed only to collect an asset movement's
+ * transaction references
+ * @returns the derived values; nothing here has side effects
+ */
+export function useHistoryEventsIdentifier(
+  event: MaybeRefOrGetter<HistoryEventEntry>,
+  groupEvents: MaybeRefOrGetter<HistoryEventEntry[] | undefined>,
+): UseHistoryEventsIdentifierReturn {
+  const { is2xlAndUp, isMd } = useBreakpoint();
+
+  const blockEvent = isEthBlockEventRef(() => toValue(event));
+  const withdrawEvent = isWithdrawalEventRef(() => toValue(event));
+  const assetMovementEvent = isAssetMovementEventRef(() => toValue(event));
+
+  const truncateLength = computed<number>(() => {
+    if (get(is2xlAndUp))
+      return 12;
+
+    if (get(isMd))
+      return 6;
+
+    return 8;
+  });
+
+  const eventWithTxRef = computed<LocatedTxRef | undefined>(() => {
+    const current = toValue(event);
+    if ('txRef' in current && current.txRef) {
+      return {
+        location: current.location,
+        txRef: current.txRef,
+      };
+    }
+    return undefined;
+  });
+
+  const allTxRefs = computed<LocatedTxRef[]>(() => {
+    const group = toValue(groupEvents);
+    if (!get(assetMovementEvent) || !group)
+      return [];
+
+    const seen = new Set<string>();
+    const result: LocatedTxRef[] = [];
+
+    for (const child of group) {
+      if (!('txRef' in child) || !child.txRef || seen.has(child.txRef))
+        continue;
+
+      seen.add(child.txRef);
+      result.push({
+        location: child.location,
+        txRef: child.txRef,
+      });
+    }
+
+    return result;
+  });
+
+  const extraHashCount = computed<number>(() => Math.max(get(allTxRefs).length - 1, 0));
+
+  const translationKey = computed<MessageKey>(() => {
+    let entryType = toValue(event).entryType;
+
+    if (get(eventWithTxRef) && !SPECIAL_TYPES_WITH_TX_REF.includes(entryType))
+      entryType = HistoryEventEntryType.EVM_EVENT;
+
+    return HEADER_KEYS[entryType];
+  });
+
+  const assetMovementTransactionId = computed<string | undefined>(
+    () => get(assetMovementEvent)?.extraData?.transactionId ?? undefined,
+  );
+
+  const key = computed<'tx_hash' | 'block' | 'withdraw' | 'asset_movement' | undefined>(() => {
+    if (get(eventWithTxRef))
+      return 'tx_hash';
+    if (get(blockEvent))
+      return 'block';
+    if (get(withdrawEvent))
+      return 'withdraw';
+    if (get(assetMovementEvent))
+      return 'asset_movement';
+    return undefined;
+  });
+
+  return {
+    allTxRefs,
+    assetMovementEvent,
+    assetMovementTransactionId,
+    blockEvent,
+    eventWithTxRef,
+    extraHashCount,
+    key,
+    translationKey,
+    truncateLength,
+    withdrawEvent,
+  };
+}

--- a/frontend/app/src/modules/history/events/use-skipped-events-actions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-skipped-events-actions.spec.ts
@@ -1,0 +1,302 @@
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope } from 'vue';
+import { useSkippedEventsActions } from './use-skipped-events-actions';
+
+const {
+  appSession,
+  downloadSkippedEventsCSV,
+  exportSkippedEventsCSV,
+  getSkippedEventsSummary,
+  openDirectory,
+  reProcessSkippedEvents,
+  setMessage,
+} = vi.hoisted(() => ({
+  appSession: { value: true },
+  downloadSkippedEventsCSV: vi.fn(),
+  exportSkippedEventsCSV: vi.fn(),
+  getSkippedEventsSummary: vi.fn(),
+  openDirectory: vi.fn(),
+  reProcessSkippedEvents: vi.fn(),
+  setMessage: vi.fn(),
+}));
+
+vi.mock('@/modules/history/api/events/use-skipped-history-events-api', () => ({
+  useSkippedHistoryEventsApi: (): Record<string, unknown> => ({
+    downloadSkippedEventsCSV,
+    exportSkippedEventsCSV,
+    getSkippedEventsSummary,
+    reProcessSkippedEvents,
+  }),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): Record<string, unknown> => ({
+    get appSession(): boolean {
+      return appSession.value;
+    },
+    openDirectory,
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+vi.mock('@/modules/core/common/logging/logging', () => ({
+  getDefaultLogLevel: vi.fn(() => 'debug'),
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  setLevel: vi.fn(),
+}));
+
+let scope: ReturnType<typeof effectScope>;
+
+async function actions(): Promise<ReturnType<typeof useSkippedEventsActions>> {
+  scope = effectScope();
+  const api = scope.run(() => useSkippedEventsActions())!;
+  await flushPromises();
+  return api;
+}
+
+describe('modules/history/events/useSkippedEventsActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appSession.value = true;
+    getSkippedEventsSummary.mockResolvedValue({ locations: { kraken: 2 }, total: 2 });
+    exportSkippedEventsCSV.mockResolvedValue(true);
+    downloadSkippedEventsCSV.mockResolvedValue({ success: true });
+    openDirectory.mockResolvedValue('/tmp/exports');
+    reProcessSkippedEvents.mockResolvedValue({ successful: 2, total: 2 });
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the summary', () => {
+    it('should read it as soon as the row is shown', async () => {
+      const { skippedEvents } = await actions();
+
+      expect(getSkippedEventsSummary).toHaveBeenCalledOnce();
+      expect(get(skippedEvents).total).toBe(2);
+    });
+
+    it('should turn the per-location counts into rows', async () => {
+      getSkippedEventsSummary.mockResolvedValue({ locations: { binance: 1, kraken: 3 }, total: 4 });
+
+      const { locationsData } = await actions();
+
+      expect(get(locationsData)).toEqual([
+        { location: 'binance', number: 1 },
+        { location: 'kraken', number: 3 },
+      ]);
+    });
+
+    it('should have no rows when nothing was skipped', async () => {
+      getSkippedEventsSummary.mockResolvedValue({ locations: {}, total: 0 });
+
+      const { locationsData } = await actions();
+
+      expect(get(locationsData)).toEqual([]);
+    });
+  });
+
+  describe('exporting from the desktop app', () => {
+    it('should write to the directory the user picked', async () => {
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(openDirectory).toHaveBeenCalledOnce();
+      expect(exportSkippedEventsCSV).toHaveBeenCalledExactlyOnceWith('/tmp/exports');
+      expect(downloadSkippedEventsCSV).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing when the user picked no directory', async () => {
+      openDirectory.mockResolvedValue(undefined);
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(exportSkippedEventsCSV).not.toHaveBeenCalled();
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+
+    it('should report a successful write', async () => {
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ success: true }));
+    });
+
+    it('should report a write the backend refused', async () => {
+      exportSkippedEventsCSV.mockResolvedValue(false);
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+        description: 'actions.online_events.skipped.csv_export.message.failure',
+        success: false,
+      }));
+    });
+
+    it('should report a write that threw', async () => {
+      exportSkippedEventsCSV.mockRejectedValue(new Error('disk full'));
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+        description: 'disk full',
+        success: false,
+      }));
+    });
+  });
+
+  describe('exporting from the browser', () => {
+    beforeEach(() => {
+      appSession.value = false;
+    });
+
+    it('should download rather than ask for a directory there is none of', async () => {
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(downloadSkippedEventsCSV).toHaveBeenCalledOnce();
+      expect(openDirectory).not.toHaveBeenCalled();
+      expect(exportSkippedEventsCSV).not.toHaveBeenCalled();
+    });
+
+    it('should stay quiet when the download worked, since the browser shows it', async () => {
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+
+    it('should surface the reason a download failed', async () => {
+      downloadSkippedEventsCSV.mockResolvedValue({ message: 'no events', success: false });
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+        description: 'no events',
+        success: false,
+      }));
+    });
+
+    it('should fall back to a generic reason when the failure names none', async () => {
+      downloadSkippedEventsCSV.mockResolvedValue({ success: false });
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({
+        description: 'transactions.events.skipped.download_failed',
+      }));
+    });
+
+    it('should report a download that threw', async () => {
+      downloadSkippedEventsCSV.mockRejectedValue(new Error('offline'));
+      const { exportCSV } = await actions();
+
+      await exportCSV();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+        description: 'offline',
+        success: false,
+      }));
+    });
+  });
+
+  describe('reprocessing', () => {
+    it('should report success when every skipped event was decoded', async () => {
+      const { reProcessSkippedEvents: reProcess } = await actions();
+
+      await reProcess();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+        description: 'transactions.events.skipped.reprocess.success.all',
+        success: true,
+      }));
+    });
+
+    it('should still count a partial run as a success', async () => {
+      reProcessSkippedEvents.mockResolvedValue({ successful: 1, total: 3 });
+      const { reProcessSkippedEvents: reProcess } = await actions();
+
+      await reProcess();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+        description: 'transactions.events.skipped.reprocess.success.some::1, 3',
+        success: true,
+      }));
+    });
+
+    it('should report a failure when nothing could be decoded', async () => {
+      reProcessSkippedEvents.mockResolvedValue({ successful: 0, total: 3 });
+      const { reProcessSkippedEvents: reProcess } = await actions();
+
+      await reProcess();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+        description: 'transactions.events.skipped.reprocess.failed.no_processed_events',
+        success: false,
+      }));
+    });
+
+    it('should report a run that threw', async () => {
+      reProcessSkippedEvents.mockRejectedValue(new Error('decoder crashed'));
+      const { reProcessSkippedEvents: reProcess } = await actions();
+
+      await reProcess();
+
+      expect(setMessage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+        description: 'decoder crashed',
+        success: false,
+      }));
+    });
+
+    it('should re-read the summary, since the counts have changed', async () => {
+      const { reProcessSkippedEvents: reProcess } = await actions();
+      getSkippedEventsSummary.mockClear();
+      getSkippedEventsSummary.mockResolvedValue({ locations: {}, total: 0 });
+
+      await reProcess();
+
+      expect(getSkippedEventsSummary).toHaveBeenCalledOnce();
+    });
+
+    it('should re-read the summary even when the run failed', async () => {
+      reProcessSkippedEvents.mockRejectedValue(new Error('decoder crashed'));
+      const { reProcessSkippedEvents: reProcess } = await actions();
+      getSkippedEventsSummary.mockClear();
+
+      await reProcess();
+
+      expect(getSkippedEventsSummary).toHaveBeenCalledOnce();
+    });
+
+    it('should stop showing progress once it is done', async () => {
+      const { loading, reProcessSkippedEvents: reProcess } = await actions();
+
+      await reProcess();
+
+      expect(get(loading)).toBe(false);
+    });
+
+    it('should stop showing progress when the run threw', async () => {
+      reProcessSkippedEvents.mockRejectedValue(new Error('decoder crashed'));
+      const { loading, reProcessSkippedEvents: reProcess } = await actions();
+
+      await reProcess();
+
+      expect(get(loading)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-skipped-events-actions.ts
+++ b/frontend/app/src/modules/history/events/use-skipped-events-actions.ts
@@ -1,0 +1,168 @@
+import type { Message } from '@rotki/common';
+import type { ComputedRef, Ref } from 'vue';
+import type { SkippedHistoryEventsSummary } from '@/modules/history/events/event-payloads';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { logger } from '@/modules/core/common/logging/logging';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useSkippedHistoryEventsApi } from '@/modules/history/api/events/use-skipped-history-events-api';
+import { useInterop } from '@/modules/shell/app/use-electron-interop';
+
+/** One row of the summary: how many events were skipped at a given location. */
+export interface SkippedEventsLocation {
+  location: string;
+  number: number;
+}
+
+interface UseSkippedEventsActionsReturn {
+  /**
+   * Writes the skipped events to a CSV.
+   *
+   * @remarks
+   * In the desktop app this asks for a directory and writes there; on the web it downloads instead,
+   * since there is no filesystem to write to.
+   */
+  exportCSV: () => Promise<void>;
+  /** True while the skipped events are being reprocessed. */
+  loading: Readonly<Ref<boolean>>;
+  /** The per-location counts, as table rows. */
+  locationsData: ComputedRef<SkippedEventsLocation[]>;
+  /** Asks the backend to decode the skipped events again, then refreshes the summary. */
+  reProcessSkippedEvents: () => Promise<void>;
+  /** The counts behind the table, refreshed after a reprocess. */
+  skippedEvents: Ref<SkippedHistoryEventsSummary>;
+}
+
+/**
+ * Drives the skipped-events settings row: the summary it shows and the two actions on it.
+ *
+ * @returns the summary and the actions; both actions report their outcome as a message
+ */
+export function useSkippedEventsActions(): UseSkippedEventsActionsReturn {
+  const loading = shallowRef<boolean>(false);
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { setMessage } = useMessageStore();
+  const { appSession, openDirectory } = useInterop();
+  const {
+    downloadSkippedEventsCSV,
+    exportSkippedEventsCSV,
+    getSkippedEventsSummary,
+    reProcessSkippedEvents: reProcessSkippedEventsCaller,
+  } = useSkippedHistoryEventsApi();
+
+  const { execute: refreshSkippedEvents, state: skippedEvents } = useAsyncState<SkippedHistoryEventsSummary>(
+    getSkippedEventsSummary,
+    {
+      locations: {},
+      total: 0,
+    },
+    {
+      delay: 0,
+      immediate: true,
+      resetOnExecute: false,
+    },
+  );
+
+  const locationsData = computed<SkippedEventsLocation[]>(() =>
+    Object.entries(get(skippedEvents).locations).map(([location, number]) => ({
+      location,
+      number,
+    })),
+  );
+
+  function showExportCSVError(description: string): void {
+    setMessage({
+      description,
+      success: false,
+      title: t('transactions.events.skipped.csv_export_error'),
+    });
+  }
+
+  async function createCsv(path: string): Promise<void> {
+    let message: Message;
+    try {
+      const success = await exportSkippedEventsCSV(path);
+      message = {
+        description: success
+          ? t('actions.online_events.skipped.csv_export.message.success')
+          : t('actions.online_events.skipped.csv_export.message.failure'),
+        success,
+        title: t('actions.online_events.skipped.csv_export.title'),
+      };
+    }
+    catch (error: unknown) {
+      message = {
+        description: getErrorMessage(error),
+        success: false,
+        title: t('actions.online_events.skipped.csv_export.title'),
+      };
+    }
+    setMessage(message);
+  }
+
+  async function exportCSV(): Promise<void> {
+    try {
+      if (appSession) {
+        const directory = await openDirectory(t('common.select_directory'));
+        if (!directory)
+          return;
+
+        await createCsv(directory);
+      }
+      else {
+        const result = await downloadSkippedEventsCSV();
+        if (!result.success)
+          showExportCSVError(result.message ?? t('transactions.events.skipped.download_failed'));
+      }
+    }
+    catch (error: unknown) {
+      showExportCSVError(getErrorMessage(error));
+    }
+  }
+
+  async function reProcessSkippedEvents(): Promise<void> {
+    set(loading, true);
+    let message: Message;
+    try {
+      const { successful, total } = await reProcessSkippedEventsCaller();
+      if (successful === 0) {
+        message = {
+          description: t('transactions.events.skipped.reprocess.failed.no_processed_events'),
+          success: false,
+          title: t('transactions.events.skipped.reprocess.failed.title'),
+        };
+      }
+      else {
+        message = {
+          description: successful < total
+            ? t('transactions.events.skipped.reprocess.success.some', { successful, total })
+            : t('transactions.events.skipped.reprocess.success.all'),
+          success: true,
+          title: t('transactions.events.skipped.reprocess.success.title'),
+        };
+      }
+    }
+    catch (error: unknown) {
+      logger.error(error);
+      message = {
+        description: getErrorMessage(error),
+        success: false,
+        title: t('transactions.events.skipped.reprocess.failed.title'),
+      };
+    }
+    finally {
+      set(loading, false);
+    }
+
+    setMessage(message);
+    await refreshSkippedEvents();
+  }
+
+  return {
+    exportCSV,
+    loading: readonly(loading),
+    locationsData,
+    reProcessSkippedEvents,
+    skippedEvents,
+  };
+}

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.spec.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.spec.ts
@@ -1,0 +1,246 @@
+import type { ResolutionCallbacks } from '@/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution';
+import { libraryDefaults } from '@test/utils/provide-defaults';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import InternalTxConflictsContent from '@/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue';
+import {
+  type InternalTxConflict,
+  InternalTxConflictActions,
+  InternalTxConflictStatuses,
+  RedecodeReasons,
+  RepullReasons,
+} from '@/modules/history/internal-tx-conflicts/types';
+
+const conflictsApi = {
+  conflicts: ref<InternalTxConflict[]>([]),
+  failedCount: ref<number>(0),
+  fetchConflicts: vi.fn(async () => Promise.resolve()),
+  fetchCounts: vi.fn(async () => Promise.resolve()),
+  filters: ref({}),
+  loading: ref<boolean>(false),
+  pagination: ref({ limit: 10, page: 1, total: 0 }),
+  pendingCount: ref<number>(0),
+  setFilter: vi.fn(),
+  sort: ref([]),
+};
+
+const selectionApi = {
+  areAllSelected: vi.fn(() => false),
+  clearSelection: vi.fn(),
+  isSelected: vi.fn(() => false),
+  selectedConflicts: ref<InternalTxConflict[]>([]),
+  selectedCount: ref<number>(0),
+  toggleAllOnPage: vi.fn(),
+  toggleSelection: vi.fn(),
+};
+
+const resolutionApi = {
+  cancelResolution: vi.fn(),
+  isResolving: vi.fn(() => false),
+  progress: ref({ isRunning: false }),
+  resolveMany: vi.fn<(conflicts: InternalTxConflict[], callbacks: ResolutionCallbacks) => Promise<void>>(
+    async () => Promise.resolve(),
+  ),
+  resolveOne: vi.fn<(conflict: InternalTxConflict, callbacks: ResolutionCallbacks) => Promise<void>>(
+    async () => Promise.resolve(),
+  ),
+};
+
+vi.mock('@/modules/history/internal-tx-conflicts/use-internal-tx-conflicts', () => ({
+  useInternalTxConflicts: (): typeof conflictsApi => conflictsApi,
+}));
+
+vi.mock('@/modules/history/internal-tx-conflicts/use-internal-tx-conflict-selection', () => ({
+  useInternalTxConflictSelection: (): typeof selectionApi => selectionApi,
+}));
+
+vi.mock('@/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution', () => ({
+  useInternalTxConflictResolution: (): typeof resolutionApi => resolutionApi,
+}));
+
+vi.mock('@/modules/history/internal-tx-conflicts/use-internal-tx-conflict-fields', () => ({
+  useInternalTxConflictFields: (): unknown[] => [],
+}));
+
+const stubs = {
+  CopyButton: true,
+  DateDisplay: true,
+  HashLink: true,
+  InternalTxConflictRowActions: true,
+  LocationIcon: true,
+  PillFilterBar: true,
+  ScrollableDialogContent: { template: '<div><slot /></div>' },
+};
+
+const wrappers: VueWrapper[] = [];
+
+function conflict(overrides: Partial<InternalTxConflict> = {}): InternalTxConflict {
+  return {
+    action: InternalTxConflictActions.REPULL,
+    chain: 'ethereum',
+    groupIdentifier: null,
+    lastError: null,
+    lastRetryTs: null,
+    redecodeReason: null,
+    repullReason: null,
+    timestamp: 1700000000,
+    txHash: '0xdead',
+    ...overrides,
+  };
+}
+
+async function mountContent(props: Record<string, unknown> = {}): Promise<VueWrapper> {
+  const wrapper = mount(InternalTxConflictsContent, {
+    global: { provide: libraryDefaults, stubs },
+    props,
+  });
+  wrappers.push(wrapper);
+  await flushPromises();
+  return wrapper;
+}
+
+function columnKeys(wrapper: VueWrapper): string[] {
+  return wrapper.findComponent({ name: 'RuiDataTable' }).props('cols').map((col: { key: string }) => col.key);
+}
+
+describe('modules/history/internal-tx-conflicts/InternalTxConflictsContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(conflictsApi.conflicts, []);
+    set(selectionApi.selectedConflicts, []);
+    set(selectionApi.selectedCount, 0);
+    set(resolutionApi.progress, { isRunning: false });
+  });
+
+  afterEach(() => {
+    while (wrappers.length > 0)
+      wrappers.pop()?.unmount();
+  });
+
+  describe('what it does on mount', () => {
+    it('should load both the rows and the counts', async () => {
+      await mountContent();
+
+      expect(conflictsApi.fetchConflicts).toHaveBeenCalledOnce();
+      expect(conflictsApi.fetchCounts).toHaveBeenCalledOnce();
+    });
+
+    it('should resolve nothing by itself', async () => {
+      await mountContent();
+
+      expect(resolutionApi.resolveOne).not.toHaveBeenCalled();
+      expect(resolutionApi.resolveMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('switching tabs', () => {
+    it('should clear the selection, so rows picked on one tab cannot be resolved from another', async () => {
+      const wrapper = await mountContent();
+
+      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:model-value', 1);
+      await flushPromises();
+
+      expect(selectionApi.clearSelection).toHaveBeenCalledOnce();
+    });
+
+    it.each([
+      [1, InternalTxConflictStatuses.FAILED],
+      [2, InternalTxConflictStatuses.FIXED],
+    ])('should filter to the status behind tab %s', async (tab, status) => {
+      const wrapper = await mountContent();
+
+      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:model-value', tab);
+      await flushPromises();
+
+      expect(conflictsApi.setFilter).toHaveBeenLastCalledWith(status);
+    });
+
+    it('should filter back to pending on returning to the first tab', async () => {
+      const wrapper = await mountContent();
+      const tabs = wrapper.findComponent({ name: 'RuiTabs' });
+
+      await tabs.vm.$emit('update:model-value', 2);
+      await flushPromises();
+      await tabs.vm.$emit('update:model-value', 0);
+      await flushPromises();
+
+      expect(conflictsApi.setFilter).toHaveBeenLastCalledWith(InternalTxConflictStatuses.PENDING);
+    });
+  });
+
+  describe('resolving the selection', () => {
+    it('should send exactly the selected conflicts, not the whole page', async () => {
+      const picked = conflict({ txHash: '0xpicked' });
+      set(conflictsApi.conflicts, [picked, conflict({ txHash: '0xother' })]);
+      set(selectionApi.selectedConflicts, [picked]);
+      set(selectionApi.selectedCount, 1);
+      const wrapper = await mountContent();
+
+      await wrapper.find('[data-testid="resolve-selected"]').trigger('click');
+      await flushPromises();
+
+      expect(resolutionApi.resolveMany).toHaveBeenCalledOnce();
+      expect(resolutionApi.resolveMany.mock.calls[0][0]).toEqual([picked]);
+    });
+
+    it('should refresh the rows and counts once resolution completes', async () => {
+      set(selectionApi.selectedConflicts, [conflict()]);
+      set(selectionApi.selectedCount, 1);
+      const wrapper = await mountContent();
+      conflictsApi.fetchConflicts.mockClear();
+      conflictsApi.fetchCounts.mockClear();
+
+      await wrapper.find('[data-testid="resolve-selected"]').trigger('click');
+      await resolutionApi.resolveMany.mock.calls[0][1].onComplete();
+
+      expect(conflictsApi.fetchConflicts).toHaveBeenCalledOnce();
+      expect(conflictsApi.fetchCounts).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('the columns it shows', () => {
+    it('should drop the diagnostic columns when compact, where there is no room', async () => {
+      const wrapper = await mountContent({ compact: true });
+
+      expect(columnKeys(wrapper)).toEqual(['selection', 'chain', 'txHash', 'timestamp', 'actions']);
+    });
+
+    it('should show the reason and last error at full width', async () => {
+      const wrapper = await mountContent();
+
+      expect(columnKeys(wrapper)).toContain('reason');
+      expect(columnKeys(wrapper)).toContain('lastError');
+      expect(columnKeys(wrapper)).toContain('lastRetryTs');
+    });
+  });
+
+  describe('the reason it shows per row', () => {
+    it('should prefer the repull reason when a row carries both', async () => {
+      set(conflictsApi.conflicts, [conflict({
+        redecodeReason: RedecodeReasons.MIXED_ZERO_GAS,
+        repullReason: RepullReasons.ALL_ZERO_GAS,
+      })]);
+
+      const wrapper = await mountContent();
+
+      expect(wrapper.text()).toContain('internal_tx_conflicts.reasons.all_zero_gas');
+      expect(wrapper.text()).not.toContain('internal_tx_conflicts.reasons.mixed_zero_gas');
+    });
+
+    it('should fall back to the redecode reason', async () => {
+      set(conflictsApi.conflicts, [conflict({ redecodeReason: RedecodeReasons.DUPLICATE_EXACT_ROWS })]);
+
+      const wrapper = await mountContent();
+
+      expect(wrapper.text()).toContain('internal_tx_conflicts.reasons.duplicate_exact_rows');
+    });
+
+    it('should show a dash when a row names no reason at all', async () => {
+      set(conflictsApi.conflicts, [conflict()]);
+
+      const wrapper = await mountContent();
+
+      expect(wrapper.text()).toContain('—');
+    });
+  });
+});

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
@@ -225,6 +225,7 @@ defineExpose({
             color="primary"
             size="sm"
             :disabled="selectedCount === 0"
+            data-testid="resolve-selected"
             @click="onResolveSelected()"
           >
             {{ t('internal_tx_conflicts.resolution.resolve_selected', { count: selectedCount }) }}

--- a/frontend/app/src/modules/history/refresh/HistoryRefreshChains.vue
+++ b/frontend/app/src/modules/history/refresh/HistoryRefreshChains.vue
@@ -1,15 +1,8 @@
 <script lang="ts" setup>
-import type { ChainData } from '@/modules/history/refresh/types';
-import { getTextToken } from '@rotki/common';
-import { cloneDeep, isEqual } from 'es-toolkit';
-import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
-import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import {
-  type ChainAddress,
-  TransactionChainType,
-} from '@/modules/history/events/event-payloads';
+import type { ChainAddress } from '@/modules/history/events/event-payloads';
 import HistoryRefreshAddressSelection from '@/modules/history/refresh/HistoryRefreshAddressSelection.vue';
 import HistoryRefreshChainItem from '@/modules/history/refresh/HistoryRefreshChainItem.vue';
+import { useHistoryRefreshChainSelection } from '@/modules/history/refresh/use-history-refresh-chain-selection';
 
 const modelValue = defineModel<ChainAddress[]>({ required: true });
 const selectedChain = defineModel<string | undefined>('chain', { required: true });
@@ -21,137 +14,18 @@ defineProps<{
 
 const emit = defineEmits<{ 'update:all-selected': [allSelected: boolean] }>();
 
-const selection = ref<Record<string, string[]>>({});
-
-const { bitcoinChainsData, evmLikeChainsData, solanaChainsData, txEvmChains } = useSupportedChains();
-const { getAddresses } = useAccountAddresses();
 const { t } = useI18n({ useScope: 'global' });
 
-const refreshChains = computed<ChainData[]>(() => [
-  ...get(txEvmChains).map(item => ({
-    chain: item.id,
-    id: item.id,
-    name: item.name,
-    type: TransactionChainType.EVM,
-  })),
-  ...get(evmLikeChainsData).map(item => ({
-    chain: item.id,
-    id: item.id,
-    name: item.name,
-    type: TransactionChainType.EVMLIKE,
-  })),
-  ...get(bitcoinChainsData).map(item => ({
-    chain: item.id,
-    id: item.id,
-    name: item.name,
-    type: TransactionChainType.BITCOIN,
-  })),
-  ...get(solanaChainsData).map(item => ({
-    chain: item.id,
-    id: item.id,
-    name: item.name,
-    type: TransactionChainType.SOLANA,
-  })),
-]);
-
-const filtered = computed<ChainData[]>(() => {
-  const chains = get(refreshChains).filter(item => getAddresses(item.id)?.length > 0);
-  const query = getTextToken(get(search));
-  if (!query)
-    return chains;
-
-  return chains.filter(item => getTextToken(item.chain).includes(query) || getTextToken(item.name).includes(query));
-});
-
-const chainAddresses = computed<Record<string, string[]>>(() => {
-  const chains = [...get(refreshChains)];
-  const record: Record<string, string[]> = {};
-  return chains.reduce((acc, item) => {
-    acc[item.chain] = getAddresses(item.id) ?? [];
-    return acc;
-  }, record);
-});
-
-const selected = computed<number>(() => getAccounts(get(selection)).length);
-
-function getAccounts(record: Record<string, string[]>): ChainAddress[] {
-  return Object.entries(record).flatMap(([chainKey, addresses]) => addresses.map((address): ChainAddress => ({
-    address,
-    chain: chainKey,
-  })));
-}
-
-function emptySelection(): Record<string, string[]> {
-  return Object.fromEntries(get(refreshChains).map(item => [item.chain, []]));
-}
-
-function toggleSelectAll() {
-  if (isDefined(selectedChain)) {
-    toggleSpecificChain(get(selectedChain));
-  }
-  else {
-    toggleAllChains();
-  }
-}
-
-function toggleSpecificChain(chain: string) {
-  const currentSelection = get(selection);
-  if (currentSelection[chain].length === 0) {
-    updateSelection({
-      ...currentSelection,
-      [chain]: get(chainAddresses)[chain],
-    });
-  }
-  else {
-    updateSelection({
-      ...currentSelection,
-      [chain]: [],
-    });
-  }
-}
-
-function toggleAllChains() {
-  if (get(selected) === 0) {
-    updateSelection(cloneDeep(get(chainAddresses)));
-  }
-  else {
-    updateSelection(emptySelection());
-  }
-}
-
-function updateAllSelected() {
-  if (isDefined(selectedChain)) {
-    const selected = get(selection);
-    const evmChain = get(selectedChain);
-    emit('update:all-selected', isEqual(get(chainAddresses)[evmChain], selected[evmChain]));
-  }
-  else {
-    const all = getAccounts(get(chainAddresses));
-    const selected = getAccounts(get(selection));
-    emit('update:all-selected', isEqual(all, selected));
-  }
-}
-
-function updateSelection(newSelection: Record<string, string[]>) {
-  set(selection, newSelection);
-  set(modelValue, getAccounts(newSelection));
-  updateAllSelected();
-}
-
-watch(selectedChain, () => {
-  set(search, '');
-  updateAllSelected();
-});
-
-watch(selection, (newSelection) => {
-  set(modelValue, getAccounts(newSelection));
-  updateAllSelected();
-}, {
-  deep: true,
-});
-
-onBeforeMount(() => {
-  updateSelection(emptySelection());
+const {
+  chainAddresses,
+  filtered,
+  modelSelection: selection,
+  toggleSelectAll,
+} = useHistoryRefreshChainSelection({
+  chain: selectedChain,
+  modelValue,
+  onAllSelected: allSelected => emit('update:all-selected', allSelected),
+  search,
 });
 
 defineExpose({

--- a/frontend/app/src/modules/history/refresh/use-history-refresh-chain-selection.spec.ts
+++ b/frontend/app/src/modules/history/refresh/use-history-refresh-chain-selection.spec.ts
@@ -1,0 +1,259 @@
+import type { ChainAddress } from '@/modules/history/events/event-payloads';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import { useHistoryRefreshChainSelection } from './use-history-refresh-chain-selection';
+
+const { addressesByChain, bitcoinChainsData, evmLikeChainsData, solanaChainsData, txEvmChains } = await vi.hoisted(
+  async () => {
+    const { ref } = await import('vue');
+    return {
+      addressesByChain: ref<Record<string, string[]>>({}),
+      bitcoinChainsData: ref<{ id: string; name: string }[]>([]),
+      evmLikeChainsData: ref<{ id: string; name: string }[]>([]),
+      solanaChainsData: ref<{ id: string; name: string }[]>([]),
+      txEvmChains: ref<{ id: string; name: string }[]>([]),
+    };
+  },
+);
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({
+    bitcoinChainsData,
+    evmLikeChainsData,
+    solanaChainsData,
+    txEvmChains,
+  }),
+}));
+
+vi.mock('@/modules/balances/blockchain/use-account-addresses', () => ({
+  useAccountAddresses: (): Record<string, unknown> => ({
+    getAddresses: (chain: string): string[] => get(addressesByChain)[chain] ?? [],
+  }),
+}));
+
+let scope: ReturnType<typeof effectScope>;
+
+interface Harness {
+  api: ReturnType<typeof useHistoryRefreshChainSelection>;
+  chain: ReturnType<typeof ref<string | undefined>>;
+  modelValue: ReturnType<typeof ref<ChainAddress[]>>;
+  onAllSelected: ReturnType<typeof vi.fn<(allSelected: boolean) => void>>;
+  search: ReturnType<typeof ref<string>>;
+}
+
+function harness(selectedChain?: string): Harness {
+  const chain = ref<string | undefined>(selectedChain);
+  const modelValue = ref<ChainAddress[]>([]);
+  const search = ref<string>('');
+  const onAllSelected = vi.fn<(allSelected: boolean) => void>();
+  scope = effectScope();
+  const api = scope.run(() => useHistoryRefreshChainSelection({ chain, modelValue, onAllSelected, search }))!;
+  return { api, chain, modelValue, onAllSelected, search };
+}
+
+describe('modules/history/refresh/useHistoryRefreshChainSelection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(txEvmChains, [{ id: 'ethereum', name: 'Ethereum' }, { id: 'optimism', name: 'Optimism' }]);
+    set(evmLikeChainsData, [{ id: 'zksync_lite', name: 'zkSync Lite' }]);
+    set(bitcoinChainsData, [{ id: 'btc', name: 'Bitcoin' }]);
+    set(solanaChainsData, [{ id: 'solana', name: 'Solana' }]);
+    set(addressesByChain, {
+      btc: ['bc1qaaa'],
+      ethereum: ['0xaaa', '0xbbb'],
+      optimism: [],
+      solana: ['sol1'],
+      zksync_lite: ['0xccc'],
+    });
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the chains it offers', () => {
+    it('should list every kind of chain the app can refresh', () => {
+      const { api } = harness();
+
+      expect(get(api.filtered).map(item => item.id)).toEqual(['ethereum', 'zksync_lite', 'btc', 'solana']);
+    });
+
+    it('should leave out a chain the user holds no account on', () => {
+      const { api } = harness();
+
+      expect(get(api.filtered).map(item => item.id)).not.toContain('optimism');
+    });
+
+    it.each([
+      ['bitcoin', ['btc']],
+      ['sol', ['solana']],
+      ['zk', ['zksync_lite']],
+    ])('should match %s against both the chain id and its name', (query, expected) => {
+      const { api, search } = harness();
+
+      set(search, query);
+
+      expect(get(api.filtered).map(item => item.id)).toEqual(expected);
+    });
+
+    it('should carry every address per chain, whether it is selected or not', () => {
+      const { api } = harness();
+
+      expect(get(api.chainAddresses)).toEqual({
+        btc: ['bc1qaaa'],
+        ethereum: ['0xaaa', '0xbbb'],
+        optimism: [],
+        solana: ['sol1'],
+        zksync_lite: ['0xccc'],
+      });
+    });
+  });
+
+  describe('what it starts from', () => {
+    it('should select nothing, so a refresh never runs wider than asked', () => {
+      const { api, modelValue } = harness();
+
+      expect(get(modelValue)).toEqual([]);
+      expect(get(api.modelSelection)).toEqual({
+        btc: [],
+        ethereum: [],
+        optimism: [],
+        solana: [],
+        zksync_lite: [],
+      });
+    });
+
+    it('should report that nothing is fully selected', () => {
+      const { onAllSelected } = harness();
+
+      expect(onAllSelected).toHaveBeenLastCalledWith(false);
+    });
+  });
+
+  describe('selecting everything', () => {
+    it('should pair each address with its own chain', () => {
+      const { api, modelValue } = harness();
+
+      api.toggleSelectAll();
+
+      expect(get(modelValue)).toEqual([
+        { address: '0xaaa', chain: 'ethereum' },
+        { address: '0xbbb', chain: 'ethereum' },
+        { address: '0xccc', chain: 'zksync_lite' },
+        { address: 'bc1qaaa', chain: 'btc' },
+        { address: 'sol1', chain: 'solana' },
+      ]);
+    });
+
+    it('should report that everything is now selected', () => {
+      const { api, onAllSelected } = harness();
+
+      api.toggleSelectAll();
+
+      expect(onAllSelected).toHaveBeenLastCalledWith(true);
+    });
+
+    it('should clear the selection when it is toggled again', () => {
+      const { api, modelValue } = harness();
+
+      api.toggleSelectAll();
+      api.toggleSelectAll();
+
+      expect(get(modelValue)).toEqual([]);
+    });
+
+    it('should not hand out the chain address arrays themselves', () => {
+      const { api } = harness();
+
+      api.toggleSelectAll();
+      get(api.modelSelection).ethereum.push('0xddd');
+
+      expect(get(api.chainAddresses).ethereum).toEqual(['0xaaa', '0xbbb']);
+    });
+  });
+
+  describe('selecting within one chain', () => {
+    it('should select only that chain, leaving the others alone', () => {
+      const { api, modelValue } = harness('ethereum');
+
+      api.toggleSelectAll();
+
+      expect(get(modelValue)).toEqual([
+        { address: '0xaaa', chain: 'ethereum' },
+        { address: '0xbbb', chain: 'ethereum' },
+      ]);
+    });
+
+    it('should report that chain as fully selected', () => {
+      const { api, onAllSelected } = harness('ethereum');
+
+      api.toggleSelectAll();
+
+      expect(onAllSelected).toHaveBeenLastCalledWith(true);
+    });
+
+    it('should clear only that chain when toggled again', () => {
+      const { api, modelValue } = harness('ethereum');
+
+      api.toggleSelectAll();
+      api.toggleSelectAll();
+
+      expect(get(modelValue)).toEqual([]);
+    });
+
+    it('should not report a partly selected chain as fully selected', async () => {
+      const { api, onAllSelected } = harness('ethereum');
+
+      get(api.modelSelection).ethereum = ['0xaaa'];
+      await nextTick();
+
+      expect(onAllSelected).toHaveBeenLastCalledWith(false);
+    });
+  });
+
+  describe('when the picked chain changes', () => {
+    it('should clear the search, which was scoped to the previous view', async () => {
+      const { chain, search } = harness();
+      set(search, 'ethereum');
+
+      set(chain, 'btc');
+      await nextTick();
+
+      expect(get(search)).toBe('');
+    });
+
+    it('should re-report against the newly picked chain', async () => {
+      const { api, chain, onAllSelected } = harness();
+      api.toggleSelectAll();
+
+      set(chain, 'btc');
+      await nextTick();
+
+      expect(onAllSelected).toHaveBeenLastCalledWith(true);
+    });
+  });
+
+  describe('when a row changes the selection directly', () => {
+    it('should keep the accounts to refresh in step', async () => {
+      const { api, modelValue } = harness();
+
+      set(api.modelSelection, { ...get(api.modelSelection), btc: ['bc1qaaa'] });
+      await nextTick();
+
+      expect(get(modelValue)).toEqual([{ address: 'bc1qaaa', chain: 'btc' }]);
+    });
+
+    it('should report everything selected once every address is picked', async () => {
+      const { api, onAllSelected } = harness();
+
+      const selection = get(api.modelSelection);
+      selection.ethereum = ['0xaaa', '0xbbb'];
+      selection.zksync_lite = ['0xccc'];
+      selection.btc = ['bc1qaaa'];
+      selection.solana = ['sol1'];
+      await nextTick();
+
+      expect(onAllSelected).toHaveBeenLastCalledWith(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/history/refresh/use-history-refresh-chain-selection.ts
+++ b/frontend/app/src/modules/history/refresh/use-history-refresh-chain-selection.ts
@@ -1,0 +1,165 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { ChainData } from '@/modules/history/refresh/types';
+import { getTextToken } from '@rotki/common';
+import { cloneDeep, isEqual } from 'es-toolkit';
+import { useAccountAddresses } from '@/modules/balances/blockchain/use-account-addresses';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { type ChainAddress, TransactionChainType } from '@/modules/history/events/event-payloads';
+
+interface UseHistoryRefreshChainSelectionOptions {
+  /** The chain whose addresses are being picked individually; undefined lists every chain. */
+  chain: Ref<string | undefined>;
+  /** The accounts to refresh, kept in sync with the selection. */
+  modelValue: Ref<ChainAddress[]>;
+  /** The chain-list filter; cleared whenever the drilled-into chain changes. */
+  search: Ref<string>;
+  /** Called whenever the selection covers everything currently in view, or stops doing so. */
+  onAllSelected?: (allSelected: boolean) => void;
+}
+
+interface UseHistoryRefreshChainSelectionReturn {
+  /** Every address the user holds, per chain, whether selected or not. */
+  chainAddresses: ComputedRef<Record<string, string[]>>;
+  /** The chains worth listing: the ones with accounts, narrowed by the search. */
+  filtered: ComputedRef<ChainData[]>;
+  /** The picked addresses per chain, bound per row. */
+  modelSelection: Ref<Record<string, string[]>>;
+  /**
+   * Selects everything in view, or clears it if it is already all selected.
+   *
+   * @remarks
+   * Scoped to the drilled-into chain when there is one, so selecting all inside a chain does not
+   * silently select every other chain's addresses too.
+   */
+  toggleSelectAll: () => void;
+}
+
+/**
+ * Drives which accounts a history refresh covers.
+ *
+ * @returns the chain list and the selection; only
+ * {@link UseHistoryRefreshChainSelectionReturn.toggleSelectAll} and writes to `modelSelection`
+ * change it
+ */
+export function useHistoryRefreshChainSelection(
+  options: UseHistoryRefreshChainSelectionOptions,
+): UseHistoryRefreshChainSelectionReturn {
+  const { chain: selectedChain, modelValue, onAllSelected, search } = options;
+
+  const modelSelection = ref<Record<string, string[]>>({});
+
+  const { bitcoinChainsData, evmLikeChainsData, solanaChainsData, txEvmChains } = useSupportedChains();
+  const { getAddresses } = useAccountAddresses();
+
+  const refreshChains = computed<ChainData[]>(() => [
+    ...get(txEvmChains).map(item => ({
+      chain: item.id,
+      id: item.id,
+      name: item.name,
+      type: TransactionChainType.EVM,
+    })),
+    ...get(evmLikeChainsData).map(item => ({
+      chain: item.id,
+      id: item.id,
+      name: item.name,
+      type: TransactionChainType.EVMLIKE,
+    })),
+    ...get(bitcoinChainsData).map(item => ({
+      chain: item.id,
+      id: item.id,
+      name: item.name,
+      type: TransactionChainType.BITCOIN,
+    })),
+    ...get(solanaChainsData).map(item => ({
+      chain: item.id,
+      id: item.id,
+      name: item.name,
+      type: TransactionChainType.SOLANA,
+    })),
+  ]);
+
+  const filtered = computed<ChainData[]>(() => {
+    const chains = get(refreshChains).filter(item => getAddresses(item.id)?.length > 0);
+    const query = getTextToken(get(search));
+    if (!query)
+      return chains;
+
+    return chains.filter(item => getTextToken(item.chain).includes(query) || getTextToken(item.name).includes(query));
+  });
+
+  const chainAddresses = computed<Record<string, string[]>>(() => {
+    const record: Record<string, string[]> = {};
+    return get(refreshChains).reduce((acc, item) => {
+      acc[item.chain] = getAddresses(item.id) ?? [];
+      return acc;
+    }, record);
+  });
+
+  function getAccounts(record: Record<string, string[]>): ChainAddress[] {
+    return Object.entries(record).flatMap(([chainKey, addresses]) => addresses.map((address): ChainAddress => ({
+      address,
+      chain: chainKey,
+    })));
+  }
+
+  const selected = computed<number>(() => getAccounts(get(modelSelection)).length);
+
+  function emptySelection(): Record<string, string[]> {
+    return Object.fromEntries(get(refreshChains).map(item => [item.chain, []]));
+  }
+
+  function updateAllSelected(): void {
+    if (isDefined(selectedChain)) {
+      const current = get(modelSelection);
+      const evmChain = get(selectedChain);
+      onAllSelected?.(isEqual(get(chainAddresses)[evmChain], current[evmChain]));
+    }
+    else {
+      onAllSelected?.(isEqual(getAccounts(get(chainAddresses)), getAccounts(get(modelSelection))));
+    }
+  }
+
+  function updateSelection(newSelection: Record<string, string[]>): void {
+    set(modelSelection, newSelection);
+    set(modelValue, getAccounts(newSelection));
+    updateAllSelected();
+  }
+
+  function toggleSpecificChain(chain: string): void {
+    const currentSelection = get(modelSelection);
+    updateSelection({
+      ...currentSelection,
+      [chain]: currentSelection[chain].length === 0 ? get(chainAddresses)[chain] : [],
+    });
+  }
+
+  function toggleAllChains(): void {
+    updateSelection(get(selected) === 0 ? cloneDeep(get(chainAddresses)) : emptySelection());
+  }
+
+  function toggleSelectAll(): void {
+    if (isDefined(selectedChain))
+      toggleSpecificChain(get(selectedChain));
+    else
+      toggleAllChains();
+  }
+
+  watch(selectedChain, () => {
+    set(search, '');
+    updateAllSelected();
+  });
+
+  watch(modelSelection, (newSelection) => {
+    set(modelValue, getAccounts(newSelection));
+    updateAllSelected();
+  }, { deep: true });
+
+  updateSelection(emptySelection());
+
+  return {
+    chainAddresses,
+    filtered,
+    modelSelection,
+    toggleSelectAll,
+  };
+}

--- a/frontend/app/src/modules/session/session-utils.ts
+++ b/frontend/app/src/modules/session/session-utils.ts
@@ -9,7 +9,7 @@ const MIN_SCRAMBLE_MULTIPLIER = 1;
  * correctness boundary rather than the inputs. Small values are lifted rather than clamped flat,
  * so they stay distinct from one another.
  *
- * @param multiplier the raw setting value, which may be negative, zero or not a number
+ * @param multiplier - the raw setting value, which may be negative, zero or not a number
  * @returns a multiplier of at least {@link MIN_SCRAMBLE_MULTIPLIER}
  */
 export function normalizeScrambleMultiplier(multiplier: number): number {

--- a/frontend/app/tests/unit/utils/history-events.ts
+++ b/frontend/app/tests/unit/utils/history-events.ts
@@ -1,6 +1,8 @@
 import { bigNumberify, HistoryEventEntryType } from '@rotki/common';
 import {
   type AssetMovementEvent,
+  type EthBlockEvent,
+  type EthWithdrawalEvent,
   type EvmHistoryEvent,
   HistoryEventAccountingRuleStatus,
   type HistoryEventEntry,
@@ -44,6 +46,20 @@ export function createOnlineHistoryEvent(
   overrides: Partial<Omit<OnlineHistoryEvent, 'entryType'>> = {},
 ): HistoryEventEntry {
   return { ...commonFields, entryType: HistoryEventEntryType.HISTORY_EVENT, ...overrides };
+}
+
+/** Creates a block production event, whose identifier is a block number rather than a hash. */
+export function createEthBlockEvent(
+  overrides: Partial<Omit<EthBlockEvent, 'entryType'>> = {},
+): HistoryEventEntry {
+  return { ...commonFields, blockNumber: 1, validatorIndex: 1, entryType: HistoryEventEntryType.ETH_BLOCK_EVENT, ...overrides };
+}
+
+/** Creates a validator withdrawal, whose identifier is a validator index. */
+export function createWithdrawalEvent(
+  overrides: Partial<Omit<EthWithdrawalEvent, 'entryType'>> = {},
+): HistoryEventEntry {
+  return { ...commonFields, isExit: false, validatorIndex: 1, entryType: HistoryEventEntryType.ETH_WITHDRAWAL_EVENT, ...overrides };
 }
 
 /** Creates a decoded on-chain event. */


### PR DESCRIPTION
Closes #13025.

Batch I of the frontend coverage work, covering the history/events cluster.
Ten components, one commit each.

Five of the ten were extract-first: the logic moved into a composable that a
spec can drive directly, and the SFC was left as wiring. That is where the
coverage actually comes from, and it is what makes the tests worth keeping.

| Component | Script lines | Extracted into | Tests |
|---|---|---|---|
| `MatchAssetMovementsContent` | | | 18 |
| `MatchBridgeTransactionsContent` | | | 13 |
| `HistoryEventsDecodingStatus` | | | 10 |
| `HistoryEventsIdentifier` | 127 -> 27 | `use-history-events-identifier` | 21 |
| `InternalTxConflictsContent` | | | 13 |
| `EventAssetPriceUpdateDialog` | 134 -> 29 | `use-event-price-update-dialog` | 22 |
| `PotentialMatchesContent` | 175 -> 33 | `use-potential-matches` | 24 |
| `RepullingTransactionFormDialog` | 140 -> 30 | `use-repulling-transaction-submission` | 23 |
| `HistoryRefreshChains` | 159 -> 33 | `use-history-refresh-chain-selection` | 20 |
| `HistoryEventsSkippedExternalEvents` | 158 -> 26 | `use-skipped-events-actions` | 21 |

Every extracted composable is at 100% statements and branches, bar one dead
defensive branch in `use-history-refresh-chain-selection` (`getAddresses() ?? []`,
where `getAddresses` already returns `[]`); reaching it would need a mock that
lies about the dependency's contract.

Project line coverage: **67.57% -> 68.63%**.

### Negative controls

Each unit was controlled by breaking the specific line it covers and checking
that the expected tests, and only those, went red. Two controls found problems
in the tests rather than the code:

- A "partly selected chain is not fully selected" assertion passed against a
  broken predicate, because it asserted before the deep watcher had run. It was
  reading the initial call, not the change. Fixed to await, and it now fails
  against the break.
- An "all selected" test failed against correct code: `updateAllSelected`
  compares the flattened account lists, so the result depends on the selection
  record's key insertion order, not just its contents. No caller hits this (rows
  mutate the record in place), so this is a note, not a fix in this PR.

### Notes

- `use-event-price-update-dialog` keeps a short-circuit that writes nothing when
  the price has not changed, so reopening the dialog and pressing save cannot
  create a duplicate manual entry. Both sides of it are pinned.
- `use-potential-matches` is shared between exchange asset movements and bridge
  transactions via the `MatchingFlow` strategy; the tests cover both routes.
- `RepullingFormHandle` is a structural interface rather than the SFC's instance
  type, so the submission flow tests without mounting the form.
