### PR TITLE
Fix Windows backend compatibility

### DIFF
--- a/rotkehlchen/db/drivers/sqlite.py
+++ b/rotkehlchen/db/drivers/sqlite.py
@@ -380,6 +380,7 @@ class DBConnection:
             connection_type: DBConnectionType,
             sql_vm_instructions_cb: int,
             read_only: bool = False,
+            cached_statements: int | None = None,
     ) -> None:
         """A read_only connection is a pool reader: it is opened with mode=ro so
         sqlite rejects any write attempt, it is never registered in CONNECTION_MAP
@@ -388,6 +389,12 @@ class DBConnection:
         self._conn: UnderlyingConnection
         self._path = path
         self._read_only = read_only
+        # CPython can retain a Windows file handle when a statement outlives Connection.close():
+        # https://github.com/python/cpython/issues/135117
+        # Disabling the statement cache is also the documented workaround for a separate
+        # multithreaded cache bug: https://github.com/python/cpython/issues/118172
+        # Keep this optional so cleanup-sensitive tests can opt in without slowing production.
+        self._cached_statements = cached_statements
         self._cursors: WeakSet[DBCursor] = WeakSet()
         # Pool of read-only connections configured by enable_read_pool() and created
         # lazily as concurrent reads need them. LIFO reuse keeps sequential reads on
@@ -444,20 +451,24 @@ class DBConnection:
         # (False when the savepoints nest inside this task's own write transaction)
         self._savepoint_holds_transaction_lock = False
         if connection_type in (DBConnectionType.GLOBAL, DBConnectionType.PACKAGED_GLOBAL):
+            connect_kwargs: dict[str, Any] = {
+                'check_same_thread': False,
+                'isolation_level': None,
+            }
+            if cached_statements is not None:
+                connect_kwargs['cached_statements'] = cached_statements
             if read_only:
                 # as_uri() gives a percent-encoded file:// URI that sqlite accepts
                 # on all platforms (a plain f'file:{path}' breaks on windows paths)
                 self._conn = rsqlite.connect(
                     database=Path(path).absolute().as_uri() + '?mode=ro',
                     uri=True,
-                    check_same_thread=False,
-                    isolation_level=None,
+                    **connect_kwargs,
                 )
             else:
                 self._conn = rsqlite.connect(
                     database=path,
-                    check_same_thread=False,
-                    isolation_level=None,
+                    **connect_kwargs,
                 )
         elif read_only:
             # as_uri() gives a percent-encoded file:// URI that sqlite accepts
@@ -634,6 +645,7 @@ class DBConnection:
             connection_type=self.connection_type,
             sql_vm_instructions_cb=self.sql_vm_instructions_cb,
             read_only=True,
+            cached_statements=self._cached_statements,
         )
         try:
             if reader_setup is not None:

--- a/rotkehlchen/globaldb/handler.py
+++ b/rotkehlchen/globaldb/handler.py
@@ -166,6 +166,7 @@ class GlobalDBHandler:
             sql_vm_instructions_cb: int | None = None,
             perform_assets_updates: bool | None = None,
             msg_aggregator: MessagesAggregator | None = None,
+            cached_statements: int | None = None,
     ) -> GlobalDBHandler:
         """
         Initializes the GlobalDB.
@@ -202,6 +203,7 @@ class GlobalDBHandler:
             global_dir=global_dir,
             db_filename=GLOBALDB_NAME,
             sql_vm_instructions_cb=sql_vm_instructions_cb,
+            cached_statements=cached_statements,
         )
         GlobalDBHandler.__instance.packaged_db_lock = Lock()
 

