### PR TITLE
fix: ignore withdrawals to untracked addresses

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`13034` Withdrawals from a validator whose withdrawal address you do not track no longer show up in your history or count as staking income.
 * :bug:`-` Across and CCTP bridges involving Solana are now decoded, and their Solana and EVM history events are matched as the two sides of the same bridge transfer.
 * :bug:`-` Claiming your Safenet staking rewards is now recorded as a staking reward.
 * :bug:`13027` Adding an ETH2 validator by index or public key works again. Since 1.44.0 the Add Account button on the validators tab opened the generic blockchain account form instead of the validator form, and saving from it did nothing, so a validator that was not picked up automatically from its deposit could not be added at all.

--- a/rotkehlchen/accounting/pot.py
+++ b/rotkehlchen/accounting/pot.py
@@ -22,7 +22,7 @@ from rotkehlchen.errors.serialization import DeserializationError
 from rotkehlchen.history.events.structures.types import EventDirection
 from rotkehlchen.history.price import PriceHistorian
 from rotkehlchen.logging import RotkehlchenLogsAdapter
-from rotkehlchen.types import Location, Price, Timestamp
+from rotkehlchen.types import ChecksumEvmAddress, Location, Price, Timestamp
 from rotkehlchen.utils.data_structures import LRUCacheWithRemove
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
@@ -103,6 +103,18 @@ class AccountingPot(CustomizableDateMixin):
         # fixed event set, so we load them once (on first eth2 withdrawal/exit event) instead
         # of re-scanning the whole eth2_validators table per event. None means not yet loaded.
         self._validators_with_status: dict[int, ValidatorDetailsWithStatus] | None = None
+        # memoize the tracked ethereum accounts per report, for the same reason. None means
+        # not yet loaded.
+        self._tracked_eth_accounts: set[ChecksumEvmAddress] | None = None
+
+    def is_tracked_eth_account(self, address: str | None) -> bool:
+        """Check if the given address is a tracked ethereum mainnet account, loading and
+        caching all of them on the first call of a report."""
+        if self._tracked_eth_accounts is None:
+            with self.database.conn.read_ctx() as cursor:
+                self._tracked_eth_accounts = set(self.database.get_blockchain_accounts(cursor).eth)
+
+        return address in self._tracked_eth_accounts
 
     def get_validator_with_status(self, validator_index: int) -> ValidatorDetailsWithStatus | None:
         """Return the status details for a tracked validator, loading and caching all
@@ -197,6 +209,7 @@ class AccountingPot(CustomizableDateMixin):
         self.profit_currency = self.settings.main_currency.resolve_to_asset_with_oracles()
         self._profit_currency_rates.clear()
         self._validators_with_status = None
+        self._tracked_eth_accounts = None
         self.query_start_ts = start_ts
         self.query_end_ts = end_ts
         self.pnls.reset()

--- a/rotkehlchen/api/v1/schemas.py
+++ b/rotkehlchen/api/v1/schemas.py
@@ -5,7 +5,7 @@ import typing
 from contextvars import ContextVar
 from itertools import zip_longest
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal, cast, get_args
+from typing import TYPE_CHECKING, Any, ClassVar, Final, Literal, cast, get_args
 
 import marshmallow
 import webargs
@@ -637,6 +637,9 @@ class HistoryEventFilterSchema(
     TimestampRangeSchema,
 ):
     """Base schema for filtering history events. Contains common filter fields and methods."""
+    # Withdrawals to an untracked address are not the user's, so they are kept out of every
+    # user facing query. Deletion turns this off so such events remain deletable.
+    EXCLUDE_UNTRACKED_WITHDRAWALS: ClassVar[bool] = True
     exclude_ignored_assets = fields.Boolean(load_default=True)
     group_identifiers = DelimitedOrNormalList(EmptyAsNoneStringField(), load_default=None)
     location = SerializableEnumField(Location, load_default=None)
@@ -733,6 +736,7 @@ class HistoryEventFilterSchema(
             'from_ts': data['from_timestamp'],
             'to_ts': data['to_timestamp'],
             'exclude_ignored_assets': data['exclude_ignored_assets'],
+            'exclude_untracked_withdrawals': self.EXCLUDE_UNTRACKED_WITHDRAWALS,
             'group_identifiers': data['group_identifiers'],
             'location_labels': location_labels,
             'assets': [data['asset']] if data['asset'] is not None else None,
@@ -3621,6 +3625,7 @@ class HistoryEventsDeletionSchema(HistoryEventFilterSchema):
     All provided filters are combined (intersection) to determine which events to delete.
     At least one filter parameter must be provided to prevent accidental mass deletion.
     """
+    EXCLUDE_UNTRACKED_WITHDRAWALS: ClassVar[bool] = False  # we should be able to delete withdrawals of untracked addresses  # noqa: E501
     force_delete = fields.Boolean(load_default=False)
     exclude_ignored_assets = fields.Boolean(load_default=False)  # we should be able to delete events with ignored assets  # noqa: E501
 

--- a/rotkehlchen/chain/aggregator.py
+++ b/rotkehlchen/chain/aggregator.py
@@ -1037,6 +1037,8 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         """Extra code to run when eth account addition happens"""
         if blockchain == SupportedBlockchain.ETHEREUM:  # add it first so that it's there for module's on account addition  # noqa: E501
             self.ethereum.node_inquirer.proxies_inquirer.query_address_for_proxies(address)
+
+        DBEth2(self.database).invalidate_withdrawals_derived_data(address)
         for _, module in self.iterate_modules():
             module.on_account_addition(address)
 
@@ -1049,6 +1051,7 @@ class ChainsAggregator(CacheableMixIn, LockableQueryMixIn):
         if blockchain == SupportedBlockchain.ETHEREUM:
             self.ethereum.node_inquirer.proxies_inquirer.reset_last_query_ts()
 
+        DBEth2(self.database).invalidate_withdrawals_derived_data(address)
         for _, module in self.iterate_modules():
             module.on_account_removal(address)
 

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -1063,6 +1063,28 @@ class Eth2(EthereumModule):
                 set_bindings=(event_type.serialize(),),
             )
 
