### PR TITLE
fix: decode SafeNet staking rewards claims

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Claiming your Safenet staking rewards is now recorded as a staking reward.
 * :bug:`13027` Adding an ETH2 validator by index or public key works again. Since 1.44.0 the Add Account button on the validators tab opened the generic blockchain account form instead of the validator form, and saving from it did nothing, so a validator that was not picked up automatically from its deposit could not be added at all.
 * :bug:`-` Historical prices of a token that exists on several chains now come from the main asset it is grouped with, so WETH on Arbitrum, Optimism and Base is priced as ETH. They used to be priced on their own and could come back at roughly half of ETH's value.
 * :bug:`-` Changing the asset or chain in the send form while a gas estimate is still being fetched no longer makes the estimate look finished before it is. The spinner stopped as soon as the request you moved away from unwound, so the fee shown while the real request was still in flight read as the final one.

--- a/rotkehlchen/chain/ethereum/modules/safe/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/safe/constants.py
@@ -7,6 +7,7 @@ SAFE_VESTING: Final = string_to_evm_address('0x96B71e2551915d98d22c448b040A3BC48
 SAFEPASS_AIRDROP: Final = string_to_evm_address('0x57eC1930f3E5c8062926c2F3ee49316E116143df')
 SAFE_LOCKING: Final = string_to_evm_address('0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2')
 SAFENET_STAKING: Final = string_to_evm_address('0x115E78f160e1E3eF163B05C84562Fa16fA338509')
+SAFENET_REWARDS_DISTRIBUTOR: Final = string_to_evm_address('0xe5139Fc0FB8eae81e30d8a85C22E88c6757120f2')  # noqa: E501
 CLAIMED_VESTING: Final = b'1\xb7\x188\x9b\x1e\xb9-\xf8:\xb0\x0c\x1aQ\x12\xe5\xbb\x8a\x02\xc7\xc1\xc9\xc0.\x1e<\x15\xad3\xe0S&'  # noqa: E501
 LOCKED: Final = b'\xe8~\xf8M\x87\x01!\xe4\x90Q\xdd\xa6\xf8\xd2\x97q<\xb0\n\x0c\x07,\rw\x1fx\xea6\x88\x15\x00\x9f'  # noqa: E501
 UNLOCKED: Final = b'\x1b\xd2\xaa\xc5\xb8\xfb\xf8\xaa\xccK\x88\r\xbdr0\xd6/\xc2\x08\xb7\xc3\x17\xa6\xf2\x19\xa27\x03\xa8\x02b\xc8'  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/safe/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/safe/decoder.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 from rotkehlchen.assets.asset import EvmToken
 from rotkehlchen.assets.utils import token_normalized_value_decimals
 from rotkehlchen.chain.decoding.types import CounterpartyDetails
-from rotkehlchen.chain.evm.constants import DEFAULT_TOKEN_DECIMALS
+from rotkehlchen.chain.evm.constants import CLAIMED_TOPIC, DEFAULT_TOKEN_DECIMALS
 from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
 from rotkehlchen.chain.evm.decoding.structures import (
     DEFAULT_EVM_DECODING_OUTPUT,
@@ -24,6 +24,7 @@ from .constants import (
     LOCKED,
     SAFE_LOCKING,
     SAFE_VESTING,
+    SAFENET_REWARDS_DISTRIBUTOR,
     SAFENET_STAKING,
     SAFEPASS_AIRDROP,
     STAKE_INCREASED,
@@ -249,6 +250,42 @@ class SafeDecoder(EvmDecoderInterface):
 
         return DEFAULT_EVM_DECODING_OUTPUT
 
+    def _decode_safenet_rewards_claim(self, context: DecoderContext) -> EvmDecodingOutput:
+        """Decode a SafeNet staking rewards claim from the merkle drop distributor. The SAFE
+        transfer to the claimer is logged before the Claimed event, so the already decoded
+        receive event is transformed in place."""
+        if (
+                context.tx_log.topics[0] != CLAIMED_TOPIC or
+                not self.base.is_tracked(claimer := bytes_to_address(context.tx_log.topics[1]))
+        ):
+            return DEFAULT_EVM_DECODING_OUTPUT
+
+        amount = token_normalized_value_decimals(
+            token_amount=int.from_bytes(context.tx_log.data[0:32]),
+            token_decimals=DEFAULT_TOKEN_DECIMALS,
+        )
+        for event in context.decoded_events:
+            if (
+                    event.event_type == HistoryEventType.RECEIVE and
+                    event.event_subtype == HistoryEventSubType.NONE and
+                    event.location_label == claimer and
+                    event.asset == self.safe_token and
+                    event.amount == amount
+            ):
+                event.event_type = HistoryEventType.STAKING
+                event.event_subtype = HistoryEventSubType.REWARD
+                event.counterparty = CPT_SAFE
+                event.notes = f'Claim {amount} SAFE as SafeNet staking rewards'
+                break
+
+        else:  # transfer not found
+            log.error(
+                'Could not find the SAFE transfer of the SafeNet rewards claim for %s',
+                context.transaction.tx_hash,
+            )
+
+        return DEFAULT_EVM_DECODING_OUTPUT
+
     # -- DecoderInterface methods
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
@@ -257,6 +294,7 @@ class SafeDecoder(EvmDecoderInterface):
             SAFE_LOCKING: (self._decode_safe_locker,),
             SAFEPASS_AIRDROP: (self._decode_safpass_claim,),
             SAFENET_STAKING: (self._decode_safenet_staking,),
+            SAFENET_REWARDS_DISTRIBUTOR: (self._decode_safenet_rewards_claim,),
         }
 
     @staticmethod

--- a/rotkehlchen/tests/unit/decoders/test_safe.py
+++ b/rotkehlchen/tests/unit/decoders/test_safe.py
@@ -9,6 +9,7 @@ from rotkehlchen.chain.ethereum.modules.safe.constants import (
     CPT_SAFE,
     SAFE_LOCKING,
     SAFE_VESTING,
+    SAFENET_REWARDS_DISTRIBUTOR,
     SAFENET_STAKING,
     SAFEPASS_AIRDROP,
 )
@@ -692,6 +693,42 @@ def test_safenet_withdrawal_claim(ethereum_inquirer, ethereum_accounts):
             notes=f'Unstake {amount} SAFE from SafeNet',
             counterparty=CPT_SAFE,
             address=SAFENET_STAKING,
+        ),
+    ]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0x982Ee94031F6998A2DDc2C3FE1B3413bFbc61F30']])
+def test_safenet_rewards_claim(ethereum_inquirer, ethereum_accounts):
+    """Test claiming SafeNet staking rewards from the merkle drop distributor"""
+    tx_hash = deserialize_evm_tx_hash('0x48978f77327986a7aacaa0c020608e8a6776c3d5c61ae79222b9d12fb8e23753')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
+    assert events == [
+        EvmEvent(
+            tx_ref=tx_hash,
+            sequence_index=0,
+            timestamp=(timestamp := TimestampMS(1787899751000)),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_ETH,
+            amount=FVal(gas := '0.000005389112828244'),
+            location_label=(user_address := ethereum_accounts[0]),
+            notes=f'Burn {gas} ETH for gas',
+            counterparty=CPT_GAS,
+        ), EvmEvent(
+            tx_ref=tx_hash,
+            sequence_index=580,
+            timestamp=timestamp,
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.STAKING,
+            event_subtype=HistoryEventSubType.REWARD,
+            asset=EvmToken('eip155:1/erc20:0x5aFE3855358E112B5647B952709E6165e1c1eEEe'),
+            amount=FVal(amount := '12.660388766244482508'),
+            location_label=user_address,
+            notes=f'Claim {amount} SAFE as SafeNet staking rewards',
+            counterparty=CPT_SAFE,
+            address=SAFENET_REWARDS_DISTRIBUTOR,
         ),
     ]
 


### PR DESCRIPTION
Safenet beta staking rewards are not paid out by the staking contract but by a separate CumulativeMerkleDrop distributor, which had no decoder, so claiming them showed up as a plain SAFE receive.

Decode the distributor's Claimed event and turn the SAFE transfer that precedes it into a staking reward event.
