### PR TITLE
fix(frontend): open the validator form on eth2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`13027` Adding an ETH2 validator by index or public key works again. Since 1.44.0 the Add Account button on the validators tab opened the generic blockchain account form instead of the validator form, and saving from it did nothing, so a validator that was not picked up automatically from its deposit could not be added at all.
 * :bug:`-` Historical prices of a token that exists on several chains now come from the main asset it is grouped with, so WETH on Arbitrum, Optimism and Base is priced as ETH. They used to be priced on their own and could come back at roughly half of ETH's value.
 * :bug:`-` Changing the asset or chain in the send form while a gas estimate is still being fetched no longer makes the estimate look finished before it is. The spinner stopped as soon as the request you moved away from unwound, so the fee shown while the real request was still in flight read as the final one.
 * :bug:`-` When a history refresh skips an online source you have switched off or not connected, the reason shown in the task centre now names that source the way the rest of rotki does. It read as the raw internal name, so a skipped block production query was explained as "block_productions is not available".

--- a/frontend/app/src/modules/accounts/AccountBalancesDefaultPage.vue
+++ b/frontend/app/src/modules/accounts/AccountBalancesDefaultPage.vue
@@ -4,6 +4,7 @@ import { useTemplateRef } from 'vue';
 import AccountBalances from '@/modules/accounts/AccountBalances.vue';
 import AccountBalancesExportImport from '@/modules/accounts/AccountBalancesExportImport.vue';
 import AccountImportProgress from '@/modules/accounts/AccountImportProgress.vue';
+import { createNewAccountForChain } from '@/modules/accounts/blockchain/new-account-state';
 import AccountDialog from '@/modules/accounts/management/AccountDialog.vue';
 import { useAccountCategoryHelper } from '@/modules/accounts/use-account-category-helper';
 import { useAccountImportProgressStore } from '@/modules/accounts/use-account-import-progress-store';