+    def _adjust_withdrawals_at_account_modification(self, address: ChecksumEvmAddress) -> None:
+        """Invalidate everything that depends on whether the given address' withdrawals count.
+
+        Withdrawals to an untracked address are filtered out of history, accounting and
+        validator performance at query time, but the derived data computed from them is
+        cached, so tracking or untracking the address has to drop those caches.
+        """
+        self.performance_cache.clear()
+        with self.database.user_write() as write_cursor:
+            write_cursor.execute(
+                'DELETE FROM eth_validators_data_cache WHERE validator_index IN ('
+                'SELECT S.validator_index FROM history_events H INNER JOIN '
+                'eth_staking_events_info S ON H.identifier=S.identifier '
+                'WHERE H.entry_type=? AND H.location_label=?)',
+                (HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT.serialize_for_db(), address),
+            )
+            DBHistoryEvents(self.database).mark_events_stale_by_query(
+                write_cursor=write_cursor,
+                query='SELECT timestamp FROM history_events WHERE entry_type=? AND location_label=?',  # noqa: E501
+                bindings=(HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT.serialize_for_db(), address),
+            )
+
     # -- Methods following the EthereumModule interface -- #
     def on_account_addition(self, address: ChecksumEvmAddress) -> None:
         """
@@ -1078,12 +1100,14 @@ class Eth2(EthereumModule):
             )
 
         self._adjust_blockproduction_at_account_modification(address, HistoryEventType.STAKING)
+        self._adjust_withdrawals_at_account_modification(address)
 
     def on_account_removal(self, address: ChecksumEvmAddress) -> None:
         """
         Adjust existing block production events to become informational if they involve the address
         """
         self._adjust_blockproduction_at_account_modification(address, HistoryEventType.INFORMATIONAL)  # noqa: E501
+        self._adjust_withdrawals_at_account_modification(address)
 
         with self.database.conn.write_ctx() as write_cursor:
             self.database.delete_dynamic_cache(

--- a/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
+++ b/rotkehlchen/chain/ethereum/modules/eth2/eth2.py
@@ -1063,28 +1063,6 @@ class Eth2(EthereumModule):
                 set_bindings=(event_type.serialize(),),
             )
 
-    def _adjust_withdrawals_at_account_modification(self, address: ChecksumEvmAddress) -> None:
-        """Invalidate everything that depends on whether the given address' withdrawals count.
-
-        Withdrawals to an untracked address are filtered out of history, accounting and
-        validator performance at query time, but the derived data computed from them is
-        cached, so tracking or untracking the address has to drop those caches.
-        """
-        self.performance_cache.clear()
-        with self.database.user_write() as write_cursor:
-            write_cursor.execute(
-                'DELETE FROM eth_validators_data_cache WHERE validator_index IN ('
-                'SELECT S.validator_index FROM history_events H INNER JOIN '
-                'eth_staking_events_info S ON H.identifier=S.identifier '
-                'WHERE H.entry_type=? AND H.location_label=?)',
-                (HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT.serialize_for_db(), address),
-            )
-            DBHistoryEvents(self.database).mark_events_stale_by_query(
-                write_cursor=write_cursor,
-                query='SELECT timestamp FROM history_events WHERE entry_type=? AND location_label=?',  # noqa: E501
-                bindings=(HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT.serialize_for_db(), address),
-            )
-
     # -- Methods following the EthereumModule interface -- #
     def on_account_addition(self, address: ChecksumEvmAddress) -> None:
         """
@@ -1100,14 +1078,17 @@ class Eth2(EthereumModule):
             )
 
         self._adjust_blockproduction_at_account_modification(address, HistoryEventType.STAKING)
-        self._adjust_withdrawals_at_account_modification(address)
+        # whether the address' withdrawals count as ours changed, so the performance results
+        # computed from them are no longer valid. The persisted data derived from them is
+        # dropped by the chains aggregator, which runs even when this module is not active.
+        self.performance_cache.clear()
 
     def on_account_removal(self, address: ChecksumEvmAddress) -> None:
         """
         Adjust existing block production events to become informational if they involve the address
         """
         self._adjust_blockproduction_at_account_modification(address, HistoryEventType.INFORMATIONAL)  # noqa: E501
-        self._adjust_withdrawals_at_account_modification(address)
+        self.performance_cache.clear()  # its results counted this address' withdrawals
 
         with self.database.conn.write_ctx() as write_cursor:
             self.database.delete_dynamic_cache(

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -382,6 +382,7 @@ class DBEth2:
                     event_subtypes=[HistoryEventSubType.REMOVE_ASSET],
                     entry_types=IncludeExcludeFilterData(values=[HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT]),
                     withdrawal_types_filter=withdrawal_types_filter,
+                    exclude_untracked_withdrawals=True,  # withdrawals to an address we don't track are not our pnl  # noqa: E501
                 ),
             ).items():
                 withdrawal_sums[key] += value
@@ -451,6 +452,10 @@ class DBEth2:
         events_db = DBHistoryEvents(self.db)
         events: list[HistoryBaseEntry] = []
         with self.db.conn.read_ctx() as cursor:
