### PR TITLE
Close retained database cursors on shutdown

### DIFF
--- a/rotkehlchen/db/drivers/sqlite.py
+++ b/rotkehlchen/db/drivers/sqlite.py
@@ -28,6 +28,7 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self
 from uuid import uuid4
+from weakref import WeakSet
 
 import rsqlite
 from polyleven import levenshtein
@@ -274,7 +275,10 @@ class DBCursor:
     def close(self) -> None:
         self._prefetched_rows.clear()
         with self.connection.statement_lock:
-            self._cursor.close()
+            try:
+                self._cursor.close()
+            finally:
+                self.connection._cursors.discard(self)
 
 
 class DBConnectionType(Enum):
@@ -384,6 +388,7 @@ class DBConnection:
         self._conn: UnderlyingConnection
         self._path = path
         self._read_only = read_only
+        self._cursors: WeakSet[DBCursor] = WeakSet()
         # Pool of read-only connections configured by enable_read_pool() and created
         # lazily as concurrent reads need them. LIFO reuse keeps sequential reads on
         # the same warm SQLite page cache instead of rotating through every reader.
@@ -515,7 +520,9 @@ class DBConnection:
 
     def cursor(self) -> DBCursor:
         with self.statement_lock:
-            return DBCursor(connection=self, cursor=self._conn.cursor())
+            cursor = DBCursor(connection=self, cursor=self._conn.cursor())
+            self._cursors.add(cursor)
+            return cursor
 
     def interrupt(self) -> None:
         """Abort this connection's in-flight statements (sqlite3_interrupt). Safe
@@ -526,6 +533,8 @@ class DBConnection:
     def close(self) -> None:
         self.disable_read_pool()
         with self.statement_lock:
+            for cursor in tuple(self._cursors):
+                cursor.close()
             self._conn.close()
         if not self._read_only:  # a reader was never registered in the map
             CONNECTION_MAP.pop(self.connection_type, None)

--- a/rotkehlchen/tests/db/test_cursor.py
+++ b/rotkehlchen/tests/db/test_cursor.py
@@ -1,5 +1,6 @@
 """Tests for DBCursor semantics that the prefetch buffer must preserve"""
 import pytest
+import rsqlite
 
 from rotkehlchen.db.drivers.sqlite import DBConnection, DBConnectionType
 
@@ -44,3 +45,13 @@ def test_fetchmany_mixes_prefetched_and_remaining_rows(
         cursor.execute('SELECT a FROM t ORDER BY a')
         assert next(cursor) == (0,)  # prefetches rows 0 and 1, leaving 1 buffered
         assert cursor.fetchmany(4) == [(1,), (2,), (3,), (4,)]
+
+
+def test_connection_close_closes_retained_cursor(conn: DBConnection) -> None:
+    cursor = conn.cursor()
+    cursor.execute('SELECT 1')
+
+    conn.close()
+
+    with pytest.raises(rsqlite.ProgrammingError, match='closed cursor'):
+        cursor.fetchone()


### PR DESCRIPTION
SQLite connection.close() uses sqlite3_close_v2(), which marks the connection closed but defers releasing the database handle while cursor statements are still alive. The asset update tests relied on cursor destruction to release those statements. With Python 3.14t that destruction is no longer reliably immediate, and Windows consequently rejected removal of global.db with WinError 32.

Track each DBConnection's cursors through weak references, remove cursors from that tracking set when they are explicitly closed, and close any survivors before closing the underlying connection. Weak references avoid extending cursor lifetimes while making connection shutdown deterministic. Add a regression test proving that a cursor retained by its caller is closed by connection shutdown.