@@ -29,17 +30,7 @@ const route = useRoute();
 const router = useRouter();
 
 function createNewBlockchainAccount(): void {
-  set(account, {
-    chain: get(chainIds)[0],
-    data: [
-      {
-        address: '',
-        tags: null,
-      },
-    ],
-    mode: 'add',
-    type: 'account',
-  });
+  set(account, createNewAccountForChain(get(chainIds)[0]));
 }
 
 function refresh() {

--- a/frontend/app/src/modules/accounts/blockchain/new-account-state.ts
+++ b/frontend/app/src/modules/accounts/blockchain/new-account-state.ts
@@ -1,0 +1,32 @@
+import type { AccountManageAdd, StakingValidatorManage } from '@/modules/accounts/blockchain/use-account-manage';
+import { Blockchain } from '@rotki/common';
+
+export function createNewBlockchainAccount(): AccountManageAdd {
+  return {
+    chain: 'all',
+    data: [
+      {
+        address: '',
+        tags: null,
+      },
+    ],
+    mode: 'add',
+    type: 'account',
+  };
+}
+
+export function createNewAccountForChain(chain: string): AccountManageAdd | StakingValidatorManage {
+  if (chain === Blockchain.ETH2) {
+    return {
+      chain: Blockchain.ETH2,
+      data: {},
+      mode: 'add',
+      type: 'validator',
+    };
+  }
+
+  return {
+    ...createNewBlockchainAccount(),
+    chain,
+  };
+}

--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.ts
@@ -39,7 +39,7 @@ export interface StakingValidatorManage extends AccountManageMode {
   data: Eth2Validator;
 }
 
-interface AccountManageAdd extends AccountManageMode {
+export interface AccountManageAdd extends AccountManageMode {
   readonly mode: 'add';
   chain: string;
   type: 'account';
@@ -68,20 +68,6 @@ export interface AccountAgnosticManage extends AccountManageMode {
 export type AccountManage = AccountManageAdd | AccountManageEdit;
 
 export type AccountManageState = AccountManage | StakingValidatorManage | XpubManage | AccountAgnosticManage;
-
-export function createNewBlockchainAccount(): AccountManageAdd {
-  return {
-    chain: 'all',
-    data: [
-      {
-        address: '',
-        tags: null,
-      },
-    ],
-    mode: 'add',
-    type: 'account',
-  };
-}
 
 function buildValidatorManage(data: ValidatorData): StakingValidatorManage {
   const { index, ownershipPercentage = '100', publicKey } = data;

--- a/frontend/app/src/modules/accounts/management/AccountForm.spec.ts
+++ b/frontend/app/src/modules/accounts/management/AccountForm.spec.ts
@@ -1,9 +1,10 @@
+import type { AccountManageState } from '@/modules/accounts/blockchain/use-account-manage';
 import { Blockchain } from '@rotki/common';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type ComponentPublicInstance, nextTick } from 'vue';
 import { XpubKeyType } from '@/modules/accounts/blockchain-accounts';
-import { type AccountManageState, createNewBlockchainAccount } from '@/modules/accounts/blockchain/use-account-manage';
+import { createNewBlockchainAccount } from '@/modules/accounts/blockchain/new-account-state';
 import AccountForm from '@/modules/accounts/management/AccountForm.vue';
 
 /**
@@ -195,6 +196,13 @@ describe('modules/accounts/management/AccountForm', () => {
       expect(states.length).toBeGreaterThan(0);
       for (const [state] of states)
         expect(state.type === 'validator').toBe(state.chain === Blockchain.ETH2);
+    });
+
+    it('should render the validator form for a validator seeded without a chain being chosen', () => {
+      wrapper = createWrapper({ chain: Blockchain.ETH2, data: {}, mode: 'add', type: 'validator' });
+
+      expect(wrapper.findComponent({ name: 'Eth2Input' }).exists()).toBe(true);
+      expect(wrapper.findComponent({ name: 'AddressInput' }).exists()).toBe(false);
     });
 
     it('should not report an edit the form never made', () => {

--- a/frontend/app/src/modules/accounts/management/AccountForm.vue
+++ b/frontend/app/src/modules/accounts/management/AccountForm.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
+import type {
+  AccountManageState,
+  StakingValidatorManage,
+  XpubManage,
+} from '@/modules/accounts/blockchain/use-account-manage';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
 import { assert, Blockchain } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { camelCase } from 'es-toolkit';
 import { XpubKeyType } from '@/modules/accounts/blockchain-accounts';
-import {
-  type AccountManageState,
-  createNewBlockchainAccount,
-  type StakingValidatorManage,
-  type XpubManage,
-} from '@/modules/accounts/blockchain/use-account-manage';
+import { createNewAccountForChain } from '@/modules/accounts/blockchain/new-account-state';
 import AccountFormApiKeyAlertContent from '@/modules/accounts/management/AccountFormApiKeyAlertContent.vue';
 import AccountSelector from '@/modules/accounts/management/inputs/AccountSelector.vue';
 import AddressAccountForm from '@/modules/accounts/management/types/AddressAccountForm.vue';
@@ -279,21 +279,16 @@ function selectChain(next: string | undefined): void {
   if (get(inputMode) === InputMode.XPUB_ADD)
     set(inputMode, InputMode.MANUAL_ADD);
 
-  if (next === Blockchain.ETH2) {
-    set(modelValue, {
-      chain: Blockchain.ETH2,
-      data: {},
-      mode: 'add',
-      type: 'validator',
-    } satisfies StakingValidatorManage);
+  const state = createNewAccountForChain(next);
+  if (state.type === 'validator') {
+    set(modelValue, state);
     return;
   }
 
   // Only the chain was answered, so addresses already typed still answer a different question.
   const data = get(modelValue).data;
   set(modelValue, {
-    ...createNewBlockchainAccount(),
-    chain: next,
+    ...state,
     ...(Array.isArray(data) ? { data } : {}),
   });
 }
@@ -320,12 +315,7 @@ watch(inputMode, (mode) => {
     } satisfies XpubManage);
   }
   else {
-    const account = createNewBlockchainAccount();
-
-    set(modelValue, {
-      ...account,
-      chain: selectedChain,
-    });
+    set(modelValue, createNewAccountForChain(selectedChain));
   }
 });
 

--- a/frontend/app/src/pages/accounts/evm/[[tab]].vue
+++ b/frontend/app/src/pages/accounts/evm/[[tab]].vue
@@ -6,6 +6,7 @@ import { useTemplateRef } from 'vue';
 import { msg } from '@/message-key';
 import AccountBalances from '@/modules/accounts/AccountBalances.vue';
 import AccountImportProgress from '@/modules/accounts/AccountImportProgress.vue';
+import { createNewAccountForChain } from '@/modules/accounts/blockchain/new-account-state';
 import EthStakingValidators from '@/modules/accounts/EthStakingValidators.vue';
 import EvmAccountPageButtons from '@/modules/accounts/EvmAccountPageButtons.vue';
 import AccountDialog from '@/modules/accounts/management/AccountDialog.vue';
@@ -58,17 +59,12 @@ const usedChainIds = computed<string[]>(() => {
 });
 
 function createNewBlockchainAccount(address?: string): void {
-  set(account, {
-    chain: get(usedChainIds)[0],
-    data: [
-      {
-        address: address || '',
-        tags: null,
-      },
-    ],
-    mode: 'add',
-    type: 'account',
-  });
+  const state = createNewAccountForChain(get(usedChainIds)[0]);
+
+  if (address && state.type === 'account')
+    state.data = [{ address, tags: null }];
+
+  set(account, state);
 }
 
 function refresh(): void {

--- a/frontend/app/src/pages/accounts/evm/add-account-query.spec.ts
+++ b/frontend/app/src/pages/accounts/evm/add-account-query.spec.ts
@@ -1,5 +1,6 @@
 import type { LocationQuery, RouteLocationNormalizedLoaded } from 'vue-router';
 import type { AccountManageState } from '@/modules/accounts/blockchain/use-account-manage';
+import { Blockchain } from '@rotki/common';
 import { libraryDefaults } from '@test/utils/provide-defaults';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
@@ -47,9 +48,9 @@ vi.mock('@/modules/staking/eth/use-eth-staking-access', () => ({
   useEthStakingAccess: (): { allowed: Ref<boolean> } => ({ allowed: ref(true) }),
 }));
 
-function mountPage(): VueWrapper<InstanceType<typeof EvmAccountsPage>> {
+function mountPage(tab: string = 'accounts'): VueWrapper<InstanceType<typeof EvmAccountsPage>> {
   return mount(EvmAccountsPage, {
-    props: { tab: 'accounts' },
+    props: { tab },
     global: {
       provide: libraryDefaults,
       stubs: {
@@ -126,6 +127,17 @@ describe('pages/accounts/evm — add query handling', () => {
     expect(model).toBeDefined();
     expect(getFirstAddress(model)).toBe(address);
     expect(replaceMock).toHaveBeenCalledWith({ query: {} });
+  });
+
+  it('should seed a validator, not an address account, on the validators tab', async () => {
+    routeQuery.value = { add: 'true' };
+    wrapper = mountPage('validators');
+    await flushPromises();
+
+    const model = getDialogModel(wrapper);
+
+    expect(model?.type).toBe('validator');
+    expect(model?.chain).toBe(Blockchain.ETH2);
   });
 
   it('should not open the dialog without ?add', async () => {

--- a/frontend/app/src/pages/balances/blockchain/index.vue
+++ b/frontend/app/src/pages/balances/blockchain/index.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
+import type { AccountManageState } from '@/modules/accounts/blockchain/use-account-manage';
 import { startPromise } from '@shared/utils';
 import { msg } from '@/message-key';
-import {
-  type AccountManageState,
-  createNewBlockchainAccount,
-} from '@/modules/accounts/blockchain/use-account-manage';
+import { createNewBlockchainAccount } from '@/modules/accounts/blockchain/new-account-state';
 import { useBlockchainAccountLoading } from '@/modules/accounts/use-blockchain-account-loading';
 import PriceRefresh from '@/modules/assets/prices/PriceRefresh.vue';
 import AssetBalances from '@/modules/balances/AssetBalances.vue';


### PR DESCRIPTION
Fixes #13027.

## The bug

`Accounts → EVM Accounts → Validators → Add Account` opened the generic blockchain account form instead of the validator form, and typing an index into it and saving sent no request. Auto-detection from ETH deposits still worked, so only the manual add path was affected. Present on `develop`, `bugfixes` and `master` since 1.44.0.

## Cause

The validators tab seeds the dialog with the only chain it offers, eth2, but hardcoded `type: 'account'`:

```ts
set(account, { chain: get(usedChainIds)[0], data: [{ address: '', tags: null }], mode: 'add', type: 'account' });
```

That pair is one the state union does not admit. It was always constructed; what changed in `6a2c3598` is that the rebuild moved from `watchImmediate(chain, …)` into `selectChain()`. The immediate watcher had been repairing the pair on mount, and `selectChain` only runs on the selector's `@update:chain`, which nothing emits for a pre-seeded value. So the state stayed on `(chain: eth2, type: account)` and `AccountForm` fell through to the generic branch.

## The fix

A chain is answered with the whole state it implies, in one place that both the tab seeders and `selectChain` go through, so the contradictory pair can no longer be constructed. `createNewBlockchainAccount` moves alongside it (`use-account-manage.ts` was 8 lines under the 400-line `max-lines` cap).

## Tests

Two regression tests, each negative-controlled:

- `add-account-query.spec.ts` — "should seed a validator, not an address account, on the validators tab". Fails with `expected 'account' to be 'validator'` when the seeder is reverted.
- `AccountForm.spec.ts` — "should render the validator form for a validator seeded without a chain being chosen". No spec asserted `ValidatorAccountForm` renders at all; fails when the template's validator branch is narrowed.

## Verified in the app

Against a running 1.44 backend on this branch: Add Account on the validators tab opens the validator form (`eth2-validator-index`, `eth2-public-key`, `eth2-ownership-percentage`); saving index `100` added it (`status: active`, key `0xb5bc96b7…5ec55`); removed again afterwards.

Docs `usage-guides/staking.md` describes this dialog, so the docs are unblocked by this.