+            # Withdrawals to an address we don't track are not ours, so they contribute no pnl.
+            # They are still needed to reconstruct the validator's balance over time, so they
+            # are queried here and skipped only where pnl gets accumulated below.
+            tracked_addresses = set(self.db.get_blockchain_accounts(cursor).eth)
             cached_balances_over_time, cached_withdrawals_pnl, cached_exits_pnl, cached_last_stored_ts = self._load_eth2_validator_cache(  # noqa: E501
                 cursor=cursor,
                 from_ts=from_ts,
@@ -515,11 +520,14 @@ class DBEth2:
                 validator_balances[v_index := event.validator_index] += event.amount
             elif isinstance(event, EthWithdrawalEvent):
                 v_index = event.validator_index
+                is_tracked = event.location_label in tracked_addresses
                 if event.is_exit_or_blocknumber is True:  # Exit withdrawals
                     if from_ts_ms <= event.timestamp <= to_ts_ms:  # only count pnl within the specified range  # noqa: E501
-                        # For accumulating validators, subtract already counted withdrawals
-                        # from exit PnL to avoid double-counting consensus rewards
-                        exits_pnl[v_index] = event.amount - validator_balances[v_index] - sum(withdrawals_pnl_over_time[v_index].values())  # noqa: E501
+                        if is_tracked:
+                            # For accumulating validators, subtract already counted withdrawals
+                            # from exit PnL to avoid double-counting consensus rewards
+                            exits_pnl[v_index] = event.amount - validator_balances[v_index] - sum(withdrawals_pnl_over_time[v_index].values())  # noqa: E501
+
                         validator_balances[v_index] = ZERO
                     else:
                         continue
@@ -530,7 +538,9 @@ class DBEth2:
                             withdrawal_request_events[v_index].remove(request_event)  # remove this request event so we don't match it again.  # noqa: E501
                             break
                     else:  # skimming withdrawal - doesn't change the effective balance, but is counted as profit  # noqa: E501
-                        withdrawals_pnl_over_time[v_index][event.timestamp] += event.amount
+                        if is_tracked:
+                            withdrawals_pnl_over_time[v_index][event.timestamp] += event.amount
+
                         continue
             elif (
                 event.event_type == HistoryEventType.INFORMATIONAL and

--- a/rotkehlchen/db/eth2.py
+++ b/rotkehlchen/db/eth2.py
@@ -265,6 +265,31 @@ class DBEth2:
                 f'that is not in the database',
             )
 
+    def invalidate_withdrawals_derived_data(self, address: ChecksumEvmAddress) -> None:
+        """Drop everything derived from whether the given address' withdrawals count as ours.
+
+        Withdrawals to an untracked address are filtered out of history, accounting and
+        validator performance at query time, but the data derived from them is stored, so
+        tracking or untracking the address has to drop it.
+
+        Called on every ethereum account modification, whether or not the eth2 module is
+        active, since what it invalidates is queried independently of the module and would
+        otherwise stay stale until the next time the account happened to change.
+        """
+        with self.db.user_write() as write_cursor:
+            write_cursor.execute(
+                'DELETE FROM eth_validators_data_cache WHERE validator_index IN ('
+                'SELECT S.validator_index FROM history_events H INNER JOIN '
+                'eth_staking_events_info S ON H.identifier=S.identifier '
+                'WHERE H.entry_type=? AND H.location_label=?)',
+                (HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT.serialize_for_db(), address),
+            )
+            DBHistoryEvents(self.db).mark_events_stale_by_query(
+                write_cursor=write_cursor,
+                query='SELECT timestamp FROM history_events WHERE entry_type=? AND location_label=?',  # noqa: E501
+                bindings=(HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT.serialize_for_db(), address),
+            )
+
     def delete_validators(self, validator_indices: list[int]) -> None:
         """Deletes the given validators from the DB. Due to marshmallow here at least one
         of the two arguments is not None.

--- a/rotkehlchen/db/filtering.py
+++ b/rotkehlchen/db/filtering.py
@@ -919,6 +919,26 @@ class HistoryEventStateMarkersJoinsFilter(DBFilter):
         return [query], bindings
 
 
+@dataclass(init=True, repr=True, eq=True, order=False, unsafe_hash=False, frozen=False)
+class DBUntrackedWithdrawalsFilter(DBFilter):
+    """Excludes eth withdrawal events whose withdrawal address is not a tracked ETH account.
+
+    The withdrawn ETH lands on ethereum mainnet, so an address we don't track there is not
+    ours and its withdrawals are neither income nor part of the portfolio. This is evaluated
+    against blockchain_accounts at query time so that tracking or untracking the address
+    later flips the events in and out of view without any stored state to keep in sync.
+    """
+
+    def prepare(self) -> tuple[list[str], list[Any]]:
+        return [
+            ('(entry_type!=? OR location_label IN '
+             '(SELECT account FROM blockchain_accounts WHERE blockchain=?))'),
+        ], [
+            HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT.serialize_for_db(),
+            SupportedBlockchain.ETHEREUM.value,
+        ]
+
+
 class HistoryBaseEntryFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWithLocation, ABC):
 
     @classmethod
@@ -944,6 +964,7 @@ class HistoryBaseEntryFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWith
             group_identifiers: list[str] | None = None,
             entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
+            exclude_untracked_withdrawals: bool = False,
             state_markers: list[HistoryMappingState] | None = None,
             notes_substring: str | None = None,
             min_amount: FVal | None = None,
@@ -1070,6 +1091,8 @@ class HistoryBaseEntryFilterQuery(DBFilterQuery, FilterWithTimestamp, FilterWith
                 column='ignored',
                 value=0,
             ))
+        if exclude_untracked_withdrawals is True:
+            filters.append(DBUntrackedWithdrawalsFilter(and_op=True))
         if identifiers is not None:
             filters.append(
                 DBMultiIntegerFilter(
@@ -1166,6 +1189,7 @@ class AssetMovementMatchFilterQuery(HistoryEventFilterQuery):
             group_identifiers: list[str] | None = None,
             entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
+            exclude_untracked_withdrawals: bool = False,
             state_markers: list[HistoryMappingState] | None = None,
             notes_substring: str | None = None,
             min_amount: FVal | None = None,
@@ -1202,6 +1226,7 @@ class AssetMovementMatchFilterQuery(HistoryEventFilterQuery):
                 operator='NOT IN',
             ),
             exclude_ignored_assets=exclude_ignored_assets,
+            exclude_untracked_withdrawals=exclude_untracked_withdrawals,
             state_markers=state_markers,
             notes_substring=notes_substring,
             min_amount=min_amount,
@@ -1240,6 +1265,7 @@ class HistoryEventWithTxRefFilterQuery(HistoryBaseEntryFilterQuery):
             group_identifiers: list[str] | None = None,
             entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
+            exclude_untracked_withdrawals: bool = False,
             state_markers: list[HistoryMappingState] | None = None,
             notes_substring: str | None = None,
             min_amount: FVal | None = None,
@@ -1277,6 +1303,7 @@ class HistoryEventWithTxRefFilterQuery(HistoryBaseEntryFilterQuery):
             group_identifiers=group_identifiers,
             entry_types=entry_types,
             exclude_ignored_assets=exclude_ignored_assets,
+            exclude_untracked_withdrawals=exclude_untracked_withdrawals,
             state_markers=state_markers,
             notes_substring=notes_substring,
             min_amount=min_amount,
@@ -1349,6 +1376,7 @@ class HistoryEventWithCounterpartyFilterQuery(HistoryEventWithTxRefFilterQuery):
             group_identifiers: list[str] | None = None,
             entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
+            exclude_untracked_withdrawals: bool = False,
             state_markers: list[HistoryMappingState] | None = None,
             notes_substring: str | None = None,
             min_amount: FVal | None = None,
@@ -1388,6 +1416,7 @@ class HistoryEventWithCounterpartyFilterQuery(HistoryEventWithTxRefFilterQuery):
             group_identifiers=group_identifiers,
             entry_types=entry_types,
             exclude_ignored_assets=exclude_ignored_assets,
+            exclude_untracked_withdrawals=exclude_untracked_withdrawals,
             state_markers=state_markers,
             notes_substring=notes_substring,
             min_amount=min_amount,
@@ -1443,6 +1472,7 @@ class SolanaEventFilterQuery(HistoryEventWithCounterpartyFilterQuery):
             group_identifiers: list[str] | None = None,
             entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
+            exclude_untracked_withdrawals: bool = False,
             state_markers: list[HistoryMappingState] | None = None,
             notes_substring: str | None = None,
             min_amount: FVal | None = None,
@@ -1478,6 +1508,7 @@ class SolanaEventFilterQuery(HistoryEventWithCounterpartyFilterQuery):
             group_identifiers=group_identifiers,
             entry_types=entry_types,
             exclude_ignored_assets=exclude_ignored_assets,
+            exclude_untracked_withdrawals=exclude_untracked_withdrawals,
             state_markers=state_markers,
             notes_substring=notes_substring,
             min_amount=min_amount,
@@ -1556,6 +1587,7 @@ class EvmEventFilterQuery(HistoryEventWithCounterpartyFilterQuery):
             group_identifiers: list[str] | None = None,
             entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
+            exclude_untracked_withdrawals: bool = False,
             state_markers: list[HistoryMappingState] | None = None,
             notes_substring: str | None = None,
             min_amount: FVal | None = None,
@@ -1589,6 +1621,7 @@ class EvmEventFilterQuery(HistoryEventWithCounterpartyFilterQuery):
             group_identifiers=group_identifiers,
             entry_types=entry_types,
             exclude_ignored_assets=exclude_ignored_assets,
+            exclude_untracked_withdrawals=exclude_untracked_withdrawals,
             state_markers=state_markers,
             notes_substring=notes_substring,
             min_amount=min_amount,
@@ -1677,6 +1710,7 @@ class EthStakingEventFilterQuery(HistoryBaseEntryFilterQuery, ABC):
             group_identifiers: list[str] | None = None,
             entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
+            exclude_untracked_withdrawals: bool = False,
             state_markers: list[HistoryMappingState] | None = None,
             notes_substring: str | None = None,
             min_amount: FVal | None = None,
@@ -1708,6 +1742,7 @@ class EthStakingEventFilterQuery(HistoryBaseEntryFilterQuery, ABC):
             group_identifiers=group_identifiers,
             entry_types=entry_types,
             exclude_ignored_assets=exclude_ignored_assets,
+            exclude_untracked_withdrawals=exclude_untracked_withdrawals,
             state_markers=state_markers,
             notes_substring=notes_substring,
             min_amount=min_amount,
@@ -1763,6 +1798,7 @@ class EthWithdrawalFilterQuery(EthStakingEventFilterQuery):
             group_identifiers: list[str] | None = None,
             entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
+            exclude_untracked_withdrawals: bool = False,
             state_markers: list[HistoryMappingState] | None = None,
             notes_substring: str | None = None,
             min_amount: FVal | None = None,
@@ -1795,6 +1831,7 @@ class EthWithdrawalFilterQuery(EthStakingEventFilterQuery):
             group_identifiers=group_identifiers,
             entry_types=entry_types,
             exclude_ignored_assets=exclude_ignored_assets,
+            exclude_untracked_withdrawals=exclude_untracked_withdrawals,
             state_markers=state_markers,
             notes_substring=notes_substring,
             min_amount=min_amount,
@@ -1839,6 +1876,7 @@ class EthDepositEventFilterQuery(EvmEventFilterQuery, EthStakingEventFilterQuery
             group_identifiers: list[str] | None = None,
             entry_types: IncludeExcludeFilterData | None = None,
             exclude_ignored_assets: bool = False,
+            exclude_untracked_withdrawals: bool = False,
             state_markers: list[HistoryMappingState] | None = None,
             tx_hashes: list[EVMTxHash] | None = None,
             validator_indices: list[int] | None = None,
@@ -1868,6 +1906,7 @@ class EthDepositEventFilterQuery(EvmEventFilterQuery, EthStakingEventFilterQuery
             group_identifiers=group_identifiers,
             entry_types=entry_types,
             exclude_ignored_assets=exclude_ignored_assets,
+            exclude_untracked_withdrawals=exclude_untracked_withdrawals,
             tx_hashes=tx_hashes,
             state_markers=state_markers,
         )

--- a/rotkehlchen/db/history_events.py
+++ b/rotkehlchen/db/history_events.py
@@ -258,6 +258,26 @@ class DBHistoryEvents:
             self._mark_events_modified(write_cursor=write_cursor, timestamp=min_ts)
         return count
 
+    def mark_events_stale_by_query(
+            self,
+            write_cursor: DBCursor,
+            query: str,
+            bindings: tuple,
+    ) -> int:
+        """Mark the historical balances stale from the earliest timestamp the given query
+        selects, without modifying any event.
+
+        This is for changes that alter how already stored events are interpreted (e.g. an
+        eth account being tracked or untracked flipping whether its validator withdrawals
+        count) rather than changing the events themselves.
+
+        The query must select a single timestamp column. Returns the number of rows it matched.
+        """
+        return self._execute_and_track_modified(
+            write_cursor=write_cursor,
+            result=write_cursor.execute(query, bindings),
+        )
+
     def delete_events_and_track(
             self,
             write_cursor: DBCursor,

--- a/rotkehlchen/history/events/structures/eth2.py
+++ b/rotkehlchen/history/events/structures/eth2.py
@@ -224,6 +224,15 @@ class EthWithdrawalEvent(EthStakingEvent):
             accounting: AccountingPot,
             events_iterator: Iterator[AccountingEventMixin],  # pylint: disable=unused-argument
     ) -> int:
+        if accounting.is_tracked_eth_account(self.location_label) is False:
+            log.debug(
+                'Skipping withdrawal event for accounting since its withdrawal address '
+                'is not a tracked ethereum account',
+                event=self,
+                withdrawal_address=self.location_label,
+            )
+            return 1
+
         if (validator_info := accounting.get_validator_with_status(self.validator_index)) is None:
             log.error(
                 f'Could not find validator {self.validator_index} in the DB while processing '

--- a/rotkehlchen/history/manager.py
+++ b/rotkehlchen/history/manager.py
@@ -248,6 +248,7 @@ class HistoryQueryingManager:
                     # We need to have history since before the range
                     from_ts=Timestamp(0),
                     to_ts=end_ts,
+                    exclude_untracked_withdrawals=True,
                 ),
                 aggregate_by_group_ids=False,
             )

--- a/rotkehlchen/tasks/historical_balances.py
+++ b/rotkehlchen/tasks/historical_balances.py
@@ -299,6 +299,7 @@ def process_historical_balances(
                 from_ts=ts_ms_to_sec(from_ts) if from_ts is not None else None,
                 order_by_rules=[('timestamp', True), ('sequence_index', True)],
                 exclude_ignored_assets=True,
+                exclude_untracked_withdrawals=True,
             ),
         )
         # Snapshot the modification timestamp after reading events. This allows us to

--- a/rotkehlchen/tests/api/test_eth2.py
+++ b/rotkehlchen/tests/api/test_eth2.py
@@ -26,6 +26,7 @@ from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import APIKeyNotAvailable, RemoteError
 from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.base import HistoryBaseEntryType
 from rotkehlchen.history.events.structures.eth2 import (
     EthBlockEvent,
     EthDepositEvent,
@@ -53,6 +54,7 @@ from rotkehlchen.tests.utils.factories import (
 from rotkehlchen.tests.utils.rotkehlchen import setup_balances
 from rotkehlchen.types import (
     ChainID,
+    ChecksumEvmAddress,
     Eth2PubKey,
     EvmTransaction,
     Location,
@@ -68,7 +70,6 @@ if TYPE_CHECKING:
 
     from rotkehlchen.api.server import APIServer
     from rotkehlchen.premium.premium import Premium
-    from rotkehlchen.types import ChecksumEvmAddress
 
 
 # Validators with clean short history and different withdrawal address where only they withdrew
@@ -1877,3 +1878,65 @@ def test_refetch_withdrawal_events(rotkehlchen_api_server: APIServer) -> None:
     # the new withdrawal should have been added, existing one skipped
     with db.conn.read_ctx() as cursor:
         assert cursor.execute('SELECT COUNT(*) FROM history_events').fetchone()[0] == 2
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b']])
+def test_history_hides_withdrawals_of_untracked_address(
+        rotkehlchen_api_server: APIServer,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Withdrawals to an address we don't track are still stored, since the validator's
+    balance history is reconstructed from them, but must not show up in the history. Once
+    the address is tracked they do, and untracking it hides them again."""
+    rotki = rotkehlchen_api_server.rest_api.rotkehlchen
+    untracked_address = string_to_evm_address('0xc37b40ABdB939635068d3c5f13E7faF686F03B65')
+    with rotki.data.db.user_write() as write_cursor:
+        DBHistoryEvents(rotki.data.db).add_history_events(write_cursor, [EthWithdrawalEvent(
+            validator_index=(v_tracked := 45555),
+            timestamp=TimestampMS(1666693607000),
+            amount=FVal('5'),
+            withdrawal_address=ethereum_accounts[0],
+            is_exit=False,
+        ), EthWithdrawalEvent(
+            validator_index=(v_untracked := 114543),
+            timestamp=TimestampMS(1666697207000),
+            amount=FVal('7'),
+            withdrawal_address=untracked_address,
+            is_exit=False,
+        )])
+
+    def query_validator_indices() -> set[int]:
+        result = assert_proper_response_with_result(
+            response=requests.post(
+                api_url_for(rotkehlchen_api_server, 'historyeventresource'),
+                json={'entry_types': {'values': ['eth withdrawal event']}},
+            ),
+            rotkehlchen_api_server=rotkehlchen_api_server,
+        )
+        assert result['entries_found'] == len(result['entries'])
+        return {entry['entry']['validator_index'] for entry in result['entries']}
+
+    assert query_validator_indices() == {v_tracked}
+    with rotki.data.db.conn.read_ctx() as cursor:  # but they are still in the DB
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM history_events WHERE entry_type=?',
+            (HistoryBaseEntryType.ETH_WITHDRAWAL_EVENT.serialize_for_db(),),
+        ).fetchone()[0] == 2
+
+    with rotki.data.db.user_write() as write_cursor:
+        rotki.data.db.add_blockchain_accounts(
+            write_cursor=write_cursor,
+            account_data=[BlockchainAccountData(
+                chain=SupportedBlockchain.ETHEREUM,
+                address=untracked_address,
+            )],
+        )
+    assert query_validator_indices() == {v_tracked, v_untracked}
+
+    with rotki.data.db.user_write() as write_cursor:  # and untracking hides them again
+        rotki.data.db.remove_single_blockchain_accounts(
+            write_cursor=write_cursor,
+            blockchain=SupportedBlockchain.ETHEREUM,
+            accounts=[untracked_address],
+        )
+    assert query_validator_indices() == {v_tracked}

