### PR TITLE
Rebasing tokens balances in accounting refactor

### DIFF
--- a/.github/workflows/task_backend_tests.yml
+++ b/.github/workflows/task_backend_tests.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-group: [ api, decoders, others ]
+        test-group: [ api, decoders, others, accounting ]
     permissions:
       contents: read
     steps:
@@ -141,8 +141,8 @@ jobs:
           FORCE_COLOR: 1
           MATRIX_JOB: ${{ matrix.test-group }}
         run: |
-          if [ "${{ inputs.collect_coverage }}" = 'true' ]; then
-            export COVERAGE_FILE=".coverage.${{ matrix.test-group }}"
+          if [ "$COLLECT_COVERAGE" = 'true' ]; then
+            export COVERAGE_FILE=".coverage.$MATRIX_JOB"
             COVERAGE_ARGS='--cov=rotkehlchen --cov-report=term-missing'
           else
             COVERAGE_ARGS=''
@@ -150,17 +150,20 @@ jobs:
 
           export CASSETTES_DIR="$(pwd)/test-caching"
 
-          if [ "${{ matrix.test-group }}" == 'api' ]
+          if [ "$MATRIX_JOB" == 'accounting' ]
+          then
+            ROTKI_ACCOUNTING_UPDATE=True uv run pytest $PYTEST_ARGS $COVERAGE_ARGS -n 6 -v -m accounting_update rotkehlchen/tests/
+          elif [ "$MATRIX_JOB" == 'api' ]
           then
             uv run pytest $PYTEST_ARGS $COVERAGE_ARGS -n 6 -v rotkehlchen/tests/api
-          elif [ "${{ matrix.test-group }}" == 'decoders' ]
+          elif [ "$MATRIX_JOB" == 'decoders' ]
           then
             uv run pytest $PYTEST_ARGS $COVERAGE_ARGS -n 6 -v rotkehlchen/tests/unit/decoders rotkehlchen/tests/unit/solana_decoders
           else
             uv run pytest $PYTEST_ARGS $COVERAGE_ARGS -n 6 -v --ignore=rotkehlchen/tests/api --ignore=rotkehlchen/tests/unit/decoders --ignore=rotkehlchen/tests/unit/solana_decoders rotkehlchen/tests/
           fi
 