--- a/rotkehlchen/globaldb/utils.py
+++ b/rotkehlchen/globaldb/utils.py
@@ -72,6 +72,7 @@ def initialize_globaldb(
         global_dir: Path,
         db_filename: str,
         sql_vm_instructions_cb: int,
+        cached_statements: int | None = None,
 ) -> tuple[DBConnection, bool]:
     """
     Checks the database whether there are any not finished upgrades and automatically uses a
@@ -89,6 +90,7 @@ def initialize_globaldb(
         path=global_dir / db_filename,
         connection_type=DBConnectionType.GLOBAL,
         sql_vm_instructions_cb=sql_vm_instructions_cb,
+        cached_statements=cached_statements,
     )
     try:
         with connection.read_ctx() as cursor:
@@ -125,5 +127,6 @@ def initialize_globaldb(
         path=global_dir / db_filename,
         connection_type=DBConnectionType.GLOBAL,
         sql_vm_instructions_cb=sql_vm_instructions_cb,
+        cached_statements=cached_statements,
     )
     return connection, True

--- a/rotkehlchen/mcp/__init__.py
+++ b/rotkehlchen/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Compatibility setup for rotki's MCP server."""
+
+from rotkehlchen.mcp._compat import prepare_mcp_server
+
+__all__ = ['prepare_mcp_server']

--- a/rotkehlchen/mcp/_compat.py
+++ b/rotkehlchen/mcp/_compat.py
@@ -1,0 +1,35 @@
+import importlib
+import importlib.util
+import sys
+from types import ModuleType
+from typing import Final
+
+_MCP_WIN32_CLIENT_MODULES: Final = ('pywintypes', 'win32api', 'win32con', 'win32job')
+
+
+def prepare_mcp_server() -> None:
+    """Load MCP's server modules when pywin32 is unavailable on free-threaded Python.
+
+    MCP 1.x eagerly imports its Windows stdio client from the package initializer,
+    although rotki only runs its HTTP server. pywin32 has no cp314t wheel. Supply
+    temporary import placeholders, then disable the unused client integration in
+    MCP's already-loaded Windows utility module.
+    """
+    placeholders = {
+        module_name: ModuleType(module_name)
+        for module_name in _MCP_WIN32_CLIENT_MODULES
+    }
+    sys.modules.update(placeholders)
+    try:
+        importlib.import_module('mcp')
+        win32_utilities = sys.modules['mcp.os.win32.utilities']
+        for module_name in _MCP_WIN32_CLIENT_MODULES:
+            setattr(win32_utilities, module_name, None)
+    finally:
+        for module_name, placeholder in placeholders.items():
+            if sys.modules.get(module_name) is placeholder:
+                del sys.modules[module_name]
+
+
+if sys.platform == 'win32' and importlib.util.find_spec('pywintypes') is None:
+    prepare_mcp_server()

--- a/rotkehlchen/tests/api/test_assets_updates.py
+++ b/rotkehlchen/tests/api/test_assets_updates.py
@@ -1,4 +1,5 @@
 import json
+import os
 import random
 import re
 from http import HTTPStatus
@@ -31,6 +32,11 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from rotkehlchen.api.server import APIServer
+
+
+# These tests delete their disk-backed global DB immediately after shutdown. Windows refuses to
+# unlink it if sqlite's statement cache defers finalizing a statement past Connection.close().
+GLOBALDB_CACHED_STATEMENTS_FOR_FILE_CLEANUP = 0 if os.name == 'nt' else None
 
 
 def count_total_assets() -> int:
@@ -71,6 +77,10 @@ def mock_asset_updates(original_requests_get: Callable[..., requests.Response], 
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('use_in_memory_globaldb', [False])
+@pytest.mark.parametrize(
+    'globaldb_cached_statements',
+    [GLOBALDB_CACHED_STATEMENTS_FOR_FILE_CLEANUP],
+)
 def test_simple_update(rotkehlchen_api_server: APIServer, globaldb: GlobalDBHandler) -> None:
     """Test that the happy case of update works.
 
@@ -253,6 +263,10 @@ INSERT INTO assets(identifier, name, type) VALUES('EUR', 'Ευρώ', 'A'); INSER
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('use_in_memory_globaldb', [False])
+@pytest.mark.parametrize(
+    'globaldb_cached_statements',
+    [GLOBALDB_CACHED_STATEMENTS_FOR_FILE_CLEANUP],
+)
 def test_update_conflicts(rotkehlchen_api_server: APIServer, globaldb: GlobalDBHandler) -> None:
     """Test that conflicts in an asset update are handled properly"""
     async_query = random.choice([False, True])
@@ -469,7 +483,6 @@ INSERT INTO assets(identifier, name, type) VALUES('eip155:1/erc20:0x1b175474E890
                 status_code=HTTPStatus.OK,
             )
 
-        cursor = globaldb.conn.cursor()
         # check conflicts were solved as per the given choices and new asset also added
         assert result is True
         assert globaldb.get_setting_value(ASSETS_VERSION_KEY, 0) == 999999991
@@ -491,8 +504,6 @@ INSERT INTO assets(identifier, name, type) VALUES('eip155:1/erc20:0x1b175474E890
         assert dai.decimals == 8
         assert dai.protocol == 'maker'
         # make sure data is in both tables
-        assert cursor.execute('SELECT COUNT(*) from evm_tokens WHERE address=?', ('0x6B175474E89094C44Da98b954EedeAC495271d0F',)).fetchone()[0] == 1  # noqa: E501
-        assert cursor.execute('SELECT COUNT(*) from assets WHERE identifier=?', ('eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F',)).fetchone()[0] == 1  # noqa: E501
 
         dash = CryptoAsset('DASH')
         assert dash.identifier == 'DASH'
@@ -504,8 +515,6 @@ INSERT INTO assets(identifier, name, type) VALUES('eip155:1/erc20:0x1b175474E890
         assert dash.swapped_for is None
         assert dash.coingecko == 'dash'
         assert dash.cryptocompare == 'DASH'
-        assert cursor.execute('SELECT COUNT(*) from common_asset_details WHERE identifier=?', ('DASH',)).fetchone()[0] == 1  # noqa: E501
-        assert cursor.execute('SELECT COUNT(*) from assets WHERE identifier=?', ('DASH',)).fetchone()[0] == 1  # noqa: E501
 
         new_asset = CryptoAsset('121-ada-FADS-as')
         assert new_asset.identifier == '121-ada-FADS-as'
@@ -517,8 +526,6 @@ INSERT INTO assets(identifier, name, type) VALUES('eip155:1/erc20:0x1b175474E890
         assert new_asset.swapped_for is None
         assert new_asset.coingecko == ''
         assert new_asset.cryptocompare == ''
-        assert cursor.execute('SELECT COUNT(*) from common_asset_details WHERE identifier=?', ('121-ada-FADS-as',)).fetchone()[0] == 1  # noqa: E501
-        assert cursor.execute('SELECT COUNT(*) from assets WHERE identifier=?', ('121-ada-FADS-as',)).fetchone()[0] == 1  # noqa: E501
 
         ctk = EvmToken('eip155:1/erc20:0x1b175474E89094C44DA98B954EeDEAC495271d0f')
         assert ctk.name == 'Conflicting token'
@@ -532,8 +539,15 @@ INSERT INTO assets(identifier, name, type) VALUES('eip155:1/erc20:0x1b175474E890
         assert ctk.evm_address == '0x1b175474E89094C44DA98B954EeDEAC495271d0f'
         assert ctk.decimals == 18
         assert ctk.protocol is None
-        assert cursor.execute('SELECT COUNT(*) from evm_tokens WHERE address=?', ('0x1b175474E89094C44DA98B954EeDEAC495271d0f',)).fetchone()[0] == 1  # noqa: E501
-        assert cursor.execute('SELECT COUNT(*) from assets WHERE identifier=?', ('eip155:1/erc20:0x1b175474E89094C44DA98B954EeDEAC495271d0f',)).fetchone()[0] == 1  # noqa: E501
+        with globaldb.conn.read_ctx() as cursor:
+            assert cursor.execute('SELECT COUNT(*) from evm_tokens WHERE address=?', ('0x6B175474E89094C44Da98b954EedeAC495271d0F',)).fetchone()[0] == 1  # noqa: E501
+            assert cursor.execute('SELECT COUNT(*) from assets WHERE identifier=?', ('eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F',)).fetchone()[0] == 1  # noqa: E501
+            assert cursor.execute('SELECT COUNT(*) from common_asset_details WHERE identifier=?', ('DASH',)).fetchone()[0] == 1  # noqa: E501
+            assert cursor.execute('SELECT COUNT(*) from assets WHERE identifier=?', ('DASH',)).fetchone()[0] == 1  # noqa: E501
+            assert cursor.execute('SELECT COUNT(*) from common_asset_details WHERE identifier=?', ('121-ada-FADS-as',)).fetchone()[0] == 1  # noqa: E501
+            assert cursor.execute('SELECT COUNT(*) from assets WHERE identifier=?', ('121-ada-FADS-as',)).fetchone()[0] == 1  # noqa: E501
+            assert cursor.execute('SELECT COUNT(*) from evm_tokens WHERE address=?', ('0x1b175474E89094C44DA98B954EeDEAC495271d0f',)).fetchone()[0] == 1  # noqa: E501
+            assert cursor.execute('SELECT COUNT(*) from assets WHERE identifier=?', ('eip155:1/erc20:0x1b175474E89094C44DA98B954EeDEAC495271d0f',)).fetchone()[0] == 1  # noqa: E501
 
 
 @pytest.mark.skip('Broken after changes in the assets. Check #4876')
@@ -718,6 +732,10 @@ INSERT INTO assets(identifier, name, type) VALUES("eip155:1/erc20:0xa74476443119
 
 @pytest.mark.parametrize('use_clean_caching_directory', [True])
 @pytest.mark.parametrize('use_in_memory_globaldb', [False])
+@pytest.mark.parametrize(
+    'globaldb_cached_statements',
+    [GLOBALDB_CACHED_STATEMENTS_FOR_FILE_CLEANUP],
+)
 def test_update_from_early_clean_db(
         rotkehlchen_api_server: APIServer,
         globaldb: GlobalDBHandler,
@@ -742,8 +760,8 @@ INSERT INTO evm_tokens(identifier, token_kind, chain, address, decimals, protoco
         }},
         sql_actions={'15': {'assets': update_15, 'collections': '', 'mappings': ''}},
     )
-    cursor = globaldb.conn.cursor()
-    cursor.execute('DELETE FROM settings WHERE name=?', (ASSETS_VERSION_KEY,))
+    with globaldb.conn.write_ctx() as write_cursor:
+        write_cursor.execute('DELETE FROM settings WHERE name=?', (ASSETS_VERSION_KEY,))
     start_assets_num = count_total_assets()
     with update_patch:
         response = requests.get(
@@ -914,6 +932,10 @@ INSERT INTO assets(identifier, name, type) VALUES("eip155:1/erc20:0x5dbcF33D8c2E
 @pytest.mark.parametrize('start_with_logged_in_user', [False])
 @pytest.mark.parametrize('number_of_eth_accounts', [0])
 @pytest.mark.parametrize('use_in_memory_globaldb', [False])
+@pytest.mark.parametrize(
+    'globaldb_cached_statements',
+    [GLOBALDB_CACHED_STATEMENTS_FOR_FILE_CLEANUP],
+)
 def test_update_no_user_loggedin(rotkehlchen_api_server: APIServer) -> None:
     response = requests.post(
         api_url_for(

--- a/rotkehlchen/tests/db/test_cursor.py
+++ b/rotkehlchen/tests/db/test_cursor.py
@@ -1,8 +1,19 @@
 """Tests for DBCursor semantics that the prefetch buffer must preserve"""
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
 import pytest
 import rsqlite
 
 from rotkehlchen.db.drivers.sqlite import DBConnection, DBConnectionType
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _execute_query(connection: DBConnection) -> None:
+    with connection.read_ctx() as cursor:
+        cursor.execute('SELECT 1').fetchone()
 
 
 @pytest.fixture(name='conn')
@@ -55,3 +66,19 @@ def test_connection_close_closes_retained_cursor(conn: DBConnection) -> None:
 
     with pytest.raises(rsqlite.ProgrammingError, match='closed cursor'):
         cursor.fetchone()
+
+
+def test_cross_thread_statement_does_not_retain_database(tmp_path: Path) -> None:
+    database_path = tmp_path / 'cross-thread.db'
+    connection = DBConnection(
+        path=database_path,
+        connection_type=DBConnectionType.GLOBAL,
+        sql_vm_instructions_cb=100,
+        cached_statements=0,
+    )
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(_execute_query, connection).result()
+
+    connection.close()
+
+    database_path.unlink()

--- a/rotkehlchen/tests/fixtures/globaldb.py
+++ b/rotkehlchen/tests/fixtures/globaldb.py
@@ -90,11 +90,17 @@ def fixture_use_in_memory_globaldb() -> bool:
     return True
 
 
+@pytest.fixture(name='globaldb_cached_statements')
+def fixture_globaldb_cached_statements() -> int | None:
+    return None
+
+
 def create_globaldb(
         data_directory,
         sql_vm_instructions_cb,
         messages_aggregator,
         perform_assets_updates=False,
+        cached_statements: int | None = None,
 ) -> GlobalDBHandler:
     # Since this is a singleton and we want it initialized everytime the fixture
     # is called make sure its instance is always starting from scratch
@@ -106,6 +112,7 @@ def create_globaldb(
         sql_vm_instructions_cb=sql_vm_instructions_cb,
         msg_aggregator=messages_aggregator,
         perform_assets_updates=perform_assets_updates,
+        cached_statements=cached_statements,
     )
 
 
@@ -123,6 +130,7 @@ def _initialize_fixture_globaldb(
         load_global_caches,
         messages_aggregator,
         use_in_memory_globaldb,
+        globaldb_cached_statements,
 ) -> tuple[GlobalDBHandler, Path]:
     # clean the previous resolver memory cache, as it
     # may have cached results from a discarded database
@@ -144,11 +152,13 @@ def _initialize_fixture_globaldb(
                     global_dir: Path,
                     db_filename: str,
                     sql_vm_instructions_cb: int,
+                    cached_statements: int | None = None,
             ) -> tuple[DBConnection, bool]:
                 connection = DBConnection(
                     path=':memory:',
                     connection_type=DBConnectionType.GLOBAL,
                     sql_vm_instructions_cb=sql_vm_instructions_cb,
+                    cached_statements=cached_statements,
                 )
                 disk_conn = rsqlite.connect(
                     database=source_db_path,
@@ -192,6 +202,7 @@ def _initialize_fixture_globaldb(
             data_directory=new_data_dir,
             sql_vm_instructions_cb=0,
             messages_aggregator=messages_aggregator,
+            cached_statements=globaldb_cached_statements,
         )
 
     if empty_global_addressbook is True:
@@ -223,6 +234,7 @@ def fixture_globaldb(
         load_global_caches,
         messages_aggregator,
         use_in_memory_globaldb,
+        globaldb_cached_statements,
 ):
     globaldb, new_data_dir = _initialize_fixture_globaldb(
         custom_globaldb=custom_globaldb,
@@ -238,6 +250,7 @@ def fixture_globaldb(
         load_global_caches=load_global_caches,
         messages_aggregator=messages_aggregator,
         use_in_memory_globaldb=use_in_memory_globaldb,
+        globaldb_cached_statements=globaldb_cached_statements,
     )
     yield globaldb
 

--- a/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
+++ b/rotkehlchen/tests/unit/globaldb/test_globaldb_consistency.py
@@ -55,7 +55,7 @@ def _latest_released_version() -> Version:
     Read rather than hardcoded so a release can not leave this pointing at an older version
     than the one the remote updates gate themselves against.
     """
-    changelog = (Path(__file__).parents[4] / 'docs' / 'changelog.rst').read_text()
+    changelog = (Path(__file__).parents[4] / 'docs' / 'changelog.rst').read_text(encoding='utf8')
     if (match := re.search(r'^\* :release:`(\d+\.\d+\.\d+) <', changelog, re.MULTILINE)) is None:
         raise AssertionError('Could not find the latest release in docs/changelog.rst')
 


### PR DESCRIPTION
- load the MCP server without unavailable pywin32 modules on Python 3.14t
- make SQLite statement caching configurable for Windows cleanup tests
- use deterministic cursor lifetimes and cover cross-thread database release
- read the changelog with an explicit UTF-8 encoding