--- a/rotkehlchen/tests/unit/accounting/test_settings.py
+++ b/rotkehlchen/tests/unit/accounting/test_settings.py
@@ -31,6 +31,7 @@ from rotkehlchen.tests.utils.history import prices
 from rotkehlchen.tests.utils.messages import no_message_errors
 from rotkehlchen.types import (
     AssetAmount,
+    ChecksumEvmAddress,
     Eth2PubKey,
     Location,
     Timestamp,
@@ -277,7 +278,12 @@ def test_not_calculate_past_cost_basis(accountant, expected, google_service):
 @pytest.mark.parametrize('default_mock_price_value', [ONE])
 @pytest.mark.parametrize('accountant_without_rules', [True])
 @pytest.mark.parametrize('staking_taxable', [True, False])
-def test_eth_withdrawal_not_taxable(accountant: Accountant, staking_taxable: bool) -> None:
+@pytest.mark.parametrize('ethereum_accounts', [[make_evm_address()]])
+def test_eth_withdrawal_not_taxable(
+        accountant: Accountant,
+        staking_taxable: bool,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
     """Test that eth withdrawal events respect the accounting rules"""
     db = DBAccountingRules(accountant.db)
     db.add_accounting_rule(
@@ -300,7 +306,7 @@ def test_eth_withdrawal_not_taxable(accountant: Accountant, staking_taxable: boo
             validator_index=1,
             timestamp=TimestampMS(1699319051000),
             amount=staking_reward,
-            withdrawal_address=make_evm_address(),
+            withdrawal_address=ethereum_accounts[0],
             is_exit=False,
         ),
     ]
@@ -329,9 +335,11 @@ def test_eth_withdrawal_not_taxable(accountant: Accountant, staking_taxable: boo
     ({'eth_staking_taxable_after_withdrawal_enabled': False}, False),
     ({'eth_staking_taxable_after_withdrawal_enabled': True}, True),
 ])
+@pytest.mark.parametrize('ethereum_accounts', [[make_evm_address()]])
 def test_eth_withdrawal_respects_db_settings(
         accountant: Accountant,
         is_staking_taxable: bool,
+        ethereum_accounts: list[ChecksumEvmAddress],
 ) -> None:
     """Test that eth withdrawal events respect the user settings regarding taxation"""
     staking_reward = FVal('0.017197')
@@ -350,7 +358,7 @@ def test_eth_withdrawal_respects_db_settings(
             validator_index=vindex1,
             timestamp=TimestampMS(1699319051000),
             amount=staking_reward,
-            withdrawal_address=make_evm_address(),
+            withdrawal_address=ethereum_accounts[0],
             is_exit=False,
         ),
     ]