-          if [ "${{ matrix.test-group }}" == 'others' ]
+          if [ "$MATRIX_JOB" == 'others' ]
           then
             # dead-fixtures needs only one full collection, so run it once in this leg
             uv run pytest --dead-fixtures

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2680,6 +2680,7 @@
     "description": {
       "current_balance_mismatch": "rotki's calculated {asset} balance ({derived}) doesn't match the actual on-chain balance ({observed}), a difference of {delta}. Some {asset} transactions are probably missing or were recorded incorrectly.",
       "negative_balance": "An event spent more {asset} than rotki had tracked, so your balance went negative to {amount} (it was {before} just before). This usually means an earlier {asset} transaction is missing or was recorded incorrectly.",
+      "rebasing_token": "rotki could not verify the historical balance of rebasing token {asset} from authoritative on-chain data. The event-derived balance was not used.",
       "unknown": "rotki flagged a data issue. Open the details below to see what was recorded.",
       "unmatched_bridge_deposit": "A {asset} bridge deposit has no matched counterpart event on the destination chain. Match it manually or resolve it as an external payment.",
       "unmatched_bridge_withdrawal": "A {asset} bridge withdrawal has no matched counterpart deposit on the source chain. Match it manually to link the two legs."
@@ -2687,6 +2688,7 @@
     "description_short": {
       "current_balance_mismatch": "{asset} balance is off by {delta} from the on-chain amount.",
       "negative_balance": "{asset} balance went negative to {amount}, likely from a missing earlier transaction.",
+      "rebasing_token": "The historical balance of rebasing token {asset} could not be verified.",
       "unknown": "rotki flagged a data issue. Open the details for more.",
       "unmatched_bridge_deposit": "Unmatched {asset} bridge deposit. Match it manually.",
       "unmatched_bridge_withdrawal": "Unmatched {asset} bridge withdrawal. Match it manually."
@@ -2729,6 +2731,7 @@
     "kind": {
       "current_balance_mismatch": "Balance mismatch",
       "negative_balance": "Negative balance",
+      "rebasing_token": "Rebasing token",
       "unmatched_bridge": "Unmatched bridge"
     },
     "panel": {

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2680,7 +2680,10 @@
     "description": {
       "current_balance_mismatch": "rotki's calculated {asset} balance ({derived}) doesn't match the actual on-chain balance ({observed}), a difference of {delta}. Some {asset} transactions are probably missing or were recorded incorrectly.",
       "negative_balance": "An event spent more {asset} than rotki had tracked, so your balance went negative to {amount} (it was {before} just before). This usually means an earlier {asset} transaction is missing or was recorded incorrectly.",
-      "rebasing_token": "rotki could not verify the historical balance of rebasing token {asset} from authoritative on-chain data. The event-derived balance was not used.",
+      "rebasing_token_archive_node_unavailable": "rotki could not verify the historical balance of rebasing token {asset} because no archive node is available for this network. Configure an archive node and retry auto-remediation.",
+      "rebasing_token_historical_balance_query_failed": "rotki could not verify the historical balance of rebasing token {asset} because the archive-node query failed. Check the configured node or retry auto-remediation later.",
+      "rebasing_token_missing_transaction": "rotki could not verify the historical balance of rebasing token {asset} because its transaction block data is missing. Refresh the transaction history before retrying auto-remediation.",
+      "rebasing_token_unsupported_bucket": "rotki could not verify the historical balance of rebasing token {asset} because this balance bucket cannot be checked using the token contract's wallet balance. Review the related event and resolve the issue manually.",
       "unknown": "rotki flagged a data issue. Open the details below to see what was recorded.",
       "unmatched_bridge_deposit": "A {asset} bridge deposit has no matched counterpart event on the destination chain. Match it manually or resolve it as an external payment.",
       "unmatched_bridge_withdrawal": "A {asset} bridge withdrawal has no matched counterpart deposit on the source chain. Match it manually to link the two legs."
@@ -2688,7 +2691,10 @@
     "description_short": {
       "current_balance_mismatch": "{asset} balance is off by {delta} from the on-chain amount.",
       "negative_balance": "{asset} balance went negative to {amount}, likely from a missing earlier transaction.",
-      "rebasing_token": "The historical balance of rebasing token {asset} could not be verified.",
+      "rebasing_token_archive_node_unavailable": "No archive node is available to verify the historical {asset} balance.",
+      "rebasing_token_historical_balance_query_failed": "The historical on-chain query for {asset} failed.",
+      "rebasing_token_missing_transaction": "Transaction block data is missing for the {asset} balance check.",
+      "rebasing_token_unsupported_bucket": "The {asset} balance is held in a bucket that cannot be verified on-chain.",
       "unknown": "rotki flagged a data issue. Open the details for more.",
       "unmatched_bridge_deposit": "Unmatched {asset} bridge deposit. Match it manually.",
       "unmatched_bridge_withdrawal": "Unmatched {asset} bridge withdrawal. Match it manually."

--- a/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
@@ -13,6 +13,13 @@ const mockSetHistoricalDailyPriceStatus = vi.fn();
 const mockSetHistoricalPriceStatus = vi.fn();
 const mockSetStatsPriceQueryStatus = vi.fn();
 const mockReportProgress = vi.fn();
+const mockNotifyHistoricalBalanceProcessingCompleted = vi.fn();
+
+vi.mock('@/modules/history/data-issues/use-data-issues-inbox-store', () => ({
+  useDataIssuesInboxStore: vi.fn(() => ({
+    notifyHistoricalBalanceProcessingCompleted: mockNotifyHistoricalBalanceProcessingCompleted,
+  })),
+}));
 
 vi.mock('@/modules/history/use-decoding-status-store', () => ({
   useDecodingStatusStore: vi.fn(() => ({
@@ -110,6 +117,17 @@ describe('createProgressUpdateHandler', () => {
       makeActivityId(ActivityKind.HISTORICAL_BALANCES),
       expect.objectContaining({ current: expect.anything(), total: expect.anything() }),
     );
+  });
+
+  it('should signal data-issue refresh when historical balance processing completes', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(createMock<ProgressUpdateResultData>({
+      processed: 2,
+      subtype: SocketMessageProgressUpdateSubType.HISTORICAL_BALANCE_PROCESSING,
+      total: 2,
+    }));
+
+    expect(mockNotifyHistoricalBalanceProcessingCompleted).toHaveBeenCalledOnce();
   });
 
   it('should delegate csv import results to the csv handler', async () => {

--- a/frontend/app/src/modules/core/messaging/handlers/progress-updates.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/progress-updates.ts
@@ -2,6 +2,7 @@ import type { MessageHandler } from '../interfaces';
 import type { ProgressUpdateResultData } from '../types/status-types';
 import { useHistoricCachePriceStore } from '@/modules/assets/prices/use-historic-cache-price-store';
 import { createConditionalHandler } from '@/modules/core/messaging/utils';
+import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import { useProtocolCacheStatusStore } from '@/modules/history/use-protocol-cache-status-store';
 import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
@@ -13,6 +14,7 @@ export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']):
   const { setUndecodedTransactionsStatus } = useDecodingStatusStore();
   const { setProtocolCacheStatus, setReceivingProtocolCacheStatus } = useProtocolCacheStatusStore();
   const { setHistoricalDailyPriceStatus, setHistoricalPriceStatus, setStatsPriceQueryStatus } = useHistoricCachePriceStore();
+  const { notifyHistoricalBalanceProcessingCompleted } = useDataIssuesInboxStore();
   const { reportProgress, reportProgressByPrefix } = useTaskOrchestrator();
 
   return createConditionalHandler<ProgressUpdateResultData>(async (data) => {
@@ -53,6 +55,8 @@ export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']):
         break;
       case SocketMessageProgressUpdateSubType.HISTORICAL_BALANCE_PROCESSING:
         reportProgress(makeActivityId(ActivityKind.HISTORICAL_BALANCES), { current: data.processed, total: data.total });
+        if (data.processed >= data.total)
+          notifyHistoricalBalanceProcessingCompleted();
         break;
     }
 

--- a/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
+++ b/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
@@ -80,7 +80,7 @@ const {
   onResolveRequest,
   onRetry,
   openDetail,
-} = useDataIssueDetailActions(reloadAll);
+} = useDataIssueDetailActions(reloadAll, () => get(state).data);
 
 const activeStates = computed<string[]>(() => {
   const value = get(filters).state;

--- a/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
+++ b/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
@@ -14,6 +14,7 @@ import { DEFAULT_LIST_STATES, IssueState } from '@/modules/history/data-issues/c
 import { useDataIssueDetailActions } from '@/modules/history/data-issues/use-data-issue-detail-actions';
 import { useDataIssueFields } from '@/modules/history/data-issues/use-data-issue-fields';
 import { useDataIssues } from '@/modules/history/data-issues/use-data-issues';
+import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
 import { useDataIssuesSummary } from '@/modules/history/data-issues/use-data-issues-summary';
 import NoDataScreen from '@/modules/shell/components/NoDataScreen.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
@@ -32,6 +33,7 @@ const router = useRouter();
 
 const { fetchData } = useDataIssues();
 const { baselineTotal, counts, dismissInlinePanels, refreshSummary } = useDataIssuesSummary();
+const { historicalBalanceProcessingCompleted } = storeToRefs(useDataIssuesInboxStore());
 const { syncCompleted } = useSyncCompleted();
 
 const fields = useDataIssueFields();
@@ -169,6 +171,10 @@ watch(hasRemediatingRows, (remediating) => {
 
 // A finished sync is what detects new issues, so reload rather than wait for the 10s poll.
 watch(syncCompleted, () => {
+  startPromise(reloadAll());
+});
+
+watch(historicalBalanceProcessingCompleted, () => {
   startPromise(reloadAll());
 });
 

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueCardActions.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueCardActions.spec.ts
@@ -1,0 +1,37 @@
+import type { DataIssue } from '@/modules/history/data-issues/schemas';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import DataIssueCardActions from '@/modules/history/data-issues/components/DataIssueCardActions.vue';
+import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
+
+function createIssue(state: IssueState): DataIssue {
+  return {
+    asset: 'ETH',
+    autoRemediationAttempts: [],
+    createdAt: 1710000100,
+    groupIdentifier: null,
+    id: 1,
+    kind: IssueKind.REBASING_TOKEN,
+    location: 'ethereum',
+    locationLabel: '0x0000000000000000000000000000000000000001',
+    payload: {},
+    protocol: null,
+    resolvedAt: null,
+    severity: IssueSeverity.WARNING,
+    state,
+    tsEnd: 1710000000,
+    tsStart: 1710000000,
+  };
+}
+
+describe('dataIssueCardActions', () => {
+  it('should keep retry visible but disabled while remediation is running', () => {
+    const wrapper = mount(DataIssueCardActions, {
+      props: { issue: createIssue(IssueState.AUTO_REMEDIATING) },
+    });
+
+    const retry = wrapper.find('[data-testid=data-issues-panel-retry]');
+    expect(retry.exists()).toBe(true);
+    expect(retry.attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueCardActions.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueCardActions.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import type { RouteLocationRaw } from 'vue-router';
 import type { DataIssue } from '@/modules/history/data-issues/schemas';
-import { canDismiss, canResolveManually, canRetry } from '@/modules/history/data-issues/constants';
+import {
+  canDismiss,
+  canResolveManually,
+  canRetry,
+  IssueState,
+} from '@/modules/history/data-issues/constants';
 
 const { issue, eventRoute } = defineProps<{
   issue: DataIssue;
@@ -68,7 +73,7 @@ function onGoto(): void {
       {{ t('data_issues.action.dismiss.label') }}
     </RuiTooltip>
     <RuiTooltip
-      v-if="canRetry(issue.kind, issue.state)"
+      v-if="canRetry(issue.kind, issue.state) || issue.state === IssueState.AUTO_REMEDIATING"
       :open-delay="300"
     >
       <template #activator>
@@ -78,6 +83,7 @@ function onGoto(): void {
           size="sm"
           :aria-label="t('data_issues.action.retry.label')"
           data-testid="data-issues-panel-retry"
+          :disabled="!canRetry(issue.kind, issue.state)"
           @click.stop="emit('retry', issue)"
         >
           <RuiIcon

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueCardActions.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueCardActions.vue
@@ -68,7 +68,7 @@ function onGoto(): void {
       {{ t('data_issues.action.dismiss.label') }}
     </RuiTooltip>
     <RuiTooltip
-      v-if="canRetry(issue.state)"
+      v-if="canRetry(issue.kind, issue.state)"
       :open-delay="300"
     >
       <template #activator>

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueDetailContent.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueDetailContent.vue
@@ -203,9 +203,10 @@ const resolutionNote = computed<string | undefined>(() => {
         {{ t('data_issues.action.dismiss.label') }}
       </RuiButton>
       <RuiButton
+        v-if="canRetry(issue.kind, issue.state)"
         variant="outlined"
         color="primary"
-        :disabled="busy || !canRetry(issue.state)"
+        :disabled="busy"
         data-testid="data-issue-detail-retry"
         @click="emit('retry', issue.id)"
       >

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueDetailContent.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueDetailContent.vue
@@ -7,7 +7,7 @@ import DataIssueDetectedTime from '@/modules/history/data-issues/components/Data
 import DataIssueKindChip from '@/modules/history/data-issues/components/DataIssueKindChip.vue';
 import DataIssueRemediationTimeline from '@/modules/history/data-issues/components/DataIssueRemediationTimeline.vue';
 import DataIssueStateChip from '@/modules/history/data-issues/components/DataIssueStateChip.vue';
-import { canDismiss, canResolveManually, canRetry } from '@/modules/history/data-issues/constants';
+import { canDismiss, canResolveManually, canRetry, IssueState } from '@/modules/history/data-issues/constants';
 import { describeIssue, relatedEventRoute, toTimelineItems } from '@/modules/history/data-issues/transforms';
 import HistoryEventAccount from '@/modules/history/events/HistoryEventAccount.vue';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
@@ -203,10 +203,10 @@ const resolutionNote = computed<string | undefined>(() => {
         {{ t('data_issues.action.dismiss.label') }}
       </RuiButton>
       <RuiButton
-        v-if="canRetry(issue.kind, issue.state)"
+        v-if="canRetry(issue.kind, issue.state) || issue.state === IssueState.AUTO_REMEDIATING"
         variant="outlined"
         color="primary"
-        :disabled="busy"
+        :disabled="busy || !canRetry(issue.kind, issue.state)"
         data-testid="data-issue-detail-retry"
         @click="emit('retry', issue.id)"
       >

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueDetailDrawer.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueDetailDrawer.spec.ts
@@ -132,4 +132,15 @@ describe('dataIssueDetailDrawer', () => {
     expect(wrapper.emitted('dismiss')?.[0]).toStrictEqual([8]);
     expect(wrapper.emitted('resolve')?.[0]).toStrictEqual([8]);
   });
+
+  it('should keep the retry action visible and disabled while remediation is running', () => {
+    const wrapper = createWrapper(createIssue({
+      kind: IssueKind.REBASING_TOKEN,
+      state: IssueState.AUTO_REMEDIATING,
+    }));
+    const retry = wrapper.find('[data-testid="data-issue-detail-retry"]');
+
+    expect(retry.exists()).toBe(true);
+    expect(retry.attributes('disabled')).toBeDefined();
+  });
 });

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesPanelContent.vue
@@ -55,7 +55,10 @@ const {
   onResolveRequest,
   onRetry,
   openDetail,
-} = useDataIssueDetailActions(reloadAll);
+} = useDataIssueDetailActions(
+  reloadAll,
+  () => get(rows).map(({ issue }) => issue),
+);
 
 const { clearSelection, goToEvent, hasActiveSelection, isActiveRow } = useDataIssuesPanelSelection();
 

--- a/frontend/app/src/modules/history/data-issues/constants.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/constants.spec.ts
@@ -4,6 +4,7 @@ import {
   canResolveManually,
   canRetry,
   DEFAULT_LIST_STATES,
+  IssueKind,
   IssueState,
   NON_TERMINAL_STATES,
 } from '@/modules/history/data-issues/constants';
@@ -56,13 +57,14 @@ describe('data-issues constants', () => {
     });
 
     it.each([
-      [IssueState.OPEN, true],
-      [IssueState.AUTO_REMEDIATING, true],
-      [IssueState.UNRESOLVED, true],
-      [IssueState.RESOLVED, false],
-      [IssueState.DISMISSED, false],
-    ])('canRetry(%s) === %s', (state, expected) => {
-      expect(canRetry(state)).toBe(expected);
+      [IssueKind.REBASING_TOKEN, IssueState.OPEN, true],
+      [IssueKind.REBASING_TOKEN, IssueState.AUTO_REMEDIATING, false],
+      [IssueKind.REBASING_TOKEN, IssueState.UNRESOLVED, true],
+      [IssueKind.REBASING_TOKEN, IssueState.RESOLVED, false],
+      [IssueKind.REBASING_TOKEN, IssueState.DISMISSED, false],
+      [IssueKind.NEGATIVE_BALANCE, IssueState.OPEN, false],
+    ])('canRetry(%s, %s) === %s', (kind, state, expected) => {
+      expect(canRetry(kind, state)).toBe(expected);
     });
   });
 });

--- a/frontend/app/src/modules/history/data-issues/constants.ts
+++ b/frontend/app/src/modules/history/data-issues/constants.ts
@@ -7,6 +7,7 @@ import type { RuiIcons } from '@rotki/ui-library';
 export enum IssueKind {
   CURRENT_BALANCE_MISMATCH = 'current_balance_mismatch',
   NEGATIVE_BALANCE = 'negative_balance',
+  REBASING_TOKEN = 'rebasing_token',
   UNMATCHED_BRIDGE = 'unmatched_bridge',
 }
 
@@ -70,6 +71,7 @@ interface KindMeta {
 export const KIND_META: Record<IssueKind, KindMeta> = {
   [IssueKind.NEGATIVE_BALANCE]: { color: 'error', icon: 'lu-trending-down' },
   [IssueKind.CURRENT_BALANCE_MISMATCH]: { color: 'warning', icon: 'lu-scale' },
+  [IssueKind.REBASING_TOKEN]: { color: 'warning', icon: 'lu-refresh-cw' },
   [IssueKind.UNMATCHED_BRIDGE]: { color: 'warning', icon: 'lu-git-compare-arrows' },
 };
 

--- a/frontend/app/src/modules/history/data-issues/constants.ts
+++ b/frontend/app/src/modules/history/data-issues/constants.ts
@@ -80,7 +80,7 @@ export const KIND_META: Record<IssueKind, KindMeta> = {
  * transition rules (rotkehlchen/history/data_issues/manager.py):
  *  - dismiss: any non-terminal state (terminal states are already closed).
  *  - resolveManually: blocked once resolved or dismissed.
- *  - retry: blocked once dismissed; a no-op (still allowed) for open/auto_remediating.
+ *  - retry: available for rebasing issues that are open or previously unresolved.
  */
 export function canDismiss(state: IssueState): boolean {
   return state !== IssueState.RESOLVED && state !== IssueState.DISMISSED;
@@ -90,6 +90,7 @@ export function canResolveManually(state: IssueState): boolean {
   return state !== IssueState.RESOLVED && state !== IssueState.DISMISSED;
 }
 
-export function canRetry(state: IssueState): boolean {
-  return state !== IssueState.DISMISSED && state !== IssueState.RESOLVED;
+export function canRetry(kind: IssueKind, state: IssueState): boolean {
+  return kind === IssueKind.REBASING_TOKEN
+    && (state === IssueState.OPEN || state === IssueState.UNRESOLVED);
 }

--- a/frontend/app/src/modules/history/data-issues/schemas.ts
+++ b/frontend/app/src/modules/history/data-issues/schemas.ts
@@ -83,6 +83,19 @@ export const NegativeBalancePayload = z.object({
 
 export type NegativeBalancePayload = z.infer<typeof NegativeBalancePayload>;
 
+export const RebasingTokenPayload = z.object({
+  blockNumber: z.number().nullable(),
+  eventIdentifier: z.number(),
+  reason: z.enum([
+    'archive_node_unavailable',
+    'historical_balance_query_failed',
+    'missing_transaction',
+    'unsupported_bucket',
+  ]),
+});
+
+export type RebasingTokenPayload = z.infer<typeof RebasingTokenPayload>;
+
 export const CurrentBalanceMismatchPayload = z.object({
   delta: NumericString,
   derivedBalance: NumericString,

--- a/frontend/app/src/modules/history/data-issues/transforms.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.spec.ts
@@ -92,6 +92,25 @@ describe('data-issues transforms', () => {
       expect(describeIssue(issue).eventIdentifier).toBeUndefined();
     });
 
+    it('should describe an unverifiable rebasing-token balance', () => {
+      const issue = createIssue({
+        asset: 'stETH',
+        kind: IssueKind.REBASING_TOKEN,
+        payload: {
+          blockNumber: 123,
+          eventIdentifier: 9,
+          reason: 'archive_node_unavailable',
+        },
+      });
+
+      const result = describeIssue(issue);
+
+      expect(result.messageKey).toBe('data_issues.description.rebasing_token');
+      expect(result.shortMessageKey).toBe('data_issues.description_short.rebasing_token');
+      expect(result.eventIdentifier).toBe(9);
+      expect(result.asset).toBe('stETH');
+    });
+
     it('should describe an unmatched bridge leg with a direction-specific message', () => {
       const issue = createIssue({
         kind: IssueKind.UNMATCHED_BRIDGE,

--- a/frontend/app/src/modules/history/data-issues/transforms.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.spec.ts
@@ -92,21 +92,42 @@ describe('data-issues transforms', () => {
       expect(describeIssue(issue).eventIdentifier).toBeUndefined();
     });
 
-    it('should describe an unverifiable rebasing-token balance', () => {
+    it.each([
+      [
+        'archive_node_unavailable',
+        'data_issues.description.rebasing_token_archive_node_unavailable',
+        'data_issues.description_short.rebasing_token_archive_node_unavailable',
+      ],
+      [
+        'historical_balance_query_failed',
+        'data_issues.description.rebasing_token_historical_balance_query_failed',
+        'data_issues.description_short.rebasing_token_historical_balance_query_failed',
+      ],
+      [
+        'missing_transaction',
+        'data_issues.description.rebasing_token_missing_transaction',
+        'data_issues.description_short.rebasing_token_missing_transaction',
+      ],
+      [
+        'unsupported_bucket',
+        'data_issues.description.rebasing_token_unsupported_bucket',
+        'data_issues.description_short.rebasing_token_unsupported_bucket',
+      ],
+    ])('should describe the rebasing-token reason %s', (reason, messageKey, shortMessageKey) => {
       const issue = createIssue({
         asset: 'stETH',
         kind: IssueKind.REBASING_TOKEN,
         payload: {
           blockNumber: 123,
           eventIdentifier: 9,
-          reason: 'archive_node_unavailable',
+          reason,
         },
       });
 
       const result = describeIssue(issue);
 
-      expect(result.messageKey).toBe('data_issues.description.rebasing_token');
-      expect(result.shortMessageKey).toBe('data_issues.description_short.rebasing_token');
+      expect(result.messageKey).toBe(messageKey);
+      expect(result.shortMessageKey).toBe(shortMessageKey);
       expect(result.eventIdentifier).toBe(9);
       expect(result.asset).toBe('stETH');
     });

--- a/frontend/app/src/modules/history/data-issues/transforms.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.spec.ts
@@ -194,6 +194,17 @@ describe('data-issues transforms', () => {
       });
     });
 
+    it('should deep-link a rebasing issue to its highlighted event', () => {
+      expect(relatedEventRoute(IssueKind.REBASING_TOKEN, 9, '0xdef', 'stETH')).toEqual({
+        name: '/history/events/',
+        query: {
+          asset: 'stETH',
+          highlightedNegativeBalanceEvent: '9',
+          targetGroupIdentifier: '0xdef',
+        },
+      });
+    });
+
     it('should link a non negative-balance kind to the events page without a highlight', () => {
       expect(relatedEventRoute(IssueKind.CURRENT_BALANCE_MISMATCH, 7)).toEqual({
         name: '/history/events/',

--- a/frontend/app/src/modules/history/data-issues/transforms.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.ts
@@ -171,7 +171,7 @@ export function relatedEventRoute(
     return { name, query: { openMatchBridgesDialog: 'true' } };
   }
 
-  if (kind === IssueKind.NEGATIVE_BALANCE) {
+  if (kind === IssueKind.NEGATIVE_BALANCE || kind === IssueKind.REBASING_TOKEN) {
     query.highlightedNegativeBalanceEvent = eventIdentifier.toString();
     if (groupIdentifier)
       query.targetGroupIdentifier = groupIdentifier;

--- a/frontend/app/src/modules/history/data-issues/transforms.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.ts
@@ -12,6 +12,7 @@ import {
   CurrentBalanceMismatchPayload,
   type DataIssue,
   NegativeBalancePayload,
+  RebasingTokenPayload,
   UnmatchedBridgePayload,
 } from '@/modules/history/data-issues/schemas';
 
@@ -71,6 +72,19 @@ function describeBalanceMismatch(issue: DataIssue): IssueDescription | undefined
   };
 }
 
+function describeRebasingToken(issue: DataIssue): IssueDescription | undefined {
+  const parsed = RebasingTokenPayload.safeParse(issue.payload);
+  if (!parsed.success)
+    return undefined;
+  return {
+    amounts: {},
+    asset: issue.asset ?? undefined,
+    eventIdentifier: parsed.data.eventIdentifier,
+    messageKey: msg.$t('data_issues.description.rebasing_token'),
+    shortMessageKey: msg.$t('data_issues.description_short.rebasing_token'),
+  };
+}
+
 function describeUnmatchedBridge(issue: DataIssue): IssueDescription | undefined {
   const parsed = UnmatchedBridgePayload.safeParse(issue.payload);
   if (!parsed.success)
@@ -92,6 +106,7 @@ function describeUnmatchedBridge(issue: DataIssue): IssueDescription | undefined
 const KIND_DESCRIBERS: Partial<Record<IssueKind, (issue: DataIssue) => IssueDescription | undefined>> = {
   [IssueKind.CURRENT_BALANCE_MISMATCH]: describeBalanceMismatch,
   [IssueKind.NEGATIVE_BALANCE]: describeNegativeBalance,
+  [IssueKind.REBASING_TOKEN]: describeRebasingToken,
   [IssueKind.UNMATCHED_BRIDGE]: describeUnmatchedBridge,
 };
 

--- a/frontend/app/src/modules/history/data-issues/transforms.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.ts
@@ -76,13 +76,39 @@ function describeRebasingToken(issue: DataIssue): IssueDescription | undefined {
   const parsed = RebasingTokenPayload.safeParse(issue.payload);
   if (!parsed.success)
     return undefined;
-  return {
+
+  const description = {
     amounts: {},
     asset: issue.asset ?? undefined,
     eventIdentifier: parsed.data.eventIdentifier,
-    messageKey: msg.$t('data_issues.description.rebasing_token'),
-    shortMessageKey: msg.$t('data_issues.description_short.rebasing_token'),
   };
+
+  switch (parsed.data.reason) {
+    case 'archive_node_unavailable':
+      return {
+        ...description,
+        messageKey: msg.$t('data_issues.description.rebasing_token_archive_node_unavailable'),
+        shortMessageKey: msg.$t('data_issues.description_short.rebasing_token_archive_node_unavailable'),
+      };
+    case 'historical_balance_query_failed':
+      return {
+        ...description,
+        messageKey: msg.$t('data_issues.description.rebasing_token_historical_balance_query_failed'),
+        shortMessageKey: msg.$t('data_issues.description_short.rebasing_token_historical_balance_query_failed'),
+      };
+    case 'missing_transaction':
+      return {
+        ...description,
+        messageKey: msg.$t('data_issues.description.rebasing_token_missing_transaction'),
+        shortMessageKey: msg.$t('data_issues.description_short.rebasing_token_missing_transaction'),
+      };
+    case 'unsupported_bucket':
+      return {
+        ...description,
+        messageKey: msg.$t('data_issues.description.rebasing_token_unsupported_bucket'),
+        shortMessageKey: msg.$t('data_issues.description_short.rebasing_token_unsupported_bucket'),
+      };
+  }
 }
 
 function describeUnmatchedBridge(issue: DataIssue): IssueDescription | undefined {

--- a/frontend/app/src/modules/history/data-issues/use-data-issue-detail-actions.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issue-detail-actions.spec.ts
@@ -1,6 +1,7 @@
 import type { DataIssue } from '@/modules/history/data-issues/schemas';
-import { get } from '@vueuse/core';
+import { get, set } from '@vueuse/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, ref } from 'vue';
 import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-issues/constants';
 import { useDataIssueDetailActions } from '@/modules/history/data-issues/use-data-issue-detail-actions';
 
@@ -124,6 +125,19 @@ describe('useDataIssueDetailActions', () => {
 
     expect(get(modelSelectedIssue)).toStrictEqual(updated);
     expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('should synchronize an open issue after the list refreshes', async () => {
+    const issue = createIssue({ state: IssueState.AUTO_REMEDIATING });
+    const issues = ref<DataIssue[]>([issue]);
+    const { modelSelectedIssue, openDetail } = useDataIssueDetailActions(vi.fn(), issues);
+    openDetail(issue);
+
+    const resolved = createIssue({ state: IssueState.RESOLVED });
+    set(issues, [resolved]);
+    await nextTick();
+
+    expect(get(modelSelectedIssue)).toStrictEqual(resolved);
   });
 
   it('should open the resolve dialog on request', () => {

--- a/frontend/app/src/modules/history/data-issues/use-data-issue-detail-actions.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issue-detail-actions.ts
@@ -1,4 +1,4 @@
-import type { Ref } from 'vue';
+import type { MaybeRefOrGetter, Ref } from 'vue';
 import type { DataIssue } from '@/modules/history/data-issues/schemas';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useDataIssues } from '@/modules/history/data-issues/use-data-issues';
@@ -20,6 +20,7 @@ interface UseDataIssueDetailActionsReturn {
  * the full page. Owns the selected issue, the drawer/resolve-dialog visibility,
  * and a busy flag; each successful action triggers the caller-supplied `reload`
  * so both the list and the badge summary refresh from a single place.
+ * The selected issue is synchronized from `issues` after polling or an explicit refresh.
  *
  * The returned refs use the `model` prefix because they are two-way bindings the
  * consumer drives via `v-model` / mutates, which the `composable-return-readonly`
@@ -27,6 +28,7 @@ interface UseDataIssueDetailActionsReturn {
  */
 export function useDataIssueDetailActions(
   reload: () => Promise<void>,
+  issues: MaybeRefOrGetter<DataIssue[]> = () => [],
 ): UseDataIssueDetailActionsReturn {
   const { t } = useI18n({ useScope: 'global' });
   const { dismiss, resolveManually, retry } = useDataIssues();
@@ -108,6 +110,16 @@ export function useDataIssueDetailActions(
       set(modelActionBusy, false);
     }
   }
+
+  watch(() => toValue(issues), (updatedIssues) => {
+    const selected = get(modelSelectedIssue);
+    if (!selected)
+      return;
+
+    const updated = updatedIssues.find(issue => issue.id === selected.id);
+    if (updated)
+      set(modelSelectedIssue, updated);
+  });
 
   return {
     modelActionBusy,

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-format.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-format.ts
@@ -33,6 +33,8 @@ export function useDataIssuesFormat(): UseDataIssuesFormatReturn {
         return t('data_issues.kind.negative_balance');
       case IssueKind.CURRENT_BALANCE_MISMATCH:
         return t('data_issues.kind.current_balance_mismatch');
+      case IssueKind.REBASING_TOKEN:
+        return t('data_issues.kind.rebasing_token');
       case IssueKind.UNMATCHED_BRIDGE:
         return t('data_issues.kind.unmatched_bridge');
     }

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-inbox-store.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-inbox-store.spec.ts
@@ -47,6 +47,14 @@ describe('useDataIssuesInboxStore', () => {
     expect(get(store.baselineTotal)).toBe(42);
   });
 
+  it('should signal completed historical balance processing', () => {
+    const store = useDataIssuesInboxStore();
+
+    store.notifyHistoricalBalanceProcessingCompleted();
+
+    expect(get(store.historicalBalanceProcessingCompleted)).toBe(1);
+  });
+
   it('should remove the data-issues tab when dismissing inline panels', () => {
     const store = useDataIssuesInboxStore();
     const visibility = useAreaVisibilityStore();

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-inbox-store.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-inbox-store.ts
@@ -23,6 +23,7 @@ export function emptyCounts(): StateCounts {
 export const useDataIssuesInboxStore = defineStore('history/data-issues-inbox', () => {
   const counts = ref<StateCounts>(emptyCounts());
   const baselineTotal = ref<number>(0);
+  const historicalBalanceProcessingCompleted = ref<number>(0);
 
   /** Issues awaiting the user: open + needs-attention. Auto-remediating issues
    * are in progress and need no action, so they are intentionally excluded. */
@@ -32,6 +33,10 @@ export const useDataIssuesInboxStore = defineStore('history/data-issues-inbox', 
   function setSummary(newCounts: StateCounts, baseline: number): void {
     set(counts, newCounts);
     set(baselineTotal, baseline);
+  }
+
+  function notifyHistoricalBalanceProcessingCompleted(): void {
+    set(historicalBalanceProcessingCompleted, get(historicalBalanceProcessingCompleted) + 1);
   }
 
   /** Removes the pinned-rail copy of the inbox. Called when the dedicated
@@ -46,6 +51,8 @@ export const useDataIssuesInboxStore = defineStore('history/data-issues-inbox', 
     baselineTotal,
     counts,
     dismissInlinePanels,
+    historicalBalanceProcessingCompleted,
+    notifyHistoricalBalanceProcessingCompleted,
     setSummary,
   };
 });

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-panel-polling.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-panel-polling.spec.ts
@@ -1,7 +1,9 @@
 import { mount } from '@vue/test-utils';
 import { set } from '@vueuse/core';
+import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, h, KeepAlive, type Ref, ref, shallowRef } from 'vue';
+import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
 import { useDataIssuesPanelPolling } from '@/modules/history/data-issues/use-data-issues-panel-polling';
 
 const syncCompleted = ref<boolean>(false);
@@ -49,6 +51,7 @@ function mountPanel(hasRemediatingRows: Ref<boolean>, reload: () => Promise<void
 describe('useDataIssuesPanelPolling', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    setActivePinia(createPinia());
     set(syncCompleted, false);
   });
 
@@ -138,6 +141,17 @@ describe('useDataIssuesPanelPolling', () => {
     const panel = mountPanel(ref(false), reload);
 
     set(syncCompleted, true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(reload).toHaveBeenCalledOnce();
+    panel.unmount();
+  });
+
+  it('should reload when historical balance processing completes while visible', async () => {
+    const reload = vi.fn().mockResolvedValue(undefined);
+    const panel = mountPanel(ref(false), reload);
+
+    useDataIssuesInboxStore().notifyHistoricalBalanceProcessingCompleted();
     await vi.advanceTimersByTimeAsync(0);
 
     expect(reload).toHaveBeenCalledOnce();

--- a/frontend/app/src/modules/history/data-issues/use-data-issues-panel-polling.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues-panel-polling.ts
@@ -1,5 +1,6 @@
 import type { MaybeRefOrGetter } from 'vue';
 import { startPromise } from '@shared/utils';
+import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
 import { useSyncCompleted } from '@/modules/shell/sync-progress/use-sync-completed';
 
 /** How often the panel re-reads the list while auto-remediation is running. */
@@ -21,6 +22,7 @@ export function useDataIssuesPanelPolling(
   reload: () => Promise<void>,
 ): void {
   const { syncCompleted } = useSyncCompleted();
+  const { historicalBalanceProcessingCompleted } = storeToRefs(useDataIssuesInboxStore());
   const { pause, resume } = useIntervalFn(() => {
     startPromise(reload());
   }, POLL_INTERVAL, { immediate: false });
@@ -38,6 +40,13 @@ export function useDataIssuesPanelPolling(
   watch(() => toValue(hasRemediatingRows), syncPolling);
 
   watch(syncCompleted, () => {
+    if (get(active))
+      startPromise(reload());
+    else
+      set(pendingRefresh, true);
+  });
+
+  watch(historicalBalanceProcessingCompleted, () => {
     if (get(active))
       startPromise(reload());
     else

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -150,7 +150,11 @@ from rotkehlchen.feature_flags import is_accounting_update_enabled
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.asset_updates.manager import ASSETS_VERSION_KEY
 from rotkehlchen.globaldb.handler import GlobalDBHandler
-from rotkehlchen.history.data_issues.manager import DataIssuesManager
+from rotkehlchen.history.data_issues.constants import IssueState
+from rotkehlchen.history.data_issues.manager import (
+    DataIssuesManager,
+    make_auto_remediation_attempt,
+)
 from rotkehlchen.history.events.structures.asset_movement import AssetMovement
 from rotkehlchen.history.events.structures.base import (
     HistoryBaseEntryType,
@@ -237,6 +241,7 @@ from rotkehlchen.types import (
     SubstrateAddress,
     SupportedBlockchain,
     Timestamp,
+    TimestampMS,
     UserNote,
 )
 from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now
@@ -3691,16 +3696,41 @@ class RestAPI:
 
     @accounting_update_required('Data issues are disabled', response=True)
     def retry_data_issue_auto_remediation(self, issue_id: int) -> Response:
+        if (task_manager := self.rotkehlchen.task_manager) is None:
+            return api_response(
+                wrap_in_fail_result('Cannot retry auto-remediation while logging out'),
+                status_code=HTTPStatus.CONFLICT,
+            )
+
+        issues_manager = DataIssuesManager(self.rotkehlchen.data.db)
         try:
-            result = self._serialize_data_issue(DataIssuesManager(
-                self.rotkehlchen.data.db,
-            ).retry_auto_remediation(issue_id))
+            issue, should_schedule = issues_manager.retry_auto_remediation(issue_id)
         except NotFoundError as e:
             return api_response(wrap_in_fail_result(str(e)), status_code=HTTPStatus.NOT_FOUND)
         except InputError as e:
             return api_response(wrap_in_fail_result(str(e)), status_code=HTTPStatus.CONFLICT)
 
-        return api_response(_wrap_in_ok_result(result=result, status_code=HTTPStatus.OK))
+        if should_schedule and task_manager.retry_data_issue_auto_remediation(
+            issue_id=issue.id,
+            from_ts=TimestampMS(issue.ts_start),
+        ) is False:
+            issues_manager.update_state(
+                issue_id=issue.id,
+                state=IssueState.UNRESOLVED,
+                attempt=make_auto_remediation_attempt(
+                    success=False,
+                    reason='processing_already_running',
+                ),
+            )
+            return api_response(
+                wrap_in_fail_result('Historical balance processing is already running'),
+                status_code=HTTPStatus.CONFLICT,
+            )
+
+        return api_response(_wrap_in_ok_result(
+            result=self._serialize_data_issue(issue),
+            status_code=HTTPStatus.OK,
+        ))
 
     @async_api_call()
     @accounting_update_required('Historical balances are disabled')

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3812,11 +3812,11 @@ class RestAPI:
             from_timestamp: Timestamp,
             to_timestamp: Timestamp,
     ) -> Response:
-        """Return graph balances for an asset or collection.
+        """Return graph balances by calculating them from history events on demand.
 
-        The accounting-update path reads precomputed event metrics and reports whether processing
-        is required. Outside the feature flag the frontend-facing legacy path continues calculating
-        balances from history events on demand.
+        Keep this legacy graph endpoint outside the accounting-update feature flag.
+        Its event-metrics replacement depends on background processing that remains
+        experimental, whereas the frontend still exposes this historical source.
         """
         assets: tuple[Asset, ...]
         try:
@@ -3830,22 +3830,9 @@ class RestAPI:
                     )
                     assets = tuple(Asset(row[0]) for row in cursor)
 
-            balances_manager = HistoricalBalancesManager(self.rotkehlchen.data.db)
-            if is_accounting_update_enabled():
-                processing_required, balances = balances_manager.get_assets_amounts_event_metrics(
-                    assets=assets,
-                    from_ts=from_timestamp,
-                    to_ts=to_timestamp,
-                )
-                response_result: dict[str, Any] = {'processing_required': processing_required}
-                if balances is not None:
-                    response_result.update({
-                        'times': list(balances),
-                        'values': [str(value) for value in balances.values()],
-                    })
-                return api_response(_wrap_in_ok_result(result=response_result))
-
-            balances, last_group_identifier = balances_manager.get_assets_amounts(
+            balances, last_group_identifier = HistoricalBalancesManager(
+                self.rotkehlchen.data.db,
+            ).get_assets_amounts(
                 assets=assets,
                 from_ts=from_timestamp,
                 to_ts=to_timestamp,

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3812,11 +3812,11 @@ class RestAPI:
             from_timestamp: Timestamp,
             to_timestamp: Timestamp,
     ) -> Response:
-        """Return graph balances by calculating them from history events on demand.
+        """Return graph balances for an asset or collection.
 
-        Keep this legacy graph endpoint outside the accounting-update feature flag.
-        Its event-metrics replacement depends on background processing that remains
-        experimental, whereas the frontend still exposes this historical source.
+        The accounting-update path reads precomputed event metrics and reports whether processing
+        is required. Outside the feature flag the frontend-facing legacy path continues calculating
+        balances from history events on demand.
         """
         assets: tuple[Asset, ...]
         try:
@@ -3830,9 +3830,22 @@ class RestAPI:
                     )
                     assets = tuple(Asset(row[0]) for row in cursor)
 
-            balances, last_group_identifier = HistoricalBalancesManager(
-                self.rotkehlchen.data.db,
-            ).get_assets_amounts(
+            balances_manager = HistoricalBalancesManager(self.rotkehlchen.data.db)
+            if is_accounting_update_enabled():
+                processing_required, balances = balances_manager.get_assets_amounts_event_metrics(
+                    assets=assets,
+                    from_ts=from_timestamp,
+                    to_ts=to_timestamp,
+                )
+                response_result: dict[str, Any] = {'processing_required': processing_required}
+                if balances is not None:
+                    response_result.update({
+                        'times': list(balances),
+                        'values': [str(value) for value in balances.values()],
+                    })
+                return api_response(_wrap_in_ok_result(result=response_result))
+
+            balances, last_group_identifier = balances_manager.get_assets_amounts(
                 assets=assets,
                 from_ts=from_timestamp,
                 to_ts=to_timestamp,

--- a/rotkehlchen/api/services/assets.py
+++ b/rotkehlchen/api/services/assets.py
@@ -231,6 +231,17 @@ class AssetsService:
         types = [str(x) for x in AssetType if x not in ASSET_TYPES_EXCLUDED_FOR_USERS]
         return {'result': types, 'message': '', 'status_code': HTTPStatus.OK}
 
+    def _set_rebasing_flag(self, identifier: str, enabled: bool | None) -> None:
+        if enabled is None or GlobalDBHandler.set_asset_flag(
+            identifier=identifier,
+            flag=AssetFlag.REBASING,
+            enabled=enabled,
+        ) is False:
+            return
+
+        with self.rotkehlchen.data.db.user_write() as write_cursor:
+            DBHistoryEvents(self.rotkehlchen.data.db).mark_all_events_modified(write_cursor)
+
     def add_user_asset(
             self,
             asset: AssetWithOracles,
@@ -261,15 +272,7 @@ class AssetsService:
 
         with self.rotkehlchen.data.db.user_write() as cursor:
             self.rotkehlchen.data.db.add_asset_identifiers(cursor, [asset.identifier])
-        if is_rebasing is not None:
-            flag_changed = GlobalDBHandler.set_asset_flag(
-                identifier=asset.identifier,
-                flag=AssetFlag.REBASING,
-                enabled=is_rebasing,
-            )
-            if flag_changed:
-                with self.rotkehlchen.data.db.user_write() as write_cursor:
-                    DBHistoryEvents(self.rotkehlchen.data.db).mark_all_events_modified(write_cursor)
+        self._set_rebasing_flag(identifier=asset.identifier, enabled=is_rebasing)
 
         return {
             'result': {'identifier': asset.identifier},
@@ -289,15 +292,7 @@ class AssetsService:
 
         AssetResolver.clean_memory_cache(asset.identifier)
         self.rotkehlchen.icon_manager.failed_asset_ids.remove(asset.identifier)
-        if is_rebasing is not None:
-            flag_changed = GlobalDBHandler.set_asset_flag(
-                identifier=asset.identifier,
-                flag=AssetFlag.REBASING,
-                enabled=is_rebasing,
-            )
-            if flag_changed:
-                with self.rotkehlchen.data.db.user_write() as write_cursor:
-                    DBHistoryEvents(self.rotkehlchen.data.db).mark_all_events_modified(write_cursor)
+        self._set_rebasing_flag(identifier=asset.identifier, enabled=is_rebasing)
 
         return {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
 

--- a/rotkehlchen/api/services/assets.py
+++ b/rotkehlchen/api/services/assets.py
@@ -58,6 +58,7 @@ from rotkehlchen.constants.timing import ENS_AVATARS_REFRESH
 from rotkehlchen.db.cache import DBCacheDynamic
 from rotkehlchen.db.custom_assets import DBCustomAssets
 from rotkehlchen.db.ens import DBEns
+from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.search_assets import search_assets_levenshtein
 from rotkehlchen.errors.asset import UnknownAsset, UnsupportedAsset
 from rotkehlchen.errors.misc import EthSyncError, InputError, NotERC20Conformant, RemoteError
@@ -261,11 +262,14 @@ class AssetsService:
         with self.rotkehlchen.data.db.user_write() as cursor:
             self.rotkehlchen.data.db.add_asset_identifiers(cursor, [asset.identifier])
         if is_rebasing is not None:
-            GlobalDBHandler.set_asset_flag(
+            flag_changed = GlobalDBHandler.set_asset_flag(
                 identifier=asset.identifier,
                 flag=AssetFlag.REBASING,
                 enabled=is_rebasing,
             )
+            if flag_changed:
+                with self.rotkehlchen.data.db.user_write() as write_cursor:
+                    DBHistoryEvents(self.rotkehlchen.data.db).mark_all_events_modified(write_cursor)
 
         return {
             'result': {'identifier': asset.identifier},
@@ -286,11 +290,14 @@ class AssetsService:
         AssetResolver.clean_memory_cache(asset.identifier)
         self.rotkehlchen.icon_manager.failed_asset_ids.remove(asset.identifier)
         if is_rebasing is not None:
-            GlobalDBHandler.set_asset_flag(
+            flag_changed = GlobalDBHandler.set_asset_flag(
                 identifier=asset.identifier,
                 flag=AssetFlag.REBASING,
                 enabled=is_rebasing,
             )
+            if flag_changed:
+                with self.rotkehlchen.data.db.user_write() as write_cursor:
+                    DBHistoryEvents(self.rotkehlchen.data.db).mark_all_events_modified(write_cursor)
 
         return {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
 

--- a/rotkehlchen/api/services/assets.py
+++ b/rotkehlchen/api/services/assets.py
@@ -240,7 +240,10 @@ class AssetsService:
             return
 
         with self.rotkehlchen.data.db.user_write() as write_cursor:
-            DBHistoryEvents(self.rotkehlchen.data.db).mark_all_events_modified(write_cursor)
+            DBHistoryEvents(self.rotkehlchen.data.db).mark_asset_events_modified(
+                write_cursor=write_cursor,
+                asset=identifier,
+            )
 
     def add_user_asset(
             self,
@@ -747,12 +750,24 @@ class AssetsService:
             up_to_version: int | None,
             conflicts: dict[Asset, Literal['remote', 'local']] | None,
     ) -> dict[str, Any]:
+        rebasing_assets_before = GlobalDBHandler.get_asset_ids_with_flag(AssetFlag.REBASING)
         try:
             result = self.rotkehlchen.assets_updater.perform_update(up_to_version, conflicts)
         except RemoteError as e:
             return {'result': None, 'message': str(e), 'status_code': HTTPStatus.BAD_GATEWAY}
 
         if result is None:
+            changed_rebasing_assets = rebasing_assets_before.symmetric_difference(
+                GlobalDBHandler.get_asset_ids_with_flag(AssetFlag.REBASING),
+            )
+            if len(changed_rebasing_assets) != 0:
+                history_db = DBHistoryEvents(self.rotkehlchen.data.db)
+                with self.rotkehlchen.data.db.user_write() as write_cursor:
+                    for asset in changed_rebasing_assets:
+                        history_db.mark_asset_events_modified(
+                            write_cursor=write_cursor,
+                            asset=asset,
+                        )
             return {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
 
         return {

--- a/rotkehlchen/api/services/assets.py
+++ b/rotkehlchen/api/services/assets.py
@@ -750,24 +750,12 @@ class AssetsService:
             up_to_version: int | None,
             conflicts: dict[Asset, Literal['remote', 'local']] | None,
     ) -> dict[str, Any]:
-        rebasing_assets_before = GlobalDBHandler.get_asset_ids_with_flag(AssetFlag.REBASING)
         try:
             result = self.rotkehlchen.assets_updater.perform_update(up_to_version, conflicts)
         except RemoteError as e:
             return {'result': None, 'message': str(e), 'status_code': HTTPStatus.BAD_GATEWAY}
 
         if result is None:
-            changed_rebasing_assets = rebasing_assets_before.symmetric_difference(
-                GlobalDBHandler.get_asset_ids_with_flag(AssetFlag.REBASING),
-            )
-            if len(changed_rebasing_assets) != 0:
-                history_db = DBHistoryEvents(self.rotkehlchen.data.db)
-                with self.rotkehlchen.data.db.user_write() as write_cursor:
-                    for asset in changed_rebasing_assets:
-                        history_db.mark_asset_events_modified(
-                            write_cursor=write_cursor,
-                            asset=asset,
-                        )
             return {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
 
         return {

--- a/rotkehlchen/balances/historical.py
+++ b/rotkehlchen/balances/historical.py
@@ -107,8 +107,9 @@ class HistoricalBalancesManager:
     ) -> tuple[bool, dict[Asset, FVal] | list[HistoricalBalanceEntry] | None]:
         """Get historical balances for all assets at a given timestamp.
 
-        The inner query ranks metrics by the complete event ordering so events that share a
-        timestamp and sequence index still select the deterministic latest event identifier.
+        The inner query gets the latest balance per bucket via MAX(sort_key),
+        relying on SQLite's bare column behavior to return non-aggregated columns from that row.
+        See https://www.sqlite.org/lang_select.html#bareagg
 
         Returns a tuple of (processing_required, balances):
         - processing_required: True if events exist but haven't been processed yet
@@ -122,20 +123,15 @@ class HistoricalBalancesManager:
         with self.db.conn.read_ctx() as cursor:
             if group_by_account is True:
                 cursor.execute(
-                    f"""WITH ranked_metrics AS (
-                        SELECT location, location_label, protocol, asset, metric_value,
-                            ROW_NUMBER() OVER (
-                                PARTITION BY location, location_label, protocol, asset
-                                ORDER BY timestamp DESC, sequence_index DESC, event_identifier DESC
-                            ) AS metric_rank
-                        FROM event_metrics em
-                        WHERE metric_key = ? {filter_str}
-                        AND asset NOT IN (
-                            SELECT value FROM multisettings WHERE name='ignored_asset'
-                        )
+                    f"""SELECT
+                        location, location_label, protocol, asset, metric_value, MAX(sort_key)
+                    FROM event_metrics em
+                    WHERE metric_key = ? {filter_str}
+                    AND asset NOT IN (
+                        SELECT value FROM multisettings WHERE name='ignored_asset'
                     )
-                    SELECT location, location_label, protocol, asset, metric_value
-                    FROM ranked_metrics WHERE metric_rank = 1 AND metric_value > 0
+                    GROUP BY location, location_label, protocol, asset
+                    HAVING metric_value > 0
                     """,
                     query_bindings,
                 )
@@ -146,24 +142,19 @@ class HistoricalBalancesManager:
                         protocol=protocol,
                         asset=Asset(asset_id),
                         amount=FVal(amount),
-                    ) for location, location_label, protocol, asset_id, amount in cursor
+                    ) for location, location_label, protocol, asset_id, amount, _sort_key in cursor
                 ] or None
             else:
                 cursor.execute(
-                    f"""WITH ranked_metrics AS (
-                        SELECT asset, metric_value,
-                            ROW_NUMBER() OVER (
-                                PARTITION BY location, location_label, protocol, asset
-                                ORDER BY timestamp DESC, sequence_index DESC, event_identifier DESC
-                            ) AS metric_rank
+                    f"""SELECT asset, SUM(metric_value) FROM (
+                        SELECT asset, metric_value, MAX(sort_key)
                         FROM event_metrics em
                         WHERE metric_key = ? {filter_str}
                         AND asset NOT IN (
                             SELECT value FROM multisettings WHERE name='ignored_asset'
                         )
-                    )
-                    SELECT asset, SUM(metric_value) FROM ranked_metrics
-                    WHERE metric_rank = 1 GROUP BY asset HAVING SUM(metric_value) > 0
+                        GROUP BY location, location_label, protocol, asset
+                    ) GROUP BY asset HAVING SUM(metric_value) > 0
                     """,
                     query_bindings,
                 )
@@ -192,8 +183,7 @@ class HistoricalBalancesManager:
                 WHERE metric_key = ? {filter_str}
                 AND asset NOT IN (SELECT value FROM multisettings WHERE name='ignored_asset')
                 AND metric_value > 0
-                ORDER BY location, location_label, protocol, asset,
-                    timestamp, sequence_index, event_identifier
+                ORDER BY location, location_label, protocol, asset, timestamp, sort_key
                 """,
                 query_bindings,
             )
@@ -498,7 +488,7 @@ class HistoricalBalancesManager:
         from_ts_ms, to_ts_ms = ts_sec_to_ms(from_ts), ts_sec_to_ms(to_ts)
         metric_key = EventMetricKey.BALANCE.serialize()
         asset_ids = [asset.resolve_swapped_for().identifier for asset in assets]
-        columns = ['timestamp', 'sequence_index', 'event_identifier', 'delta']
+        columns = ['timestamp', 'sort_key', 'delta']
         frames: list[pd.DataFrame] = []
         with self.db.conn.read_ctx() as cursor:
             for chunk, placeholders in get_query_chunks(data=asset_ids):
@@ -509,8 +499,7 @@ class HistoricalBalancesManager:
                             SELECT
                                 timestamp,
                                 CAST(metric_value AS REAL) as balance,
-                                sequence_index,
-                                event_identifier,
+                                sort_key,
                                 location,
                                 location_label,
                                 protocol,
@@ -524,18 +513,17 @@ class HistoricalBalancesManager:
                         with_delta AS (
                             SELECT
                                 timestamp,
-                                sequence_index,
-                                event_identifier,
+                                sort_key,
                                 balance - COALESCE(
                                     LAG(balance) OVER (
                                         PARTITION BY location, location_label, protocol, asset
-                                        ORDER BY timestamp, sequence_index, event_identifier
+                                        ORDER BY sort_key
                                     ),
                                     0
                                 ) as delta
                             FROM all_events
                         )
-                        SELECT timestamp, sequence_index, event_identifier, delta
+                        SELECT timestamp, sort_key, delta
                         FROM with_delta
                         WHERE timestamp >= ? AND timestamp <= ?
                         """,
@@ -549,13 +537,8 @@ class HistoricalBalancesManager:
         data = None
         if frames:
             df = pd.concat(frames, ignore_index=True).astype(
-                {
-                    'timestamp': 'int64',
-                    'sequence_index': 'int64',
-                    'event_identifier': 'int64',
-                    'delta': 'float64',
-                },
-            ).sort_values(['timestamp', 'sequence_index', 'event_identifier'])
+                {'timestamp': 'int64', 'sort_key': 'int64', 'delta': 'float64'},
+            ).sort_values('sort_key')
             df['amount'] = df['delta'].cumsum()
             data = {
                 ts_ms_to_sec(TimestampMS(int(ts))): FVal(amt)
@@ -591,30 +574,29 @@ class HistoricalBalancesManager:
                     """
                     WITH all_events AS (
                         SELECT timestamp, asset, CAST(metric_value AS REAL) as balance,
-                               sequence_index, event_identifier, location, location_label, protocol
+                               sort_key, location, location_label, protocol
                         FROM event_metrics em
                         WHERE metric_key = ?
                         AND asset NOT IN (
                             SELECT value FROM multisettings WHERE name='ignored_asset'
                         )
                     ), with_delta AS (
-                        SELECT timestamp, sequence_index, event_identifier, asset,
+                        SELECT timestamp, sort_key, asset,
                                balance - COALESCE(
                                    LAG(balance) OVER (
                                        PARTITION BY location, location_label, protocol, asset
-                                       ORDER BY timestamp, sequence_index, event_identifier
+                                       ORDER BY sort_key
                                    ),
                                    0
                                ) as delta
                         FROM all_events
                     )
-                    SELECT timestamp, sequence_index, event_identifier, asset, delta
-                    FROM with_delta
+                    SELECT timestamp, sort_key, asset, delta FROM with_delta
                     WHERE timestamp >= ? AND timestamp <= ?
                     """,
                     (EventMetricKey.BALANCE.serialize(), from_ts_ms, to_ts_ms),
                 ),
-                columns=['timestamp', 'sequence_index', 'event_identifier', 'asset', 'delta'],
+                columns=['timestamp', 'sort_key', 'asset', 'delta'],
             )
 
         data = None
@@ -623,14 +605,8 @@ class HistoricalBalancesManager:
             # Sum them up in order to reconstruct the running balance for each asset,
             # then keep only the last balance of each day (the end-of-day snapshot).
             df = df.astype(
-                {
-                    'timestamp': 'int64',
-                    'sequence_index': 'int64',
-                    'event_identifier': 'int64',
-                    'asset': 'str',
-                    'delta': 'float64',
-                },
-            ).sort_values(['timestamp', 'sequence_index', 'event_identifier'])
+                {'timestamp': 'int64', 'sort_key': 'int64', 'asset': 'str', 'delta': 'float64'},
+            ).sort_values('sort_key')
             df['balance'] = df.groupby('asset', sort=False)['delta'].cumsum()
             df['day'] = (df['timestamp'] // DAY_IN_MILLISECONDS) * DAY_IN_MILLISECONDS
             pivoted = (
@@ -726,7 +702,7 @@ class HistoricalBalancesManager:
                     LEFT JOIN evm_transactions et ON et.tx_hash = cei.tx_ref AND et.chain_id = ?
                     WHERE em.metric_key = ? AND em.location = ? AND em.location_label = ?
                     AND em.protocol IS NULL AND em.asset = ?
-                    ORDER BY em.timestamp, em.sequence_index, em.event_identifier
+                    ORDER BY em.sort_key
                     """,
                     (
                         evm_chain.serialize_for_db(),

--- a/rotkehlchen/balances/historical.py
+++ b/rotkehlchen/balances/historical.py
@@ -107,9 +107,8 @@ class HistoricalBalancesManager:
     ) -> tuple[bool, dict[Asset, FVal] | list[HistoricalBalanceEntry] | None]:
         """Get historical balances for all assets at a given timestamp.
 
-        The inner query gets the latest balance per bucket via MAX(sort_key),
-        relying on SQLite's bare column behavior to return non-aggregated columns from that row.
-        See https://www.sqlite.org/lang_select.html#bareagg
+        The inner query ranks metrics by the complete event ordering so events that share a
+        timestamp and sequence index still select the deterministic latest event identifier.
 
         Returns a tuple of (processing_required, balances):
         - processing_required: True if events exist but haven't been processed yet
@@ -123,15 +122,20 @@ class HistoricalBalancesManager:
         with self.db.conn.read_ctx() as cursor:
             if group_by_account is True:
                 cursor.execute(
-                    f"""SELECT
-                        location, location_label, protocol, asset, metric_value, MAX(sort_key)
-                    FROM event_metrics em
-                    WHERE metric_key = ? {filter_str}
-                    AND asset NOT IN (
-                        SELECT value FROM multisettings WHERE name='ignored_asset'
+                    f"""WITH ranked_metrics AS (
+                        SELECT location, location_label, protocol, asset, metric_value,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY location, location_label, protocol, asset
+                                ORDER BY timestamp DESC, sequence_index DESC, event_identifier DESC
+                            ) AS metric_rank
+                        FROM event_metrics em
+                        WHERE metric_key = ? {filter_str}
+                        AND asset NOT IN (
+                            SELECT value FROM multisettings WHERE name='ignored_asset'
+                        )
                     )
-                    GROUP BY location, location_label, protocol, asset
-                    HAVING metric_value > 0
+                    SELECT location, location_label, protocol, asset, metric_value
+                    FROM ranked_metrics WHERE metric_rank = 1 AND metric_value > 0
                     """,
                     query_bindings,
                 )
@@ -142,19 +146,24 @@ class HistoricalBalancesManager:
                         protocol=protocol,
                         asset=Asset(asset_id),
                         amount=FVal(amount),
-                    ) for location, location_label, protocol, asset_id, amount, _sort_key in cursor
+                    ) for location, location_label, protocol, asset_id, amount in cursor
                 ] or None
             else:
                 cursor.execute(
-                    f"""SELECT asset, SUM(metric_value) FROM (
-                        SELECT asset, metric_value, MAX(sort_key)
+                    f"""WITH ranked_metrics AS (
+                        SELECT asset, metric_value,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY location, location_label, protocol, asset
+                                ORDER BY timestamp DESC, sequence_index DESC, event_identifier DESC
+                            ) AS metric_rank
                         FROM event_metrics em
                         WHERE metric_key = ? {filter_str}
                         AND asset NOT IN (
                             SELECT value FROM multisettings WHERE name='ignored_asset'
                         )
-                        GROUP BY location, location_label, protocol, asset
-                    ) GROUP BY asset HAVING SUM(metric_value) > 0
+                    )
+                    SELECT asset, SUM(metric_value) FROM ranked_metrics
+                    WHERE metric_rank = 1 GROUP BY asset HAVING SUM(metric_value) > 0
                     """,
                     query_bindings,
                 )
@@ -183,7 +192,8 @@ class HistoricalBalancesManager:
                 WHERE metric_key = ? {filter_str}
                 AND asset NOT IN (SELECT value FROM multisettings WHERE name='ignored_asset')
                 AND metric_value > 0
-                ORDER BY location, location_label, protocol, asset, timestamp, sort_key
+                ORDER BY location, location_label, protocol, asset,
+                    timestamp, sequence_index, event_identifier
                 """,
                 query_bindings,
             )
@@ -488,7 +498,7 @@ class HistoricalBalancesManager:
         from_ts_ms, to_ts_ms = ts_sec_to_ms(from_ts), ts_sec_to_ms(to_ts)
         metric_key = EventMetricKey.BALANCE.serialize()
         asset_ids = [asset.resolve_swapped_for().identifier for asset in assets]
-        columns = ['timestamp', 'sort_key', 'delta']
+        columns = ['timestamp', 'sequence_index', 'event_identifier', 'delta']
         frames: list[pd.DataFrame] = []
         with self.db.conn.read_ctx() as cursor:
             for chunk, placeholders in get_query_chunks(data=asset_ids):
@@ -499,7 +509,8 @@ class HistoricalBalancesManager:
                             SELECT
                                 timestamp,
                                 CAST(metric_value AS REAL) as balance,
-                                sort_key,
+                                sequence_index,
+                                event_identifier,
                                 location,
                                 location_label,
                                 protocol,
@@ -513,17 +524,18 @@ class HistoricalBalancesManager:
                         with_delta AS (
                             SELECT
                                 timestamp,
-                                sort_key,
+                                sequence_index,
+                                event_identifier,
                                 balance - COALESCE(
                                     LAG(balance) OVER (
                                         PARTITION BY location, location_label, protocol, asset
-                                        ORDER BY sort_key
+                                        ORDER BY timestamp, sequence_index, event_identifier
                                     ),
                                     0
                                 ) as delta
                             FROM all_events
                         )
-                        SELECT timestamp, sort_key, delta
+                        SELECT timestamp, sequence_index, event_identifier, delta
                         FROM with_delta
                         WHERE timestamp >= ? AND timestamp <= ?
                         """,
@@ -537,8 +549,13 @@ class HistoricalBalancesManager:
         data = None
         if frames:
             df = pd.concat(frames, ignore_index=True).astype(
-                {'timestamp': 'int64', 'sort_key': 'int64', 'delta': 'float64'},
-            ).sort_values('sort_key')
+                {
+                    'timestamp': 'int64',
+                    'sequence_index': 'int64',
+                    'event_identifier': 'int64',
+                    'delta': 'float64',
+                },
+            ).sort_values(['timestamp', 'sequence_index', 'event_identifier'])
             df['amount'] = df['delta'].cumsum()
             data = {
                 ts_ms_to_sec(TimestampMS(int(ts))): FVal(amt)
@@ -574,29 +591,30 @@ class HistoricalBalancesManager:
                     """
                     WITH all_events AS (
                         SELECT timestamp, asset, CAST(metric_value AS REAL) as balance,
-                               sort_key, location, location_label, protocol
+                               sequence_index, event_identifier, location, location_label, protocol
                         FROM event_metrics em
                         WHERE metric_key = ?
                         AND asset NOT IN (
                             SELECT value FROM multisettings WHERE name='ignored_asset'
                         )
                     ), with_delta AS (
-                        SELECT timestamp, sort_key, asset,
+                        SELECT timestamp, sequence_index, event_identifier, asset,
                                balance - COALESCE(
                                    LAG(balance) OVER (
                                        PARTITION BY location, location_label, protocol, asset
-                                       ORDER BY sort_key
+                                       ORDER BY timestamp, sequence_index, event_identifier
                                    ),
                                    0
                                ) as delta
                         FROM all_events
                     )
-                    SELECT timestamp, sort_key, asset, delta FROM with_delta
+                    SELECT timestamp, sequence_index, event_identifier, asset, delta
+                    FROM with_delta
                     WHERE timestamp >= ? AND timestamp <= ?
                     """,
                     (EventMetricKey.BALANCE.serialize(), from_ts_ms, to_ts_ms),
                 ),
-                columns=['timestamp', 'sort_key', 'asset', 'delta'],
+                columns=['timestamp', 'sequence_index', 'event_identifier', 'asset', 'delta'],
             )
 
         data = None
@@ -605,8 +623,14 @@ class HistoricalBalancesManager:
             # Sum them up in order to reconstruct the running balance for each asset,
             # then keep only the last balance of each day (the end-of-day snapshot).
             df = df.astype(
-                {'timestamp': 'int64', 'sort_key': 'int64', 'asset': 'str', 'delta': 'float64'},
-            ).sort_values('sort_key')
+                {
+                    'timestamp': 'int64',
+                    'sequence_index': 'int64',
+                    'event_identifier': 'int64',
+                    'asset': 'str',
+                    'delta': 'float64',
+                },
+            ).sort_values(['timestamp', 'sequence_index', 'event_identifier'])
             df['balance'] = df.groupby('asset', sort=False)['delta'].cumsum()
             df['day'] = (df['timestamp'] // DAY_IN_MILLISECONDS) * DAY_IN_MILLISECONDS
             pivoted = (
@@ -659,9 +683,16 @@ class HistoricalBalancesManager:
             return cursor.execute(
                 f"""SELECT 1 FROM history_events he
                 WHERE {where_clause} AND he.ignored = 0 AND NOT ({exclusions})
-                AND NOT EXISTS (SELECT 1 FROM event_metrics em WHERE em.event_identifier = he.identifier) LIMIT 1
-                """,  # noqa: E501
-                [*bindings, *[v for pair in self._neutral_balance_tracking_pairs for v in pair]],
+                AND NOT EXISTS (
+                    SELECT 1 FROM event_metrics em
+                    WHERE em.event_identifier = he.identifier AND em.metric_key = ?
+                ) LIMIT 1
+                """,
+                [
+                    *bindings,
+                    *[v for pair in self._neutral_balance_tracking_pairs for v in pair],
+                    EventMetricKey.BALANCE.serialize(),
+                ],
             ).fetchone() is not None
 
     def _get_tracked_wallet_balance_events(
@@ -695,7 +726,7 @@ class HistoricalBalancesManager:
                     LEFT JOIN evm_transactions et ON et.tx_hash = cei.tx_ref AND et.chain_id = ?
                     WHERE em.metric_key = ? AND em.location = ? AND em.location_label = ?
                     AND em.protocol IS NULL AND em.asset = ?
-                    ORDER BY em.sort_key
+                    ORDER BY em.timestamp, em.sequence_index, em.event_identifier
                     """,
                     (
                         evm_chain.serialize_for_db(),

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -240,6 +240,17 @@ class DBHistoryEvents:
             ),
         )
 
+    def mark_asset_events_modified(self, write_cursor: DBCursor, asset: str) -> None:
+        """Mark historical balances stale from the first event holding the given asset."""
+        if (first_event := write_cursor.execute(
+            'SELECT MIN(timestamp) FROM history_events WHERE asset=?',
+            (asset,),
+        ).fetchone()) is not None and first_event[0] is not None:
+            self._mark_events_modified(
+                write_cursor=write_cursor,
+                timestamp=TimestampMS(first_event[0]),
+            )
+
     def mark_all_events_modified(self, write_cursor: DBCursor) -> None:
         """Mark historical balances stale from the first event, if any."""
         if (first_event := write_cursor.execute(

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -240,6 +240,16 @@ class DBHistoryEvents:
             ),
         )
 
+    def mark_all_events_modified(self, write_cursor: DBCursor) -> None:
+        """Mark historical balances stale from the first event, if any."""
+        if (first_event := write_cursor.execute(
+            'SELECT MIN(timestamp) FROM history_events',
+        ).fetchone()) is not None and first_event[0] is not None:
+            self._mark_events_modified(
+                write_cursor=write_cursor,
+                timestamp=TimestampMS(first_event[0]),
+            )
+
     def _execute_and_track_modified(
             self,
             write_cursor: DBCursor,

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -251,16 +251,6 @@ class DBHistoryEvents:
                 timestamp=TimestampMS(first_event[0]),
             )
 
-    def mark_all_events_modified(self, write_cursor: DBCursor) -> None:
-        """Mark historical balances stale from the first event, if any."""
-        if (first_event := write_cursor.execute(
-            'SELECT MIN(timestamp) FROM history_events',
-        ).fetchone()) is not None and first_event[0] is not None:
-            self._mark_events_modified(
-                write_cursor=write_cursor,
-                timestamp=TimestampMS(first_event[0]),
-            )
-
     def _execute_and_track_modified(
             self,
             write_cursor: DBCursor,

--- a/rotkehlchen/history/data_issues/constants.py
+++ b/rotkehlchen/history/data_issues/constants.py
@@ -5,6 +5,7 @@ from typing import Final
 class IssueKind(StrEnum):
     CURRENT_BALANCE_MISMATCH = 'current_balance_mismatch'
     NEGATIVE_BALANCE = 'negative_balance'
+    REBASING_TOKEN = 'rebasing_token'
     UNMATCHED_BRIDGE = 'unmatched_bridge'
 
 
@@ -23,6 +24,7 @@ class IssueSeverity(StrEnum):
 ISSUE_KIND_SEVERITY: Final[dict[IssueKind, IssueSeverity]] = {
     IssueKind.CURRENT_BALANCE_MISMATCH: IssueSeverity.WARNING,
     IssueKind.NEGATIVE_BALANCE: IssueSeverity.WARNING,
+    IssueKind.REBASING_TOKEN: IssueSeverity.WARNING,
     IssueKind.UNMATCHED_BRIDGE: IssueSeverity.WARNING,
 }
 

--- a/rotkehlchen/history/data_issues/manager.py
+++ b/rotkehlchen/history/data_issues/manager.py
@@ -333,14 +333,21 @@ class DataIssuesManager:
             self,
             issue_id: int,
             attempt: Mapping[str, Any],
+            resolution: dict[str, Any] | None = None,
     ) -> DataIssue:
         issue = self.get_issue(issue_id)
+        payload = (
+            issue.payload if resolution is None else
+            {**issue.payload, 'resolution': resolution}
+        )
         with self.db.user_write() as write_cursor:
             row = write_cursor.execute(
-                'UPDATE data_issues SET auto_remediation_attempts_json = ? WHERE id = ? '
+                'UPDATE data_issues SET auto_remediation_attempts_json = ?, payload_json = ? '
+                'WHERE id = ? '
                 f'RETURNING {DATA_ISSUE_COLUMNS}',
                 (
                     json.dumps([*issue.auto_remediation_attempts, attempt], separators=(',', ':')),
+                    json.dumps(payload, separators=(',', ':')),
                     issue_id,
                 ),
             ).fetchone()

--- a/rotkehlchen/history/data_issues/manager.py
+++ b/rotkehlchen/history/data_issues/manager.py
@@ -3,6 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any, cast
 
 from rotkehlchen.db.filtering import DataIssuesFilterQuery
+from rotkehlchen.db.utils import get_query_chunks
 from rotkehlchen.errors.misc import InputError, NotFoundError
 from rotkehlchen.history.data_issues.constants import (
     ALLOWED_STATE_TRANSITIONS,
@@ -145,6 +146,31 @@ class DataIssuesManager:
             severity: IssueSeverity | None = None,
     ) -> int:
         """Write an issue row idempotently and return its id."""
+        return self.write_issue_with_state(
+            kind=kind,
+            location=location,
+            location_label=location_label,
+            protocol=protocol,
+            asset=asset,
+            payload=payload,
+            ts_start=ts_start,
+            ts_end=ts_end,
+            severity=severity,
+        )[0]
+
+    def write_issue_with_state(
+            self,
+            kind: IssueKind,
+            location: str,
+            location_label: str | None,
+            protocol: str | None,
+            asset: str | None,
+            payload: DataIssuePayload,
+            ts_start: int,
+            ts_end: int,
+            severity: IssueSeverity | None = None,
+    ) -> tuple[int, str | IssueState]:
+        """Write an issue idempotently and return its id and resulting state."""
         location_label = '' if location_label is None else location_label
         protocol = '' if protocol is None else protocol
         asset = '' if asset is None else asset
@@ -182,7 +208,7 @@ class DataIssuesManager:
                 ),
             )
             if write_cursor.rowcount == 1:
-                return write_cursor.lastrowid
+                return write_cursor.lastrowid, IssueState.OPEN
 
         issue_id, existing_state = self._get_issue_id_and_state_by_natural_key(
             kind=kind,
@@ -193,7 +219,7 @@ class DataIssuesManager:
             event_identifier=event_identifier,
         )
         if existing_state == IssueState.DISMISSED:
-            return issue_id
+            return issue_id, existing_state
 
         with self.db.user_write() as write_cursor:
             if existing_state == IssueState.RESOLVED:
@@ -208,7 +234,39 @@ class DataIssuesManager:
                     'WHERE id = ?',
                     (ts_start, ts_end, payload_json, issue_id),
                 )
-        return issue_id
+        resulting_state = (
+            IssueState.OPEN if existing_state == IssueState.RESOLVED else existing_state
+        )
+        return issue_id, resulting_state
+
+    def resolve_superseded_negative_balance_issues(self, assets: frozenset[str]) -> None:
+        """Resolve negative-balance issues for assets now handled as rebasing tokens."""
+        if len(assets) == 0:
+            return
+
+        resolved_at = ts_now()
+        with self.db.user_write() as write_cursor:
+            for chunk, placeholders in get_query_chunks(data=list(assets)):
+                write_cursor.execute(
+                    'UPDATE data_issues SET state = ?, resolved_at = ? WHERE kind = ? '
+                    f'AND asset IN ({placeholders}) AND state NOT IN (?, ?)',
+                    [
+                        IssueState.RESOLVED,
+                        resolved_at,
+                        IssueKind.NEGATIVE_BALANCE,
+                        *chunk,
+                        IssueState.RESOLVED,
+                        IssueState.DISMISSED,
+                    ],
+                )
+
+    def reset_orphaned_remediations(self) -> None:
+        """Make remediation rows left by a previous process retryable after login."""
+        with self.db.user_write() as write_cursor:
+            write_cursor.execute(
+                'UPDATE data_issues SET state = ? WHERE state = ?',
+                (IssueState.UNRESOLVED, IssueState.AUTO_REMEDIATING),
+            )
 
     def resolve_event_issues(
             self,
@@ -403,15 +461,14 @@ class DataIssuesManager:
 
     def retry_auto_remediation(self, issue_id: int) -> tuple[DataIssue, bool]:
         issue = self.get_issue(issue_id)
+        if issue.kind != IssueKind.REBASING_TOKEN:
+            raise InputError(f'Auto-remediation is not supported for {issue.kind} data issues')
         if issue.state == IssueState.AUTO_REMEDIATING:
             return issue, False
         if issue.state not in {IssueState.OPEN, IssueState.UNRESOLVED}:
             raise InputError(
-                f'Cannot retry auto-remediation for {issue.state} data issue. '
-                f'Current state is {issue.state}',
+                f'Cannot retry auto-remediation for a {issue.state} data issue',
             )
-        if issue.kind != IssueKind.REBASING_TOKEN:
-            raise InputError(f'Auto-remediation is not supported for {issue.kind} data issues')
 
         return self.update_state(issue_id, IssueState.AUTO_REMEDIATING), True
 

--- a/rotkehlchen/history/data_issues/manager.py
+++ b/rotkehlchen/history/data_issues/manager.py
@@ -12,6 +12,7 @@ from rotkehlchen.history.data_issues.constants import (
     IssueState,
 )
 from rotkehlchen.history.data_issues.types import (
+    AutoRemediationAttempt,
     DataIssue,
     DataIssueFilters,
     DataIssuePayload,
@@ -23,6 +24,8 @@ from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.utils.misc import ts_now
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from rotkehlchen.db.dbhandler import DBHandler
 
 logger = logging.getLogger(__name__)
@@ -106,6 +109,21 @@ def _validate_state_transition(current_state: str | IssueState, new_state: Issue
         raise InputError(
             f'Invalid data issue state transition from {current_state} to {new_state}',
         )
+
+
+def make_auto_remediation_attempt(
+        success: bool,
+        reason: str | None = None,
+) -> AutoRemediationAttempt:
+    attempt = AutoRemediationAttempt(
+        attribution='system',
+        strategy='historical_balance_reprocessing',
+        success=success,
+        timestamp=ts_now(),
+    )
+    if reason is not None:
+        attempt['reason'] = reason
+    return attempt
 
 
 class DataIssuesManager:
@@ -275,7 +293,7 @@ class DataIssuesManager:
             self,
             issue_id: int,
             state: IssueState,
-            attempt: dict[str, Any] | None = None,
+            attempt: Mapping[str, Any] | None = None,
             resolution: dict[str, Any] | None = None,
     ) -> DataIssue:
         _validate_state_transition((issue := self.get_issue(issue_id)).state, state)
@@ -304,6 +322,25 @@ class DataIssuesManager:
                     json.dumps(attempts, separators=(',', ':')),
                     json.dumps(payload, separators=(',', ':')),
                     resolved_at,
+                    issue_id,
+                ),
+            ).fetchone()
+        if row is None:
+            raise NotFoundError(f'Data issue with id {issue_id} not found')
+        return _row_to_data_issue(row, group_identifier=issue.group_identifier)
+
+    def append_auto_remediation_attempt(
+            self,
+            issue_id: int,
+            attempt: Mapping[str, Any],
+    ) -> DataIssue:
+        issue = self.get_issue(issue_id)
+        with self.db.user_write() as write_cursor:
+            row = write_cursor.execute(
+                'UPDATE data_issues SET auto_remediation_attempts_json = ? WHERE id = ? '
+                f'RETURNING {DATA_ISSUE_COLUMNS}',
+                (
+                    json.dumps([*issue.auto_remediation_attempts, attempt], separators=(',', ':')),
                     issue_id,
                 ),
             ).fetchone()
@@ -357,24 +394,19 @@ class DataIssuesManager:
             raise NotFoundError(f'Data issue with id {issue_id} not found')
         return _row_to_data_issue(row, group_identifier=issue.group_identifier)
 
-    def retry_auto_remediation(self, issue_id: int) -> DataIssue:
+    def retry_auto_remediation(self, issue_id: int) -> tuple[DataIssue, bool]:
         issue = self.get_issue(issue_id)
-        if issue.state in {IssueState.OPEN, IssueState.AUTO_REMEDIATING}:
-            return issue
-        if issue.state == IssueState.DISMISSED:
-            raise InputError(f'Cannot retry auto-remediation for dismissed data issue. Current state is {issue.state}')  # noqa: E501
+        if issue.state == IssueState.AUTO_REMEDIATING:
+            return issue, False
+        if issue.state not in {IssueState.OPEN, IssueState.UNRESOLVED}:
+            raise InputError(
+                f'Cannot retry auto-remediation for {issue.state} data issue. '
+                f'Current state is {issue.state}',
+            )
+        if issue.kind != IssueKind.REBASING_TOKEN:
+            raise InputError(f'Auto-remediation is not supported for {issue.kind} data issues')
 
-        payload = dict(issue.payload)
-        payload.pop('resolution', None)
-        with self.db.user_write() as write_cursor:
-            row = write_cursor.execute(
-                'UPDATE data_issues SET state = ?, payload_json = ?, resolved_at = NULL '
-                f'WHERE id = ? RETURNING {DATA_ISSUE_COLUMNS}',
-                (IssueState.OPEN, json.dumps(payload, separators=(',', ':')), issue_id),
-            ).fetchone()
-        if row is None:
-            raise NotFoundError(f'Data issue with id {issue_id} not found')
-        return _row_to_data_issue(row, group_identifier=issue.group_identifier)
+        return self.update_state(issue_id, IssueState.AUTO_REMEDIATING), True
 
     def _get_issue_id_and_state_by_natural_key(
             self,

--- a/rotkehlchen/history/data_issues/manager.py
+++ b/rotkehlchen/history/data_issues/manager.py
@@ -187,6 +187,34 @@ class DataIssuesManager:
                 )
         return issue_id
 
+    def resolve_negative_balance_issues(
+            self,
+            issues: list[tuple[str, str | None, str | None, str, int]],
+    ) -> None:
+        """Resolve negative-balance issues whose buckets processed successfully."""
+        if len(issues) == 0:
+            return
+
+        resolved_at = ts_now()
+        with self.db.user_write() as write_cursor:
+            write_cursor.executemany(
+                'UPDATE data_issues SET state = ?, resolved_at = ? WHERE kind = ? '
+                'AND location = ? AND location_label = ? AND protocol = ? AND asset = ? '
+                'AND event_identifier = ? AND state NOT IN (?, ?)',
+                [(
+                    IssueState.RESOLVED,
+                    resolved_at,
+                    IssueKind.NEGATIVE_BALANCE,
+                    location,
+                    location_label or '',
+                    protocol or '',
+                    asset,
+                    event_identifier,
+                    IssueState.RESOLVED,
+                    IssueState.DISMISSED,
+                ) for location, location_label, protocol, asset, event_identifier in issues],
+            )
+
     def list_issues(
             self,
             filters: DataIssueFilters | DataIssuesFilterQuery | None = None,

--- a/rotkehlchen/history/data_issues/manager.py
+++ b/rotkehlchen/history/data_issues/manager.py
@@ -16,6 +16,7 @@ from rotkehlchen.history.data_issues.types import (
     DataIssueFilters,
     DataIssuePayload,
     NegativeBalanceIssuePayload,
+    RebasingTokenIssuePayload,
     UnmatchedBridgeIssuePayload,
 )
 from rotkehlchen.logging import RotkehlchenLogsAdapter
@@ -132,9 +133,13 @@ class DataIssuesManager:
         issue_severity = severity if severity is not None else ISSUE_KIND_SEVERITY[kind]
         payload_json = json.dumps(payload, separators=(',', ':'))
         created_at = ts_now()
-        if kind in (IssueKind.NEGATIVE_BALANCE, IssueKind.UNMATCHED_BRIDGE):
+        if kind in (
+            IssueKind.NEGATIVE_BALANCE,
+            IssueKind.REBASING_TOKEN,
+            IssueKind.UNMATCHED_BRIDGE,
+        ):
             event_identifier = cast(
-                'NegativeBalanceIssuePayload | UnmatchedBridgeIssuePayload',
+                'NegativeBalanceIssuePayload | RebasingTokenIssuePayload | UnmatchedBridgeIssuePayload',  # noqa: E501
                 payload,
             )['event_identifier']
         else:  # kind == IssueKind.CURRENT_BALANCE_MISMATCH
@@ -187,11 +192,12 @@ class DataIssuesManager:
                 )
         return issue_id
 
-    def resolve_negative_balance_issues(
+    def resolve_event_issues(
             self,
+            kind: IssueKind,
             issues: list[tuple[str, str | None, str | None, str, int]],
     ) -> None:
-        """Resolve negative-balance issues whose buckets processed successfully."""
+        """Resolve event-scoped issues whose buckets processed successfully."""
         if len(issues) == 0:
             return
 
@@ -204,7 +210,7 @@ class DataIssuesManager:
                 [(
                     IssueState.RESOLVED,
                     resolved_at,
-                    IssueKind.NEGATIVE_BALANCE,
+                    kind,
                     location,
                     location_label or '',
                     protocol or '',

--- a/rotkehlchen/history/data_issues/types.py
+++ b/rotkehlchen/history/data_issues/types.py
@@ -1,6 +1,13 @@
 from dataclasses import dataclass
 from typing import Any, Literal, NotRequired, TypedDict
 
+type RebasingQueryFailure = Literal[
+    'archive_node_unavailable',
+    'historical_balance_query_failed',
+    'missing_transaction',
+    'unsupported_bucket',
+]
+
 
 class BaseIssuePayload(TypedDict):
     """Common optional payload fields shared by all data issue kinds."""
@@ -35,12 +42,7 @@ class RebasingTokenIssuePayload(BaseIssuePayload):
     """Payload for a rebasing balance that could not be verified on-chain."""
     event_identifier: int
     block_number: int | None
-    reason: Literal[
-        'archive_node_unavailable',
-        'historical_balance_query_failed',
-        'missing_transaction',
-        'unsupported_bucket',
-    ]
+    reason: RebasingQueryFailure
 
 
 class UnmatchedBridgeIssuePayload(BaseIssuePayload):

--- a/rotkehlchen/history/data_issues/types.py
+++ b/rotkehlchen/history/data_issues/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, NotRequired, TypedDict
+from typing import Any, Literal, NotRequired, TypedDict
 
 
 class BaseIssuePayload(TypedDict):
@@ -23,6 +23,18 @@ class CurrentBalanceMismatchIssuePayload(BaseIssuePayload):
     latest_event_identifier: int | None
 
 
+class RebasingTokenIssuePayload(BaseIssuePayload):
+    """Payload for a rebasing balance that could not be verified on-chain."""
+    event_identifier: int
+    block_number: int | None
+    reason: Literal[
+        'archive_node_unavailable',
+        'historical_balance_query_failed',
+        'missing_transaction',
+        'unsupported_bucket',
+    ]
+
+
 class UnmatchedBridgeIssuePayload(BaseIssuePayload):
     """Payload for an event-scoped issue about a bridge leg with no matched counterpart.
 
@@ -40,6 +52,7 @@ class UnmatchedBridgeIssuePayload(BaseIssuePayload):
 type DataIssuePayload = (
     NegativeBalanceIssuePayload |
     CurrentBalanceMismatchIssuePayload |
+    RebasingTokenIssuePayload |
     UnmatchedBridgeIssuePayload
 )
 """Typed payload variants accepted when writing data issues."""

--- a/rotkehlchen/history/data_issues/types.py
+++ b/rotkehlchen/history/data_issues/types.py
@@ -7,6 +7,14 @@ class BaseIssuePayload(TypedDict):
     resolution: NotRequired[dict[str, Any]]
 
 
+class AutoRemediationAttempt(TypedDict):
+    attribution: str
+    strategy: str
+    success: bool
+    timestamp: int
+    reason: NotRequired[str]
+
+
 class NegativeBalanceIssuePayload(BaseIssuePayload):
     """Payload for an event-scoped issue where derived balance goes below zero."""
     event_identifier: int

--- a/rotkehlchen/rotkehlchen.py
+++ b/rotkehlchen/rotkehlchen.py
@@ -98,6 +98,7 @@ from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.asset_updates.manager import AssetsUpdater
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.globaldb.manual_price_oracles import ManualCurrentOracle
+from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.manager import HistoryQueryingManager
 from rotkehlchen.history.price import Price, PriceHistorian
 from rotkehlchen.history.price_oracles.coinbase import CoinbaseHistoricalPriceOracle
@@ -410,6 +411,7 @@ class Rotkehlchen:
             # else let's just continue. User signed in successfully, but he just
             # has unauthenticable/invalid premium credentials remaining in his DB
 
+        DataIssuesManager(self.data.db).reset_orphaned_remediations()
         with self.data.db.conn.read_ctx() as cursor:
             settings = self.get_settings(cursor)
             CachedSettings().initialize(settings)  # initialize with saved DB settings

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -7,7 +7,7 @@ from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.types import AssetFlag
 from rotkehlchen.chain.evm.decoding.cowswap.constants import CPT_COWSWAP
 from rotkehlchen.chain.evm.types import string_to_evm_address
-from rotkehlchen.concurrency import checkpoint
+from rotkehlchen.concurrency import TaskCancelledError, checkpoint
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH, A_ETH2
 from rotkehlchen.db.cache import DBCacheStatic
@@ -24,7 +24,10 @@ from rotkehlchen.exchanges.constants import ALL_SUPPORTED_EXCHANGES
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
-from rotkehlchen.history.data_issues.manager import DataIssuesManager
+from rotkehlchen.history.data_issues.manager import (
+    DataIssuesManager,
+    make_auto_remediation_attempt,
+)
 from rotkehlchen.history.data_issues.types import (
     RebasingTokenIssuePayload,
     UnmatchedBridgeIssuePayload,
@@ -42,7 +45,14 @@ from rotkehlchen.tasks.bridges import (
     get_event_bridge_data,
     get_unmatched_bridge_events,
 )
-from rotkehlchen.types import EventMetricKey, Location, Timestamp, TimestampMS
+from rotkehlchen.types import (
+    EVM_CHAIN_IDS_WITH_TRANSACTIONS,
+    ChainID,
+    EventMetricKey,
+    Location,
+    Timestamp,
+    TimestampMS,
+)
 from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now, ts_sec_to_ms
 from rotkehlchen.utils.mixins.lockable import skip_if_running
 
@@ -397,11 +407,13 @@ def _query_rebasing_balance(
 
     try:
         token = Asset(bucket.asset).resolve_to_evm_token()
-        evm_manager = chains_aggregator.get_evm_manager(
-            event.location.to_chain_id(),  # type: ignore[arg-type]  # EvmEvent locations always map to a supported EVM chain.
-        )
-    except (AttributeError, UnknownAsset, WrongAssetType):
+        chain_id = ChainID(event.location.to_chain_id())
+    except (UnknownAsset, ValueError, WrongAssetType):
         return None, 'unsupported_bucket'
+
+    if chain_id not in EVM_CHAIN_IDS_WITH_TRANSACTIONS:
+        return None, 'unsupported_bucket'
+    evm_manager = chains_aggregator.get_evm_manager(chain_id)
 
     balance = evm_manager.node_inquirer.get_historical_token_balance(
         address=string_to_evm_address(bucket.location_label),
@@ -425,7 +437,8 @@ def _write_rebasing_issue(
 ) -> None:
     """Persist why a rebasing balance could not be verified."""
     assert event.identifier is not None, 'Processed history events should have identifiers'
-    DataIssuesManager(database).write_issue(
+    issues_manager = DataIssuesManager(database)
+    issue_id = issues_manager.write_issue(
         kind=IssueKind.REBASING_TOKEN,
         location=bucket.location,
         location_label=bucket.location_label,
@@ -439,6 +452,12 @@ def _write_rebasing_issue(
         ts_start=event.timestamp,
         ts_end=event.timestamp,
     )
+    if issues_manager.get_issue(issue_id).state == IssueState.AUTO_REMEDIATING:
+        issues_manager.update_state(
+            issue_id=issue_id,
+            state=IssueState.UNRESOLVED,
+            attempt=make_auto_remediation_attempt(success=False, reason=reason),
+        )
 
 
 @skip_if_running
@@ -447,7 +466,7 @@ def process_historical_balances(
         msg_aggregator: MessagesAggregator,
         from_ts: TimestampMS | None = None,
         chains_aggregator: ChainsAggregator | None = None,
-) -> None:
+) -> bool:
     """Process events and compute balance metrics."""
     log.debug(f'Starting historical balance processing from_ts={from_ts}')
     rebasing_assets = GlobalDBHandler.get_asset_ids_with_flag(AssetFlag.REBASING)
@@ -494,7 +513,7 @@ def process_historical_balances(
             database=database,
             modification_ts_at_start=modification_ts_at_start,
         )
-        return
+        return True
 
     metrics_batch: list[MetricRow] = []
     modified_buckets: ModifiedBuckets = {}
@@ -583,6 +602,63 @@ def process_historical_balances(
         total_events,
         len(modified_buckets),
     )
+    return True
+
+
+def _fail_rebasing_remediation(
+        database: DBHandler,
+        issue_id: int,
+        reason: str,
+) -> None:
+    issues_manager = DataIssuesManager(database)
+    if issues_manager.get_issue(issue_id).state != IssueState.AUTO_REMEDIATING:
+        return
+
+    issues_manager.update_state(
+        issue_id=issue_id,
+        state=IssueState.UNRESOLVED,
+        attempt=make_auto_remediation_attempt(success=False, reason=reason),
+    )
+
+
+def retry_rebasing_token_issue(
+        database: DBHandler,
+        msg_aggregator: MessagesAggregator,
+        chains_aggregator: ChainsAggregator,
+        issue_id: int,
+        from_ts: TimestampMS,
+) -> None:
+    """Reprocess balances from a rebasing issue and finish its remediation attempt."""
+    try:
+        processing_completed = process_historical_balances(
+            database=database,
+            msg_aggregator=msg_aggregator,
+            from_ts=from_ts,
+            chains_aggregator=chains_aggregator,
+        )
+    except TaskCancelledError:
+        _fail_rebasing_remediation(database, issue_id, 'processing_cancelled')
+        raise
+    except Exception:
+        _fail_rebasing_remediation(database, issue_id, 'processing_failed')
+        raise
+
+    if processing_completed is None:
+        _fail_rebasing_remediation(database, issue_id, 'processing_already_running')
+        return
+
+    issues_manager = DataIssuesManager(database)
+    issue = issues_manager.get_issue(issue_id)
+    attempt = make_auto_remediation_attempt(success=True)
+    if issue.state == IssueState.AUTO_REMEDIATING:
+        issues_manager.update_state(
+            issue_id=issue_id,
+            state=IssueState.RESOLVED,
+            attempt=attempt,
+            resolution={'reason': 'no_longer_reproduces'},
+        )
+    elif issue.state == IssueState.RESOLVED:
+        issues_manager.append_auto_remediation_attempt(issue_id, attempt)
 
 
 def _detect_unmatched_bridge_issues(database: DBHandler) -> None:

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -6,20 +6,30 @@ from rotkehlchen.api.websockets.typedefs import ProgressUpdateSubType, WSMessage
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.types import AssetFlag
 from rotkehlchen.chain.evm.decoding.cowswap.constants import CPT_COWSWAP
+from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.concurrency import checkpoint
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH, A_ETH2
 from rotkehlchen.db.cache import DBCacheStatic
-from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
+from rotkehlchen.db.constants import (
+    HISTORY_MAPPING_KEY_STATE,
+    SQL_VARIABLE_CHUNK_SIZE,
+    HistoryMappingState,
+)
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents, get_bitcoin_counterparty_addresses
 from rotkehlchen.db.settings import CachedSettings
+from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
 from rotkehlchen.exchanges.constants import ALL_SUPPORTED_EXCHANGES
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
 from rotkehlchen.history.data_issues.manager import DataIssuesManager
-from rotkehlchen.history.data_issues.types import UnmatchedBridgeIssuePayload
+from rotkehlchen.history.data_issues.types import (
+    RebasingTokenIssuePayload,
+    UnmatchedBridgeIssuePayload,
+)
+from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.onchain_event import OnchainEvent
 from rotkehlchen.history.events.structures.types import (
     EventDirection,
@@ -37,6 +47,7 @@ from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now, ts_sec_to_ms
 from rotkehlchen.utils.mixins.lockable import skip_if_running
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.aggregator import ChainsAggregator
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.sqlite import DBCursor
     from rotkehlchen.history.events.structures.base import HistoryBaseEntry
@@ -256,7 +267,15 @@ class Bucket(NamedTuple):
 
 type ModifiedBucketData = tuple[TimestampMS, int]
 type ModifiedBuckets = dict[Bucket, ModifiedBucketData]
-type NegativeBalanceResolution = tuple[str, str | None, str | None, str, int]
+type EventIssueScope = tuple[str, str | None, str | None, str, int]
+type RebasingReconciliationPoints = dict[tuple[int, Bucket], int | None]
+type PendingRebasingEvents = dict[Bucket, HistoryBaseEntry]
+type RebasingQueryFailure = Literal[
+    'archive_node_unavailable',
+    'historical_balance_query_failed',
+    'missing_transaction',
+    'unsupported_bucket',
+]
 
 
 def _load_bucket_balances_before_ts(
@@ -292,18 +311,146 @@ def _load_bucket_balances_before_ts(
     return bucket_balances
 
 
+def _get_rebasing_reconciliation_points(
+        database: DBHandler,
+        events: list[HistoryBaseEntry],
+        rebasing_assets: frozenset[str],
+        treat_eth2_as_eth: bool,
+) -> RebasingReconciliationPoints:
+    """Return the final rebasing event per block and bucket with its transaction block."""
+    event_buckets: list[tuple[EvmEvent, list[Bucket]]] = []
+    transaction_keys: set[tuple[bytes, int]] = set()
+    for event in events:
+        if event.identifier is None or not isinstance(event, EvmEvent):
+            continue
+
+        if len(buckets := [
+            bucket for bucket, _direction in Bucket.from_event(
+                event=event,
+                treat_eth2_as_eth=treat_eth2_as_eth,
+            ) if bucket.asset in rebasing_assets
+        ]) == 0:
+            continue
+
+        event_buckets.append((event, buckets))
+        transaction_keys.add((
+            bytes(event.tx_ref),
+            event.location.to_chain_id(),
+        ))
+
+    transaction_blocks: dict[tuple[bytes, int], int] = {}
+    keys = list(transaction_keys)
+    chunk_size = SQL_VARIABLE_CHUNK_SIZE // 2
+    with database.conn.read_ctx() as cursor:
+        for start in range(0, len(keys), chunk_size):
+            chunk = keys[start:start + chunk_size]
+            conditions = ' OR '.join('(tx_hash=? AND chain_id=?)' for _ in chunk)
+            bindings = [value for key in chunk for value in key]
+            transaction_blocks.update({
+                (bytes(tx_hash), chain_id): block_number
+                for tx_hash, chain_id, block_number in cursor.execute(
+                    f'SELECT tx_hash, chain_id, block_number FROM evm_transactions WHERE {conditions}',  # noqa: E501
+                    bindings,
+                )
+            })
+
+    last_points: dict[tuple[int, int, Bucket], int] = {}
+    missing_points: dict[tuple[bytes, int, Bucket], int] = {}
+    for event, buckets in event_buckets:
+        assert event.identifier is not None
+        chain_id = event.location.to_chain_id()
+        tx_key = (bytes(event.tx_ref), chain_id)
+        if (block_number := transaction_blocks.get(tx_key)) is None:
+            for bucket in buckets:
+                missing_points[*tx_key, bucket] = event.identifier
+            continue
+
+        for bucket in buckets:
+            last_points[chain_id, block_number, bucket] = event.identifier
+
+    return {
+        **{(event_identifier, bucket): block_number for (
+            _chain_id, block_number, bucket,
+        ), event_identifier in last_points.items()},
+        **{(event_identifier, bucket): None for (
+            _tx_hash, _chain_id, bucket,
+        ), event_identifier in missing_points.items()},
+    }
+
+
+def _query_rebasing_balance(
+        event: HistoryBaseEntry,
+        bucket: Bucket,
+        block_number: int | None,
+        chains_aggregator: ChainsAggregator | None,
+) -> tuple[FVal | None, RebasingQueryFailure | None]:
+    """Return the cached or queried post-block token balance for a rebasing wallet bucket."""
+    if block_number is None:
+        return None, 'missing_transaction'
+    if (
+        chains_aggregator is None or
+        bucket.location_label is None or
+        bucket.protocol is not None or
+        not isinstance(event, EvmEvent)
+    ):
+        return None, 'unsupported_bucket'
+
+    try:
+        token = Asset(bucket.asset).resolve_to_evm_token()
+        evm_manager = chains_aggregator.get_evm_manager(
+            event.location.to_chain_id(),  # type: ignore[arg-type]  # EvmEvent locations always map to a supported EVM chain.
+        )
+    except (AttributeError, UnknownAsset, WrongAssetType):
+        return None, 'unsupported_bucket'
+
+    balance = evm_manager.node_inquirer.get_historical_token_balance(
+        address=string_to_evm_address(bucket.location_label),
+        token=token,
+        block_number=block_number,
+        queried_timestamp=ts_ms_to_sec(event.timestamp),
+    )
+    if balance is not None:
+        return balance, None
+    if evm_manager.node_inquirer.has_archive_node() is False:
+        return None, 'archive_node_unavailable'
+    return None, 'historical_balance_query_failed'
+
+
+def _write_rebasing_issue(
+        database: DBHandler,
+        event: HistoryBaseEntry,
+        bucket: Bucket,
+        block_number: int | None,
+        reason: RebasingQueryFailure,
+) -> None:
+    """Persist why a rebasing balance could not be verified."""
+    assert event.identifier is not None, 'Processed history events should have identifiers'
+    DataIssuesManager(database).write_issue(
+        kind=IssueKind.REBASING_TOKEN,
+        location=bucket.location,
+        location_label=bucket.location_label,
+        protocol=bucket.protocol,
+        asset=bucket.asset,
+        payload=RebasingTokenIssuePayload(
+            event_identifier=event.identifier,
+            block_number=block_number,
+            reason=reason,
+        ),
+        ts_start=event.timestamp,
+        ts_end=event.timestamp,
+    )
+
+
 @skip_if_running
 def process_historical_balances(
         database: DBHandler,
         msg_aggregator: MessagesAggregator,
         from_ts: TimestampMS | None = None,
+        chains_aggregator: ChainsAggregator | None = None,
 ) -> None:
     """Process events and compute balance metrics."""
     log.debug(f'Starting historical balance processing from_ts={from_ts}')
-    rebasing_assets = frozenset(
-        Asset(identifier).resolve_swapped_for().identifier
-        for identifier in GlobalDBHandler.get_asset_ids_with_flag(AssetFlag.REBASING)
-    )
+    rebasing_assets = GlobalDBHandler.get_asset_ids_with_flag(AssetFlag.REBASING)
     bucket_balances: dict[Bucket, FVal] = {}
     if from_ts is not None:
         bucket_balances = _load_bucket_balances_before_ts(database, from_ts)
@@ -334,6 +481,13 @@ def process_historical_balances(
         )
         treat_eth2_as_eth = CachedSettings().get_entry('treat_eth2_as_eth') is True
 
+    rebasing_reconciliation_points = _get_rebasing_reconciliation_points(
+        database=database,
+        events=events,
+        rebasing_assets=rebasing_assets,
+        treat_eth2_as_eth=treat_eth2_as_eth,
+    )
+
     if (total_events := len(events)) == 0:
         log.debug('No events to process for historical balances')
         _finalize_processing(
@@ -344,7 +498,8 @@ def process_historical_balances(
 
     metrics_batch: list[MetricRow] = []
     modified_buckets: ModifiedBuckets = {}
-    negative_balance_resolutions: list[NegativeBalanceResolution] = []
+    pending_rebasing_events: PendingRebasingEvents = {}
+    resolved_rebasing_events: list[EventIssueScope] = []
     first_batch_written, send_ws_every = False, msg_aggregator.how_many_events_per_ws(total_events)
     for idx, event in enumerate(events):
         for event_to_apply in events_to_apply if (events_to_apply := _maybe_add_profit_event(
@@ -358,11 +513,14 @@ def process_historical_balances(
                 database=database,
                 event=event_to_apply,
                 bucket_balances=bucket_balances,
+                chains_aggregator=chains_aggregator,
                 metrics_batch=metrics_batch,
                 modified_buckets=modified_buckets,
-                negative_balance_resolutions=negative_balance_resolutions,
+                pending_rebasing_events=pending_rebasing_events,
+                resolved_rebasing_events=resolved_rebasing_events,
                 last_run_ts=last_run_ts,
                 rebasing_assets=rebasing_assets,
+                rebasing_reconciliation_points=rebasing_reconciliation_points,
                 treat_eth2_as_eth=treat_eth2_as_eth,
             )
 
@@ -400,7 +558,15 @@ def process_historical_balances(
                 first_batch_written=first_batch_written,
             )
 
-    DataIssuesManager(database).resolve_negative_balance_issues(negative_balance_resolutions)
+    issues_manager = DataIssuesManager(database)
+    issues_manager.resolve_event_issues(
+        kind=IssueKind.NEGATIVE_BALANCE,
+        issues=resolved_rebasing_events,
+    )
+    issues_manager.resolve_event_issues(
+        kind=IssueKind.REBASING_TOKEN,
+        issues=resolved_rebasing_events,
+    )
 
     msg_aggregator.add_message(
         message_type=WSMessageType.PROGRESS_UPDATES,
@@ -554,11 +720,14 @@ def _apply_to_buckets(
         database: DBHandler,
         event: HistoryBaseEntry,
         bucket_balances: dict[Bucket, FVal],
+        chains_aggregator: ChainsAggregator | None,
         metrics_batch: list[MetricRow],
         modified_buckets: ModifiedBuckets,
-        negative_balance_resolutions: list[NegativeBalanceResolution],
+        pending_rebasing_events: PendingRebasingEvents,
+        resolved_rebasing_events: list[EventIssueScope],
         last_run_ts: Timestamp | None,
         rebasing_assets: frozenset[str],
+        rebasing_reconciliation_points: RebasingReconciliationPoints,
         treat_eth2_as_eth: bool,
 ) -> None:
     """Apply the given event to the buckets it affects."""
@@ -568,95 +737,122 @@ def _apply_to_buckets(
     )) == 0:
         return
 
-    for bucket, direction in bucket_directions:
-        if (current_balance := bucket_balances.get(bucket, ZERO)) < ZERO:
+    for bucket_idx, (bucket, direction) in enumerate(bucket_directions):
+        if (
+            (current_balance := bucket_balances.get(bucket, ZERO)) < ZERO and
+            bucket not in pending_rebasing_events
+        ):
             continue
 
-        if direction == EventDirection.IN:
-            new_balance = current_balance + event.amount
-        elif (new_balance := current_balance - event.amount) < ZERO:  # direction == EventDirection.OUT (direction from from_event will not be NEUTRAL) # noqa: E501
+        new_balance = (
+            current_balance + event.amount if direction == EventDirection.IN else
+            current_balance - event.amount
+        )
+        if bucket.asset in rebasing_assets:
             assert event.identifier is not None, 'Processed history events should have identifiers'
-            if bucket.asset in rebasing_assets:
-                metrics_batch.append(_make_metric_row(
+            if new_balance < ZERO and not isinstance(event, EvmEvent):
+                _write_rebasing_issue(
+                    database=database,
                     event=event,
                     bucket=bucket,
-                    metric_key=EventMetricKey.REBASE_YIELD,
-                    value=(rebase_yield := abs(new_balance)),
-                ))
-                negative_balance_resolutions.append((
-                    bucket.location,
-                    bucket.location_label,
-                    bucket.protocol,
-                    bucket.asset,
-                    event.identifier,
-                ))
-                new_balance = current_balance + rebase_yield - event.amount
-            else:
-                database.msg_aggregator.add_message(
-                    message_type=WSMessageType.NEGATIVE_BALANCE_DETECTED,
-                    data={
-                        'event_identifier': event.identifier,
-                        'group_identifier': event.group_identifier,
-                        'asset': event.asset.identifier,
-                        'bucket': bucket.serialize(),
-                        'balance_before': str(current_balance),
-                        'last_run_ts': last_run_ts,
-                    },
-                )
-                DataIssuesManager(database).write_issue(
-                    IssueKind.NEGATIVE_BALANCE,
-                    location=bucket.location,
-                    location_label=bucket.location_label,
-                    protocol=bucket.protocol,
-                    asset=bucket.asset,
-                    payload={
-                        'event_identifier': event.identifier,
-                        'in_memory_negative_amount': str(new_balance),
-                        'derived_balance_before_event': str(current_balance),
-                    },
-                    ts_start=event.timestamp,
-                    ts_end=event.timestamp,
-                )
-                log.warning(
-                    'Negative balance detected for %s at event %s. Skipping %s.',
-                    event.asset.identifier,
-                    event.identifier,
-                    bucket,
+                    block_number=None,
+                    reason='unsupported_bucket',
                 )
                 bucket_balances[bucket] = new_balance
                 continue
 
+            if new_balance < ZERO:
+                pending_rebasing_events.setdefault(bucket, event)
+
+            if (negative_event := pending_rebasing_events.get(bucket)) is not None:
+                reconciliation_key = (event.identifier, bucket)
+                if (
+                    reconciliation_key not in rebasing_reconciliation_points or
+                    any(other_bucket == bucket for other_bucket, _direction in bucket_directions[bucket_idx + 1:])  # noqa: E501
+                ):
+                    bucket_balances[bucket] = new_balance
+                    continue  # balanceOf is end-of-block state; reconcile only at the final event
+
+                block_number = rebasing_reconciliation_points[reconciliation_key]
+                onchain_balance, failure = _query_rebasing_balance(
+                    event=event,
+                    bucket=bucket,
+                    block_number=block_number,
+                    chains_aggregator=chains_aggregator,
+                )
+                del pending_rebasing_events[bucket]
+                if failure is not None:
+                    _write_rebasing_issue(
+                        database=database,
+                        event=negative_event,
+                        bucket=bucket,
+                        block_number=block_number,
+                        reason=failure,
+                    )
+                    bucket_balances[bucket] = new_balance
+                    continue
+
+                assert onchain_balance is not None
+                assert negative_event.identifier is not None
+                resolved_rebasing_events.append((
+                    bucket.location,
+                    bucket.location_label,
+                    bucket.protocol,
+                    bucket.asset,
+                    negative_event.identifier,
+                ))
+                new_balance = onchain_balance
+        elif new_balance < ZERO:
+            assert event.identifier is not None, 'Processed history events should have identifiers'
+            database.msg_aggregator.add_message(
+                message_type=WSMessageType.NEGATIVE_BALANCE_DETECTED,
+                data={
+                    'event_identifier': event.identifier,
+                    'group_identifier': event.group_identifier,
+                    'asset': event.asset.identifier,
+                    'bucket': bucket.serialize(),
+                    'balance_before': str(current_balance),
+                    'last_run_ts': last_run_ts,
+                },
+            )
+            DataIssuesManager(database).write_issue(
+                IssueKind.NEGATIVE_BALANCE,
+                location=bucket.location,
+                location_label=bucket.location_label,
+                protocol=bucket.protocol,
+                asset=bucket.asset,
+                payload={
+                    'event_identifier': event.identifier,
+                    'in_memory_negative_amount': str(new_balance),
+                    'derived_balance_before_event': str(current_balance),
+                },
+                ts_start=event.timestamp,
+                ts_end=event.timestamp,
+            )
+            log.warning(
+                'Negative balance detected for %s at event %s. Skipping %s.',
+                event.asset.identifier,
+                event.identifier,
+                bucket,
+            )
+            bucket_balances[bucket] = new_balance
+            continue
+
         bucket_balances[bucket] = new_balance
-        metrics_batch.append(_make_metric_row(
-            event=event,
-            bucket=bucket,
-            metric_key=EventMetricKey.BALANCE,
-            value=new_balance,
+        metrics_batch.append((
+            event.identifier,
+            bucket.location,
+            bucket.location_label,
+            bucket.protocol,
+            EventMetricKey.BALANCE.serialize(),
+            str(new_balance),
+            bucket.asset,
+            event.timestamp,
+            event.sequence_index,
+            event.timestamp + event.sequence_index,
         ))
         if event.identifier is not None:
             modified_buckets[bucket] = (event.timestamp, event.identifier)
-
-
-def _make_metric_row(
-        event: HistoryBaseEntry,
-        bucket: Bucket,
-        metric_key: EventMetricKey,
-        value: FVal,
-) -> MetricRow:
-    """Create a metric row, ordering adjustments immediately before the resulting balance."""
-    metric_order = 0 if metric_key == EventMetricKey.REBASE_YIELD else 1
-    return (
-        event.identifier,
-        bucket.location,
-        bucket.location_label,
-        bucket.protocol,
-        metric_key.serialize(),
-        str(value),
-        bucket.asset,
-        event.timestamp,
-        event.sequence_index,
-        (event.timestamp + event.sequence_index) * 2 + metric_order,
-    )
 
 
 def _maybe_add_profit_event(

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -1,5 +1,7 @@
 import logging
 import time
+from collections import defaultdict
+from contextlib import suppress
 from typing import TYPE_CHECKING, Final, Literal, NamedTuple
 
 from rotkehlchen.api.websockets.typedefs import ProgressUpdateSubType, WSMessageType
@@ -11,15 +13,13 @@ from rotkehlchen.concurrency import TaskCancelledError, checkpoint
 from rotkehlchen.constants import ZERO
 from rotkehlchen.constants.assets import A_ETH, A_ETH2
 from rotkehlchen.db.cache import DBCacheStatic
-from rotkehlchen.db.constants import (
-    HISTORY_MAPPING_KEY_STATE,
-    SQL_VARIABLE_CHUNK_SIZE,
-    HistoryMappingState,
-)
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents, get_bitcoin_counterparty_addresses
 from rotkehlchen.db.settings import CachedSettings
+from rotkehlchen.db.utils import get_query_chunks
 from rotkehlchen.errors.asset import UnknownAsset, WrongAssetType
+from rotkehlchen.errors.misc import NotFoundError
 from rotkehlchen.exchanges.constants import ALL_SUPPORTED_EXCHANGES
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
@@ -29,6 +29,7 @@ from rotkehlchen.history.data_issues.manager import (
     make_auto_remediation_attempt,
 )
 from rotkehlchen.history.data_issues.types import (
+    RebasingQueryFailure,
     RebasingTokenIssuePayload,
     UnmatchedBridgeIssuePayload,
 )
@@ -57,6 +58,8 @@ from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now, ts_sec_to_ms
 from rotkehlchen.utils.mixins.lockable import skip_if_running
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from rotkehlchen.chain.aggregator import ChainsAggregator
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.db.drivers.sqlite import DBCursor
@@ -280,12 +283,6 @@ type ModifiedBuckets = dict[Bucket, ModifiedBucketData]
 type EventIssueScope = tuple[str, str | None, str | None, str, int]
 type RebasingReconciliationPoints = dict[tuple[int, Bucket], int | None]
 type PendingRebasingEvents = dict[Bucket, HistoryBaseEntry]
-type RebasingQueryFailure = Literal[
-    'archive_node_unavailable',
-    'historical_balance_query_failed',
-    'missing_transaction',
-    'unsupported_bucket',
-]
 
 
 def _load_bucket_balances_before_ts(
@@ -323,11 +320,17 @@ def _load_bucket_balances_before_ts(
 
 def _get_rebasing_reconciliation_points(
         database: DBHandler,
-        events: list[HistoryBaseEntry],
+        events: Sequence[HistoryBaseEntry],
         rebasing_assets: frozenset[str],
         treat_eth2_as_eth: bool,
 ) -> RebasingReconciliationPoints:
-    """Return the final rebasing event per block and bucket with its transaction block."""
+    """Return the final rebasing event per timestamp and bucket with its highest block.
+
+    Events are processed by timestamp and sequence index, while chains with sub-second blocks can
+    have multiple blocks at the same timestamp whose log indexes do not preserve block order.
+    Reconciling once at the timestamp's final event against its highest block ensures the queried
+    end-of-block balance covers every event applied for that timestamp and no later event.
+    """
     if len(rebasing_assets) == 0:
         return {}
 
@@ -356,22 +359,23 @@ def _get_rebasing_reconciliation_points(
         ))
 
     transaction_blocks: dict[tuple[bytes, int], int] = {}
-    keys = list(transaction_keys)
-    chunk_size = SQL_VARIABLE_CHUNK_SIZE // 2
-    with database.conn.read_ctx() as cursor:
-        for start in range(0, len(keys), chunk_size):
-            chunk = keys[start:start + chunk_size]
-            conditions = ' OR '.join('(tx_hash=? AND chain_id=?)' for _ in chunk)
-            bindings = [value for key in chunk for value in key]
-            transaction_blocks.update({
-                (bytes(tx_hash), chain_id): block_number
-                for tx_hash, chain_id, block_number in cursor.execute(
-                    f'SELECT tx_hash, chain_id, block_number FROM evm_transactions WHERE {conditions}',  # noqa: E501
-                    bindings,
-                )
-            })
+    hashes_by_chain: defaultdict[int, list[bytes]] = defaultdict(list)
+    for tx_hash, chain_id in transaction_keys:
+        hashes_by_chain[chain_id].append(tx_hash)
 
-    last_points: dict[tuple[int, int, Bucket], int] = {}
+    with database.conn.read_ctx() as cursor:
+        for chain_id, tx_hashes in hashes_by_chain.items():
+            for chunk, placeholders in get_query_chunks(data=tx_hashes):
+                transaction_blocks.update({
+                    (bytes(tx_hash), chain_id): block_number
+                    for tx_hash, block_number in cursor.execute(
+                        'SELECT tx_hash, block_number FROM evm_transactions '
+                        f'WHERE chain_id=? AND tx_hash IN ({placeholders})',
+                        [chain_id, *chunk],
+                    )
+                })
+
+    last_points: dict[tuple[int, TimestampMS, Bucket], tuple[int, int]] = {}
     missing_points: dict[tuple[bytes, int, Bucket], int] = {}
     for event, buckets in event_buckets:
         assert event.identifier is not None
@@ -383,12 +387,17 @@ def _get_rebasing_reconciliation_points(
             continue
 
         for bucket in buckets:
-            last_points[chain_id, block_number, bucket] = event.identifier
+            point_key = (chain_id, event.timestamp, bucket)
+            previous = last_points.get(point_key)
+            last_points[point_key] = (
+                event.identifier,
+                block_number if previous is None else max(block_number, previous[1]),
+            )
 
     return {
         **{(event_identifier, bucket): block_number for (
-            _chain_id, block_number, bucket,
-        ), event_identifier in last_points.items()},
+            _chain_id, _timestamp, bucket,
+        ), (event_identifier, block_number) in last_points.items()},
         **{(event_identifier, bucket): None for (
             _tx_hash, _chain_id, bucket,
         ), event_identifier in missing_points.items()},
@@ -445,7 +454,7 @@ def _write_rebasing_issue(
     """Persist why a rebasing balance could not be verified."""
     assert event.identifier is not None, 'Processed history events should have identifiers'
     issues_manager = DataIssuesManager(database)
-    issue_id = issues_manager.write_issue(
+    issue_id, issue_state = issues_manager.write_issue_with_state(
         kind=IssueKind.REBASING_TOKEN,
         location=bucket.location,
         location_label=bucket.location_label,
@@ -459,7 +468,7 @@ def _write_rebasing_issue(
         ts_start=event.timestamp,
         ts_end=event.timestamp,
     )
-    if issues_manager.get_issue(issue_id).state == IssueState.AUTO_REMEDIATING:
+    if issue_state == IssueState.AUTO_REMEDIATING:
         issues_manager.update_state(
             issue_id=issue_id,
             state=IssueState.UNRESOLVED,
@@ -474,7 +483,13 @@ def process_historical_balances(
         from_ts: TimestampMS | None = None,
         chains_aggregator: ChainsAggregator | None = None,
 ) -> bool:
-    """Process events and compute balance metrics."""
+    """Process events and compute balance metrics.
+
+    Returns True once processing runs to completion. The ``skip_if_running`` decorator returns
+    None instead when another run holds the lock; remediation callers must distinguish that case.
+    When a chain aggregator is supplied, negative rebasing balances can make cached or archive-node
+    historical balance queries. Results are cached per address, token and block.
+    """
     log.debug(f'Starting historical balance processing from_ts={from_ts}')
     rebasing_assets = GlobalDBHandler.get_asset_ids_with_flag(AssetFlag.REBASING)
     bucket_balances: dict[Bucket, FVal] = {}
@@ -585,10 +600,7 @@ def process_historical_balances(
             )
 
     issues_manager = DataIssuesManager(database)
-    issues_manager.resolve_event_issues(
-        kind=IssueKind.NEGATIVE_BALANCE,
-        issues=resolved_rebasing_events,
-    )
+    issues_manager.resolve_superseded_negative_balance_issues(assets=rebasing_assets)
     issues_manager.resolve_event_issues(
         kind=IssueKind.REBASING_TOKEN,
         issues=resolved_rebasing_events,
@@ -644,10 +656,12 @@ def retry_rebasing_token_issue(
             chains_aggregator=chains_aggregator,
         )
     except TaskCancelledError:
-        _fail_rebasing_remediation(database, issue_id, 'processing_cancelled')
+        with suppress(NotFoundError):
+            _fail_rebasing_remediation(database, issue_id, 'processing_cancelled')
         raise
-    except Exception:
-        _fail_rebasing_remediation(database, issue_id, 'processing_failed')
+    except Exception:  # the remediation state must be recovered for any processing failure
+        with suppress(NotFoundError):
+            _fail_rebasing_remediation(database, issue_id, 'processing_failed')
         raise
 
     if processing_completed is None:
@@ -835,7 +849,10 @@ def _apply_to_buckets(
             current_balance + event.amount if direction == EventDirection.IN else
             current_balance - event.amount
         )
-        if bucket.asset in rebasing_assets:
+        if (
+            bucket.asset in rebasing_assets and
+            event.asset.identifier in rebasing_assets
+        ):
             assert event.identifier is not None, 'Processed history events should have identifiers'
             if new_balance < ZERO and not isinstance(event, EvmEvent):
                 _write_rebasing_issue(
@@ -867,7 +884,6 @@ def _apply_to_buckets(
                     block_number=block_number,
                     chains_aggregator=chains_aggregator,
                 )
-                del pending_rebasing_events[bucket]
                 if failure is not None:
                     _write_rebasing_issue(
                         database=database,
@@ -881,12 +897,25 @@ def _apply_to_buckets(
 
                 assert onchain_balance is not None
                 assert negative_event.identifier is not None
+                del pending_rebasing_events[bucket]
                 resolved_rebasing_events.append((
                     bucket.location,
                     bucket.location_label,
                     bucket.protocol,
                     bucket.asset,
                     negative_event.identifier,
+                ))
+                metrics_batch.append((
+                    event.identifier,
+                    bucket.location,
+                    bucket.location_label,
+                    bucket.protocol,
+                    EventMetricKey.REBASE_YIELD.serialize(),
+                    str(onchain_balance - new_balance),
+                    bucket.asset,
+                    event.timestamp,
+                    event.sequence_index,
+                    event.timestamp + event.sequence_index,
                 ))
                 new_balance = onchain_balance
         elif new_balance < ZERO:

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -291,18 +291,24 @@ def _load_bucket_balances_before_ts(
 ) -> dict[Bucket, FVal]:
     """Load the latest balance per bucket before from_ts.
 
-    We use MAX(sort_key) to identify the most recent row per bucket,
-    relying on SQLite's bare column behavior to return non-aggregated columns from
-    that row. See https://www.sqlite.org/lang_select.html#bareagg
+    Rank metrics by the complete event ordering so events that share a timestamp and sequence
+    index still select the deterministic latest event identifier.
     """
     bucket_balances: dict[Bucket, FVal] = {}
     with database.conn.read_ctx() as cursor:
         treat_eth2_as_eth = CachedSettings().get_entry('treat_eth2_as_eth') is True
         cursor.execute(
             """
-            SELECT location, location_label, protocol, asset, metric_value, MAX(sort_key)
-            FROM event_metrics WHERE metric_key = ? AND timestamp < ?
-            GROUP BY location, location_label, protocol, asset
+            WITH ranked_metrics AS (
+                SELECT location, location_label, protocol, asset, metric_value,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY location, location_label, protocol, asset
+                        ORDER BY timestamp DESC, sequence_index DESC, event_identifier DESC
+                    ) AS metric_rank
+                FROM event_metrics WHERE metric_key = ? AND timestamp < ?
+            )
+            SELECT location, location_label, protocol, asset, metric_value
+            FROM ranked_metrics WHERE metric_rank = 1
             """,
             (EventMetricKey.BALANCE.serialize(), from_ts),
         )
@@ -501,13 +507,20 @@ def process_historical_balances(
             cursor=cursor,
             name=DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
         )
+        event_filter = HistoryEventFilterQuery.make(
+            order_by_rules=[
+                ('timestamp', True),
+                ('sequence_index', True),
+                ('history_events_identifier', True),
+            ],
+            exclude_ignored_assets=True,
+        )
+        if from_ts is not None:
+            event_filter.timestamp_filter.from_ts = Timestamp(from_ts)
+            event_filter.timestamp_filter.scaling_factor = None
         events = DBHistoryEvents(database).get_history_events_internal(
             cursor=cursor,
-            filter_query=HistoryEventFilterQuery.make(
-                from_ts=ts_ms_to_sec(from_ts) if from_ts is not None else None,
-                order_by_rules=[('timestamp', True), ('sequence_index', True)],
-                exclude_ignored_assets=True,
-            ),
+            filter_query=event_filter,
         )
         # Snapshot the modification timestamp after reading events. This allows us to
         # detect concurrent modifications: if the modification timestamp changed between
@@ -540,6 +553,7 @@ def process_historical_balances(
     metrics_batch: list[MetricRow] = []
     modified_buckets: ModifiedBuckets = {}
     pending_rebasing_events: PendingRebasingEvents = {}
+    reported_rebasing_buckets: set[Bucket] = set()
     resolved_rebasing_events: list[EventIssueScope] = []
     first_batch_written, send_ws_every = False, msg_aggregator.how_many_events_per_ws(total_events)
     for idx, event in enumerate(events):
@@ -558,6 +572,7 @@ def process_historical_balances(
                 metrics_batch=metrics_batch,
                 modified_buckets=modified_buckets,
                 pending_rebasing_events=pending_rebasing_events,
+                reported_rebasing_buckets=reported_rebasing_buckets,
                 resolved_rebasing_events=resolved_rebasing_events,
                 last_run_ts=last_run_ts,
                 rebasing_assets=rebasing_assets,
@@ -647,7 +662,18 @@ def retry_rebasing_token_issue(
         issue_id: int,
         from_ts: TimestampMS,
 ) -> None:
-    """Reprocess balances from a rebasing issue and finish its remediation attempt."""
+    """Reprocess balances from a rebasing issue and finish its remediation attempt.
+
+    A pending stale-balances marker older than the issue widens the reprocessed range because
+    finalizing this run clears that marker.
+    """
+    with database.conn.read_ctx() as cursor:
+        if (stale_from_ts := database.get_static_cache(
+            cursor=cursor,
+            name=DBCacheStatic.STALE_BALANCES_FROM_TS,
+        )) is not None:
+            from_ts = min(from_ts, TimestampMS(int(stale_from_ts)))
+
     try:
         processing_completed = process_historical_balances(
             database=database,
@@ -659,7 +685,7 @@ def retry_rebasing_token_issue(
         with suppress(NotFoundError):
             _fail_rebasing_remediation(database, issue_id, 'processing_cancelled')
         raise
-    except Exception:  # the remediation state must be recovered for any processing failure
+    except Exception:  # remediation state must recover from any processing failure
         with suppress(NotFoundError):
             _fail_rebasing_remediation(database, issue_id, 'processing_failed')
         raise
@@ -825,6 +851,7 @@ def _apply_to_buckets(
         metrics_batch: list[MetricRow],
         modified_buckets: ModifiedBuckets,
         pending_rebasing_events: PendingRebasingEvents,
+        reported_rebasing_buckets: set[Bucket],
         resolved_rebasing_events: list[EventIssueScope],
         last_run_ts: Timestamp | None,
         rebasing_assets: frozenset[str],
@@ -885,19 +912,22 @@ def _apply_to_buckets(
                     chains_aggregator=chains_aggregator,
                 )
                 if failure is not None:
-                    _write_rebasing_issue(
-                        database=database,
-                        event=negative_event,
-                        bucket=bucket,
-                        block_number=block_number,
-                        reason=failure,
-                    )
+                    if bucket not in reported_rebasing_buckets:
+                        reported_rebasing_buckets.add(bucket)
+                        _write_rebasing_issue(
+                            database=database,
+                            event=negative_event,
+                            bucket=bucket,
+                            block_number=block_number,
+                            reason=failure,
+                        )
                     bucket_balances[bucket] = new_balance
                     continue
 
                 assert onchain_balance is not None
                 assert negative_event.identifier is not None
                 del pending_rebasing_events[bucket]
+                reported_rebasing_buckets.discard(bucket)
                 resolved_rebasing_events.append((
                     bucket.location,
                     bucket.location_label,

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -291,24 +291,18 @@ def _load_bucket_balances_before_ts(
 ) -> dict[Bucket, FVal]:
     """Load the latest balance per bucket before from_ts.
 
-    Rank metrics by the complete event ordering so events that share a timestamp and sequence
-    index still select the deterministic latest event identifier.
+    We use MAX(sort_key) to identify the most recent row per bucket,
+    relying on SQLite's bare column behavior to return non-aggregated columns from
+    that row. See https://www.sqlite.org/lang_select.html#bareagg
     """
     bucket_balances: dict[Bucket, FVal] = {}
     with database.conn.read_ctx() as cursor:
         treat_eth2_as_eth = CachedSettings().get_entry('treat_eth2_as_eth') is True
         cursor.execute(
             """
-            WITH ranked_metrics AS (
-                SELECT location, location_label, protocol, asset, metric_value,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY location, location_label, protocol, asset
-                        ORDER BY timestamp DESC, sequence_index DESC, event_identifier DESC
-                    ) AS metric_rank
-                FROM event_metrics WHERE metric_key = ? AND timestamp < ?
-            )
-            SELECT location, location_label, protocol, asset, metric_value
-            FROM ranked_metrics WHERE metric_rank = 1
+            SELECT location, location_label, protocol, asset, metric_value, MAX(sort_key)
+            FROM event_metrics WHERE metric_key = ? AND timestamp < ?
+            GROUP BY location, location_label, protocol, asset
             """,
             (EventMetricKey.BALANCE.serialize(), from_ts),
         )

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -3,6 +3,8 @@ import time
 from typing import TYPE_CHECKING, Final, Literal, NamedTuple
 
 from rotkehlchen.api.websockets.typedefs import ProgressUpdateSubType, WSMessageType
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.types import AssetFlag
 from rotkehlchen.chain.evm.decoding.cowswap.constants import CPT_COWSWAP
 from rotkehlchen.concurrency import checkpoint
 from rotkehlchen.constants import ZERO
@@ -14,6 +16,7 @@ from rotkehlchen.db.history_events import DBHistoryEvents, get_bitcoin_counterpa
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.exchanges.constants import ALL_SUPPORTED_EXCHANGES
 from rotkehlchen.fval import FVal
+from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
 from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.data_issues.types import UnmatchedBridgeIssuePayload
@@ -43,6 +46,18 @@ logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
 
 type EventTypeSubtypePairs = set[tuple[HistoryEventType, HistoryEventSubType]]
+type MetricRow = tuple[
+    int | None,
+    str,
+    str | None,
+    str | None,
+    str,
+    str,
+    str,
+    int,
+    int,
+    int,
+]
 
 # Event subtypes that route to a protocol bucket (single bucket).
 # These represent positions within a protocol (e.g., generating debt).
@@ -241,6 +256,7 @@ class Bucket(NamedTuple):
 
 type ModifiedBucketData = tuple[TimestampMS, int]
 type ModifiedBuckets = dict[Bucket, ModifiedBucketData]
+type NegativeBalanceResolution = tuple[str, str | None, str | None, str, int]
 
 
 def _load_bucket_balances_before_ts(
@@ -284,6 +300,10 @@ def process_historical_balances(
 ) -> None:
     """Process events and compute balance metrics."""
     log.debug(f'Starting historical balance processing from_ts={from_ts}')
+    rebasing_assets = frozenset(
+        Asset(identifier).resolve_swapped_for().identifier
+        for identifier in GlobalDBHandler.get_asset_ids_with_flag(AssetFlag.REBASING)
+    )
     bucket_balances: dict[Bucket, FVal] = {}
     if from_ts is not None:
         bucket_balances = _load_bucket_balances_before_ts(database, from_ts)
@@ -322,14 +342,16 @@ def process_historical_balances(
         )
         return
 
-    metrics_batch: list[tuple[int | None, str, str | None, str | None, str, str, str, int, int, int]] = []  # noqa: E501
+    metrics_batch: list[MetricRow] = []
     modified_buckets: ModifiedBuckets = {}
+    negative_balance_resolutions: list[NegativeBalanceResolution] = []
     first_batch_written, send_ws_every = False, msg_aggregator.how_many_events_per_ws(total_events)
     for idx, event in enumerate(events):
         for event_to_apply in events_to_apply if (events_to_apply := _maybe_add_profit_event(
             database=database,
             event=event,
             bucket_balances=bucket_balances,
+            rebasing_assets=rebasing_assets,
             treat_eth2_as_eth=treat_eth2_as_eth,
         )) is not None else (event,):
             _apply_to_buckets(
@@ -338,7 +360,9 @@ def process_historical_balances(
                 bucket_balances=bucket_balances,
                 metrics_batch=metrics_batch,
                 modified_buckets=modified_buckets,
+                negative_balance_resolutions=negative_balance_resolutions,
                 last_run_ts=last_run_ts,
+                rebasing_assets=rebasing_assets,
                 treat_eth2_as_eth=treat_eth2_as_eth,
             )
 
@@ -375,6 +399,8 @@ def process_historical_balances(
                 from_ts=from_ts,
                 first_batch_written=first_batch_written,
             )
+
+    DataIssuesManager(database).resolve_negative_balance_issues(negative_balance_resolutions)
 
     msg_aggregator.add_message(
         message_type=WSMessageType.PROGRESS_UPDATES,
@@ -502,7 +528,7 @@ def _finalize_processing(
 
 def _write_metrics_batch(
         write_cursor: DBCursor,
-        metrics_batch: list[tuple[int | None, str, str | None, str | None, str, str, str, int, int, int]],  # noqa: E501
+        metrics_batch: list[MetricRow],
         from_ts: TimestampMS | None,
         first_batch_written: bool,
 ) -> None:
@@ -528,9 +554,11 @@ def _apply_to_buckets(
         database: DBHandler,
         event: HistoryBaseEntry,
         bucket_balances: dict[Bucket, FVal],
-        metrics_batch: list[tuple[int | None, str, str | None, str | None, str, str, str, int, int, int]],  # noqa: E501
+        metrics_batch: list[MetricRow],
         modified_buckets: ModifiedBuckets,
+        negative_balance_resolutions: list[NegativeBalanceResolution],
         last_run_ts: Timestamp | None,
+        rebasing_assets: frozenset[str],
         treat_eth2_as_eth: bool,
 ) -> None:
     """Apply the given event to the buckets it affects."""
@@ -548,59 +576,94 @@ def _apply_to_buckets(
             new_balance = current_balance + event.amount
         elif (new_balance := current_balance - event.amount) < ZERO:  # direction == EventDirection.OUT (direction from from_event will not be NEUTRAL) # noqa: E501
             assert event.identifier is not None, 'Processed history events should have identifiers'
-            database.msg_aggregator.add_message(
-                message_type=WSMessageType.NEGATIVE_BALANCE_DETECTED,
-                data={
-                    'event_identifier': event.identifier,
-                    'group_identifier': event.group_identifier,
-                    'asset': event.asset.identifier,
-                    'bucket': bucket.serialize(),
-                    'balance_before': str(current_balance),
-                    'last_run_ts': last_run_ts,
-                },
-            )
-            DataIssuesManager(database).write_issue(
-                IssueKind.NEGATIVE_BALANCE,
-                location=bucket.location,
-                location_label=bucket.location_label,
-                protocol=bucket.protocol,
-                asset=bucket.asset,
-                payload={
-                    'event_identifier': event.identifier,
-                    'in_memory_negative_amount': str(new_balance),
-                    'derived_balance_before_event': str(current_balance),
-                },
-                ts_start=event.timestamp,
-                ts_end=event.timestamp,
-            )
-            log.warning(
-                f'Negative balance detected for {event.asset.identifier} '
-                f'at event {event.identifier}. Skipping {bucket}.',
-            )
-            bucket_balances[bucket] = new_balance
-            continue
+            if bucket.asset in rebasing_assets:
+                metrics_batch.append(_make_metric_row(
+                    event=event,
+                    bucket=bucket,
+                    metric_key=EventMetricKey.REBASE_YIELD,
+                    value=(rebase_yield := abs(new_balance)),
+                ))
+                negative_balance_resolutions.append((
+                    bucket.location,
+                    bucket.location_label,
+                    bucket.protocol,
+                    bucket.asset,
+                    event.identifier,
+                ))
+                new_balance = current_balance + rebase_yield - event.amount
+            else:
+                database.msg_aggregator.add_message(
+                    message_type=WSMessageType.NEGATIVE_BALANCE_DETECTED,
+                    data={
+                        'event_identifier': event.identifier,
+                        'group_identifier': event.group_identifier,
+                        'asset': event.asset.identifier,
+                        'bucket': bucket.serialize(),
+                        'balance_before': str(current_balance),
+                        'last_run_ts': last_run_ts,
+                    },
+                )
+                DataIssuesManager(database).write_issue(
+                    IssueKind.NEGATIVE_BALANCE,
+                    location=bucket.location,
+                    location_label=bucket.location_label,
+                    protocol=bucket.protocol,
+                    asset=bucket.asset,
+                    payload={
+                        'event_identifier': event.identifier,
+                        'in_memory_negative_amount': str(new_balance),
+                        'derived_balance_before_event': str(current_balance),
+                    },
+                    ts_start=event.timestamp,
+                    ts_end=event.timestamp,
+                )
+                log.warning(
+                    'Negative balance detected for %s at event %s. Skipping %s.',
+                    event.asset.identifier,
+                    event.identifier,
+                    bucket,
+                )
+                bucket_balances[bucket] = new_balance
+                continue
 
         bucket_balances[bucket] = new_balance
-        metrics_batch.append((
-            event.identifier,
-            event.location.serialize_for_db(),
-            bucket.location_label,
-            bucket.protocol,
-            EventMetricKey.BALANCE.serialize(),
-            str(new_balance),
-            bucket.asset,
-            event.timestamp,
-            event.sequence_index,
-            event.timestamp + event.sequence_index,
+        metrics_batch.append(_make_metric_row(
+            event=event,
+            bucket=bucket,
+            metric_key=EventMetricKey.BALANCE,
+            value=new_balance,
         ))
         if event.identifier is not None:
             modified_buckets[bucket] = (event.timestamp, event.identifier)
+
+
+def _make_metric_row(
+        event: HistoryBaseEntry,
+        bucket: Bucket,
+        metric_key: EventMetricKey,
+        value: FVal,
+) -> MetricRow:
+    """Create a metric row, ordering adjustments immediately before the resulting balance."""
+    metric_order = 0 if metric_key == EventMetricKey.REBASE_YIELD else 1
+    return (
+        event.identifier,
+        bucket.location,
+        bucket.location_label,
+        bucket.protocol,
+        metric_key.serialize(),
+        str(value),
+        bucket.asset,
+        event.timestamp,
+        event.sequence_index,
+        (event.timestamp + event.sequence_index) * 2 + metric_order,
+    )
 
 
 def _maybe_add_profit_event(
         database: DBHandler,
         event: HistoryBaseEntry,
         bucket_balances: dict[Bucket, FVal],
+        rebasing_assets: frozenset[str],
         treat_eth2_as_eth: bool,
 ) -> tuple[OnchainEvent, ...] | None:
     """Maybe add a receive/reward event for the profit earned while an asset was in a protocol.
@@ -625,6 +688,7 @@ def _maybe_add_profit_event(
         if (
             direction == EventDirection.OUT and
             (new_balance := current_balance - event.amount) < ZERO and
+            bucket.asset not in rebasing_assets and
             bucket.protocol is not None and
             (event.event_type, event.event_subtype) in PROTOCOL_WITHDRAWAL_EVENTS and
             isinstance(event, OnchainEvent)

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -328,17 +328,24 @@ def _get_rebasing_reconciliation_points(
         treat_eth2_as_eth: bool,
 ) -> RebasingReconciliationPoints:
     """Return the final rebasing event per block and bucket with its transaction block."""
+    if len(rebasing_assets) == 0:
+        return {}
+
     event_buckets: list[tuple[EvmEvent, list[Bucket]]] = []
     transaction_keys: set[tuple[bytes, int]] = set()
     for event in events:
-        if event.identifier is None or not isinstance(event, EvmEvent):
+        if (
+            event.identifier is None or
+            not isinstance(event, EvmEvent) or
+            event.asset.identifier not in rebasing_assets
+        ):
             continue
 
         if len(buckets := [
             bucket for bucket, _direction in Bucket.from_event(
                 event=event,
                 treat_eth2_as_eth=treat_eth2_as_eth,
-            ) if bucket.asset in rebasing_assets
+            )
         ]) == 0:
             continue
 
@@ -658,7 +665,11 @@ def retry_rebasing_token_issue(
             resolution={'reason': 'no_longer_reproduces'},
         )
     elif issue.state == IssueState.RESOLVED:
-        issues_manager.append_auto_remediation_attempt(issue_id, attempt)
+        issues_manager.append_auto_remediation_attempt(
+            issue_id=issue_id,
+            attempt=attempt,
+            resolution={'reason': 'no_longer_reproduces'},
+        )
 
 
 def _detect_unmatched_bridge_issues(database: DBHandler) -> None:

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -593,6 +593,12 @@ class TaskManager:
             self,
             from_ts: TimestampMS | None,
     ) -> list[Task]:
+        """Schedule historical balance processing with archive-node access.
+
+        Periodic runs may query configured archive nodes for negative rebasing balances.
+        Successful results are cached per address, token, and block, so the first pass over
+        uncached history can take longer even without a manual processing request.
+        """
         log.debug('Scheduling task to %s', HISTORICAL_BALANCE_PROCESSING_TASK_NAME)
         return [self.task_supervisor.spawn_and_track(
             after_seconds=None,

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -639,7 +639,10 @@ class TaskManager:
         return True
 
     def _maybe_process_historical_balances(self) -> list[Task] | None:
-        if self.history_processing_coordinator.is_history_fetching():
+        if (
+            self.history_processing_coordinator.is_history_fetching() or
+            self.task_supervisor.has_task(HISTORICAL_BALANCE_PROCESSING_TASK_NAME)
+        ):
             return None
 
         with self.database.conn.read_ctx() as cursor:

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -599,6 +599,7 @@ class TaskManager:
             database=self.database,
             msg_aggregator=self.msg_aggregator,
             from_ts=from_ts,
+            chains_aggregator=self.chains_aggregator,
         )]
 
     def trigger_historical_balance_processing(self) -> list[Task] | None:

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -54,7 +54,10 @@ from rotkehlchen.tasks.calendar import (
     maybe_create_calendar_reminders,
     notify_reminders,
 )
-from rotkehlchen.tasks.historical_balances import process_historical_balances
+from rotkehlchen.tasks.historical_balances import (
+    process_historical_balances,
+    retry_rebasing_token_issue,
+)
 from rotkehlchen.tasks.internal_tx_conflicts import (
     repull_internal_tx_conflicts,
 )
@@ -605,10 +608,35 @@ class TaskManager:
     def trigger_historical_balance_processing(self) -> list[Task] | None:
         if (
             is_accounting_update_enabled() is False or
-            self.history_processing_coordinator.is_history_fetching()
+            self.history_processing_coordinator.is_history_fetching() or
+            self.task_supervisor.has_task(HISTORICAL_BALANCE_PROCESSING_TASK_NAME)
         ):
             return None
         return self._spawn_historical_balance_processing(from_ts=None)
+
+    def retry_data_issue_auto_remediation(
+            self,
+            issue_id: int,
+            from_ts: TimestampMS,
+    ) -> bool:
+        if (
+            self.history_processing_coordinator.is_history_fetching() or
+            self.task_supervisor.has_task(HISTORICAL_BALANCE_PROCESSING_TASK_NAME)
+        ):
+            return False
+
+        self.task_supervisor.spawn_and_track(
+            after_seconds=None,
+            task_name=f'{HISTORICAL_BALANCE_PROCESSING_TASK_NAME} for data issue {issue_id}',
+            exception_is_error=True,
+            method=retry_rebasing_token_issue,
+            database=self.database,
+            msg_aggregator=self.msg_aggregator,
+            chains_aggregator=self.chains_aggregator,
+            issue_id=issue_id,
+            from_ts=from_ts,
+        )
+        return True
 
     def _maybe_process_historical_balances(self) -> list[Task] | None:
         if self.history_processing_coordinator.is_history_fetching():

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -1,6 +1,7 @@
 from contextlib import ExitStack
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -18,6 +19,7 @@ from rotkehlchen.constants.resolver import (
     hyperliquid_token_address_to_identifier,
     solana_address_to_identifier,
 )
+from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.custom_assets import DBCustomAssets
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import ModifiableDBSettings
@@ -660,12 +662,57 @@ def test_edit_rebasing_asset_flag(
         'symbol': None,
         'decimals': None,
     }
+    database = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
+    events_db = DBHistoryEvents(database)
+    with database.user_write() as write_cursor:
+        database.add_asset_identifiers(
+            write_cursor=write_cursor,
+            asset_identifiers=[token.identifier],
+        )
+        events_db.add_history_events(
+            write_cursor=write_cursor,
+            history=[HistoryEvent(
+                group_identifier='unrelated',
+                sequence_index=0,
+                timestamp=TimestampMS(1000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=ONE,
+            ), HistoryEvent(
+                group_identifier='rebasing',
+                sequence_index=0,
+                timestamp=TimestampMS(5000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=token,
+                amount=ONE,
+            )],
+        )
+        write_cursor.execute(
+            'DELETE FROM key_value_cache WHERE name IN (?, ?)',
+            (
+                DBCacheStatic.STALE_BALANCES_FROM_TS.value,
+                DBCacheStatic.STALE_BALANCES_MODIFICATION_TS.value,
+            ),
+        )
 
-    assert_proper_response(requests.patch(
-        api_url_for(rotkehlchen_api_server, 'allassetsresource'),
-        json=payload | {'is_rebasing': True},
-    ))
+    with patch(
+        'rotkehlchen.db.history_events.is_accounting_update_enabled',
+        return_value=True,
+    ):
+        assert_proper_response(requests.patch(
+            api_url_for(rotkehlchen_api_server, 'allassetsresource'),
+            json=payload | {'is_rebasing': True},
+        ))
     assert token.identifier in globaldb.get_asset_ids_with_flag(AssetFlag.REBASING)
+    with database.conn.read_ctx() as cursor:
+        assert database.get_static_cache(
+            cursor=cursor,
+            name=DBCacheStatic.STALE_BALANCES_FROM_TS,
+        ) == '5000'
     result = assert_proper_sync_response_with_result(requests.post(
         api_url_for(rotkehlchen_api_server, 'allassetsresource'),
         json={'identifiers': [token.identifier]},
@@ -684,6 +731,29 @@ def test_edit_rebasing_asset_flag(
         json=payload | {'is_rebasing': False},
     ))
     assert token.identifier not in globaldb.get_asset_ids_with_flag(AssetFlag.REBASING)
+
+
+def test_asset_update_invalidates_changed_rebasing_assets(
+        rotkehlchen_api_server: APIServer,
+) -> None:
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    with (
+        patch.object(rotki.assets_updater, 'perform_update', return_value=None),
+        patch.object(
+            GlobalDBHandler,
+            'get_asset_ids_with_flag',
+            side_effect=[frozenset(), frozenset({A_DAI.identifier})],
+        ),
+        patch.object(DBHistoryEvents, 'mark_asset_events_modified') as mark_modified,
+    ):
+        result = rotkehlchen_api_server.rest_api.assets_service.perform_assets_updates(
+            up_to_version=None,
+            conflicts=None,
+        )
+
+    assert result == {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
+    assert mark_modified.call_count == 1
+    assert mark_modified.call_args.kwargs['asset'] == A_DAI.identifier
 
 
 def test_get_all_assets_levenshtein_ranking(rotkehlchen_api_server: APIServer) -> None:

--- a/rotkehlchen/tests/api/test_assets.py
+++ b/rotkehlchen/tests/api/test_assets.py
@@ -733,29 +733,6 @@ def test_edit_rebasing_asset_flag(
     assert token.identifier not in globaldb.get_asset_ids_with_flag(AssetFlag.REBASING)
 
 
-def test_asset_update_invalidates_changed_rebasing_assets(
-        rotkehlchen_api_server: APIServer,
-) -> None:
-    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
-    with (
-        patch.object(rotki.assets_updater, 'perform_update', return_value=None),
-        patch.object(
-            GlobalDBHandler,
-            'get_asset_ids_with_flag',
-            side_effect=[frozenset(), frozenset({A_DAI.identifier})],
-        ),
-        patch.object(DBHistoryEvents, 'mark_asset_events_modified') as mark_modified,
-    ):
-        result = rotkehlchen_api_server.rest_api.assets_service.perform_assets_updates(
-            up_to_version=None,
-            conflicts=None,
-        )
-
-    assert result == {'result': True, 'message': '', 'status_code': HTTPStatus.OK}
-    assert mark_modified.call_count == 1
-    assert mark_modified.call_args.kwargs['asset'] == A_DAI.identifier
-
-
 def test_get_all_assets_levenshtein_ranking(rotkehlchen_api_server: APIServer) -> None:
     """Test that the paginated assets endpoint ranks name/symbol searches by levenshtein
     closeness (like the asset search dropdown) instead of an alphabetical LIKE match, while

--- a/rotkehlchen/tests/api/test_data_issues.py
+++ b/rotkehlchen/tests/api/test_data_issues.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -27,6 +28,7 @@ if TYPE_CHECKING:
 def _write_issue(
         server: APIServer,
         event_identifier: int = 1,
+        kind: IssueKind = IssueKind.NEGATIVE_BALANCE,
         state: IssueState = IssueState.OPEN,
         location: Location = Location.ETHEREUM,
         location_label: str = '0x0000000000000000000000000000000000000001',
@@ -36,12 +38,16 @@ def _write_issue(
 ) -> int:
     manager = DataIssuesManager(server.rest_api.rotkehlchen.data.db)
     issue_id = manager.write_issue(
-        IssueKind.NEGATIVE_BALANCE,
+        kind,
         location=location.serialize_for_db(),
         location_label=location_label,
         protocol=None,
         asset=asset,
         payload={
+            'block_number': 1,
+            'event_identifier': event_identifier,
+            'reason': 'archive_node_unavailable',
+        } if kind == IssueKind.REBASING_TOKEN else {
             'event_identifier': event_identifier,
             'in_memory_negative_amount': '-1',
             'derived_balance_before_event': '1',
@@ -238,21 +244,68 @@ def test_data_issue_write_endpoints(rotkehlchen_api_server: APIServer) -> None:
         status_code=HTTPStatus.CONFLICT,
     )
 
-    result = assert_proper_sync_response_with_result(requests.post(api_url_for(
-        rotkehlchen_api_server,
-        'dataissueretryautoremediationresource',
-        issue_id=issue_id,
-    )))
-    assert result['state'] == 'open'
-    assert result['resolved_at'] is None
-    assert 'resolution' not in result['payload']
+    assert_error_response(
+        response=requests.post(api_url_for(
+            rotkehlchen_api_server,
+            'dataissueretryautoremediationresource',
+            issue_id=issue_id,
+        )),
+        contained_in_msg='Cannot retry auto-remediation for resolved data issue',
+        status_code=HTTPStatus.CONFLICT,
+    )
 
-    result = assert_proper_sync_response_with_result(requests.post(api_url_for(
+    rebasing_issue_id = _write_issue(
         rotkehlchen_api_server,
-        'dataissueretryautoremediationresource',
-        issue_id=issue_id,
-    )))
-    assert result['state'] == 'open'
+        event_identifier=4,
+        kind=IssueKind.REBASING_TOKEN,
+    )
+    task_manager = rotkehlchen_api_server.rest_api.rotkehlchen.task_manager
+    assert task_manager is not None
+    with patch.object(
+        task_manager,
+        'retry_data_issue_auto_remediation',
+        return_value=True,
+    ) as retry_task:
+        result = assert_proper_sync_response_with_result(requests.post(api_url_for(
+            rotkehlchen_api_server,
+            'dataissueretryautoremediationresource',
+            issue_id=rebasing_issue_id,
+        )))
+        assert result['state'] == 'auto_remediating'
+        retry_task.assert_called_once_with(issue_id=rebasing_issue_id, from_ts=TimestampMS(1000))
+
+        result = assert_proper_sync_response_with_result(requests.post(api_url_for(
+            rotkehlchen_api_server,
+            'dataissueretryautoremediationresource',
+            issue_id=rebasing_issue_id,
+        )))
+        assert result['state'] == 'auto_remediating'
+        retry_task.assert_called_once()
+
+    busy_issue_id = _write_issue(
+        rotkehlchen_api_server,
+        event_identifier=5,
+        kind=IssueKind.REBASING_TOKEN,
+    )
+    with patch.object(
+        task_manager,
+        'retry_data_issue_auto_remediation',
+        return_value=False,
+    ):
+        assert_error_response(
+            response=requests.post(api_url_for(
+                rotkehlchen_api_server,
+                'dataissueretryautoremediationresource',
+                issue_id=busy_issue_id,
+            )),
+            contained_in_msg='Historical balance processing is already running',
+            status_code=HTTPStatus.CONFLICT,
+        )
+    busy_issue = DataIssuesManager(
+        rotkehlchen_api_server.rest_api.rotkehlchen.data.db,
+    ).get_issue(busy_issue_id)
+    assert busy_issue.state == IssueState.UNRESOLVED
+    assert busy_issue.auto_remediation_attempts[0]['reason'] == 'processing_already_running'
 
     resolved_issue_id = _write_issue(
         rotkehlchen_api_server,

--- a/rotkehlchen/tests/api/test_data_issues.py
+++ b/rotkehlchen/tests/api/test_data_issues.py
@@ -206,7 +206,7 @@ def test_data_issue_write_endpoints(rotkehlchen_api_server: APIServer) -> None:
             'dataissueretryautoremediationresource',
             issue_id=issue_id,
         )),
-        contained_in_msg='Cannot retry auto-remediation for dismissed data issue',
+        contained_in_msg='Auto-remediation is not supported for negative_balance data issues',
         status_code=HTTPStatus.CONFLICT,
     )
     assert_error_response(
@@ -250,7 +250,7 @@ def test_data_issue_write_endpoints(rotkehlchen_api_server: APIServer) -> None:
             'dataissueretryautoremediationresource',
             issue_id=issue_id,
         )),
-        contained_in_msg='Cannot retry auto-remediation for resolved data issue',
+        contained_in_msg='Auto-remediation is not supported for negative_balance data issues',
         status_code=HTTPStatus.CONFLICT,
     )
 

--- a/rotkehlchen/tests/api/test_historical_balances.py
+++ b/rotkehlchen/tests/api/test_historical_balances.py
@@ -28,6 +28,7 @@ from rotkehlchen.history.events.structures.types import (
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.history.types import HistoricalPrice, HistoricalPriceOracle
 from rotkehlchen.tasks.historical_balances import process_historical_balances
+from rotkehlchen.tasks.manager import HISTORICAL_BALANCE_PROCESSING_TASK_NAME
 from rotkehlchen.tests.fixtures.messages import MockRotkiNotifier
 from rotkehlchen.tests.utils.api import (
     api_url_for,
@@ -268,13 +269,13 @@ def test_get_historical_balance_with_filters(
                 amount=FVal('3'),
                 location_label=addr1,
                 address=addr1,
-            ), EvmEvent(  # Day 1: Receive wrapped token from Aave (address 1)
+            ), EvmEvent(  # Day 1: Generate debt in Aave (address 1)
                 tx_ref=make_evm_tx_hash(),
                 sequence_index=0,
                 timestamp=ts_sec_to_ms(START_TS),
                 location=Location.ETHEREUM,
                 event_type=HistoryEventType.RECEIVE,
-                event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
+                event_subtype=HistoryEventSubType.GENERATE_DEBT,
                 asset=A_ETH,
                 amount=FVal('10'),
                 location_label=addr1,
@@ -291,13 +292,13 @@ def test_get_historical_balance_with_filters(
                 amount=FVal('2'),
                 location_label=addr1,
                 address=addr1,
-            ), EvmEvent(  # Day 2: Receive wrapped from Compound (address 1)
+            ), EvmEvent(  # Day 2: Generate debt in Compound (address 1)
                 tx_ref=make_evm_tx_hash(),
                 sequence_index=0,
                 timestamp=ts_sec_to_ms(day2_ts),
                 location=Location.ETHEREUM,
                 event_type=HistoryEventType.RECEIVE,
-                event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
+                event_subtype=HistoryEventSubType.GENERATE_DEBT,
                 asset=A_ETH,
                 amount=FVal('6'),
                 location_label=addr1,
@@ -965,7 +966,7 @@ def test_get_historical_netvalue(
             A_EUR.identifier: '16800',
         },
         {  # Day 3: After BTC spend (-0.5) and ETH -> EUR swap (-0.2 ETH, +240 EUR)
-            A_BTC.identifier: '1.7000000000000002',
+            A_BTC.identifier: '1.7',
             A_ETH.identifier: '10.5',
             A_EUR.identifier: '17040',
         },
@@ -1453,6 +1454,18 @@ def test_get_historical_asset_amounts_processing_required(
     )
     assert_proper_sync_response_with_result(response)
 
+    # The trigger acknowledges scheduling, not completion of the background processing.
+    supervisor = rotkehlchen_api_server.rest_api.rotkehlchen.task_supervisor
+    with supervisor.lock:
+        processing_tasks = [
+            task for task in supervisor.tasks
+            if task.task_name == HISTORICAL_BALANCE_PROCESSING_TASK_NAME
+        ]
+    for task in processing_tasks:
+        task.join(timeout=30)
+        assert task.dead, 'Historical balance processing did not finish'
+        task.get()  # Propagate processing failures before checking the resulting balances.
+
     # now data should be available
     response = requests.post(
         api_url_for(
@@ -1487,8 +1500,5 @@ def test_get_historical_asset_amounts_no_events(
             'to_timestamp': START_TS + DAY_IN_SECONDS,
         },
     )
-    assert_error_response(
-        response=response,
-        contained_in_msg='No historical data found',
-        status_code=HTTPStatus.NOT_FOUND,
-    )
+    result = assert_proper_sync_response_with_result(response)
+    assert result == {'processing_required': False}

--- a/rotkehlchen/tests/api/test_historical_balances.py
+++ b/rotkehlchen/tests/api/test_historical_balances.py
@@ -10,6 +10,7 @@ from rotkehlchen.api.v1.types import TaskName
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import Asset
 from rotkehlchen.assets.utils import get_or_create_evm_token
+from rotkehlchen.balances.historical import HistoricalBalancesManager
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import DAY_IN_SECONDS, HOUR_IN_SECONDS, ONE
 from rotkehlchen.constants.assets import A_BTC, A_ETH, A_EUR, A_USD
@@ -553,10 +554,14 @@ def test_find_onchain_historical_balance_divergence(
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('accounting_update_enabled', [True, False])
 def test_get_historical_asset_amounts_over_time(
         rotkehlchen_api_server: APIServer,
         setup_historical_data: None,
+        monkeypatch: pytest.MonkeyPatch,
+        accounting_update_enabled: bool,
 ) -> None:
+    monkeypatch.setenv('ROTKI_ACCOUNTING_UPDATE', str(accounting_update_enabled))
     db = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
     with db.user_write() as write_cursor:
         DBHistoryEvents(database=db).add_history_events(
@@ -585,13 +590,11 @@ def test_get_historical_asset_amounts_over_time(
         },
     )
     result = assert_proper_sync_response_with_result(response)
-    # Check all balance amount change points are present with correct amounts
-    assert len(result['times']) == len(result['values'])
-    assert 'last_group_identifier' not in result
     day_3_ts = START_TS + DAY_IN_SECONDS * 2
-    for ts, amount in zip(result['times'], result['values'], strict=True):
-        assert ts in {START_TS, day_3_ts, day_3_ts + 1, START_TS + DAY_IN_SECONDS * 3}
-        assert amount in {'2', '2.5', '1.5', '3.5'}
+    assert result == {
+        'times': [START_TS, day_3_ts, day_3_ts + 1, START_TS + DAY_IN_SECONDS * 3],
+        'values': ['2', '1.5', '1.5', '3.5'],
+    }
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -619,25 +622,19 @@ def test_get_historical_asset_amounts_over_time_event_metrics(
         )
 
     process_historical_balances(database=db, msg_aggregator=db.msg_aggregator)
-    response = requests.post(
-        api_url_for(
-            rotkehlchen_api_server,
-            'historicalassetamountsresource',
-        ),
-        json={
-            'asset': 'BTC',
-            'from_timestamp': START_TS,
-            'to_timestamp': START_TS + DAY_IN_SECONDS * 10,
-        },
+    processing_required, balances = HistoricalBalancesManager(db).get_assets_amounts_event_metrics(
+        assets=(A_BTC,),
+        from_ts=START_TS,
+        to_ts=Timestamp(START_TS + DAY_IN_SECONDS * 10),
     )
-    result = assert_proper_sync_response_with_result(response)
-    # Check all balance amount change points are present with correct amounts
-    # Day 1: 2 (receive), Day 3: 2.5 (deposit to exchange), Day 3+1s: 1.5 (withdrawal), Day 4: 3.5 (swaps)  # noqa: E501
-    assert len(result['times']) == len(result['values'])
     day_3_ts = START_TS + DAY_IN_SECONDS * 2
-    for ts, amount in zip(result['times'], result['values'], strict=True):
-        assert ts in {START_TS, day_3_ts, day_3_ts + 1, START_TS + DAY_IN_SECONDS * 3}
-        assert amount in {'2', '2.5', '1.5', '3.5'}
+    assert processing_required is False
+    assert balances == {
+        START_TS: FVal('2'),
+        day_3_ts: FVal('2.5'),
+        day_3_ts + 1: FVal('1.5'),
+        START_TS + DAY_IN_SECONDS * 3: FVal('3.5'),
+    }
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -645,11 +642,7 @@ def test_get_historical_asset_amounts_over_time_with_negative_amount(
         rotkehlchen_api_server: APIServer,
         setup_historical_data: None,
 ) -> None:
-    """Test that historical asset amounts are returned correctly with pre-processed event_metrics.
-
-    Negative balance detection happens during processing (via WS message), not during querying.
-    The legacy last_group_identifier is no longer returned by the event_metrics path.
-    """
+    """The graph stops at the first negative balance and identifies the offending event."""
     db = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
     db.msg_aggregator.rotki_notifier = MockRotkiNotifier()  # type: ignore[assignment]
     events = [
@@ -677,10 +670,12 @@ def test_get_historical_asset_amounts_over_time_with_negative_amount(
         ),
     ]
     with db.user_write() as write_cursor:
-        DBHistoryEvents(database=db).add_history_events(
+        db_events = DBHistoryEvents(database=db)
+        first_negative_event_id = db_events.add_history_event(
             write_cursor=write_cursor,
-            history=events,
+            event=events[0],
         )
+        db_events.add_history_event(write_cursor=write_cursor, event=events[1])
 
     # Process events so event_metrics has the data (including negative balance detection)
     process_historical_balances(database=db, msg_aggregator=db.msg_aggregator)
@@ -701,10 +696,12 @@ def test_get_historical_asset_amounts_over_time_with_negative_amount(
         },
     )
     result = assert_proper_sync_response_with_result(response)
-    assert result['processing_required'] is False
-    assert len(result['times']) == len(result['values'])
-    # event_metrics path returns all processed balance changes (including exchange movements)
-    assert len(result['times']) == 3
+    day_3_ts = START_TS + DAY_IN_SECONDS * 2
+    assert result == {
+        'times': [START_TS, day_3_ts, day_3_ts + 1],
+        'values': ['2', '1.5', '1.5'],
+        'last_group_identifier': [first_negative_event_id, events[0].group_identifier],
+    }
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -751,29 +748,18 @@ def test_get_historical_asset_amounts_over_time_with_negative_amount_event_metri
     messages = db.msg_aggregator.rotki_notifier.messages  # type: ignore[union-attr]
     assert any(m.message_type == WSMessageType.NEGATIVE_BALANCE_DETECTED for m in messages)
 
-    response = requests.post(
-        api_url_for(
-            rotkehlchen_api_server,
-            'historicalassetamountsresource',
-        ),
-        json={
-            'asset': 'BTC',
-            'from_timestamp': START_TS,
-            'to_timestamp': four_days_after_start,
-        },
+    processing_required, balances = HistoricalBalancesManager(db).get_assets_amounts_event_metrics(
+        assets=(A_BTC,),
+        from_ts=START_TS,
+        to_ts=four_days_after_start,
     )
-    result = assert_proper_sync_response_with_result(response)
-    assert result['processing_required'] is False
-    assert len(result['times']) == len(result['values'])
+    assert processing_required is False
     day_3_ts = START_TS + DAY_IN_SECONDS * 2
-    assert len(result['times']) == 3
-    assert result['times'][0] == START_TS  # Initial timestamp
-    assert result['times'][1] == day_3_ts  # After spend and exchange deposit
-    assert result['times'][2] == day_3_ts + 1  # After exchange withdrawal
-    # event_metrics sums across all buckets (blockchain + exchange)
-    assert result['values'][0] == '2'  # Initial balance (blockchain only)
-    assert result['values'][1] == '2.5'  # 1.5 (blockchain after spend) + 1 (exchange deposit)
-    assert result['values'][2] == '1.5'  # 1.5 (blockchain) + 0 (exchange after withdrawal)
+    assert balances == {
+        START_TS: FVal('2'),
+        day_3_ts: FVal('2.5'),
+        day_3_ts + 1: FVal('1.5'),
+    }
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -808,10 +794,12 @@ def test_get_historical_assets_in_collection_amounts_over_time(
         ),
     ]
     with db.user_write() as write_cursor:
-        DBHistoryEvents(database=db).add_history_events(
+        db_events = DBHistoryEvents(database=db)
+        first_negative_event_id = db_events.add_history_event(
             write_cursor=write_cursor,
-            history=events,
+            event=events[0],
         )
+        db_events.add_history_event(write_cursor=write_cursor, event=events[1])
 
     process_historical_balances(database=db, msg_aggregator=db.msg_aggregator)
 
@@ -831,17 +819,24 @@ def test_get_historical_assets_in_collection_amounts_over_time(
         },
     )
     result = assert_proper_sync_response_with_result(response)
-    assert result['processing_required'] is False
-    assert len(result['times']) == len(result['values'])
     day_3_ts = START_TS + DAY_IN_SECONDS * 2
-    assert len(result['times']) == 3
-    assert result['times'][0] == START_TS  # Initial timestamp
-    assert result['times'][1] == day_3_ts  # After spend and exchange deposit
-    assert result['times'][2] == day_3_ts + 1  # After exchange withdrawal
-    # event_metrics sums across all buckets (blockchain + exchange)
-    assert result['values'][0] == '2'  # Initial balance (blockchain only)
-    assert result['values'][1] == '2.5'  # 1.5 (blockchain after spend) + 1 (exchange deposit)
-    assert result['values'][2] == '1.5'  # 1.5 (blockchain) + 0 (exchange after withdrawal)
+    assert result == {
+        'times': [START_TS, day_3_ts, day_3_ts + 1],
+        'values': ['2', '1.5', '1.5'],
+        'last_group_identifier': [first_negative_event_id, events[0].group_identifier],
+    }
+
+    processing_required, balances = HistoricalBalancesManager(db).get_assets_amounts_event_metrics(
+        assets=(A_BTC, events[0].asset, events[1].asset),
+        from_ts=START_TS,
+        to_ts=four_days_after_start,
+    )
+    assert processing_required is False
+    assert balances == {
+        START_TS: FVal('2'),
+        day_3_ts: FVal('2.5'),
+        day_3_ts + 1: FVal('1.5'),
+    }
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
@@ -1397,9 +1392,14 @@ def test_historical_price_cache_only_special_assets(
 def test_get_historical_asset_amounts_processing_required(
         rotkehlchen_api_server: APIServer,
 ) -> None:
-    """Test that processing_required flag is returned correctly and that the
-    processing trigger endpoint works."""
+    """Processing updates event metrics while the graph remains available on demand."""
     db = rotkehlchen_api_server.rest_api.rotkehlchen.data.db
+    balances_manager = HistoricalBalancesManager(db)
+    assert balances_manager.get_assets_amounts_event_metrics(
+        assets=(A_BTC,),
+        from_ts=START_TS,
+        to_ts=Timestamp(START_TS + DAY_IN_SECONDS),
+    ) == (False, None)
     events = [
         HistoryEvent(
             group_identifier='btc_receive_1',
@@ -1419,7 +1419,12 @@ def test_get_historical_asset_amounts_processing_required(
             history=events,
         )
 
-    # events exist but are not yet processed
+    assert balances_manager.get_assets_amounts_event_metrics(
+        assets=(A_BTC,),
+        from_ts=START_TS,
+        to_ts=Timestamp(START_TS + DAY_IN_SECONDS),
+    ) == (True, None)
+
     response = requests.post(
         api_url_for(
             rotkehlchen_api_server,
@@ -1432,9 +1437,7 @@ def test_get_historical_asset_amounts_processing_required(
         },
     )
     result = assert_proper_sync_response_with_result(response)
-    assert result['processing_required'] is True
-    assert 'times' not in result
-    assert 'values' not in result
+    assert result == {'times': [START_TS], 'values': ['2']}
 
     response = requests.post(
         api_url_for(rotkehlchen_api_server, 'timestamphistoricalbalanceresource'),
@@ -1479,16 +1482,23 @@ def test_get_historical_asset_amounts_processing_required(
         },
     )
     result = assert_proper_sync_response_with_result(response)
-    assert result['processing_required'] is False
-    assert 'times' in result
-    assert 'values' in result
+    assert result == {'times': [START_TS], 'values': ['2']}
+    assert balances_manager.get_assets_amounts_event_metrics(
+        assets=(A_BTC,),
+        from_ts=START_TS,
+        to_ts=Timestamp(START_TS + DAY_IN_SECONDS),
+    ) == (False, {START_TS: FVal('2')})
 
 
 @pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('accounting_update_enabled', [True, False])
 def test_get_historical_asset_amounts_no_events(
         rotkehlchen_api_server: APIServer,
+        monkeypatch: pytest.MonkeyPatch,
+        accounting_update_enabled: bool,
 ) -> None:
-    """Test that processing_required=False is returned when no events exist in time range."""
+    """The graph returns 404 when no events exist, regardless of the accounting flag."""
+    monkeypatch.setenv('ROTKI_ACCOUNTING_UPDATE', str(accounting_update_enabled))
     response = requests.post(
         api_url_for(
             rotkehlchen_api_server,
@@ -1500,5 +1510,8 @@ def test_get_historical_asset_amounts_no_events(
             'to_timestamp': START_TS + DAY_IN_SECONDS,
         },
     )
-    result = assert_proper_sync_response_with_result(response)
-    assert result == {'processing_required': False}
+    assert_error_response(
+        response=response,
+        contained_in_msg='No historical data found',
+        status_code=HTTPStatus.NOT_FOUND,
+    )

--- a/rotkehlchen/tests/unit/test_app.py
+++ b/rotkehlchen/tests/unit/test_app.py
@@ -8,6 +8,7 @@ from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.errors.misc import SystemPermissionError
 from rotkehlchen.exchanges.constants import EXCHANGES_WITH_PASSPHRASE, SUPPORTED_EXCHANGES
 from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.rotkehlchen import Rotkehlchen
 from rotkehlchen.tests.fixtures.messages import MockRotkiNotifier
 from rotkehlchen.tests.utils.factories import make_api_key, make_api_secret, make_random_bytes
@@ -89,7 +90,10 @@ def test_solana_tokens_migration_notification(uninitialized_rotkehlchen):
         cursor.execute("INSERT INTO user_added_solana_tokens VALUES ('token1'), ('token2')")
 
     # Mock greenlet spawning to avoid background tasks
-    with mock.patch.object(rotki.task_supervisor, 'spawn_and_track'):
+    with (
+        mock.patch.object(rotki.task_supervisor, 'spawn_and_track'),
+        mock.patch.object(DataIssuesManager, 'reset_orphaned_remediations') as reset_mock,
+    ):
         # Unlock user
         rotki.unlock_user(
             user='testuser',
@@ -99,6 +103,8 @@ def test_solana_tokens_migration_notification(uninitialized_rotkehlchen):
             premium_credentials=None,
             resume_from_backup=False,
         )
+
+    reset_mock.assert_called_once_with()
 
     # Check notification
     messages = rotki.msg_aggregator.rotki_notifier.messages

--- a/rotkehlchen/tests/unit/test_data_issues.py
+++ b/rotkehlchen/tests/unit/test_data_issues.py
@@ -73,6 +73,23 @@ def _write_current_balance_mismatch_issue(
     )
 
 
+def _write_rebasing_issue(manager: DataIssuesManager, event_identifier: int = 1) -> int:
+    return manager.write_issue(
+        IssueKind.REBASING_TOKEN,
+        location=Location.ETHEREUM.serialize_for_db(),
+        location_label='0x0000000000000000000000000000000000000001',
+        protocol=None,
+        asset='eip155:1/erc20:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
+        payload={
+            'event_identifier': event_identifier,
+            'block_number': 1,
+            'reason': 'archive_node_unavailable',
+        },
+        ts_start=1000,
+        ts_end=1000,
+    )
+
+
 def test_write_and_list_issues(database: DBHandler) -> None:
     manager = DataIssuesManager(database)
     issue_id = _write_negative_balance_issue(manager)
@@ -132,6 +149,31 @@ def test_state_transitions(database: DBHandler) -> None:
 
     with pytest.raises(InputError):
         manager.update_state(issue_id, IssueState.OPEN)
+
+
+def test_retry_auto_remediation(database: DBHandler) -> None:
+    manager = DataIssuesManager(database)
+    issue_id = _write_rebasing_issue(manager)
+
+    issue, should_schedule = manager.retry_auto_remediation(issue_id)
+    assert should_schedule is True
+    assert issue.state == IssueState.AUTO_REMEDIATING
+
+    issue, should_schedule = manager.retry_auto_remediation(issue_id)
+    assert should_schedule is False
+    assert issue.state == IssueState.AUTO_REMEDIATING
+
+    issue = manager.update_state(issue_id, IssueState.UNRESOLVED)
+    issue, should_schedule = manager.retry_auto_remediation(issue.id)
+    assert should_schedule is True
+    assert issue.state == IssueState.AUTO_REMEDIATING
+
+    issue = manager.append_auto_remediation_attempt(issue_id, {'strategy': 'test'})
+    assert issue.auto_remediation_attempts == [{'strategy': 'test'}]
+
+    unsupported_issue_id = _write_negative_balance_issue(manager, event_identifier=2)
+    with pytest.raises(InputError, match='Auto-remediation is not supported'):
+        manager.retry_auto_remediation(unsupported_issue_id)
 
 
 def test_dismiss_and_resolve_manually(database: DBHandler) -> None:

--- a/rotkehlchen/tests/unit/test_data_issues.py
+++ b/rotkehlchen/tests/unit/test_data_issues.py
@@ -168,8 +168,13 @@ def test_retry_auto_remediation(database: DBHandler) -> None:
     assert should_schedule is True
     assert issue.state == IssueState.AUTO_REMEDIATING
 
-    issue = manager.append_auto_remediation_attempt(issue_id, {'strategy': 'test'})
+    issue = manager.append_auto_remediation_attempt(
+        issue_id=issue_id,
+        attempt={'strategy': 'test'},
+        resolution={'reason': 'fixed'},
+    )
     assert issue.auto_remediation_attempts == [{'strategy': 'test'}]
+    assert issue.payload['resolution'] == {'reason': 'fixed'}
 
     unsupported_issue_id = _write_negative_balance_issue(manager, event_identifier=2)
     with pytest.raises(InputError, match='Auto-remediation is not supported'):

--- a/rotkehlchen/tests/unit/test_data_issues.py
+++ b/rotkehlchen/tests/unit/test_data_issues.py
@@ -180,6 +180,38 @@ def test_retry_auto_remediation(database: DBHandler) -> None:
     with pytest.raises(InputError, match='Auto-remediation is not supported'):
         manager.retry_auto_remediation(unsupported_issue_id)
 
+    manager.update_state(unsupported_issue_id, IssueState.AUTO_REMEDIATING)
+    with pytest.raises(InputError, match='Auto-remediation is not supported'):
+        manager.retry_auto_remediation(unsupported_issue_id)
+
+
+def test_reset_orphaned_remediations(database: DBHandler) -> None:
+    manager = DataIssuesManager(database)
+    issue_id = _write_rebasing_issue(manager)
+    manager.retry_auto_remediation(issue_id)
+
+    manager.reset_orphaned_remediations()
+
+    issue, should_schedule = manager.retry_auto_remediation(issue_id)
+    assert should_schedule is True
+    assert issue.state == IssueState.AUTO_REMEDIATING
+
+
+def test_resolve_superseded_negative_balance_issues(database: DBHandler) -> None:
+    manager = DataIssuesManager(database)
+    superseded_id = _write_negative_balance_issue(manager, event_identifier=1)
+    unaffected_id = _write_negative_balance_issue(manager, event_identifier=2)
+    with database.user_write() as write_cursor:
+        write_cursor.execute(
+            'UPDATE data_issues SET asset=? WHERE id=?',
+            ('OTHER_ASSET', unaffected_id),
+        )
+
+    manager.resolve_superseded_negative_balance_issues(assets=frozenset({'ETH'}))
+
+    assert manager.get_issue(superseded_id).state == IssueState.RESOLVED
+    assert manager.get_issue(unaffected_id).state == IssueState.OPEN
+
 
 def test_dismiss_and_resolve_manually(database: DBHandler) -> None:
     manager = DataIssuesManager(database)

--- a/rotkehlchen/tests/unit/test_historical_balances.py
+++ b/rotkehlchen/tests/unit/test_historical_balances.py
@@ -35,6 +35,8 @@ from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tasks.historical_balances import (
+    Bucket,
+    _get_rebasing_reconciliation_points,
     process_historical_balances,
     retry_rebasing_token_issue,
 )
@@ -71,6 +73,24 @@ def _make_balance_event(timestamp: int, amount: str = '10') -> EvmEvent:
         amount=FVal(amount),
         location_label=TEST_ADDR1,
     )
+
+
+@pytest.mark.parametrize('rebasing_assets', [frozenset(), frozenset({A_DAI.identifier})])
+def test_rebasing_reconciliation_skips_unrelated_events(
+        database: DBHandler,
+        rebasing_assets: frozenset[str],
+) -> None:
+    event = _make_balance_event(timestamp=1000)
+    event.identifier = 1
+    with patch.object(Bucket, 'from_event', wraps=Bucket.from_event) as from_event_mock:
+        assert _get_rebasing_reconciliation_points(
+            database=database,
+            events=[event],
+            rebasing_assets=rebasing_assets,
+            treat_eth2_as_eth=False,
+        ) == {}
+
+    from_event_mock.assert_not_called()
 
 
 def _add_test_evm_transactions(
@@ -1919,6 +1939,28 @@ def test_negative_rebasing_token_without_archive_node_writes_specific_issue(
         assert issue.state == IssueState.UNRESOLVED
         assert issue.auto_remediation_attempts[0]['reason'] == 'archive_node_unavailable'
         assert issue.auto_remediation_attempts[0]['success'] is False
+
+        node_inquirer.get_historical_token_balance.return_value = ZERO
+        node_inquirer.has_archive_node.return_value = True
+        DataIssuesManager(database).retry_auto_remediation(issue.id)
+        retry_rebasing_token_issue(
+            database=database,
+            msg_aggregator=messages_aggregator,
+            chains_aggregator=chains_aggregator,
+            issue_id=issue.id,
+            from_ts=TimestampMS(issue.ts_start),
+        )
+
+        issue = DataIssuesManager(database).get_issue(issue.id)
+        assert issue.state == IssueState.RESOLVED
+        assert issue.payload['resolution'] == {'reason': 'no_longer_reproduces'}
+        assert len(issue.auto_remediation_attempts) == 2
+        assert issue.auto_remediation_attempts[1]['success'] is True
+        with database.conn.read_ctx() as cursor:
+            assert cursor.execute(
+                'SELECT metric_value FROM event_metrics WHERE event_identifier=?',
+                (spend_id,),
+            ).fetchone()[0] == '0'
     finally:
         GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
 

--- a/rotkehlchen/tests/unit/test_historical_balances.py
+++ b/rotkehlchen/tests/unit/test_historical_balances.py
@@ -1,7 +1,7 @@
 import json
 import time
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -23,11 +23,13 @@ from rotkehlchen.constants.assets import A_BTC, A_DAI, A_ETH, A_ETH2, A_USDC, A_
 from rotkehlchen.constants.misc import ONE, ZERO
 from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.constants import HistoryMappingState
+from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import HistoricalBalancesFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.fval import FVal
 from rotkehlchen.globaldb.handler import GlobalDBHandler
+from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
 from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -35,13 +37,22 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.tasks.historical_balances import process_historical_balances
 from rotkehlchen.tests.utils.ethereum import TEST_ADDR1, TEST_ADDR2
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
-from rotkehlchen.types import ChainID, EventMetricKey, Location, Timestamp, TimestampMS
+from rotkehlchen.types import (
+    ChainID,
+    EventMetricKey,
+    EvmTransaction,
+    EVMTxHash,
+    Location,
+    Timestamp,
+    TimestampMS,
+)
 from rotkehlchen.utils.misc import ts_now
 
 pytestmark = pytest.mark.accounting_update
 
 if TYPE_CHECKING:
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.db.drivers.sqlite import DBCursor
     from rotkehlchen.user_messages import MessagesAggregator
 
 
@@ -56,6 +67,31 @@ def _make_balance_event(timestamp: int, amount: str = '10') -> EvmEvent:
         asset=A_ETH,
         amount=FVal(amount),
         location_label=TEST_ADDR1,
+    )
+
+
+def _add_test_evm_transactions(
+        database: DBHandler,
+        write_cursor: DBCursor,
+        transactions: list[tuple[EVMTxHash, Timestamp, int]],
+) -> None:
+    DBEvmTx(database).add_transactions(
+        write_cursor=write_cursor,
+        evm_transactions=[EvmTransaction(
+            tx_hash=tx_hash,
+            chain_id=ChainID.ETHEREUM,
+            timestamp=timestamp,
+            block_number=block_number,
+            from_address=TEST_ADDR1,
+            to_address=TEST_ADDR2,
+            value=0,
+            gas=21000,
+            gas_price=1,
+            gas_used=21000,
+            input_data=b'',
+            nonce=idx,
+        ) for idx, (tx_hash, timestamp, block_number) in enumerate(transactions)],
+        relevant_address=TEST_ADDR1,
     )
 
 
@@ -1560,17 +1596,31 @@ def test_swapped_for_asset_tracked_under_new_identifier(
         ]
 
 
-def test_rebasing_token_deficit_records_yield_and_resolves_issue(
+def test_rebasing_token_deficit_uses_archive_balance_and_resolves_issue(
         database: DBHandler,
         messages_aggregator: MessagesAggregator,
 ) -> None:
-    """A rebasing OUT deficit is yield in its bucket, not a negative balance."""
+    """Archive balanceOf replaces a negative event-derived balance at the block boundary."""
     events_db = DBHistoryEvents(database)
+    receive_tx, spend_tx, final_receive_tx = (
+        make_evm_tx_hash(),
+        make_evm_tx_hash(),
+        make_evm_tx_hash(),
+    )
     with database.user_write() as write_cursor:
+        _add_test_evm_transactions(
+            database=database,
+            write_cursor=write_cursor,
+            transactions=[
+                (receive_tx, Timestamp(1), 100),
+                (spend_tx, Timestamp(2), 200),
+                (final_receive_tx, Timestamp(2), 200),
+            ],
+        )
         events_db.add_history_event(
             write_cursor=write_cursor,
             event=EvmEvent(
-                tx_ref=make_evm_tx_hash(),
+                tx_ref=receive_tx,
                 sequence_index=0,
                 timestamp=TimestampMS(1000),
                 location=Location.ETHEREUM,
@@ -1584,23 +1634,43 @@ def test_rebasing_token_deficit_records_yield_and_resolves_issue(
         spend_id = events_db.add_history_event(
             write_cursor=write_cursor,
             event=EvmEvent(
-                tx_ref=make_evm_tx_hash(),
+                tx_ref=spend_tx,
                 sequence_index=0,
                 timestamp=TimestampMS(2000),
                 location=Location.ETHEREUM,
                 event_type=HistoryEventType.SPEND,
                 event_subtype=HistoryEventSubType.NONE,
                 asset=A_DAI,
-                amount=FVal('12'),
+                amount=FVal('11'),
+                location_label=TEST_ADDR1,
+            ),
+        )
+        final_id = events_db.add_history_event(
+            write_cursor=write_cursor,
+            event=EvmEvent(
+                tx_ref=final_receive_tx,
+                sequence_index=1,
+                timestamp=TimestampMS(2000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=FVal('2'),
                 location_label=TEST_ADDR1,
             ),
         )
 
     process_historical_balances(database, messages_aggregator)
-    assert DataIssuesManager(database).list_issues()[0].state == 'open'
+    issue = DataIssuesManager(database).list_issues()[0]
+    assert issue.payload['event_identifier'] == spend_id
+    assert issue.state == 'open'
 
     GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=True)
     try:
+        node_inquirer = MagicMock()
+        node_inquirer.get_historical_token_balance.return_value = FVal('3')
+        chains_aggregator = MagicMock()
+        chains_aggregator.get_evm_manager.return_value.node_inquirer = node_inquirer
         get_rebasing_assets = GlobalDBHandler.get_asset_ids_with_flag
         with (
             patch.object(
@@ -1610,38 +1680,53 @@ def test_rebasing_token_deficit_records_yield_and_resolves_issue(
             ) as get_flags_mock,
             patch.object(database.msg_aggregator, 'add_message') as msg_mock,
         ):
-            process_historical_balances(database, messages_aggregator)
+            process_historical_balances(
+                database=database,
+                msg_aggregator=messages_aggregator,
+                chains_aggregator=chains_aggregator,
+            )
 
         get_flags_mock.assert_called_once_with(AssetFlag.REBASING)
+        assert [call.kwargs['block_number'] for call in (
+            node_inquirer.get_historical_token_balance.call_args_list
+        )] == [200]
         assert WSMessageType.NEGATIVE_BALANCE_DETECTED not in [
             call.kwargs['message_type'] for call in msg_mock.call_args_list
         ]
         with database.conn.read_ctx() as cursor:
             assert cursor.execute(
                 'SELECT metric_key, metric_value, sort_key FROM event_metrics '
-                'WHERE event_identifier = ? ORDER BY sort_key',
-                (spend_id,),
+                'WHERE event_identifier = ?',
+                (final_id,),
             ).fetchall() == [
-                (EventMetricKey.REBASE_YIELD.serialize(), '2', 4000),
-                (EventMetricKey.BALANCE.serialize(), '0', 4001),
+                (EventMetricKey.BALANCE.serialize(), '3', 2001),
             ]
         assert DataIssuesManager(database).list_issues()[0].state == 'resolved'
     finally:
         GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
 
 
-def test_rebasing_protocol_deficit_stays_metrics_only(
+def test_rebasing_protocol_deficit_writes_unsupported_bucket_issue(
         database: DBHandler,
         messages_aggregator: MessagesAggregator,
 ) -> None:
-    """Rebasing yield in a protocol bucket must not create a synthetic history event."""
+    """A token balanceOf cannot verify a rebasing balance held in a protocol bucket."""
     GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=True)
     try:
+        tx_hashes = [make_evm_tx_hash() for _ in range(3)]
         with database.user_write() as write_cursor:
+            _add_test_evm_transactions(
+                database=database,
+                write_cursor=write_cursor,
+                transactions=[
+                    (tx_hash, Timestamp(idx), idx * 100)
+                    for idx, tx_hash in enumerate(tx_hashes, start=1)
+                ],
+            )
             DBHistoryEvents(database).add_history_events(
                 write_cursor=write_cursor,
                 history=[EvmEvent(
-                    tx_ref=make_evm_tx_hash(),
+                    tx_ref=tx_hashes[0],
                     sequence_index=0,
                     timestamp=TimestampMS(1000),
                     location=Location.ETHEREUM,
@@ -1651,7 +1736,7 @@ def test_rebasing_protocol_deficit_stays_metrics_only(
                     amount=FVal('10'),
                     location_label=TEST_ADDR1,
                 ), EvmEvent(
-                    tx_ref=make_evm_tx_hash(),
+                    tx_ref=tx_hashes[1],
                     sequence_index=0,
                     timestamp=TimestampMS(2000),
                     location=Location.ETHEREUM,
@@ -1662,7 +1747,7 @@ def test_rebasing_protocol_deficit_stays_metrics_only(
                     location_label=TEST_ADDR1,
                     counterparty=CPT_LIQUITY,
                 ), EvmEvent(
-                    tx_ref=make_evm_tx_hash(),
+                    tx_ref=tx_hashes[2],
                     sequence_index=0,
                     timestamp=TimestampMS(3000),
                     location=Location.ETHEREUM,
@@ -1675,7 +1760,14 @@ def test_rebasing_protocol_deficit_stays_metrics_only(
                 )],
             )
 
-        process_historical_balances(database, messages_aggregator)
+        node_inquirer = MagicMock()
+        chains_aggregator = MagicMock()
+        chains_aggregator.get_evm_manager.return_value.node_inquirer = node_inquirer
+        process_historical_balances(
+            database=database,
+            msg_aggregator=messages_aggregator,
+            chains_aggregator=chains_aggregator,
+        )
 
         with database.conn.read_ctx() as cursor:
             assert cursor.execute('SELECT COUNT(*) FROM history_events').fetchone()[0] == 3
@@ -1685,9 +1777,133 @@ def test_rebasing_protocol_deficit_stays_metrics_only(
                 (TimestampMS(3000),),
             ).fetchall() == [
                 (None, EventMetricKey.BALANCE.serialize(), '12'),
-                (CPT_LIQUITY, EventMetricKey.BALANCE.serialize(), '0'),
-                (CPT_LIQUITY, EventMetricKey.REBASE_YIELD.serialize(), '2'),
             ]
+        issues = DataIssuesManager(database).list_issues()
+        assert len(issues) == 1
+        assert issues[0].kind == IssueKind.REBASING_TOKEN.value
+        assert issues[0].payload['reason'] == 'unsupported_bucket'
+        node_inquirer.get_historical_token_balance.assert_not_called()
+    finally:
+        GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
+
+
+def test_healthy_rebasing_token_does_not_query_archive_node(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    """Archive reconciliation is unnecessary while event-derived balances remain valid."""
+    tx_hash = make_evm_tx_hash()
+    with database.user_write() as write_cursor:
+        _add_test_evm_transactions(
+            database=database,
+            write_cursor=write_cursor,
+            transactions=[(tx_hash, Timestamp(1), 100)],
+        )
+        event_id = DBHistoryEvents(database).add_history_event(
+            write_cursor=write_cursor,
+            event=EvmEvent(
+                tx_ref=tx_hash,
+                sequence_index=0,
+                timestamp=TimestampMS(1000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=FVal('10'),
+                location_label=TEST_ADDR1,
+            ),
+        )
+
+    GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=True)
+    try:
+        node_inquirer = MagicMock()
+        node_inquirer.get_historical_token_balance.return_value = None
+        chains_aggregator = MagicMock()
+        chains_aggregator.get_evm_manager.return_value.node_inquirer = node_inquirer
+        process_historical_balances(
+            database=database,
+            msg_aggregator=messages_aggregator,
+            chains_aggregator=chains_aggregator,
+        )
+
+        with database.conn.read_ctx() as cursor:
+            assert cursor.execute(
+                'SELECT COUNT(*) FROM event_metrics WHERE event_identifier=?',
+                (event_id,),
+            ).fetchone()[0] == 1
+        assert DataIssuesManager(database).list_issues() == []
+        node_inquirer.get_historical_token_balance.assert_not_called()
+    finally:
+        GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
+
+
+def test_negative_rebasing_token_without_archive_node_writes_specific_issue(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    """Missing archive access is a rebasing-token issue, not a negative-balance issue."""
+    receive_tx, spend_tx = make_evm_tx_hash(), make_evm_tx_hash()
+    with database.user_write() as write_cursor:
+        _add_test_evm_transactions(
+            database=database,
+            write_cursor=write_cursor,
+            transactions=[
+                (receive_tx, Timestamp(1), 100),
+                (spend_tx, Timestamp(2), 200),
+            ],
+        )
+        DBHistoryEvents(database).add_history_event(
+            write_cursor=write_cursor,
+            event=EvmEvent(
+                tx_ref=receive_tx,
+                sequence_index=0,
+                timestamp=TimestampMS(1000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=FVal('10'),
+                location_label=TEST_ADDR1,
+            ),
+        )
+        spend_id = DBHistoryEvents(database).add_history_event(
+            write_cursor=write_cursor,
+            event=EvmEvent(
+                tx_ref=spend_tx,
+                sequence_index=0,
+                timestamp=TimestampMS(2000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.SPEND,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=FVal('11'),
+                location_label=TEST_ADDR1,
+            ),
+        )
+
+    GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=True)
+    try:
+        node_inquirer = MagicMock()
+        node_inquirer.get_historical_token_balance.return_value = None
+        node_inquirer.has_archive_node.return_value = False
+        chains_aggregator = MagicMock()
+        chains_aggregator.get_evm_manager.return_value.node_inquirer = node_inquirer
+        process_historical_balances(
+            database=database,
+            msg_aggregator=messages_aggregator,
+            chains_aggregator=chains_aggregator,
+        )
+
+        issues = DataIssuesManager(database).list_issues()
+        assert len(issues) == 1
+        issue = issues[0]
+        assert issue.kind == IssueKind.REBASING_TOKEN.value
+        assert issue.payload == {
+            'event_identifier': spend_id,
+            'block_number': 200,
+            'reason': 'archive_node_unavailable',
+        }
+        node_inquirer.get_historical_token_balance.assert_called_once()
     finally:
         GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
 
@@ -1821,7 +2037,6 @@ def test_unmatched_bridge_data_issues(
     inbox, and get system-resolved once the legs are matched."""
     from rotkehlchen.chain.evm.decoding.across.constants import CPT_ACROSS
     from rotkehlchen.db.constants import HistoryEventLinkType
-    from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
     from rotkehlchen.history.data_issues.types import DataIssueFilters
 
     events_db = DBHistoryEvents(database)

--- a/rotkehlchen/tests/unit/test_historical_balances.py
+++ b/rotkehlchen/tests/unit/test_historical_balances.py
@@ -34,7 +34,10 @@ from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.tasks.historical_balances import process_historical_balances
+from rotkehlchen.tasks.historical_balances import (
+    process_historical_balances,
+    retry_rebasing_token_issue,
+)
 from rotkehlchen.tests.utils.ethereum import TEST_ADDR1, TEST_ADDR2
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
 from rotkehlchen.types import (
@@ -1690,6 +1693,7 @@ def test_rebasing_token_deficit_uses_archive_balance_and_resolves_issue(
         assert [call.kwargs['block_number'] for call in (
             node_inquirer.get_historical_token_balance.call_args_list
         )] == [200]
+        chains_aggregator.get_evm_manager.assert_called_once_with(ChainID.ETHEREUM)
         assert WSMessageType.NEGATIVE_BALANCE_DETECTED not in [
             call.kwargs['message_type'] for call in msg_mock.call_args_list
         ]
@@ -1904,8 +1908,95 @@ def test_negative_rebasing_token_without_archive_node_writes_specific_issue(
             'reason': 'archive_node_unavailable',
         }
         node_inquirer.get_historical_token_balance.assert_called_once()
+
+        DataIssuesManager(database).retry_auto_remediation(issue.id)
+        process_historical_balances(
+            database=database,
+            msg_aggregator=messages_aggregator,
+            chains_aggregator=chains_aggregator,
+        )
+        issue = DataIssuesManager(database).get_issue(issue.id)
+        assert issue.state == IssueState.UNRESOLVED
+        assert issue.auto_remediation_attempts[0]['reason'] == 'archive_node_unavailable'
+        assert issue.auto_remediation_attempts[0]['success'] is False
     finally:
         GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
+
+
+def test_retry_rebasing_issue_finishes_remediation_state(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    issues_manager = DataIssuesManager(database)
+    issue_id = issues_manager.write_issue(
+        kind=IssueKind.REBASING_TOKEN,
+        location=Location.ETHEREUM.serialize_for_db(),
+        location_label=TEST_ADDR1,
+        protocol=None,
+        asset=A_DAI.identifier,
+        payload={
+            'event_identifier': 1,
+            'block_number': 100,
+            'reason': 'archive_node_unavailable',
+        },
+        ts_start=1000,
+        ts_end=1000,
+    )
+    issues_manager.retry_auto_remediation(issue_id)
+
+    with patch(
+        'rotkehlchen.tasks.historical_balances.process_historical_balances',
+        return_value=True,
+    ):
+        retry_rebasing_token_issue(
+            database=database,
+            msg_aggregator=messages_aggregator,
+            chains_aggregator=MagicMock(),
+            issue_id=issue_id,
+            from_ts=TimestampMS(1000),
+        )
+
+    issue = issues_manager.get_issue(issue_id)
+    assert issue.state == IssueState.RESOLVED
+    assert issue.payload['resolution'] == {'reason': 'no_longer_reproduces'}
+    assert issue.auto_remediation_attempts[0] == {
+        'attribution': 'system',
+        'strategy': 'historical_balance_reprocessing',
+        'success': True,
+        'timestamp': issue.auto_remediation_attempts[0]['timestamp'],
+    }
+
+    second_issue_id = issues_manager.write_issue(
+        kind=IssueKind.REBASING_TOKEN,
+        location=Location.ETHEREUM.serialize_for_db(),
+        location_label=TEST_ADDR1,
+        protocol=None,
+        asset=A_DAI.identifier,
+        payload={
+            'event_identifier': 2,
+            'block_number': 200,
+            'reason': 'archive_node_unavailable',
+        },
+        ts_start=2000,
+        ts_end=2000,
+    )
+    issues_manager.retry_auto_remediation(second_issue_id)
+    with patch(
+        'rotkehlchen.tasks.historical_balances.process_historical_balances',
+        return_value=None,
+    ):
+        retry_rebasing_token_issue(
+            database=database,
+            msg_aggregator=messages_aggregator,
+            chains_aggregator=MagicMock(),
+            issue_id=second_issue_id,
+            from_ts=TimestampMS(2000),
+        )
+
+    second_issue = issues_manager.get_issue(second_issue_id)
+    assert second_issue.state == IssueState.UNRESOLVED
+    assert second_issue.auto_remediation_attempts[0]['reason'] == 'processing_already_running'
+    assert second_issue.auto_remediation_attempts[0]['success'] is False
 
 
 def test_negative_balance_writes_data_issue(

--- a/rotkehlchen/tests/unit/test_historical_balances.py
+++ b/rotkehlchen/tests/unit/test_historical_balances.py
@@ -33,7 +33,11 @@ from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
 from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
-from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.history.events.structures.types import (
+    EventDirection,
+    HistoryEventSubType,
+    HistoryEventType,
+)
 from rotkehlchen.tasks.historical_balances import (
     Bucket,
     _get_rebasing_reconciliation_points,
@@ -116,6 +120,82 @@ def _add_test_evm_transactions(
         ) for idx, (tx_hash, timestamp, block_number) in enumerate(transactions)],
         relevant_address=TEST_ADDR1,
     )
+
+
+def test_rebasing_reconciliation_queries_more_than_sqlite_expression_limit(
+        database: DBHandler,
+) -> None:
+    """Transaction lookup uses chunked IN queries, not an expression-depth-limited OR chain."""
+    transaction_count = 1001
+    tx_hashes = [make_evm_tx_hash() for _ in range(transaction_count)]
+    with database.user_write() as write_cursor:
+        _add_test_evm_transactions(
+            database=database,
+            write_cursor=write_cursor,
+            transactions=[
+                (tx_hash, Timestamp(idx + 1), idx + 1)
+                for idx, tx_hash in enumerate(tx_hashes)
+            ],
+        )
+
+    events = [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=TimestampMS((idx + 1) * 1000),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_DAI,
+        amount=ONE,
+        location_label=TEST_ADDR1,
+        identifier=idx + 1,
+    ) for idx, tx_hash in enumerate(tx_hashes)]
+
+    points = _get_rebasing_reconciliation_points(
+        database=database,
+        events=events,
+        rebasing_assets=frozenset({A_DAI.identifier}),
+        treat_eth2_as_eth=False,
+    )
+
+    assert len(points) == transaction_count
+
+
+def test_rebasing_reconciliation_uses_highest_block_for_same_timestamp(
+        database: DBHandler,
+) -> None:
+    """Sub-second chains can sort a higher block before a lower block at one timestamp."""
+    higher_block_tx, lower_block_tx = make_evm_tx_hash(), make_evm_tx_hash()
+    with database.user_write() as write_cursor:
+        _add_test_evm_transactions(
+            database=database,
+            write_cursor=write_cursor,
+            transactions=[
+                (higher_block_tx, Timestamp(1), 101),
+                (lower_block_tx, Timestamp(1), 100),
+            ],
+        )
+
+    events = [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=sequence_index,
+        timestamp=TimestampMS(1000),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_DAI,
+        amount=ONE,
+        location_label=TEST_ADDR1,
+        identifier=sequence_index + 1,
+    ) for sequence_index, tx_hash in enumerate((higher_block_tx, lower_block_tx))]
+    bucket = Bucket.from_event(events[-1])[0][0]
+
+    assert _get_rebasing_reconciliation_points(
+        database=database,
+        events=events,
+        rebasing_assets=frozenset({A_DAI.identifier}),
+        treat_eth2_as_eth=False,
+    ) == {(2, bucket): 101}
 
 
 def _get_stale_cache_values(database: DBHandler) -> tuple[int | None, int | None]:
@@ -1723,6 +1803,7 @@ def test_rebasing_token_deficit_uses_archive_balance_and_resolves_issue(
                 'WHERE event_identifier = ?',
                 (final_id,),
             ).fetchall() == [
+                (EventMetricKey.REBASE_YIELD.serialize(), '2', 2001),
                 (EventMetricKey.BALANCE.serialize(), '3', 2001),
             ]
         assert DataIssuesManager(database).list_issues()[0].state == 'resolved'
@@ -1958,9 +2039,118 @@ def test_negative_rebasing_token_without_archive_node_writes_specific_issue(
         assert issue.auto_remediation_attempts[1]['success'] is True
         with database.conn.read_ctx() as cursor:
             assert cursor.execute(
-                'SELECT metric_value FROM event_metrics WHERE event_identifier=?',
-                (spend_id,),
+                'SELECT metric_value FROM event_metrics '
+                'WHERE event_identifier=? AND metric_key=?',
+                (spend_id, EventMetricKey.BALANCE.serialize()),
             ).fetchone()[0] == '0'
+    finally:
+        GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
+
+
+def test_rebasing_reconciliation_resumes_after_transient_query_failure(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    """A later timestamp can restore metrics after an earlier archive query fails."""
+    tx_hashes = [make_evm_tx_hash() for _ in range(3)]
+    with database.user_write() as write_cursor:
+        _add_test_evm_transactions(
+            database=database,
+            write_cursor=write_cursor,
+            transactions=[
+                (tx_hash, Timestamp(idx), idx * 100)
+                for idx, tx_hash in enumerate(tx_hashes, start=1)
+            ],
+        )
+        events_db = DBHistoryEvents(database)
+        event_ids = [events_db.add_history_event(
+            write_cursor=write_cursor,
+            event=EvmEvent(
+                tx_ref=tx_hash,
+                sequence_index=0,
+                timestamp=TimestampMS(idx * 1000),
+                location=Location.ETHEREUM,
+                event_type=event_type,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=FVal(amount),
+                location_label=TEST_ADDR1,
+            ),
+        ) for idx, (tx_hash, event_type, amount) in enumerate(zip(
+                tx_hashes,
+                (HistoryEventType.RECEIVE, HistoryEventType.SPEND, HistoryEventType.RECEIVE),
+                ('10', '11', '2'),
+                strict=True,
+            ), start=1)]
+
+    GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=True)
+    try:
+        node_inquirer = MagicMock()
+        node_inquirer.get_historical_token_balance.side_effect = [None, FVal('2')]
+        node_inquirer.has_archive_node.return_value = True
+        chains_aggregator = MagicMock()
+        chains_aggregator.get_evm_manager.return_value.node_inquirer = node_inquirer
+
+        process_historical_balances(
+            database=database,
+            msg_aggregator=messages_aggregator,
+            chains_aggregator=chains_aggregator,
+        )
+
+        issue = DataIssuesManager(database).list_issues()[0]
+        assert issue.state == IssueState.RESOLVED
+        assert issue.payload['event_identifier'] == event_ids[1]
+        assert node_inquirer.get_historical_token_balance.call_count == 2
+        with database.conn.read_ctx() as cursor:
+            assert cursor.execute(
+                'SELECT metric_key, metric_value FROM event_metrics '
+                'WHERE event_identifier=? ORDER BY rowid',
+                (event_ids[2],),
+            ).fetchall() == [
+                (EventMetricKey.REBASE_YIELD.serialize(), '1'),
+                (EventMetricKey.BALANCE.serialize(), '2'),
+            ]
+    finally:
+        GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
+
+
+@pytest.mark.parametrize(('event_asset', 'bucket_asset'), [(A_ETH, A_DAI), (A_DAI, A_ETH)])
+def test_rebasing_asset_identity_mismatch_uses_negative_balance_path(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+        event_asset: Asset,
+        bucket_asset: Asset,
+) -> None:
+    """Swapped asset identity mismatches must never leave a bucket pending without a checkpoint."""
+    event = EvmEvent(
+        tx_ref=make_evm_tx_hash(),
+        sequence_index=0,
+        timestamp=TimestampMS(1000),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=event_asset,
+        amount=ONE,
+        location_label=TEST_ADDR1,
+    )
+    with database.user_write() as write_cursor:
+        DBHistoryEvents(database).add_history_event(write_cursor=write_cursor, event=event)
+
+    bucket = Bucket(
+        location=Location.ETHEREUM.serialize_for_db(),
+        location_label=TEST_ADDR1,
+        protocol=None,
+        asset=bucket_asset.identifier,
+    )
+    GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=True)
+    try:
+        with patch.object(Bucket, 'from_event', return_value=[(bucket, EventDirection.OUT)]):
+            process_historical_balances(database, messages_aggregator)
+
+        issues = DataIssuesManager(database).list_issues()
+        assert len(issues) == 1
+        assert issues[0].kind == IssueKind.NEGATIVE_BALANCE
+        assert issues[0].asset == bucket_asset.identifier
     finally:
         GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
 

--- a/rotkehlchen/tests/unit/test_historical_balances.py
+++ b/rotkehlchen/tests/unit/test_historical_balances.py
@@ -7,6 +7,7 @@ import pytest
 
 from rotkehlchen.api.websockets.typedefs import WSMessageType
 from rotkehlchen.assets.asset import Asset
+from rotkehlchen.assets.types import AssetFlag
 from rotkehlchen.assets.utils import get_or_create_evm_token
 from rotkehlchen.balances.historical import HistoricalBalancesManager
 from rotkehlchen.chain.ethereum.modules.eigenlayer.constants import CPT_EIGENLAYER
@@ -26,6 +27,7 @@ from rotkehlchen.db.filtering import HistoricalBalancesFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import ModifiableDBSettings
 from rotkehlchen.fval import FVal
+from rotkehlchen.globaldb.handler import GlobalDBHandler
 from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.events.structures.base import HistoryEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
@@ -33,7 +35,7 @@ from rotkehlchen.history.events.structures.types import HistoryEventSubType, His
 from rotkehlchen.tasks.historical_balances import process_historical_balances
 from rotkehlchen.tests.utils.ethereum import TEST_ADDR1, TEST_ADDR2
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
-from rotkehlchen.types import ChainID, Location, Timestamp, TimestampMS
+from rotkehlchen.types import ChainID, EventMetricKey, Location, Timestamp, TimestampMS
 from rotkehlchen.utils.misc import ts_now
 
 pytestmark = pytest.mark.accounting_update
@@ -715,7 +717,7 @@ def test_empty_counterparty_does_not_create_protocol_bucket(
                 timestamp=TimestampMS(3000),
                 location=Location.ETHEREUM,
                 event_type=HistoryEventType.SPEND,
-                event_subtype=HistoryEventSubType.GENERATE_DEBT,
+                event_subtype=HistoryEventSubType.PAYBACK_DEBT,
                 asset=A_ETH,
                 amount=FVal('1'),
                 location_label=TEST_ADDR1,
@@ -1556,6 +1558,138 @@ def test_swapped_for_asset_tracked_under_new_identifier(
             (glm.identifier, glm.identifier, '60'),  # spend 10 GLM -> 70 - 10 = 60
             (glm.identifier, glm.identifier, '110'),  # receive 50 GLM -> 60 + 50 = 110
         ]
+
+
+def test_rebasing_token_deficit_records_yield_and_resolves_issue(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    """A rebasing OUT deficit is yield in its bucket, not a negative balance."""
+    events_db = DBHistoryEvents(database)
+    with database.user_write() as write_cursor:
+        events_db.add_history_event(
+            write_cursor=write_cursor,
+            event=EvmEvent(
+                tx_ref=make_evm_tx_hash(),
+                sequence_index=0,
+                timestamp=TimestampMS(1000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=FVal('10'),
+                location_label=TEST_ADDR1,
+            ),
+        )
+        spend_id = events_db.add_history_event(
+            write_cursor=write_cursor,
+            event=EvmEvent(
+                tx_ref=make_evm_tx_hash(),
+                sequence_index=0,
+                timestamp=TimestampMS(2000),
+                location=Location.ETHEREUM,
+                event_type=HistoryEventType.SPEND,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=FVal('12'),
+                location_label=TEST_ADDR1,
+            ),
+        )
+
+    process_historical_balances(database, messages_aggregator)
+    assert DataIssuesManager(database).list_issues()[0].state == 'open'
+
+    GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=True)
+    try:
+        get_rebasing_assets = GlobalDBHandler.get_asset_ids_with_flag
+        with (
+            patch.object(
+                GlobalDBHandler,
+                'get_asset_ids_with_flag',
+                wraps=get_rebasing_assets,
+            ) as get_flags_mock,
+            patch.object(database.msg_aggregator, 'add_message') as msg_mock,
+        ):
+            process_historical_balances(database, messages_aggregator)
+
+        get_flags_mock.assert_called_once_with(AssetFlag.REBASING)
+        assert WSMessageType.NEGATIVE_BALANCE_DETECTED not in [
+            call.kwargs['message_type'] for call in msg_mock.call_args_list
+        ]
+        with database.conn.read_ctx() as cursor:
+            assert cursor.execute(
+                'SELECT metric_key, metric_value, sort_key FROM event_metrics '
+                'WHERE event_identifier = ? ORDER BY sort_key',
+                (spend_id,),
+            ).fetchall() == [
+                (EventMetricKey.REBASE_YIELD.serialize(), '2', 4000),
+                (EventMetricKey.BALANCE.serialize(), '0', 4001),
+            ]
+        assert DataIssuesManager(database).list_issues()[0].state == 'resolved'
+    finally:
+        GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
+
+
+def test_rebasing_protocol_deficit_stays_metrics_only(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    """Rebasing yield in a protocol bucket must not create a synthetic history event."""
+    GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=True)
+    try:
+        with database.user_write() as write_cursor:
+            DBHistoryEvents(database).add_history_events(
+                write_cursor=write_cursor,
+                history=[EvmEvent(
+                    tx_ref=make_evm_tx_hash(),
+                    sequence_index=0,
+                    timestamp=TimestampMS(1000),
+                    location=Location.ETHEREUM,
+                    event_type=HistoryEventType.RECEIVE,
+                    event_subtype=HistoryEventSubType.NONE,
+                    asset=A_DAI,
+                    amount=FVal('10'),
+                    location_label=TEST_ADDR1,
+                ), EvmEvent(
+                    tx_ref=make_evm_tx_hash(),
+                    sequence_index=0,
+                    timestamp=TimestampMS(2000),
+                    location=Location.ETHEREUM,
+                    event_type=HistoryEventType.DEPOSIT,
+                    event_subtype=HistoryEventSubType.DEPOSIT_TO_PROTOCOL,
+                    asset=A_DAI,
+                    amount=FVal('10'),
+                    location_label=TEST_ADDR1,
+                    counterparty=CPT_LIQUITY,
+                ), EvmEvent(
+                    tx_ref=make_evm_tx_hash(),
+                    sequence_index=0,
+                    timestamp=TimestampMS(3000),
+                    location=Location.ETHEREUM,
+                    event_type=HistoryEventType.WITHDRAWAL,
+                    event_subtype=HistoryEventSubType.WITHDRAW_FROM_PROTOCOL,
+                    asset=A_DAI,
+                    amount=FVal('12'),
+                    location_label=TEST_ADDR1,
+                    counterparty=CPT_LIQUITY,
+                )],
+            )
+
+        process_historical_balances(database, messages_aggregator)
+
+        with database.conn.read_ctx() as cursor:
+            assert cursor.execute('SELECT COUNT(*) FROM history_events').fetchone()[0] == 3
+            assert cursor.execute(
+                'SELECT protocol, metric_key, metric_value FROM event_metrics '
+                'WHERE timestamp = ? ORDER BY protocol NULLS FIRST, metric_key',
+                (TimestampMS(3000),),
+            ).fetchall() == [
+                (None, EventMetricKey.BALANCE.serialize(), '12'),
+                (CPT_LIQUITY, EventMetricKey.BALANCE.serialize(), '0'),
+                (CPT_LIQUITY, EventMetricKey.REBASE_YIELD.serialize(), '2'),
+            ]
+    finally:
+        GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
 
 
 def test_negative_balance_writes_data_issue(

--- a/rotkehlchen/tests/unit/test_historical_balances.py
+++ b/rotkehlchen/tests/unit/test_historical_balances.py
@@ -527,6 +527,57 @@ def test_has_unprocessed_events(
         write_cursor.execute('DELETE FROM event_metrics WHERE event_identifier IN (SELECT identifier FROM history_events WHERE timestamp >= 5000)')  # noqa: E501
     assert manager._has_unprocessed_events('timestamp <= ?', [TimestampMS(9999)]) is True
 
+    # 11. A non-balance metric must not make an event look processed
+    with database.user_write() as write_cursor:
+        event_identifier = write_cursor.execute(
+            'SELECT identifier FROM history_events WHERE timestamp = ?',
+            (TimestampMS(5000),),
+        ).fetchone()[0]
+        write_cursor.execute(
+            'INSERT INTO event_metrics(event_identifier, location, location_label, protocol, '
+            'metric_key, metric_value, asset, timestamp, sequence_index, sort_key) '
+            'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            (
+                event_identifier,
+                Location.ETHEREUM.serialize_for_db(),
+                TEST_ADDR1,
+                None,
+                EventMetricKey.REBASE_YIELD.serialize(),
+                '1',
+                A_ETH.identifier,
+                TimestampMS(5000),
+                0,
+                5000,
+            ),
+        )
+    assert manager._has_unprocessed_events('timestamp <= ?', [TimestampMS(9999)]) is True
+
+
+def test_process_historical_balances_resumes_at_exact_millisecond(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    with database.user_write() as write_cursor:
+        DBHistoryEvents(database).add_history_events(
+            write_cursor=write_cursor,
+            history=[
+                _make_balance_event(timestamp=1000, amount='1'),
+                _make_balance_event(timestamp=1500, amount='1'),
+            ],
+        )
+
+    process_historical_balances(database, messages_aggregator)
+    process_historical_balances(
+        database=database,
+        msg_aggregator=messages_aggregator,
+        from_ts=TimestampMS(1500),
+    )
+
+    with database.conn.read_ctx() as cursor:
+        assert cursor.execute(
+            'SELECT timestamp, metric_value FROM event_metrics ORDER BY timestamp',
+        ).fetchall() == [(1000, '1'), (1500, '2')]
+
 
 def test_get_balances_with_unprocessed_events_and_timestamp_filter(
         database: DBHandler,
@@ -825,7 +876,7 @@ def test_empty_counterparty_does_not_create_protocol_bucket(
         database: DBHandler,
         messages_aggregator: MessagesAggregator,
 ) -> None:
-    """Test that an empty counterparty is not considered a valid protocol bucket."""
+    """Test that dual and single protocol events use the wallet without a counterparty."""
     with database.user_write() as write_cursor:
         DBHistoryEvents(database).add_history_events(
             write_cursor=write_cursor,
@@ -855,8 +906,8 @@ def test_empty_counterparty_does_not_create_protocol_bucket(
                 sequence_index=0,
                 timestamp=TimestampMS(3000),
                 location=Location.ETHEREUM,
-                event_type=HistoryEventType.SPEND,
-                event_subtype=HistoryEventSubType.PAYBACK_DEBT,
+                event_type=HistoryEventType.RECEIVE,
+                event_subtype=HistoryEventSubType.GENERATE_DEBT,
                 asset=A_ETH,
                 amount=FVal('1'),
                 location_label=TEST_ADDR1,
@@ -873,7 +924,7 @@ def test_empty_counterparty_does_not_create_protocol_bucket(
         ).fetchall() == [
             (1000, TEST_ADDR1, None, '10'),
             (2000, TEST_ADDR1, None, '7'),
-            (3000, TEST_ADDR1, None, '6'),
+            (3000, TEST_ADDR1, None, '8'),
         ]
 
 
@@ -2114,6 +2165,68 @@ def test_rebasing_reconciliation_resumes_after_transient_query_failure(
         GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
 
 
+def test_rebasing_reconciliation_reports_only_first_failure(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+) -> None:
+    """Later failed checkpoints must not rewrite the issue's original event and block."""
+    tx_hashes = [make_evm_tx_hash() for _ in range(3)]
+    with database.user_write() as write_cursor:
+        _add_test_evm_transactions(
+            database=database,
+            write_cursor=write_cursor,
+            transactions=[
+                (tx_hash, Timestamp(idx), idx * 100)
+                for idx, tx_hash in enumerate(tx_hashes, start=1)
+            ],
+        )
+        events_db = DBHistoryEvents(database)
+        event_ids = [events_db.add_history_event(
+            write_cursor=write_cursor,
+            event=EvmEvent(
+                tx_ref=tx_hash,
+                sequence_index=0,
+                timestamp=TimestampMS(idx * 1000),
+                location=Location.ETHEREUM,
+                event_type=event_type,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=A_DAI,
+                amount=FVal(amount),
+                location_label=TEST_ADDR1,
+            ),
+        ) for idx, (tx_hash, event_type, amount) in enumerate(zip(
+            tx_hashes,
+            (HistoryEventType.RECEIVE, HistoryEventType.SPEND, HistoryEventType.RECEIVE),
+            ('10', '11', '1'),
+            strict=True,
+        ), start=1)]
+
+    GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=True)
+    try:
+        node_inquirer = MagicMock()
+        node_inquirer.get_historical_token_balance.return_value = None
+        node_inquirer.has_archive_node.return_value = False
+        chains_aggregator = MagicMock()
+        chains_aggregator.get_evm_manager.return_value.node_inquirer = node_inquirer
+
+        process_historical_balances(
+            database=database,
+            msg_aggregator=messages_aggregator,
+            chains_aggregator=chains_aggregator,
+        )
+
+        issues = DataIssuesManager(database).list_issues()
+        assert len(issues) == 1
+        assert issues[0].payload == {
+            'event_identifier': event_ids[1],
+            'block_number': 200,
+            'reason': 'archive_node_unavailable',
+        }
+        assert node_inquirer.get_historical_token_balance.call_count == 2
+    finally:
+        GlobalDBHandler.set_asset_flag(A_DAI.identifier, AssetFlag.REBASING, enabled=False)
+
+
 @pytest.mark.parametrize(('event_asset', 'bucket_asset'), [(A_ETH, A_DAI), (A_DAI, A_ETH)])
 def test_rebasing_asset_identity_mismatch_uses_negative_balance_path(
         database: DBHandler,
@@ -2176,10 +2289,17 @@ def test_retry_rebasing_issue_finishes_remediation_state(
     )
     issues_manager.retry_auto_remediation(issue_id)
 
+    with database.user_write() as write_cursor:
+        database.set_static_cache(
+            write_cursor=write_cursor,
+            name=DBCacheStatic.STALE_BALANCES_FROM_TS,
+            value='500',
+        )
+
     with patch(
         'rotkehlchen.tasks.historical_balances.process_historical_balances',
         return_value=True,
-    ):
+    ) as process_mock:
         retry_rebasing_token_issue(
             database=database,
             msg_aggregator=messages_aggregator,
@@ -2187,6 +2307,7 @@ def test_retry_rebasing_issue_finishes_remediation_state(
             issue_id=issue_id,
             from_ts=TimestampMS(1000),
         )
+    assert process_mock.call_args.kwargs['from_ts'] == TimestampMS(500)
 
     issue = issues_manager.get_issue(issue_id)
     assert issue.state == IssueState.RESOLVED

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -45,7 +45,11 @@ from rotkehlchen.premium.premium import (
 from rotkehlchen.premium.sync import PremiumSyncManager
 from rotkehlchen.serialization.deserialize import deserialize_timestamp
 from rotkehlchen.tasks.assets import _find_missing_tokens, maybe_detect_new_tokens
-from rotkehlchen.tasks.manager import PREMIUM_STATUS_CHECK, TaskManager
+from rotkehlchen.tasks.manager import (
+    HISTORICAL_BALANCE_PROCESSING_TASK_NAME,
+    PREMIUM_STATUS_CHECK,
+    TaskManager,
+)
 from rotkehlchen.tasks.utils import (
     prefetch_scheduler_task_timestamps,
     should_run_periodic_task,
@@ -105,6 +109,20 @@ def test_potential_maybe_schedule_task(task_manager: TaskManager):
     assert [function.__name__ for function in task_manager.priority_tasks_queue] == [
         '_maybe_trigger_calendar_reminder',
     ]
+
+
+def test_periodic_historical_balances_skip_active_remediation(task_manager: TaskManager) -> None:
+    with (
+        patch.object(
+            task_manager.history_processing_coordinator,
+            'is_history_fetching',
+            return_value=False,
+        ),
+        patch.object(task_manager.task_supervisor, 'has_task', return_value=True) as has_task,
+    ):
+        assert task_manager._maybe_process_historical_balances() is None
+
+    has_task.assert_called_once_with(HISTORICAL_BALANCE_PROCESSING_TASK_NAME)
 
 
 @pytest.mark.parametrize('max_tasks_num', [5])

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -1541,7 +1541,15 @@ DEFAULT_ADDRESS_NAME_PRIORITY: Sequence[AddressNameSource] = (
 
 
 class EventMetricKey(SerializableEnumNameMixin):
-    """Keys for metrics stored in the event_metrics table."""
+    """Keys for metrics stored in the event_metrics table.
+
+    BALANCE is the canonical proof that an event was processed. REBASE_YIELD is supplemental
+    metadata recording the difference between the derived balance and an authoritative historical
+    balance. It is attached to the reconciliation checkpoint instead of creating a synthetic
+    history event because a token rebase has no corresponding event in the user's history.
+    Consumers must therefore check specifically for BALANCE rather than treating any metric as
+    proof that an event was processed.
+    """
     BALANCE = auto()
     REBASE_YIELD = auto()
 

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -1543,7 +1543,6 @@ DEFAULT_ADDRESS_NAME_PRIORITY: Sequence[AddressNameSource] = (
 class EventMetricKey(SerializableEnumNameMixin):
     """Keys for metrics stored in the event_metrics table."""
     BALANCE = auto()
-    REBASE_YIELD = auto()
 
 
 class HistoryEventQueryType(SerializableEnumNameMixin):

--- a/rotkehlchen/types.py
+++ b/rotkehlchen/types.py
@@ -1543,6 +1543,7 @@ DEFAULT_ADDRESS_NAME_PRIORITY: Sequence[AddressNameSource] = (
 class EventMetricKey(SerializableEnumNameMixin):
     """Keys for metrics stored in the event_metrics table."""
     BALANCE = auto()
+    REBASE_YIELD = auto()
 
 
 class HistoryEventQueryType(SerializableEnumNameMixin):


### PR DESCRIPTION
Closes https://github.com/rotki/rotki/issues/12315

## What was done

- Reconcile negative balances for assets flagged as rebasing against the authoritative end-of-block `balanceOf`, using the historical balance cache or an available archive node.
- Periodic background processing may query configured archive nodes when reconciling negative rebasing balances, even without a manual processing request. Successful query results are cached per address, token, and block, so the first pass over uncached history can take longer.
- Store the reconciliation delta as an internal `REBASE_YIELD` metric attached to the checkpoint event instead of creating a synthetic receive event. A rebase has no corresponding event in the user's history, and inventing one could hide missing or incorrect history. Nothing consumes this supplemental metric yet; `BALANCE` remains the canonical indication that an event was processed.
- When no authoritative historical balance is available, avoid inferring an adjustment and report a rebasing-token data issue that can be retried after archive-node access becomes available.
- Query only the final relevant event for each address, asset, and block, avoiding redundant historical RPC calls.
- Report a specific rebasing-token data issue when reconciliation cannot be performed, including missing transaction metadata, unsupported balance buckets, unavailable archive nodes, and failed historical queries.
- Make retrying auto-remediation reprocess historical balances from the affected event, record the outcome, and resolve the issue when it no longer reproduces.
- Fix the EVM chain-ID mismatch in archive-node lookup and only expose retry actions for eligible rebasing-token issues.
- Add backend and frontend regression coverage for reconciliation and remediation state transitions.