--- a/rotkehlchen/tests/unit/accounting/test_staking.py
+++ b/rotkehlchen/tests/unit/accounting/test_staking.py
@@ -6,6 +6,7 @@ import pytest
 
 from rotkehlchen.accounting.mixins.event import AccountingEventType
 from rotkehlchen.accounting.pnl import PNL, PnlTotals
+from rotkehlchen.chain.accounts import BlockchainAccountData
 from rotkehlchen.chain.ethereum.constants import SHAPPELA_TIMESTAMP
 from rotkehlchen.chain.ethereum.modules.eth2.constants import CPT_ETH2, WITHDRAWAL_REQUEST_CONTRACT
 from rotkehlchen.chain.ethereum.modules.eth2.structures import (
@@ -30,7 +31,14 @@ from rotkehlchen.tests.utils.accounting import accounting_history_process, check
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
 from rotkehlchen.tests.utils.history import prices
 from rotkehlchen.tests.utils.messages import no_message_errors
-from rotkehlchen.types import ChecksumEvmAddress, Eth2PubKey, Location, Timestamp, TimestampMS
+from rotkehlchen.types import (
+    ChecksumEvmAddress,
+    Eth2PubKey,
+    Location,
+    SupportedBlockchain,
+    Timestamp,
+    TimestampMS,
+)
 from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now, ts_sec_to_ms
 
 if TYPE_CHECKING:
@@ -490,3 +498,66 @@ def test_accumulating_validator_exit_without_balance_history(
     # zero profit/loss amount, which records no taxable event.
     assert len(accountant.pots[0].processed_events) == 0
     assert accountant.pots[0].pnls.taxable == ZERO
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b']])
+@pytest.mark.parametrize('should_mock_price_queries', [True])
+@pytest.mark.parametrize('default_mock_price_value', [FVal(3000)])  # ETH price at $3000
+@pytest.mark.parametrize('db_settings', [{
+    'eth_staking_taxable_after_withdrawal_enabled': True,
+}])
+def test_eth_withdrawal_to_untracked_address(
+        accountant: Accountant,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Withdrawals landing on an address we don't track are not the user's income, so they
+    must be skipped by accounting. Tracking that address later makes them count again."""
+    untracked_address = string_to_evm_address('0xc37b40ABdB939635068d3c5f13E7faF686F03B65')
+    events = [EthWithdrawalEvent(
+        validator_index=(v_tracked := 1001),
+        timestamp=TimestampMS(1689000000000),
+        amount=FVal(2),
+        withdrawal_address=ethereum_accounts[0],
+        is_exit=False,
+    ), EthWithdrawalEvent(
+        validator_index=(v_untracked := 1002),
+        timestamp=TimestampMS(1689000001000),
+        amount=FVal(3),
+        withdrawal_address=untracked_address,
+        is_exit=False,
+    )]
+    with accountant.db.conn.write_ctx() as write_cursor:
+        DBEth2(accountant.db).add_or_update_validators(write_cursor, [ValidatorDetails(
+            validator_index=v_tracked,
+            public_key=Eth2PubKey('0xadf4b7a39b4e56a5f5a9e06550a8b9a3251c4a8d8b7c5c9e5d8e9f0a1b2c3d4'),
+            validator_type=ValidatorType.DISTRIBUTING,
+            withdrawal_address=ethereum_accounts[0],
+        ), ValidatorDetails(
+            validator_index=v_untracked,
+            public_key=Eth2PubKey('0xbeeff7a39b4e56a5f5a9e06550a8b9a3251c4a8d8b7c5c9e5d8e9f0a1b2c3d4'),
+            validator_type=ValidatorType.DISTRIBUTING,
+            withdrawal_address=untracked_address,
+        )])
+        DBHistoryEvents(accountant.db).add_history_events(write_cursor, events)
+
+    accountant.process_history(start_ts=Timestamp(0), end_ts=ts_now(), events=events)
+    assert [
+        (x.notes, x.pnl.taxable) for x in accountant.pots[0].processed_events
+    ] == [(f'Withdrawal of 2 ETH from validator {v_tracked}', FVal(2) * 3000)]
+
+    with accountant.db.user_write() as write_cursor:  # now track the withdrawal address
+        accountant.db.add_blockchain_accounts(
+            write_cursor=write_cursor,
+            account_data=[BlockchainAccountData(
+                chain=SupportedBlockchain.ETHEREUM,
+                address=untracked_address,
+            )],
+        )
+
+    accountant.process_history(start_ts=Timestamp(0), end_ts=ts_now(), events=events)
+    assert [
+        (x.notes, x.pnl.taxable) for x in accountant.pots[0].processed_events
+    ] == [
+        (f'Withdrawal of 2 ETH from validator {v_tracked}', FVal(2) * 3000),
+        (f'Withdrawal of 3 ETH from validator {v_untracked}', FVal(3) * 3000),
+    ]

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -1063,11 +1063,12 @@ def test_clean_cache_on_account_removal(
         ) is None
 
 
+@pytest.mark.parametrize('ethereum_accounts', [[make_evm_address()]])
 @pytest.mark.parametrize('eth2_mock_data', [{
     'validator': [{'data_can_be_anything_here': 'with length of list being 1 (validator)'}],
 
 }])
-def test_staking_performance_division_by_zero_protection(eth2) -> None:
+def test_staking_performance_division_by_zero_protection(eth2, ethereum_accounts) -> None:
     """Test that division by zero is prevented when time_weighted_avg is zero in APR calculation"""
     dbevents, dbeth2 = DBHistoryEvents(eth2.database), DBEth2(eth2.database)
     with eth2.database.conn.write_ctx() as write_cursor:
@@ -1077,7 +1078,7 @@ def test_staking_performance_division_by_zero_protection(eth2) -> None:
                 activation_timestamp=Timestamp(ETH2_GENESIS_TIMESTAMP),
                 validator_index=(v_index := 999999),
                 public_key=Eth2PubKey('0xb912072ccf65435991175736cd73bcb4b2852a993f7d00c4bf3abab5fcfacbd72b37114320a60d9894eaced1ddee1cae'),
-                withdrawal_address=make_evm_address(),
+                withdrawal_address=ethereum_accounts[0],
                 status=ValidatorStatus.ACTIVE,
                 validator_type=ValidatorType.DISTRIBUTING,
             ))],
@@ -1091,7 +1092,7 @@ def test_staking_performance_division_by_zero_protection(eth2) -> None:
                 validator_index=v_index,
                 timestamp=TimestampMS(1631379127000),
                 amount=ONE,
-                withdrawal_address=make_evm_address(),
+                withdrawal_address=ethereum_accounts[0],
                 is_exit=False,
             )],
         )
@@ -1329,3 +1330,144 @@ def test_beacon_node_bad_version_response_raises_remote_error():
             pytest.raises(RemoteError),
         ):
             BeaconNode(rpc_endpoint='http://localhost:6969')
+
+
+@pytest.mark.parametrize('ethereum_accounts', [['0x0fdAe061cAE1Ad4Af83b27A96ba5496ca992139b']])
+@pytest.mark.parametrize('eth2_mock_data', [{
+    'validator': [
+        {'data_can_be_anything_here': 'with length of list being 2 (validators)'},
+        {'thatswhy': 'wehavetwo. Normally these should have been validator data response'},
+    ],
+}])
+def test_validator_performance_ignores_untracked_withdrawal_address(
+        eth2: Eth2,
+        database: DBHandler,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Withdrawals to an address we don't track are not ours, so they must not show up as
+    validator pnl. Tracking the address afterwards has to invalidate the caches built on
+    top of them so the pnl appears."""
+    dbeth2, dbevents = DBEth2(database), DBHistoryEvents(database)
+    untracked_address = string_to_evm_address('0xc37b40ABdB939635068d3c5f13E7faF686F03B65')
+    with database.user_write() as write_cursor:
+        dbeth2.add_or_update_validators(write_cursor, validators=[ValidatorDetails(
+            validator_index=(v_tracked := 45555),
+            validator_type=ValidatorType.DISTRIBUTING,
+            public_key=Eth2PubKey('0xadd9843b2eb53ccaf5afb52abcc0a13223088320656fdfb162360ca53a71ebf8775dbebd0f1f1bf6c3e823d4bf2815f7'),
+            withdrawal_address=ethereum_accounts[0],
+        ), ValidatorDetails(
+            validator_index=(v_untracked := 114543),
+            validator_type=ValidatorType.DISTRIBUTING,
+            public_key=Eth2PubKey('0xa41a0224e73270cee8e06a9984aa2cd902a20e66c8bb528caae602a7caf76c417d0bdf2ab3b6e50a579fa7d98c6d240c'),
+            withdrawal_address=untracked_address,
+        )])
+        dbevents.add_history_events(write_cursor, [EthWithdrawalEvent(
+            validator_index=v_tracked,
+            timestamp=(timestampms := TimestampMS(1666693607000)),
+            amount=(withdrawal_tracked := FVal('5')),
+            withdrawal_address=ethereum_accounts[0],
+            is_exit=False,
+        ), EthWithdrawalEvent(
+            validator_index=v_untracked,
+            timestamp=TimestampMS(timestampms + (HOUR_IN_SECONDS * 1000)),
+            amount=(withdrawal_untracked := FVal('7')),
+            withdrawal_address=untracked_address,
+            is_exit=False,
+        )])
+
+    performance = eth2.get_performance(from_ts=Timestamp(0), to_ts=Timestamp(1706866836), limit=10, offset=0, ignore_cache=False)  # noqa: E501
+    assert performance['sums']['withdrawals'] == withdrawal_tracked
+    assert performance['validators'][v_tracked]['withdrawals'] == withdrawal_tracked
+    assert v_untracked not in performance['validators']
+
+    with database.user_write() as write_cursor:  # now track the withdrawal address
+        database.add_blockchain_accounts(
+            write_cursor=write_cursor,
+            account_data=[BlockchainAccountData(
+                chain=SupportedBlockchain.ETHEREUM,
+                address=untracked_address,
+            )],
+        )
+    with patch.object(eth2, 'detect_and_refresh_validators'):  # avoid the remote query
+        eth2.on_account_addition(untracked_address)
+
+    performance = eth2.get_performance(from_ts=Timestamp(0), to_ts=Timestamp(1706866836), limit=10, offset=0, ignore_cache=False)  # noqa: E501
+    assert performance['sums']['withdrawals'] == withdrawal_tracked + withdrawal_untracked
+    assert performance['validators'][v_untracked]['withdrawals'] == withdrawal_untracked
+
+
+@pytest.mark.parametrize('start_with_valid_premium', [True])
+@pytest.mark.parametrize('ethereum_accounts', [[make_evm_address()]])
+def test_accumulating_validator_pnl_ignores_untracked_withdrawal_address(
+        eth2: Eth2,
+        database: DBHandler,
+        ethereum_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """For accumulating validators the withdrawal events are still needed to reconstruct the
+    balance over time, so they are processed but must contribute no pnl while the withdrawal
+    address is untracked. Tracking it has to drop the cached pnl and give the same numbers as
+    if it had been tracked all along."""
+    untracked_address = string_to_evm_address('0xc37b40ABdB939635068d3c5f13E7faF686F03B65')
+    validator = ValidatorDetails(
+        validator_index=(v_index := 123456),
+        validator_type=ValidatorType.ACCUMULATING,
+        public_key=Eth2PubKey('0xb016e31f633a21fbe42a015152399361184f1e2c0803d89823c224994af74a561c4ad8cfc94b18781d589d03e952cd5b'),
+        withdrawal_address=untracked_address,
+    )
+    events = [EthDepositEvent(
+        tx_ref=make_evm_tx_hash(),
+        validator_index=v_index,
+        sequence_index=0,
+        timestamp=(start_ts := TimestampMS(1700000000000)),
+        amount=MIN_EFFECTIVE_BALANCE,
+        depositor=ethereum_accounts[0],
+    ), EthWithdrawalEvent(  # skimming withdrawal
+        validator_index=v_index,
+        timestamp=TimestampMS(start_ts + 24 * HOUR_IN_MILLISECONDS),
+        amount=FVal('2'),
+        withdrawal_address=untracked_address,
+        is_exit=False,
+    ), EthWithdrawalEvent(  # exit withdrawal
+        validator_index=v_index,
+        timestamp=TimestampMS(start_ts + 72 * HOUR_IN_MILLISECONDS),
+        amount=FVal('34'),
+        withdrawal_address=untracked_address,
+        is_exit=True,
+    )]
+    with database.user_write() as write_cursor:
+        DBEth2(database).add_or_update_validators(write_cursor, [validator])
+        DBHistoryEvents(database).add_history_events(write_cursor, events)
+
+    def query_performance() -> dict:
+        with (
+            patch('rotkehlchen.chain.ethereum.modules.eth2.beacon.BeaconInquirer.get_validator_data', return_value=[validator]),  # noqa: E501
+            patch('rotkehlchen.chain.ethereum.modules.eth2.eth2.Eth2._check_eth_staking_limit'),
+        ):
+            return eth2.get_performance(
+                from_ts=ts_ms_to_sec(start_ts),
+                to_ts=ts_ms_to_sec(TimestampMS(start_ts + 100 * HOUR_IN_MILLISECONDS)),
+                limit=10,
+                offset=0,
+                ignore_cache=True,
+            )
+
+    assert v_index not in query_performance()['validators']  # nothing is ours yet
+
+    with database.user_write() as write_cursor:  # now track the withdrawal address
+        database.add_blockchain_accounts(
+            write_cursor=write_cursor,
+            account_data=[BlockchainAccountData(
+                chain=SupportedBlockchain.ETHEREUM,
+                address=untracked_address,
+            )],
+        )
+    with patch.object(eth2, 'detect_and_refresh_validators'):  # avoid the remote query
+        eth2.on_account_addition(untracked_address)
+
+    validator_performance = query_performance()['validators'][v_index]
+    assert validator_performance['withdrawals'] == FVal('2')  # the skimming withdrawal
+    # the exit adds nothing on top, its 2 ETH of profit is already in the withdrawals. This
+    # only comes out right if the balance over time was reconstructed from the withdrawals
+    # that were skipped for pnl above.
+    assert validator_performance.get('exits', ZERO) == ZERO
+    assert validator_performance['sum'] == FVal('2')

--- a/rotkehlchen/tests/unit/test_eth2.py
+++ b/rotkehlchen/tests/unit/test_eth2.py
@@ -1,3 +1,4 @@
+import os
 from typing import TYPE_CHECKING, Final
 from unittest.mock import patch
 
@@ -25,13 +26,14 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.constants.timing import HOUR_IN_SECONDS
-from rotkehlchen.db.cache import DBCacheDynamic
+from rotkehlchen.db.cache import DBCacheDynamic, DBCacheStatic
 from rotkehlchen.db.eth2 import DBEth2
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import HistoryEventFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.externalapis.beaconchain.service import BeaconChainQueryResponse
+from rotkehlchen.feature_flags import ROTKI_ACCOUNTING_UPDATE
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.eth2 import (
     EthBlockEvent,
@@ -58,6 +60,7 @@ from rotkehlchen.types import (
 from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now, ts_sec_to_ms
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.aggregator import ChainsAggregator
     from rotkehlchen.chain.ethereum.modules.eth2.eth2 import Eth2
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.history.events.structures.base import HistoryBaseEntry
@@ -1389,7 +1392,9 @@ def test_validator_performance_ignores_untracked_withdrawal_address(
             )],
         )
     with patch.object(eth2, 'detect_and_refresh_validators'):  # avoid the remote query
-        eth2.on_account_addition(untracked_address)
+        eth2.on_account_addition(untracked_address)  # drops the in-memory performance cache
+    # and this is what the chains aggregator does on any ethereum account modification
+    DBEth2(database).invalidate_withdrawals_derived_data(untracked_address)
 
     performance = eth2.get_performance(from_ts=Timestamp(0), to_ts=Timestamp(1706866836), limit=10, offset=0, ignore_cache=False)  # noqa: E501
     assert performance['sums']['withdrawals'] == withdrawal_tracked + withdrawal_untracked
@@ -1462,7 +1467,9 @@ def test_accumulating_validator_pnl_ignores_untracked_withdrawal_address(
             )],
         )
     with patch.object(eth2, 'detect_and_refresh_validators'):  # avoid the remote query
-        eth2.on_account_addition(untracked_address)
+        eth2.on_account_addition(untracked_address)  # drops the in-memory performance cache
+    # and this is what the chains aggregator does on any ethereum account modification
+    DBEth2(database).invalidate_withdrawals_derived_data(untracked_address)
 
     validator_performance = query_performance()['validators'][v_index]
     assert validator_performance['withdrawals'] == FVal('2')  # the skimming withdrawal
@@ -1471,3 +1478,58 @@ def test_accumulating_validator_pnl_ignores_untracked_withdrawal_address(
     # that were skipped for pnl above.
     assert validator_performance.get('exits', ZERO) == ZERO
     assert validator_performance['sum'] == FVal('2')
+
+
+@pytest.mark.parametrize('ethereum_modules', [[]])  # eth2 module deactivated
+@pytest.mark.parametrize('ethereum_accounts', [[]])
+def test_withdrawals_derived_data_invalidated_without_eth2_module(
+        blockchain: ChainsAggregator,
+        database: DBHandler,
+) -> None:
+    """Tracking an eth account flips whether its validator withdrawals count as ours, so the
+    data derived from them has to be dropped. That has to happen even while the eth2 module
+    is deactivated, since the derived data is queried independently of the module and nothing
+    revisits it when the module is activated again."""
+    assert blockchain.get_module('eth2') is None
+    with database.user_write() as write_cursor:
+        DBEth2(database).add_or_update_validators(write_cursor, validators=[ValidatorDetails(
+            validator_index=(v_index := 114543),
+            validator_type=ValidatorType.ACCUMULATING,
+            public_key=Eth2PubKey('0xa41a0224e73270cee8e06a9984aa2cd902a20e66c8bb528caae602a7caf76c417d0bdf2ab3b6e50a579fa7d98c6d240c'),
+            withdrawal_address=(address := make_evm_address()),
+        )])
+        DBHistoryEvents(database).add_history_events(write_cursor, [EthWithdrawalEvent(
+            validator_index=v_index,
+            timestamp=(timestamp := TimestampMS(1666693607000)),
+            amount=FVal('5'),
+            withdrawal_address=address,
+            is_exit=False,
+        )])
+        write_cursor.execute(  # the pnl/balance data derived from that withdrawal
+            'INSERT INTO eth_validators_data_cache(validator_index, timestamp, balance, '
+            'withdrawals_pnl, exit_pnl) VALUES(?, ?, ?, ?, ?)',
+            (v_index, timestamp, '32', '5', '0'),
+        )
+        write_cursor.execute(  # and pretend the historical balances are up to date
+            'DELETE FROM key_value_cache WHERE name=?',
+            (DBCacheStatic.STALE_BALANCES_FROM_TS.value,),
+        )
+
+    with (
+        patch.dict(os.environ, {ROTKI_ACCOUNTING_UPDATE: 'True'}),  # so the stale marking runs
+        patch.object(blockchain.ethereum.node_inquirer.proxies_inquirer, 'query_address_for_proxies'),  # noqa: E501
+        database.user_write() as write_cursor,
+    ):
+        blockchain.modify_blockchain_accounts(
+            write_cursor=write_cursor,
+            blockchain=SupportedBlockchain.ETHEREUM,
+            accounts=[address],
+            append_or_remove='append',
+        )
+
+    with database.conn.read_ctx() as cursor:
+        assert cursor.execute('SELECT COUNT(*) FROM eth_validators_data_cache').fetchone()[0] == 0
+        assert int(cursor.execute(
+            'SELECT value FROM key_value_cache WHERE name=?',
+            (DBCacheStatic.STALE_BALANCES_FROM_TS.value,),
+        ).fetchone()[0]) == timestamp

--- a/rotkehlchen/tests/utils/history_base_entry.py
+++ b/rotkehlchen/tests/utils/history_base_entry.py
@@ -27,7 +27,12 @@ from rotkehlchen.history.events.structures.eth2 import (
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.swap import SwapEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
-from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
+from rotkehlchen.types import (
+    Location,
+    SupportedBlockchain,
+    TimestampMS,
+    deserialize_evm_tx_hash,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -274,6 +279,13 @@ def add_entries(events_db: DBHistoryEvents) -> list[HistoryBaseEntry]:
     """Add history events to the database"""
     entries = predefined_events_to_insert()
     with events_db.db.conn.write_ctx() as write_cursor:
+        write_cursor.executemany(  # withdrawals of an untracked address are hidden everywhere
+            'INSERT OR IGNORE INTO blockchain_accounts(blockchain, account) VALUES(?, ?)',
+            [
+                (SupportedBlockchain.ETHEREUM.value, entry.location_label)
+                for entry in entries if isinstance(entry, EthWithdrawalEvent)
+            ],
+        )
         for entry in entries:
             identifier = events_db.add_history_event(
                 write_cursor=write_cursor,


### PR DESCRIPTION
Validator withdrawals were queried and saved for any validator in the DB, with nothing checking whether the withdrawal address was tracked. They then showed up in history, counted as staking income in the PnL report and built historical balance buckets for an address the user does not control.

Exclude them at query time instead of at save time: the events are still needed to reconstruct a validator's balance over time and detect its exit. A new filter matches an eth withdrawal event's location_label against the tracked ethereum mainnet accounts, and is opted into by the history events API, the PnL report, historical balances and the validator performance sums. Being evaluated against blockchain_accounts on every query means tracking or untracking the address flips the events in and out with no stored state to keep in sync.

For accumulating validators the withdrawals still have to be processed to follow the balance, so there the ownership check guards only the pnl accumulation. Adding or removing an eth account drops the derived caches that depend on it: the performance cache, eth_validators_data_cache and the historical balance buckets.

Closes #13034
