### PR TITLE
Data issues remediation task

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2713,9 +2713,12 @@
     },
     "detail": {
       "detected": "Detected",
-      "no_attempts": "No automatic fixes have been attempted yet.",
+      "no_attempts": "No automatic checks or fixes have been attempted yet.",
+      "redecoding_failed": "rotki could not compare the customized transactions with the current decoder. Your saved events were left unchanged.",
+      "redecoding_would_change_balance": "Re-decoding would change this balance. Review the customized events and restore decoder defaults where appropriate. Your saved events were left unchanged.",
+      "redecoding_would_not_change_balance": "Re-decoding the customized transactions affecting this balance would not change it. Your saved events were left unchanged.",
       "related_event": "Related history event: #{id}",
-      "remediation_history": "Auto-remediation history",
+      "remediation_history": "Automatic checks and fixes",
       "resolution_note": "Resolution note",
       "title": "Issue details",
       "whats_wrong": "What's wrong"

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueRemediationTimeline.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueRemediationTimeline.spec.ts
@@ -1,0 +1,33 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import DataIssueRemediationTimeline from '@/modules/history/data-issues/components/DataIssueRemediationTimeline.vue';
+
+describe('dataIssueRemediationTimeline', () => {
+  it('should explain when current decoding would change customized transactions', () => {
+    const wrapper = shallowMount(DataIssueRemediationTimeline, {
+      props: {
+        items: [{
+          changedTransactionCount: 1,
+          customizedTransactionCount: 2,
+          result: 'redecoding_would_change_balance',
+          strategy: 'redecode_customized_transactions',
+        }],
+      },
+    });
+
+    expect(wrapper.text()).toContain('data_issues.detail.redecoding_would_change_balance');
+  });
+
+  it('should explain that a failed comparison left saved events unchanged', () => {
+    const wrapper = shallowMount(DataIssueRemediationTimeline, {
+      props: {
+        items: [{
+          result: 'redecoding_failed',
+          strategy: 'redecode_customized_transactions',
+        }],
+      },
+    });
+
+    expect(wrapper.text()).toContain('data_issues.detail.redecoding_failed');
+  });
+});

--- a/frontend/app/src/modules/history/data-issues/components/DataIssueRemediationTimeline.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssueRemediationTimeline.vue
@@ -8,6 +8,23 @@ const { items } = defineProps<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
+
+function isFailure(item: RemediationTimelineItem): boolean {
+  return item.success === false || item.result === 'redecoding_failed';
+}
+
+function getResultText(item: RemediationTimelineItem): string | undefined {
+  switch (item.result) {
+    case 'redecoding_failed':
+      return t('data_issues.detail.redecoding_failed');
+    case 'redecoding_would_change_balance':
+      return t('data_issues.detail.redecoding_would_change_balance');
+    case 'redecoding_would_not_change_balance':
+      return t('data_issues.detail.redecoding_would_not_change_balance');
+    default:
+      return undefined;
+  }
+}
 </script>
 
 <template>
@@ -30,11 +47,17 @@ const { t } = useI18n({ useScope: 'global' });
         <RuiIcon
           class="mt-0.5"
           size="18"
-          :name="item.success === false ? 'lu-circle-x' : item.success ? 'lu-circle-check' : 'lu-circle-dot'"
-          :color="item.success === false ? 'error' : item.success ? 'success' : 'secondary'"
+          :name="isFailure(item) ? 'lu-circle-x' : item.success ? 'lu-circle-check' : 'lu-circle-dot'"
+          :color="isFailure(item) ? 'error' : item.success ? 'success' : 'secondary'"
         />
         <div class="flex flex-col">
           <span class="text-body-2 font-medium">{{ humanizeStrategy(item.strategy) }}</span>
+          <span
+            v-if="getResultText(item)"
+            class="text-body-2 text-rui-text-secondary"
+          >
+            {{ getResultText(item) }}
+          </span>
           <span
             v-if="item.attribution"
             class="text-caption text-rui-text-secondary"

--- a/frontend/app/src/modules/history/data-issues/schemas.ts
+++ b/frontend/app/src/modules/history/data-issues/schemas.ts
@@ -9,10 +9,18 @@ import { IssueKind, IssueSeverity, IssueState } from '@/modules/history/data-iss
  * schema stays permissive (extra keys are preserved, rendered when present).
  */
 export const AutoRemediationAttempt = z.looseObject({
+  attribution: z.string().optional(),
+  changedTransactionCount: z.number().optional(),
+  customizedTransactionCount: z.number().optional(),
+  reason: z.string().optional(),
+  result: z.enum([
+    'redecoding_failed',
+    'redecoding_would_change_balance',
+    'redecoding_would_not_change_balance',
+  ]).optional(),
   strategy: z.string(),
   success: z.boolean().optional(),
   timestamp: z.number().optional(),
-  attribution: z.string().optional(),
 });
 
 export type AutoRemediationAttempt = z.infer<typeof AutoRemediationAttempt>;

--- a/frontend/app/src/modules/history/data-issues/transforms.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.spec.ts
@@ -241,7 +241,14 @@ describe('data-issues transforms', () => {
     it('should order attempts oldest-first by timestamp', () => {
       const issue = createIssue({
         autoRemediationAttempts: [
-          { strategy: 'second', success: true, timestamp: 200 },
+          {
+            changedTransactionCount: 1,
+            customizedTransactionCount: 2,
+            result: 'redecoding_would_change_balance',
+            strategy: 'second',
+            success: true,
+            timestamp: 200,
+          },
           { strategy: 'first', success: false, timestamp: 100 },
         ],
       });
@@ -249,6 +256,11 @@ describe('data-issues transforms', () => {
       const items = toTimelineItems(issue);
 
       expect(items.map(item => item.strategy)).toEqual(['first', 'second']);
+      expect(items[1]).toMatchObject({
+        changedTransactionCount: 1,
+        customizedTransactionCount: 2,
+        result: 'redecoding_would_change_balance',
+      });
     });
 
     it('should return an empty array when there are no attempts', () => {

--- a/frontend/app/src/modules/history/data-issues/transforms.ts
+++ b/frontend/app/src/modules/history/data-issues/transforms.ts
@@ -186,6 +186,9 @@ export function relatedEventRoute(
 function toTimelineItem(attempt: AutoRemediationAttempt): RemediationTimelineItem {
   return {
     attribution: attempt.attribution,
+    changedTransactionCount: attempt.changedTransactionCount,
+    customizedTransactionCount: attempt.customizedTransactionCount,
+    result: attempt.result,
     strategy: attempt.strategy,
     success: attempt.success,
     timestamp: attempt.timestamp,

--- a/frontend/app/src/modules/history/data-issues/types.ts
+++ b/frontend/app/src/modules/history/data-issues/types.ts
@@ -16,10 +16,16 @@ export type DataIssueError =
 
 /** One entry in the auto-remediation timeline shown in the detail drawer. */
 export interface RemediationTimelineItem {
+  readonly attribution?: string;
+  readonly changedTransactionCount?: number;
+  readonly customizedTransactionCount?: number;
+  readonly result?:
+    | 'redecoding_failed'
+    | 'redecoding_would_change_balance'
+    | 'redecoding_would_not_change_balance';
   readonly strategy: string;
   readonly success?: boolean;
   readonly timestamp?: number;
-  readonly attribution?: string;
 }
 
 /**

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3872,8 +3872,8 @@ class RestAPI:
         """Trigger the specified async task."""
         if task == TaskName.HISTORICAL_BALANCE_PROCESSING:
             return self._trigger_historical_balance_processing()
-        elif __debug__ and task == TaskName.DATA_ISSUE_REMEDIATION:
-            if is_accounting_update_enabled() is False:
+        elif task == TaskName.DATA_ISSUE_REMEDIATION:
+            if not __debug__ or is_accounting_update_enabled() is False:
                 return wrap_in_fail_result(
                     message='Data issue remediation is disabled',
                     status_code=HTTPStatus.NOT_FOUND,

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3867,11 +3867,26 @@ class RestAPI:
             task_manager.trigger_historical_balance_processing()
         return OK_RESULT
 
+    @accounting_update_required('Data issue remediation is disabled')
+    def _trigger_data_issue_remediation(self) -> dict[str, Any]:
+        if (
+            (task_manager := self.rotkehlchen.task_manager) is None or
+            task_manager._maybe_run_data_issue_remediation(force=True) is None
+        ):
+            return wrap_in_fail_result(
+                message='Data issue remediation cannot start before historical balance processing '
+                'completes or while history work is running.',
+                status_code=HTTPStatus.CONFLICT,
+            )
+        return OK_RESULT
+
     @async_api_call()
     def trigger_task(self, task: TaskName) -> dict[str, Any]:
         """Trigger the specified async task."""
         if task == TaskName.HISTORICAL_BALANCE_PROCESSING:
             return self._trigger_historical_balance_processing()
+        elif __debug__ and task == TaskName.DATA_ISSUE_REMEDIATION:
+            return self._trigger_data_issue_remediation()
 
         else:  # task in (TaskName.ASSET_MOVEMENT_MATCHING, TaskName.BRIDGE_MATCHING)
             if has_premium_capability(

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3880,7 +3880,7 @@ class RestAPI:
                 )
             if (
                 (task_manager := self.rotkehlchen.task_manager) is None or
-                task_manager._maybe_run_data_issue_remediation(force=True) is None
+                task_manager.trigger_data_issue_remediation() is False
             ):
                 return wrap_in_fail_result(
                     message='Data issue remediation cannot start before historical balance '

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -3867,27 +3867,26 @@ class RestAPI:
             task_manager.trigger_historical_balance_processing()
         return OK_RESULT
 
-    @accounting_update_required('Data issue remediation is disabled')
-    def _trigger_data_issue_remediation(self) -> dict[str, Any]:
-        if (
-            (task_manager := self.rotkehlchen.task_manager) is None or
-            task_manager._maybe_run_data_issue_remediation(force=True) is None
-        ):
-            return wrap_in_fail_result(
-                message='Data issue remediation cannot start before historical balance processing '
-                'completes or while history work is running.',
-                status_code=HTTPStatus.CONFLICT,
-            )
-        return OK_RESULT
-
     @async_api_call()
     def trigger_task(self, task: TaskName) -> dict[str, Any]:
         """Trigger the specified async task."""
         if task == TaskName.HISTORICAL_BALANCE_PROCESSING:
             return self._trigger_historical_balance_processing()
         elif __debug__ and task == TaskName.DATA_ISSUE_REMEDIATION:
-            return self._trigger_data_issue_remediation()
-
+            if is_accounting_update_enabled() is False:
+                return wrap_in_fail_result(
+                    message='Data issue remediation is disabled',
+                    status_code=HTTPStatus.NOT_FOUND,
+                )
+            if (
+                (task_manager := self.rotkehlchen.task_manager) is None or
+                task_manager._maybe_run_data_issue_remediation(force=True) is None
+            ):
+                return wrap_in_fail_result(
+                    message='Data issue remediation cannot start before historical balance '
+                    'processing completes or while history work is running.',
+                    status_code=HTTPStatus.CONFLICT,
+                )
         else:  # task in (TaskName.ASSET_MOVEMENT_MATCHING, TaskName.BRIDGE_MATCHING)
             if has_premium_capability(
                     premium=self.rotkehlchen.premium,

--- a/rotkehlchen/api/v1/types.py
+++ b/rotkehlchen/api/v1/types.py
@@ -35,3 +35,5 @@ class TaskName(SerializableEnumNameMixin):
     HISTORICAL_BALANCE_PROCESSING = auto()
     ASSET_MOVEMENT_MATCHING = auto()
     BRIDGE_MATCHING = auto()
+    if __debug__:
+        DATA_ISSUE_REMEDIATION = auto()

--- a/rotkehlchen/api/v1/types.py
+++ b/rotkehlchen/api/v1/types.py
@@ -35,5 +35,4 @@ class TaskName(SerializableEnumNameMixin):
     HISTORICAL_BALANCE_PROCESSING = auto()
     ASSET_MOVEMENT_MATCHING = auto()
     BRIDGE_MATCHING = auto()
-    if __debug__:
-        DATA_ISSUE_REMEDIATION = auto()
+    DATA_ISSUE_REMEDIATION = auto()

--- a/rotkehlchen/chain/decoding/utils.py
+++ b/rotkehlchen/chain/decoding/utils.py
@@ -80,6 +80,7 @@ def decode_safely(
         func: Callable,
         tx_reference: str | None = None,
         *args: tuple[Any],
+        raise_on_error: bool = False,
         **kwargs: Any,
 ) -> tuple[Any, bool]:
     """
@@ -91,10 +92,14 @@ def decode_safely(
 
     It returns a tuple where the first argument is the output of func and the second is a boolean
     set to True if an error was raised from func.
+
+    With raise_on_error, errors propagate instead of returning incomplete results.
     """
     try:
         return func(*args, **kwargs), False
     except handled_exceptions as e:
+        if raise_on_error:
+            raise
         log.error(traceback.format_exc())
         error_prefix = (
             f'Decoding of transaction {tx_reference} in {blockchain}'

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from rotkehlchen.assets.asset import EvmToken
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.ethereum.transactions import EthereumTransactions
-    from rotkehlchen.chain.evm.structures import EvmTxReceipt, EvmTxReceiptLog
+    from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.externalapis.beaconchain.service import BeaconChain
     from rotkehlchen.externalapis.monerium import Monerium
@@ -309,24 +309,18 @@ class EthereumTransactionDecoder(EVMTransactionDecoderWithDSProxy):
                 extra_data={'tx_hashes': [transaction.tx_hash.hex()]},
             ))
 
-    def _decode_transaction(
+    def _post_decode_transaction(
             self,
             transaction: EvmTransaction,
-            tx_receipt: EvmTxReceipt,
+            decoded_events: list[EvmEvent],
             write_buffer: list[tuple[list[EvmEvent], str, int]] | None = None,
-    ) -> tuple[list[EvmEvent], bool, set[str] | None]:
-        """Decode an Ethereum transaction and run produced-block fallback enrichment."""
-        decoded_events, refresh_balances, reload_decoders = super()._decode_transaction(
-            transaction=transaction,
-            tx_receipt=tx_receipt,
-            write_buffer=write_buffer,
-        )
+    ) -> None:
+        """Persist produced-block fallback rewards after fresh transaction decoding."""
         self._maybe_create_produced_block_event_from_eth_receive(
             transaction=transaction,
             decoded_events=decoded_events,
             write_buffer=write_buffer,
         )
-        return decoded_events, refresh_balances, reload_decoders
 
     def _maybe_enrich_transfers(
             self,

--- a/rotkehlchen/chain/ethereum/decoding/decoder.py
+++ b/rotkehlchen/chain/ethereum/decoding/decoder.py
@@ -330,6 +330,7 @@ class EthereumTransactionDecoder(EVMTransactionDecoderWithDSProxy):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         if tx_log.topics[0] == AIRDROP_CLAIM and tx_log.address == '0xDE3e5a990bCE7fC60a6f017e7c4a95fc4939299E':  # noqa: E501
             for event in decoded_events:

--- a/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/makerdao/sai/decoder.py
@@ -464,6 +464,7 @@ class MakerdaosaiDecoder(EvmDecoderInterface):
             decoded_events: list[EvmEvent],  # pylint: disable=unused-argument
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         """This method decodes the migration of a Sai CDP to Dai CDP."""
         if tx_log.topics[0] != SAI_CDP_MIGRATION_TOPIC:

--- a/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/sushiswap/decoder.py
@@ -62,6 +62,7 @@ class SushiswapDecoder(EvmDecoderInterface):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         if tx_log.topics[0] == UNISWAP_V2_SWAP_SIGNATURE and transaction.to_address == SUSHISWAP_ROUTER:  # noqa: E501
             return decode_uniswap_v2_like_swap(
@@ -84,6 +85,7 @@ class SushiswapDecoder(EvmDecoderInterface):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         if tx_log.topics[0] == MINT_TOPIC:
             return decode_uniswap_like_deposit_and_withdrawals(

--- a/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/uniswap/v1/decoder.py
@@ -40,6 +40,7 @@ class Uniswapv1Decoder(EvmDecoderInterface):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         """Search for both events. Since the order is not guaranteed try reshuffle in both cases"""
         out_event = in_event = None

--- a/rotkehlchen/chain/ethereum/modules/yearn/vesting/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/yearn/vesting/decoder.py
@@ -358,6 +358,7 @@ class YearnvestingDecoder(EvmDecoderInterface):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],
             all_logs: list[EvmTxReceiptLog],
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         """Match escrow events by topic since the escrow addresses are not known
         statically, verifying the emitting address is a yearn vesting escrow.

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -817,6 +817,28 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
         )
         return events, refresh_balances, reload_decoders  # Propagate for post processing in the caller  # noqa: E501
 
+    def decode_transaction_without_persistence(
+            self,
+            transaction: EvmTransaction,
+            tx_receipt: EvmTxReceipt,
+    ) -> list[EvmEvent]:
+        """Generate the events for a transaction without replacing its saved events.
+
+        The regular decoder's deferred-write path is used so sequence-index normalization is
+        identical to a persisted decode. The buffer is deliberately discarded, leaving both the
+        history events and the transaction's decoded marker unchanged.
+        """
+        with self.undecoded_tx_query_lock:
+            with self.database.conn.read_ctx() as cursor:
+                self.reload_data(cursor)
+
+            events, _refresh_balances, _reload_decoders = self._decode_transaction(
+                transaction=transaction,
+                tx_receipt=tx_receipt,
+                write_buffer=[],
+            )
+        return events
+
     def _decode_transaction_hashes(
             self,
             ignore_cache: bool,

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -887,11 +887,28 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             return events, False, None
 
         # else we should decode now
-        return self._decode_transaction(
+        events, refresh_balances, reload_decoders = self._decode_transaction(
             transaction=transaction,
             tx_receipt=tx_receipt,
             write_buffer=write_buffer,
         )
+        self._post_decode_transaction(
+            transaction=transaction,
+            decoded_events=events,
+            write_buffer=write_buffer,
+        )
+        return events, refresh_balances, reload_decoders
+
+    def _post_decode_transaction(
+            self,
+            transaction: EvmTransaction,
+            decoded_events: list[EvmEvent],
+            write_buffer: list[tuple[list[EvmEvent], str, int]] | None = None,
+    ) -> None:
+        """Run chain-specific persistence after fresh decoding, excluding previews and cache hits.
+
+        Implementations may flush pending event writes before persisting related events.
+        """
 
     def _maybe_decode_internal_transactions(
             self,

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -148,6 +148,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 
 class EventDecoderFunction(Protocol):
+    """Event rules forward strict error handling when invoking nested enrichment rules."""
 
     def __call__(
             self,
@@ -157,6 +158,7 @@ class EventDecoderFunction(Protocol):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],
             all_logs: list[EvmTxReceiptLog],
+            strict: bool = False,
     ) -> EvmDecodingOutput:
         ...
 
@@ -471,6 +473,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],
             all_logs: list[EvmTxReceiptLog],
+            strict: bool = False,
     ) -> EvmDecodingOutput | None:
         """
         Execute event rules for the current tx log. Returns None when no
@@ -486,6 +489,8 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
                 tx_reference=str(transaction.tx_hash),
                 blockchain=self.evm_inquirer.blockchain,
                 func=rule,
+                raise_on_error=strict,
+                strict=strict,
                 token=token,
                 tx_log=tx_log,
                 transaction=transaction,
@@ -505,7 +510,11 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
 
         return None
 
-    def decode_by_address_rules(self, context: DecoderContext) -> EvmDecodingOutput:
+    def decode_by_address_rules(
+            self,
+            context: DecoderContext,
+            strict: bool = False,
+    ) -> EvmDecodingOutput:
         """
         Sees if the log is on an address for which we have specific decoders and calls it
 
@@ -526,6 +535,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             method,
             str(context.transaction.tx_hash),
             *(context, *args),
+            raise_on_error=strict,
         )
         if err:
             return DEFAULT_EVM_DECODING_OUTPUT
@@ -538,6 +548,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             decoded_events: list[EvmEvent],
             all_logs: list[EvmTxReceiptLog],
             counterparties: set[str],
+            strict: bool = False,
     ) -> tuple[list[EvmEvent], bool]:
         """
         The post-decoding rules list consists of tuples (priority, rule) and must be
@@ -577,6 +588,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
                 tx_reference=str(transaction.tx_hash),
                 blockchain=self.evm_inquirer.blockchain,
                 func=rule,
+                raise_on_error=strict,
                 transaction=transaction,
                 decoded_events=decoded_events,
                 all_logs=all_logs,
@@ -594,10 +606,12 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             transaction: EvmTransaction,
             tx_receipt: EvmTxReceipt,
             write_buffer: list[tuple[list[EvmEvent], str, int]] | None = None,
+            strict: bool = False,
     ) -> tuple[list[EvmEvent], bool, set[str] | None]:
         """
         Decodes an evm transaction and its receipt and saves result in the DB.
         If write_buffer is given the DB write is deferred into it instead.
+        With strict=True, rule errors propagate instead of returning partial decoding results.
 
         Returns
         - the list of decoded events
@@ -663,13 +677,14 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
                     tx_reference=str(context.transaction.tx_hash),
                     blockchain=self.evm_inquirer.blockchain,
                     func=input_rule,
+                    raise_on_error=strict,
                     context=context,
                 )
                 if not is_err and result.events:
                     events.extend(result.events)
                     continue  # since the input data rule found events for this log
 
-            decoding_output = self.decode_by_address_rules(context)
+            decoding_output = self.decode_by_address_rules(context, strict=strict)
             if decoding_output.stop_processing is True:
                 self._write_new_tx_events_to_the_db(
                     events=[],
@@ -705,6 +720,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
                 )
 
             rules_decoding_output = self.try_all_rules(
+                strict=strict,
                 token=token,
                 tx_log=tx_log,
                 transaction=transaction,
@@ -768,6 +784,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
         # should run after monerium special handling as in paraswap decoder, during post-decoding,
         # the extra EURe event receive is seen as a receival
         events, maybe_modified = self.run_all_post_decoding_rules(
+            strict=strict,
             transaction=transaction,
             decoded_events=events,
             all_logs=tx_receipt.logs,
@@ -827,6 +844,8 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
         The regular decoder's deferred-write path is used so sequence-index normalization is
         identical to a persisted decode. The buffer is deliberately discarded, leaving both the
         history events and the transaction's decoded marker unchanged.
+
+        Rule failures propagate instead of returning partially decoded events.
         """
         with self.undecoded_tx_query_lock:
             with self.database.conn.read_ctx() as cursor:
@@ -836,6 +855,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
                 transaction=transaction,
                 tx_receipt=tx_receipt,
                 write_buffer=[],
+                strict=True,
             )
         return events
 
@@ -1009,6 +1029,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             decoded_events: list[EvmEvent],  # pylint: disable=unused-argument
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         if (
             tx_log.topics[0] != ERC20_OR_ERC721_APPROVE or
@@ -1198,6 +1219,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             decoded_events: list[EvmEvent],  # pylint: disable=unused-argument
             action_items: list[ActionItem],
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            strict: bool = False,
     ) -> EvmDecodingOutput:
         if (
             tx_log.topics[0] != ERC20_OR_ERC721_TRANSFER or
@@ -1312,6 +1334,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
 
         # Add additional information to transfers for different protocols
         enrichment_output = self._enrich_protocol_transfers(
+            strict=strict,
             context=EnricherContext(
                 tx_log=tx_log,
                 transaction=transaction,
@@ -1428,7 +1451,11 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
         """Calculates gas burn based on relevant chain's formula."""
         return from_wei(FVal(tx.gas_used * tx.gas_price))
 
-    def _enrich_protocol_transfers(self, context: EnricherContext) -> TransferEnrichmentOutput:
+    def _enrich_protocol_transfers(
+            self,
+            context: EnricherContext,
+            strict: bool = False,
+    ) -> TransferEnrichmentOutput:
         """Decode special transfers made by contract execution for example at the moment
         of depositing assets or withdrawing.
         It assumes that the event being decoded has been already filtered and is a transfer.
@@ -1441,6 +1468,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
                 tx_reference=str(context.transaction.tx_hash),
                 blockchain=self.evm_inquirer.blockchain,
                 func=enrich_call,
+                raise_on_error=strict,
                 context=context,
             )
             if err:

--- a/rotkehlchen/chain/evm/decoding/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/decoder.py
@@ -838,6 +838,7 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
             self,
             transaction: EvmTransaction,
             tx_receipt: EvmTxReceipt,
+            reload: bool = True,
     ) -> list[EvmEvent]:
         """Generate the events for a transaction without replacing its saved events.
 
@@ -848,8 +849,9 @@ class EVMTransactionDecoder(TransactionDecoder['EvmTransaction', EvmDecodingRule
         Rule failures propagate instead of returning partially decoded events.
         """
         with self.undecoded_tx_query_lock:
-            with self.database.conn.read_ctx() as cursor:
-                self.reload_data(cursor)
+            if reload:
+                with self.database.conn.read_ctx() as cursor:
+                    self.reload_data(cursor)
 
             events, _refresh_balances, _reload_decoders = self._decode_transaction(
                 transaction=transaction,

--- a/rotkehlchen/chain/evm/decoding/pendle/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/pendle/decoder.py
@@ -615,6 +615,7 @@ class PendleCommonDecoder(EvmDecoderInterface, ReloadableDecoderMixin):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],
             all_logs: list[EvmTxReceiptLog],
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         if tx_log.address in self.pools:
             return DEFAULT_EVM_DECODING_OUTPUT  # already handled via addresses_to_decoders

--- a/rotkehlchen/chain/evm/decoding/uniswap/v2/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v2/decoder.py
@@ -87,6 +87,7 @@ class Uniswapv2CommonDecoder(EvmDecoderInterface):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         if tx_log.topics[0] == UNISWAP_V2_SWAP_SIGNATURE:
             if transaction.to_address == self.router_address:
@@ -118,6 +119,7 @@ class Uniswapv2CommonDecoder(EvmDecoderInterface):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         if tx_log.topics[0] == MINT_TOPIC:
             return decode_uniswap_like_deposit_and_withdrawals(

--- a/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/uniswap/v3/decoder.py
@@ -127,6 +127,7 @@ class Uniswapv3CommonDecoder(EvmDecoderInterface):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],  # pylint: disable=unused-argument
             all_logs: list[EvmTxReceiptLog],  # pylint: disable=unused-argument
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         """
         Detect some basic uniswap v3 events. This method doesn't ensure the order of the events

--- a/rotkehlchen/chain/hyperliquid/modules/kittenswap/decoder.py
+++ b/rotkehlchen/chain/hyperliquid/modules/kittenswap/decoder.py
@@ -136,6 +136,7 @@ class KittenswapDecoder(EvmDecoderInterface):
             decoded_events: list[EvmEvent],
             action_items: list[ActionItem],
             all_logs: list[EvmTxReceiptLog],
+            strict: bool = False,  # pylint: disable=unused-argument
     ) -> EvmDecodingOutput:
         return self._decode_swap(DecoderContext(
             tx_log=tx_log,

--- a/rotkehlchen/db/cache.py
+++ b/rotkehlchen/db/cache.py
@@ -41,6 +41,7 @@ class DBCacheStatic(Enum):
     # during historical balance processing.
     STALE_BALANCES_MODIFICATION_TS: Final = 'stale_balances_modification_ts'
     LAST_HISTORICAL_BALANCE_PROCESSING_TS: Final = 'last_historical_balance_processing_ts'
+    LAST_DATA_ISSUE_REMEDIATION_TS: Final = 'last_data_issue_remediation_ts'
     LAST_INTERNAL_TX_CONFLICTS_REPULL_TS: Final = 'last_internal_tx_conflicts_repull_ts'
     BEACONCHAIN_VALIDATOR_QUERY_LIMIT: Final = 'beaconchain_validator_query_limit'
     ETHERSCAN_API_KEY_TIER: Final = 'etherscan_api_key_tier'

--- a/rotkehlchen/history/data_issues/types.py
+++ b/rotkehlchen/history/data_issues/types.py
@@ -8,6 +8,12 @@ type RebasingQueryFailure = Literal[
     'unsupported_bucket',
 ]
 
+type RedecodeComparisonResult = Literal[
+    'redecoding_failed',
+    'redecoding_would_change_balance',
+    'redecoding_would_not_change_balance',
+]
+
 
 class BaseIssuePayload(TypedDict):
     """Common optional payload fields shared by all data issue kinds."""
@@ -17,9 +23,12 @@ class BaseIssuePayload(TypedDict):
 class AutoRemediationAttempt(TypedDict):
     attribution: str
     strategy: str
-    success: bool
+    success: NotRequired[bool]
     timestamp: int
     reason: NotRequired[str]
+    result: NotRequired[RedecodeComparisonResult]
+    customized_transaction_count: NotRequired[int]
+    changed_transaction_count: NotRequired[int]
 
 
 class NegativeBalanceIssuePayload(BaseIssuePayload):

--- a/rotkehlchen/tasks/data_issues.py
+++ b/rotkehlchen/tasks/data_issues.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Final, cast
 
+from rotkehlchen.chain.evm.types import EvmAccount, string_to_evm_address
 from rotkehlchen.concurrency import checkpoint
 from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.constants import HistoryMappingState
@@ -26,6 +27,7 @@ from rotkehlchen.types import (
     ChainID,
     EVMTxHash,
     Location,
+    Timestamp,
     TimestampMS,
 )
 from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now
@@ -42,7 +44,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 REDECODE_CUSTOMIZED_TRANSACTIONS: Final = 'redecode_customized_transactions'
 
-type BucketEffect = tuple[int, EventDirection, str]
+type BucketEffect = tuple[TimestampMS, int, EventDirection, str]
 type PreviewCache = dict[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash], list[EvmEvent]]
 
 
@@ -58,50 +60,71 @@ def _get_bucket_effects(
             treat_eth2_as_eth=treat_eth2_as_eth,
         ):
             if event_bucket == bucket:
-                effects.append((event.sequence_index, direction, str(event.amount)))
+                effects.append((
+                    event.timestamp,
+                    event.sequence_index,
+                    direction,
+                    str(event.amount),
+                ))
 
     return effects
 
 
-def _get_customized_transactions_affecting_issue(
+def _get_customized_transactions_for_issue(
         database: DBHandler,
         issue: DataIssue,
-        bucket: Bucket,
+        chain_id: EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
         location: Location,
-        treat_eth2_as_eth: bool,
 ) -> dict[EVMTxHash, list[EvmEvent]]:
-    """Return customized transactions whose saved events affect the issue bucket."""
-    dbevents = DBHistoryEvents(database)
+    """Return customized transactions associated with the issue account."""
+    dbevents, dbtx = DBHistoryEvents(database), DBEvmTx(database)
     with database.conn.read_ctx() as cursor:
         customized_events = dbevents.get_history_events_internal(
             cursor=cursor,
             filter_query=EvmEventFilterQuery.make(
                 location=location,
                 state_markers=[HistoryMappingState.CUSTOMIZED],
-                to_ts=ts_ms_to_sec(TimestampMS(issue.ts_end)),
             ),
         )
         if len(customized_events) == 0:
+            return {}
+
+        account_transactions = dbtx.get_transactions(
+            cursor=cursor,
+            filter_=EvmTransactionsFilterQuery.make(
+                accounts=[EvmAccount(
+                    address=string_to_evm_address(issue.location_label),
+                    chain_id=chain_id,
+                )],
+                to_ts=Timestamp(ts_ms_to_sec(TimestampMS(issue.ts_end))),
+                chain_id=chain_id,
+            ),
+        )
+        if len(account_transactions) == 0:
+            return {}
+
+        account_tx_hashes = {transaction.tx_hash for transaction in account_transactions}
+        customized_group_identifiers = {
+            event.group_identifier
+            for event in customized_events
+            if event.tx_ref in account_tx_hashes
+        }
+        if len(customized_group_identifiers) == 0:
             return {}
 
         transaction_events = dbevents.get_history_events_internal(
             cursor=cursor,
             filter_query=EvmEventFilterQuery.make(
                 location=location,
-                group_identifiers=list({event.group_identifier for event in customized_events}),
+                group_identifiers=list(customized_group_identifiers),
             ),
         )
 
     events_by_transaction: defaultdict[EVMTxHash, list[EvmEvent]] = defaultdict(list)
     for event in transaction_events:
-        if event.timestamp <= issue.ts_end:
-            events_by_transaction[event.tx_ref].append(event)
+        events_by_transaction[event.tx_ref].append(event)
 
-    return {
-        tx_hash: events
-        for tx_hash, events in events_by_transaction.items()
-        if len(_get_bucket_effects(events, bucket, treat_eth2_as_eth)) != 0
-    }
+    return dict(events_by_transaction)
 
 
 def _preview_transaction(
@@ -158,7 +181,7 @@ def _check_issue(
         preview_cache: PreviewCache,
 ) -> None:
     location = Location.deserialize_from_db(issue.location)
-    if location not in EVM_LOCATIONS:
+    if location not in EVM_LOCATIONS or issue.location_label == '':
         return
 
     chain_id = cast('EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE', ChainID(location.to_chain_id()))
@@ -168,12 +191,11 @@ def _check_issue(
         protocol=issue.protocol or None,
         asset=issue.asset,
     )
-    if len(transactions := _get_customized_transactions_affecting_issue(
+    if len(transactions := _get_customized_transactions_for_issue(
         database=database,
         issue=issue,
-        bucket=bucket,
+        chain_id=chain_id,
         location=location,
-        treat_eth2_as_eth=treat_eth2_as_eth,
     )) == 0:
         return
 

--- a/rotkehlchen/tasks/data_issues.py
+++ b/rotkehlchen/tasks/data_issues.py
@@ -1,18 +1,252 @@
-from typing import TYPE_CHECKING
+import logging
+from collections import defaultdict
+from typing import TYPE_CHECKING, Final, cast
 
+from rotkehlchen.concurrency import checkpoint
 from rotkehlchen.db.cache import DBCacheStatic
-from rotkehlchen.utils.misc import ts_now
+from rotkehlchen.db.constants import HistoryMappingState
+from rotkehlchen.db.evmtx import DBEvmTx
+from rotkehlchen.db.filtering import EvmEventFilterQuery, EvmTransactionsFilterQuery
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.db.settings import CachedSettings
+from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
+from rotkehlchen.history.data_issues.manager import DataIssuesManager
+from rotkehlchen.history.data_issues.types import (
+    AutoRemediationAttempt,
+    DataIssue,
+    DataIssueFilters,
+    RedecodeComparisonResult,
+)
+from rotkehlchen.history.events.structures.types import EventDirection
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.tasks.historical_balances import Bucket
+from rotkehlchen.types import (
+    EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
+    EVM_LOCATIONS,
+    ChainID,
+    EVMTxHash,
+    Location,
+    TimestampMS,
+)
+from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from rotkehlchen.chain.aggregator import ChainsAggregator
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.history.events.structures.evm_event import EvmEvent
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+REDECODE_CUSTOMIZED_TRANSACTIONS: Final = 'redecode_customized_transactions'
+
+type BucketEffect = tuple[int, EventDirection, str]
+type PreviewCache = dict[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash], list[EvmEvent]]
 
 
-def run_data_issue_remediation(database: DBHandler) -> None:
-    """Run the daily automatic data-issue remediation task.
+def _get_bucket_effects(
+        events: Sequence[EvmEvent],
+        bucket: Bucket,
+        treat_eth2_as_eth: bool,
+) -> list[BucketEffect]:
+    effects: list[BucketEffect] = []
+    for event in sorted(events, key=lambda entry: entry.sequence_index):
+        for event_bucket, direction in Bucket.from_event(
+            event=event,
+            treat_eth2_as_eth=treat_eth2_as_eth,
+        ):
+            if event_bucket == bucket:
+                effects.append((event.sequence_index, direction, str(event.amount)))
 
-    Remediation logic belongs behind this entry point. The timestamp is updated after all work
-    completes so failed runs remain eligible for a retry.
+    return effects
+
+
+def _get_customized_transactions_affecting_issue(
+        database: DBHandler,
+        issue: DataIssue,
+        bucket: Bucket,
+        location: Location,
+        treat_eth2_as_eth: bool,
+) -> dict[EVMTxHash, list[EvmEvent]]:
+    """Return customized transactions whose saved events affect the issue bucket."""
+    dbevents = DBHistoryEvents(database)
+    with database.conn.read_ctx() as cursor:
+        customized_events = dbevents.get_history_events_internal(
+            cursor=cursor,
+            filter_query=EvmEventFilterQuery.make(
+                location=location,
+                state_markers=[HistoryMappingState.CUSTOMIZED],
+                to_ts=ts_ms_to_sec(TimestampMS(issue.ts_end)),
+            ),
+        )
+        if len(customized_events) == 0:
+            return {}
+
+        transaction_events = dbevents.get_history_events_internal(
+            cursor=cursor,
+            filter_query=EvmEventFilterQuery.make(
+                location=location,
+                group_identifiers=list({event.group_identifier for event in customized_events}),
+            ),
+        )
+
+    events_by_transaction: defaultdict[EVMTxHash, list[EvmEvent]] = defaultdict(list)
+    for event in transaction_events:
+        if event.timestamp <= issue.ts_end:
+            events_by_transaction[event.tx_ref].append(event)
+
+    return {
+        tx_hash: events
+        for tx_hash, events in events_by_transaction.items()
+        if len(_get_bucket_effects(events, bucket, treat_eth2_as_eth)) != 0
+    }
+
+
+def _preview_transaction(
+        database: DBHandler,
+        chains_aggregator: ChainsAggregator,
+        chain_id: EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
+        tx_hash: EVMTxHash,
+) -> list[EvmEvent]:
+    dbtx = DBEvmTx(database)
+    with database.conn.read_ctx() as cursor:
+        transactions = dbtx.get_transactions(
+            cursor=cursor,
+            filter_=EvmTransactionsFilterQuery.make(tx_hash=tx_hash, chain_id=chain_id),
+        )
+        receipt = dbtx.get_receipt(cursor=cursor, tx_hash=tx_hash, chain_id=chain_id)
+
+    if len(transactions) != 1 or receipt is None:
+        raise RuntimeError(
+            f'Missing transaction data needed to preview {tx_hash!s} on {chain_id!s}',
+        )
+
+    decoder = chains_aggregator.get_evm_manager(chain_id).transactions_decoder
+    return decoder.decode_transaction_without_persistence(
+        transaction=transactions[0],
+        tx_receipt=receipt,
+    )
+
+
+def _make_comparison_attempt(
+        result: RedecodeComparisonResult,
+        customized_transaction_count: int,
+        changed_transaction_count: int,
+        reason: str | None = None,
+) -> AutoRemediationAttempt:
+    attempt = AutoRemediationAttempt(
+        attribution='system',
+        strategy=REDECODE_CUSTOMIZED_TRANSACTIONS,
+        timestamp=ts_now(),
+        result=result,
+        customized_transaction_count=customized_transaction_count,
+        changed_transaction_count=changed_transaction_count,
+    )
+    if reason is not None:
+        attempt['reason'] = reason
+    return attempt
+
+
+def _check_issue(
+        database: DBHandler,
+        chains_aggregator: ChainsAggregator,
+        issues_manager: DataIssuesManager,
+        issue: DataIssue,
+        treat_eth2_as_eth: bool,
+        preview_cache: PreviewCache,
+) -> None:
+    location = Location.deserialize_from_db(issue.location)
+    if location not in EVM_LOCATIONS:
+        return
+
+    chain_id = cast('EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE', ChainID(location.to_chain_id()))
+    bucket = Bucket(
+        location=issue.location,
+        location_label=issue.location_label or None,
+        protocol=issue.protocol or None,
+        asset=issue.asset,
+    )
+    if len(transactions := _get_customized_transactions_affecting_issue(
+        database=database,
+        issue=issue,
+        bucket=bucket,
+        location=location,
+        treat_eth2_as_eth=treat_eth2_as_eth,
+    )) == 0:
+        return
+
+    issues_manager.update_state(issue.id, IssueState.AUTO_REMEDIATING)
+    changed_transaction_count = 0
+    try:
+        for tx_hash, saved_events in transactions.items():
+            if (preview_events := preview_cache.get((chain_id, tx_hash))) is None:
+                preview_events = _preview_transaction(
+                    database=database,
+                    chains_aggregator=chains_aggregator,
+                    chain_id=chain_id,
+                    tx_hash=tx_hash,
+                )
+                preview_cache[chain_id, tx_hash] = preview_events
+            if _get_bucket_effects(saved_events, bucket, treat_eth2_as_eth) != _get_bucket_effects(
+                    preview_events,
+                    bucket,
+                    treat_eth2_as_eth,
+            ):
+                changed_transaction_count += 1
+            checkpoint()
+    except Exception as e:
+        log.exception('Failed to preview customized transactions for data issue %s', issue.id)
+        attempt = _make_comparison_attempt(
+            result='redecoding_failed',
+            customized_transaction_count=len(transactions),
+            changed_transaction_count=changed_transaction_count,
+            reason=str(e),
+        )
+    else:
+        attempt = _make_comparison_attempt(
+            result=(
+                'redecoding_would_change_balance' if changed_transaction_count != 0 else
+                'redecoding_would_not_change_balance'
+            ),
+            customized_transaction_count=len(transactions),
+            changed_transaction_count=changed_transaction_count,
+        )
+
+    issues_manager.update_state(
+        issue_id=issue.id,
+        state=IssueState.UNRESOLVED,
+        attempt=attempt,
+    )
+
+
+def run_data_issue_remediation(
+        database: DBHandler,
+        chains_aggregator: ChainsAggregator,
+) -> None:
+    """Check whether current decoders would change customized negative-balance transactions.
+
+    Saved events are never removed or replaced. Each applicable issue receives a diagnostic
+    timeline entry and remains unresolved for the user to review.
     """
+    issues_manager = DataIssuesManager(database)
+    treat_eth2_as_eth = CachedSettings().get_entry('treat_eth2_as_eth') is True
+    preview_cache: PreviewCache = {}
+    for issue in issues_manager.list_issues(DataIssueFilters(
+        kind=IssueKind.NEGATIVE_BALANCE,
+        state=IssueState.OPEN,
+    )):
+        _check_issue(
+            database=database,
+            chains_aggregator=chains_aggregator,
+            issues_manager=issues_manager,
+            issue=issue,
+            treat_eth2_as_eth=treat_eth2_as_eth,
+            preview_cache=preview_cache,
+        )
+        checkpoint()
+
     with database.user_write() as write_cursor:
         database.set_static_cache(
             write_cursor=write_cursor,

--- a/rotkehlchen/tasks/data_issues.py
+++ b/rotkehlchen/tasks/data_issues.py
@@ -1,0 +1,21 @@
+from typing import TYPE_CHECKING
+
+from rotkehlchen.db.cache import DBCacheStatic
+from rotkehlchen.utils.misc import ts_now
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.dbhandler import DBHandler
+
+
+def run_data_issue_remediation(database: DBHandler) -> None:
+    """Run the daily automatic data-issue remediation task.
+
+    Remediation logic belongs behind this entry point. The timestamp is updated after all work
+    completes so failed runs remain eligible for a retry.
+    """
+    with database.user_write() as write_cursor:
+        database.set_static_cache(
+            write_cursor=write_cursor,
+            name=DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
+            value=ts_now(),
+        )

--- a/rotkehlchen/tasks/data_issues.py
+++ b/rotkehlchen/tasks/data_issues.py
@@ -2,14 +2,15 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Final, cast
 
-from rotkehlchen.chain.evm.types import EvmAccount, string_to_evm_address
 from rotkehlchen.concurrency import checkpoint
 from rotkehlchen.db.cache import DBCacheStatic
-from rotkehlchen.db.constants import HistoryMappingState
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.filtering import EvmEventFilterQuery, EvmTransactionsFilterQuery
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
+from rotkehlchen.errors.misc import InputError
+from rotkehlchen.fval import FVal
 from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
 from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.data_issues.types import (
@@ -27,7 +28,6 @@ from rotkehlchen.types import (
     ChainID,
     EVMTxHash,
     Location,
-    Timestamp,
     TimestampMS,
 )
 from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now
@@ -44,7 +44,7 @@ log = RotkehlchenLogsAdapter(logger)
 
 REDECODE_CUSTOMIZED_TRANSACTIONS: Final = 'redecode_customized_transactions'
 
-type BucketEffect = tuple[TimestampMS, int, EventDirection, str]
+type BucketEffect = tuple[TimestampMS, EventDirection, FVal]
 type PreviewCache = dict[tuple[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE, EVMTxHash], list[EvmEvent]]
 
 
@@ -60,12 +60,7 @@ def _get_bucket_effects(
             treat_eth2_as_eth=treat_eth2_as_eth,
         ):
             if event_bucket == bucket:
-                effects.append((
-                    event.timestamp,
-                    event.sequence_index,
-                    direction,
-                    str(event.amount),
-                ))
+                effects.append((event.timestamp, direction, event.amount))
 
     return effects
 
@@ -77,38 +72,24 @@ def _get_customized_transactions_for_issue(
         location: Location,
 ) -> dict[EVMTxHash, list[EvmEvent]]:
     """Return customized transactions associated with the issue account."""
-    dbevents, dbtx = DBHistoryEvents(database), DBEvmTx(database)
+    dbevents = DBHistoryEvents(database)
     with database.conn.read_ctx() as cursor:
-        customized_events = dbevents.get_history_events_internal(
-            cursor=cursor,
-            filter_query=EvmEventFilterQuery.make(
-                location=location,
-                state_markers=[HistoryMappingState.CUSTOMIZED],
+        customized_group_identifiers = [row[0] for row in cursor.execute(
+            'SELECT DISTINCT H.group_identifier FROM history_events_mappings M '
+            'JOIN history_events H ON H.identifier = M.parent_identifier '
+            'JOIN chain_events_info C ON C.identifier = H.identifier '
+            'JOIN evm_transactions T ON T.tx_hash = C.tx_ref AND T.chain_id = ? '
+            'JOIN evmtx_address_mappings A ON A.tx_id = T.identifier AND A.address = ? '
+            'WHERE M.name = ? AND M.value = ? AND H.location = ? AND T.timestamp <= ?',
+            (
+                chain_id.serialize_for_db(),
+                issue.location_label,
+                HISTORY_MAPPING_KEY_STATE,
+                HistoryMappingState.CUSTOMIZED.serialize_for_db(),
+                location.serialize_for_db(),
+                ts_ms_to_sec(TimestampMS(issue.ts_end)),
             ),
-        )
-        if len(customized_events) == 0:
-            return {}
-
-        account_transactions = dbtx.get_transactions(
-            cursor=cursor,
-            filter_=EvmTransactionsFilterQuery.make(
-                accounts=[EvmAccount(
-                    address=string_to_evm_address(issue.location_label),
-                    chain_id=chain_id,
-                )],
-                to_ts=Timestamp(ts_ms_to_sec(TimestampMS(issue.ts_end))),
-                chain_id=chain_id,
-            ),
-        )
-        if len(account_transactions) == 0:
-            return {}
-
-        account_tx_hashes = {transaction.tx_hash for transaction in account_transactions}
-        customized_group_identifiers = {
-            event.group_identifier
-            for event in customized_events
-            if event.tx_ref in account_tx_hashes
-        }
+        )]
         if len(customized_group_identifiers) == 0:
             return {}
 
@@ -132,6 +113,7 @@ def _preview_transaction(
         chains_aggregator: ChainsAggregator,
         chain_id: EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE,
         tx_hash: EVMTxHash,
+        reload: bool,
 ) -> list[EvmEvent]:
     dbtx = DBEvmTx(database)
     with database.conn.read_ctx() as cursor:
@@ -150,6 +132,7 @@ def _preview_transaction(
     return decoder.decode_transaction_without_persistence(
         transaction=transactions[0],
         tx_receipt=receipt,
+        reload=reload,
     )
 
 
@@ -179,6 +162,7 @@ def _check_issue(
         issue: DataIssue,
         treat_eth2_as_eth: bool,
         preview_cache: PreviewCache,
+        reloaded_chains: set[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE],
 ) -> None:
     location = Location.deserialize_from_db(issue.location)
     if location not in EVM_LOCATIONS or issue.location_label == '':
@@ -199,30 +183,47 @@ def _check_issue(
     )) == 0:
         return
 
-    issues_manager.update_state(issue.id, IssueState.AUTO_REMEDIATING)
+    try:
+        issues_manager.update_state(issue.id, IssueState.AUTO_REMEDIATING)
+    except InputError:
+        return
+
+    decoder = chains_aggregator.get_evm_manager(chain_id).transactions_decoder
+    preview_exceptions: tuple[type[Exception], ...] = (
+        RuntimeError,
+        *decoder.possible_decoding_exceptions,
+    )
     changed_transaction_count = 0
+    customized_transaction_count = 0
     try:
         for tx_hash, saved_events in transactions.items():
+            saved_effects = _get_bucket_effects(saved_events, bucket, treat_eth2_as_eth)
+            if len(saved_effects) != 0:
+                customized_transaction_count += 1
             if (preview_events := preview_cache.get((chain_id, tx_hash))) is None:
                 preview_events = _preview_transaction(
                     database=database,
                     chains_aggregator=chains_aggregator,
                     chain_id=chain_id,
                     tx_hash=tx_hash,
+                    reload=chain_id not in reloaded_chains,
                 )
+                reloaded_chains.add(chain_id)
                 preview_cache[chain_id, tx_hash] = preview_events
-            if _get_bucket_effects(saved_events, bucket, treat_eth2_as_eth) != _get_bucket_effects(
-                    preview_events,
-                    bucket,
-                    treat_eth2_as_eth,
-            ):
+            preview_effects = _get_bucket_effects(preview_events, bucket, treat_eth2_as_eth)
+            if len(saved_effects) == 0 and len(preview_effects) == 0:
+                continue
+
+            if len(saved_effects) == 0:
+                customized_transaction_count += 1
+            if saved_effects != preview_effects:
                 changed_transaction_count += 1
             checkpoint()
-    except Exception as e:
+    except preview_exceptions as e:
         log.exception('Failed to preview customized transactions for data issue %s', issue.id)
         attempt = _make_comparison_attempt(
             result='redecoding_failed',
-            customized_transaction_count=len(transactions),
+            customized_transaction_count=customized_transaction_count,
             changed_transaction_count=changed_transaction_count,
             reason=str(e),
         )
@@ -232,7 +233,7 @@ def _check_issue(
                 'redecoding_would_change_balance' if changed_transaction_count != 0 else
                 'redecoding_would_not_change_balance'
             ),
-            customized_transaction_count=len(transactions),
+            customized_transaction_count=customized_transaction_count,
             changed_transaction_count=changed_transaction_count,
         )
 
@@ -255,10 +256,11 @@ def run_data_issue_remediation(
     issues_manager = DataIssuesManager(database)
     treat_eth2_as_eth = CachedSettings().get_entry('treat_eth2_as_eth') is True
     preview_cache: PreviewCache = {}
-    for issue in issues_manager.list_issues(DataIssueFilters(
-        kind=IssueKind.NEGATIVE_BALANCE,
-        state=IssueState.OPEN,
-    )):
+    reloaded_chains: set[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE] = set()
+    for issue in issues_manager.list_issues(DataIssueFilters(kind=IssueKind.NEGATIVE_BALANCE)):
+        if issue.state != IssueState.OPEN and _last_attempt_failed(issue) is False:
+            continue
+
         _check_issue(
             database=database,
             chains_aggregator=chains_aggregator,
@@ -266,6 +268,7 @@ def run_data_issue_remediation(
             issue=issue,
             treat_eth2_as_eth=treat_eth2_as_eth,
             preview_cache=preview_cache,
+            reloaded_chains=reloaded_chains,
         )
         checkpoint()
 
@@ -275,3 +278,13 @@ def run_data_issue_remediation(
             name=DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
             value=ts_now(),
         )
+
+
+def _last_attempt_failed(issue: DataIssue) -> bool:
+    """Return whether a failed comparison should be retried on the next scheduled run."""
+    return (
+        issue.state == IssueState.UNRESOLVED and
+        len(issue.auto_remediation_attempts) != 0 and
+        issue.auto_remediation_attempts[-1].get('strategy') == REDECODE_CUSTOMIZED_TRANSACTIONS and
+        issue.auto_remediation_attempts[-1].get('result') == 'redecoding_failed'
+    )

--- a/rotkehlchen/tasks/data_issues.py
+++ b/rotkehlchen/tasks/data_issues.py
@@ -2,11 +2,15 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Final, cast
 
-from rotkehlchen.concurrency import checkpoint
+from rotkehlchen.concurrency import TaskCancelledError, checkpoint
 from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.evmtx import DBEvmTx
-from rotkehlchen.db.filtering import EvmEventFilterQuery, EvmTransactionsFilterQuery
+from rotkehlchen.db.filtering import (
+    DataIssuesFilterQuery,
+    EvmEventFilterQuery,
+    EvmTransactionsFilterQuery,
+)
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.db.settings import CachedSettings
 from rotkehlchen.errors.misc import InputError
@@ -16,7 +20,6 @@ from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.data_issues.types import (
     AutoRemediationAttempt,
     DataIssue,
-    DataIssueFilters,
     RedecodeComparisonResult,
 )
 from rotkehlchen.history.events.structures.types import EventDirection
@@ -97,7 +100,7 @@ def _get_customized_transactions_for_issue(
             cursor=cursor,
             filter_query=EvmEventFilterQuery.make(
                 location=location,
-                group_identifiers=list(customized_group_identifiers),
+                group_identifiers=customized_group_identifiers,
             ),
         )
 
@@ -197,6 +200,7 @@ def _check_issue(
     customized_transaction_count = 0
     try:
         for tx_hash, saved_events in transactions.items():
+            checkpoint()
             saved_effects = _get_bucket_effects(saved_events, bucket, treat_eth2_as_eth)
             if len(saved_effects) != 0:
                 customized_transaction_count += 1
@@ -218,7 +222,6 @@ def _check_issue(
                 customized_transaction_count += 1
             if saved_effects != preview_effects:
                 changed_transaction_count += 1
-            checkpoint()
     except preview_exceptions as e:
         log.exception('Failed to preview customized transactions for data issue %s', issue.id)
         attempt = _make_comparison_attempt(
@@ -227,6 +230,19 @@ def _check_issue(
             changed_transaction_count=changed_transaction_count,
             reason=str(e),
         )
+    except TaskCancelledError:
+        attempt = _make_comparison_attempt(
+            result='redecoding_failed',
+            customized_transaction_count=customized_transaction_count,
+            changed_transaction_count=changed_transaction_count,
+            reason='Remediation was cancelled before the comparison finished',
+        )
+        issues_manager.update_state(
+            issue_id=issue.id,
+            state=IssueState.UNRESOLVED,
+            attempt=None if _is_repeated_failure(issue, attempt) else attempt,
+        )
+        raise
     else:
         attempt = _make_comparison_attempt(
             result=(
@@ -240,7 +256,7 @@ def _check_issue(
     issues_manager.update_state(
         issue_id=issue.id,
         state=IssueState.UNRESOLVED,
-        attempt=attempt,
+        attempt=None if _is_repeated_failure(issue, attempt) else attempt,
     )
 
 
@@ -257,7 +273,10 @@ def run_data_issue_remediation(
     treat_eth2_as_eth = CachedSettings().get_entry('treat_eth2_as_eth') is True
     preview_cache: PreviewCache = {}
     reloaded_chains: set[EVM_CHAIN_IDS_WITH_TRANSACTIONS_TYPE] = set()
-    for issue in issues_manager.list_issues(DataIssueFilters(kind=IssueKind.NEGATIVE_BALANCE)):
+    for issue in issues_manager.list_issues(DataIssuesFilterQuery.make(
+        kinds=[IssueKind.NEGATIVE_BALANCE],
+        states=[IssueState.OPEN, IssueState.UNRESOLVED],
+    )):
         if issue.state != IssueState.OPEN and _last_attempt_failed(issue) is False:
             continue
 
@@ -287,4 +306,15 @@ def _last_attempt_failed(issue: DataIssue) -> bool:
         len(issue.auto_remediation_attempts) != 0 and
         issue.auto_remediation_attempts[-1].get('strategy') == REDECODE_CUSTOMIZED_TRANSACTIONS and
         issue.auto_remediation_attempts[-1].get('result') == 'redecoding_failed'
+    )
+
+
+def _is_repeated_failure(issue: DataIssue, attempt: AutoRemediationAttempt) -> bool:
+    """Return whether the previous timeline entry records the same failure."""
+    return (
+        attempt.get('result') == 'redecoding_failed' and
+        len(issue.auto_remediation_attempts) != 0 and
+        {key: value for key, value in issue.auto_remediation_attempts[-1].items()
+         if key != 'timestamp'} ==
+        {key: value for key, value in attempt.items() if key != 'timestamp'}
     )

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -61,6 +61,7 @@ from rotkehlchen.tasks.calendar import (
     maybe_create_calendar_reminders,
     notify_reminders,
 )
+from rotkehlchen.tasks.data_issues import run_data_issue_remediation
 from rotkehlchen.tasks.historical_balances import (
     process_historical_balances,
     retry_rebasing_token_issue,
@@ -89,6 +90,8 @@ from .events import process_eth2_events
 
 HISTORICAL_BALANCE_PROCESSING_REFRESH: Final = DAY_IN_SECONDS
 HISTORICAL_BALANCE_PROCESSING_TASK_NAME: Final = 'Process historical balances'
+DATA_ISSUE_REMEDIATION_REFRESH: Final = DAY_IN_SECONDS
+DATA_ISSUE_REMEDIATION_TASK_NAME: Final = 'Auto-remediate data issues'
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -195,7 +198,10 @@ class TaskManager:
             self._maybe_check_premium_status,
             self._maybe_check_data_updates,
             self._maybe_update_snapshot_balances,
-            *([self._maybe_process_historical_balances] if is_accounting_update_enabled() else []),
+            *(
+                [self._maybe_process_historical_balances, self._maybe_run_data_issue_remediation]
+                if is_accounting_update_enabled() else []
+            ),
             self._maybe_detect_evm_accounts,
             self._maybe_update_ilk_cache,
             self._maybe_query_produced_blocks,
@@ -656,7 +662,8 @@ class TaskManager:
     def _maybe_process_historical_balances(self) -> list[Task] | None:
         if (
             self.history_processing_coordinator.is_history_fetching() or
-            self.task_supervisor.has_task(HISTORICAL_BALANCE_PROCESSING_TASK_NAME)
+            self.task_supervisor.has_task(HISTORICAL_BALANCE_PROCESSING_TASK_NAME) or
+            self.task_supervisor.has_task(DATA_ISSUE_REMEDIATION_TASK_NAME)
         ):
             return None
 
@@ -679,6 +686,36 @@ class TaskManager:
         return self._spawn_historical_balance_processing(
             from_ts=TimestampMS(int(stale_from_ts)) if stale_from_ts is not None else None,
         )
+
+    def _maybe_run_data_issue_remediation(self) -> list[Task] | None:
+        if (
+            self.history_processing_coordinator.is_history_fetching() or
+            self.task_supervisor.has_task(HISTORICAL_BALANCE_PROCESSING_TASK_NAME)
+        ):
+            return None
+
+        with self.database.conn.read_ctx() as cursor:
+            if self.database.get_static_cache(
+                cursor=cursor,
+                name=DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
+            ) is None:
+                return None
+
+        if should_run_periodic_task(
+            database=self.database,
+            key_name=DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
+            refresh_period=DATA_ISSUE_REMEDIATION_REFRESH,
+            cached_timestamps=self._scheduler_task_timestamps,
+        ) is False:
+            return None
+
+        return [self.task_supervisor.spawn_and_track(
+            after_seconds=None,
+            task_name=DATA_ISSUE_REMEDIATION_TASK_NAME,
+            exception_is_error=True,
+            method=run_data_issue_remediation,
+            database=self.database,
+        )]
 
     def _maybe_update_snapshot_balances(self) -> list[Task] | None:
         """

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -715,6 +715,7 @@ class TaskManager:
             exception_is_error=True,
             method=run_data_issue_remediation,
             database=self.database,
+            chains_aggregator=self.chains_aggregator,
         )]
 
     def _maybe_update_snapshot_balances(self) -> list[Task] | None:

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -687,10 +687,12 @@ class TaskManager:
             from_ts=TimestampMS(int(stale_from_ts)) if stale_from_ts is not None else None,
         )
 
-    def _maybe_run_data_issue_remediation(self) -> list[Task] | None:
+    def _maybe_run_data_issue_remediation(self, force: bool = False) -> list[Task] | None:
+        """Schedule remediation, optionally bypassing the daily cooldown."""
         if (
             self.history_processing_coordinator.is_history_fetching() or
-            self.task_supervisor.has_task(HISTORICAL_BALANCE_PROCESSING_TASK_NAME)
+            self.task_supervisor.has_task(HISTORICAL_BALANCE_PROCESSING_TASK_NAME) or
+            self.task_supervisor.has_task(DATA_ISSUE_REMEDIATION_TASK_NAME)
         ):
             return None
 
@@ -701,7 +703,7 @@ class TaskManager:
             ) is None:
                 return None
 
-        if should_run_periodic_task(
+        if not force and should_run_periodic_task(
             database=self.database,
             key_name=DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
             refresh_period=DATA_ISSUE_REMEDIATION_REFRESH,

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -696,13 +696,6 @@ class TaskManager:
         ):
             return None
 
-        with self.database.conn.read_ctx() as cursor:
-            if self.database.get_static_cache(
-                cursor=cursor,
-                name=DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
-            ) is None:
-                return None
-
         if not force and should_run_periodic_task(
             database=self.database,
             key_name=DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
@@ -710,6 +703,13 @@ class TaskManager:
             cached_timestamps=self._scheduler_task_timestamps,
         ) is False:
             return None
+
+        with self.database.conn.read_ctx() as cursor:
+            if self.database.get_static_cache(
+                cursor=cursor,
+                name=DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
+            ) is None:
+                return None
 
         return [self.task_supervisor.spawn_and_track(
             after_seconds=None,

--- a/rotkehlchen/tasks/manager.py
+++ b/rotkehlchen/tasks/manager.py
@@ -720,6 +720,9 @@ class TaskManager:
             chains_aggregator=self.chains_aggregator,
         )]
 
+    def trigger_data_issue_remediation(self) -> bool:
+        return self._maybe_run_data_issue_remediation(force=True) is not None
+
     def _maybe_update_snapshot_balances(self) -> list[Task] | None:
         """
         Update the balances of a user if the difference between last time they were updated

--- a/rotkehlchen/tasks/utils.py
+++ b/rotkehlchen/tasks/utils.py
@@ -31,6 +31,7 @@ SCHEDULER_PERIODIC_TASK_KEYS: Final = (
     DBCacheStatic.LAST_GRAPH_DELEGATIONS_CHECK_TS,
     DBCacheStatic.LAST_ETH2_EVENTS_PROCESSING_TS,
     DBCacheStatic.LAST_INTERNAL_TX_CONFLICTS_REPULL_TS,
+    DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
 )
 
 
@@ -64,6 +65,7 @@ def should_run_periodic_task(
             DBCacheStatic.LAST_GNOSISPAY_QUERY_TS,
             DBCacheStatic.LAST_SPARK_ASSETS_UPDATE,
             DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
+            DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
             DBCacheStatic.LAST_ETH2_EVENTS_PROCESSING_TS,
             DBCacheStatic.LAST_INTERNAL_TX_CONFLICTS_REPULL_TS,
         ],

--- a/rotkehlchen/tests/api/test_data_issues.py
+++ b/rotkehlchen/tests/api/test_data_issues.py
@@ -1,6 +1,8 @@
+import subprocess  # noqa: S404
+import sys
 from http import HTTPStatus
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 import requests
@@ -23,6 +25,54 @@ pytestmark = pytest.mark.accounting_update
 
 if TYPE_CHECKING:
     from rotkehlchen.api.server import APIServer
+
+
+@pytest.mark.parametrize('can_schedule', [False, True])
+def test_trigger_data_issue_remediation(
+        rotkehlchen_api_server: APIServer,
+        can_schedule: bool,
+) -> None:
+    task_manager = rotkehlchen_api_server.rest_api.rotkehlchen.task_manager
+    assert task_manager is not None
+    with patch.object(
+        task_manager,
+        '_maybe_run_data_issue_remediation',
+        return_value=[Mock()] if can_schedule else None,
+    ) as schedule:
+        response = requests.post(
+            api_url_for(rotkehlchen_api_server, 'triggertaskresource'),
+            json={'task': 'data_issue_remediation', 'async_query': False},
+        )
+    schedule.assert_called_once_with(force=True)
+    if can_schedule:
+        assert assert_proper_sync_response_with_result(response) is True
+    else:
+        assert_error_response(
+            response,
+            contained_in_msg='Data issue remediation cannot start',
+            status_code=HTTPStatus.CONFLICT,
+        )
+
+
+@pytest.mark.parametrize('optimized', [False, True])
+def test_remediation_task_api_validation_requires_debug(optimized: bool) -> None:
+    """The actual request schema rejects the debug-only task under python -O."""
+    result = subprocess.run([  # noqa: S603
+        sys.executable,
+        *(['-O'] if optimized else []),
+        '-c',
+        ('from marshmallow import ValidationError\n'
+        'from rotkehlchen.api.v1.schemas import TriggerTaskSchema\n'
+        'schema = TriggerTaskSchema()\n'
+        'schema.load({"task": "historical_balance_processing"})\n'
+        'try:\n'
+        '    schema.load({"task": "data_issue_remediation"})\n'
+        'except ValidationError:\n'
+        '    print("rejected")\n'
+        'else:\n'
+        '    print("accepted")\n'),
+    ], capture_output=True, text=True, check=True, timeout=30)
+    assert result.stdout.strip() == ('rejected' if optimized else 'accepted')
 
 
 def _write_issue(

--- a/rotkehlchen/tests/api/test_data_issues.py
+++ b/rotkehlchen/tests/api/test_data_issues.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 from typing import TYPE_CHECKING
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 import requests
@@ -34,14 +34,14 @@ def test_trigger_data_issue_remediation(
     assert task_manager is not None
     with patch.object(
         task_manager,
-        '_maybe_run_data_issue_remediation',
-        return_value=[Mock()] if can_schedule else None,
+        'trigger_data_issue_remediation',
+        return_value=can_schedule,
     ) as schedule:
         response = requests.post(
             api_url_for(rotkehlchen_api_server, 'triggertaskresource'),
             json={'task': 'data_issue_remediation', 'async_query': False},
         )
-    schedule.assert_called_once_with(force=True)
+    schedule.assert_called_once_with()
     if can_schedule:
         assert assert_proper_sync_response_with_result(response) is True
     else:

--- a/rotkehlchen/tests/api/test_data_issues.py
+++ b/rotkehlchen/tests/api/test_data_issues.py
@@ -1,5 +1,3 @@
-import subprocess  # noqa: S404
-import sys
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
@@ -52,27 +50,6 @@ def test_trigger_data_issue_remediation(
             contained_in_msg='Data issue remediation cannot start',
             status_code=HTTPStatus.CONFLICT,
         )
-
-
-@pytest.mark.parametrize('optimized', [False, True])
-def test_remediation_task_api_validation_requires_debug(optimized: bool) -> None:
-    """The actual request schema rejects the debug-only task under python -O."""
-    result = subprocess.run([  # noqa: S603
-        sys.executable,
-        *(['-O'] if optimized else []),
-        '-c',
-        ('from marshmallow import ValidationError\n'
-        'from rotkehlchen.api.v1.schemas import TriggerTaskSchema\n'
-        'schema = TriggerTaskSchema()\n'
-        'schema.load({"task": "historical_balance_processing"})\n'
-        'try:\n'
-        '    schema.load({"task": "data_issue_remediation"})\n'
-        'except ValidationError:\n'
-        '    print("rejected")\n'
-        'else:\n'
-        '    print("accepted")\n'),
-    ], capture_output=True, text=True, check=True, timeout=30)
-    assert result.stdout.strip() == ('rejected' if optimized else 'accepted')
 
 
 def _write_issue(

--- a/rotkehlchen/tests/unit/test_data_issue_remediation.py
+++ b/rotkehlchen/tests/unit/test_data_issue_remediation.py
@@ -5,6 +5,7 @@ import pytest
 
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
+from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.history_events import DBHistoryEvents
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
@@ -12,13 +13,16 @@ from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tasks.data_issues import run_data_issue_remediation
-from rotkehlchen.tests.utils.ethereum import TEST_ADDR1
+from rotkehlchen.tasks.historical_balances import process_historical_balances
+from rotkehlchen.tests.utils.ethereum import TEST_ADDR1, TEST_ADDR2
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
-from rotkehlchen.types import Location, TimestampMS
+from rotkehlchen.types import ChainID, EvmTransaction, Location, Timestamp, TimestampMS
 
 if TYPE_CHECKING:
+    from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.types import EVMTxHash
+    from rotkehlchen.user_messages import MessagesAggregator
 
 pytestmark = pytest.mark.accounting_update
 
@@ -84,6 +88,91 @@ def _get_saved_event_rows(database: DBHandler) -> tuple[list[tuple], list[tuple]
                 'SELECT * FROM history_events_mappings ORDER BY parent_identifier, name',
             ).fetchall(),
         )
+
+
+@pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1]])
+def test_negative_balance_customized_spend_is_compared_with_real_decoder(
+        database: DBHandler,
+        messages_aggregator: MessagesAggregator,
+        ethereum_transaction_decoder: EthereumTransactionDecoder,
+) -> None:
+    receive_tx_hash, spend_tx_hash = make_evm_tx_hash(), make_evm_tx_hash()
+    spend_transaction = EvmTransaction(
+        tx_hash=spend_tx_hash,
+        chain_id=ChainID.ETHEREUM,
+        timestamp=Timestamp(2),
+        block_number=1,
+        from_address=TEST_ADDR1,
+        to_address=TEST_ADDR2,
+        value=5 * 10**18,
+        gas=21_000,
+        gas_price=0,
+        gas_used=0,
+        input_data=b'',
+        nonce=0,
+    )
+    dbevents, dbtx = DBHistoryEvents(database), DBEvmTx(database)
+    with database.user_write() as write_cursor:
+        dbtx.add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[spend_transaction],
+            relevant_address=TEST_ADDR1,
+        )
+        dbtx.add_or_ignore_receipt_data(write_cursor, ChainID.ETHEREUM, {
+            'transactionHash': spend_tx_hash.hex(),
+            'type': '0x0',
+            'status': 1,
+            'contractAddress': None,
+            'logs': [],
+        })
+        dbevents.add_history_event(
+            write_cursor=write_cursor,
+            event=_make_event(
+                tx_hash=receive_tx_hash,
+                amount='10',
+                event_type=HistoryEventType.RECEIVE,
+            ),
+        )
+        spend_event_id = dbevents.add_history_event(
+            write_cursor=write_cursor,
+            event=_make_event(tx_hash=spend_tx_hash, amount='11', timestamp=2_000),
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
+        )
+    assert spend_event_id is not None
+
+    process_historical_balances(database=database, msg_aggregator=messages_aggregator)
+    issues_manager = DataIssuesManager(database)
+    issues = issues_manager.list_issues()
+    assert len(issues) == 1
+    assert issues[0].kind == IssueKind.NEGATIVE_BALANCE
+    assert issues[0].state == IssueState.OPEN
+    assert issues[0].payload == {
+        'event_identifier': spend_event_id,
+        'in_memory_negative_amount': '-1',
+        'derived_balance_before_event': '10',
+    }
+    saved_rows = _get_saved_event_rows(database)
+
+    chains_aggregator = MagicMock()
+    chains_aggregator.get_evm_manager.return_value.transactions_decoder = (
+        ethereum_transaction_decoder
+    )
+    run_data_issue_remediation(
+        database=database,
+        chains_aggregator=chains_aggregator,
+    )
+
+    issue = issues_manager.get_issue(issues[0].id)
+    assert issue.state == IssueState.UNRESOLVED
+    assert issue.auto_remediation_attempts == [{
+        'attribution': 'system',
+        'strategy': 'redecode_customized_transactions',
+        'timestamp': issue.auto_remediation_attempts[0]['timestamp'],
+        'result': 'redecoding_would_change_balance',
+        'customized_transaction_count': 1,
+        'changed_transaction_count': 1,
+    }]
+    assert _get_saved_event_rows(database) == saved_rows
 
 
 @pytest.mark.parametrize(('preview_amount', 'expected_result', 'expected_changed'), [

--- a/rotkehlchen/tests/unit/test_data_issue_remediation.py
+++ b/rotkehlchen/tests/unit/test_data_issue_remediation.py
@@ -1,0 +1,204 @@
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
+from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
+from rotkehlchen.history.data_issues.manager import DataIssuesManager
+from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.tasks.data_issues import run_data_issue_remediation
+from rotkehlchen.tests.utils.ethereum import TEST_ADDR1
+from rotkehlchen.tests.utils.factories import make_evm_tx_hash
+from rotkehlchen.types import Location, TimestampMS
+
+if TYPE_CHECKING:
+    from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.types import EVMTxHash
+
+pytestmark = pytest.mark.accounting_update
+
+
+def _make_event(
+        tx_hash: EVMTxHash,
+        amount: str,
+        timestamp: int = 1_000,
+        event_type: HistoryEventType = HistoryEventType.SPEND,
+) -> EvmEvent:
+    return EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=TimestampMS(timestamp),
+        location=Location.ETHEREUM,
+        event_type=event_type,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_ETH,
+        amount=FVal(amount),
+        location_label=TEST_ADDR1,
+        notes='saved customized event',
+    )
+
+
+def _add_negative_balance_issue(
+        database: DBHandler,
+        customized: bool,
+) -> tuple[int, EVMTxHash]:
+    tx_hash = make_evm_tx_hash()
+    with database.user_write() as write_cursor:
+        event_id = DBHistoryEvents(database).add_history_event(
+            write_cursor=write_cursor,
+            event=_make_event(tx_hash=tx_hash, amount='2'),
+            mapping_values=(
+                {HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED}
+                if customized else None
+            ),
+        )
+    assert event_id is not None
+    issue_id = DataIssuesManager(database).write_issue(
+        kind=IssueKind.NEGATIVE_BALANCE,
+        location=Location.ETHEREUM.serialize_for_db(),
+        location_label=TEST_ADDR1,
+        protocol=None,
+        asset=A_ETH.identifier,
+        payload={
+            'event_identifier': event_id,
+            'in_memory_negative_amount': '-1',
+            'derived_balance_before_event': '1',
+        },
+        ts_start=1_000,
+        ts_end=1_000,
+    )
+    return issue_id, tx_hash
+
+
+def _get_saved_event_rows(database: DBHandler) -> tuple[list[tuple], list[tuple], list[tuple]]:
+    with database.conn.read_ctx() as cursor:
+        return (
+            cursor.execute('SELECT * FROM history_events ORDER BY identifier').fetchall(),
+            cursor.execute('SELECT * FROM chain_events_info ORDER BY identifier').fetchall(),
+            cursor.execute(
+                'SELECT * FROM history_events_mappings ORDER BY parent_identifier, name',
+            ).fetchall(),
+        )
+
+
+@pytest.mark.parametrize(('preview_amount', 'expected_result', 'expected_changed'), [
+    ('1', 'redecoding_would_change_balance', 1),
+    ('2', 'redecoding_would_not_change_balance', 0),
+])
+def test_customized_transaction_redecode_comparison_preserves_saved_events(
+        database: DBHandler,
+        preview_amount: str,
+        expected_result: str,
+        expected_changed: int,
+) -> None:
+    issue_id, tx_hash = _add_negative_balance_issue(database=database, customized=True)
+    saved_rows = _get_saved_event_rows(database)
+
+    with patch(
+        'rotkehlchen.tasks.data_issues._preview_transaction',
+        return_value=[_make_event(tx_hash=tx_hash, amount=preview_amount)],
+    ) as preview:
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+    preview.assert_called_once()
+    issue = DataIssuesManager(database).get_issue(issue_id)
+    assert issue.state == IssueState.UNRESOLVED
+    assert issue.auto_remediation_attempts == [{
+        'attribution': 'system',
+        'strategy': 'redecode_customized_transactions',
+        'timestamp': issue.auto_remediation_attempts[0]['timestamp'],
+        'result': expected_result,
+        'customized_transaction_count': 1,
+        'changed_transaction_count': expected_changed,
+    }]
+    assert _get_saved_event_rows(database) == saved_rows
+
+
+def test_normal_transaction_is_not_redecoded_for_negative_balance(database: DBHandler) -> None:
+    issue_id, _tx_hash = _add_negative_balance_issue(database=database, customized=False)
+    with patch('rotkehlchen.tasks.data_issues._preview_transaction') as preview:
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+    preview.assert_not_called()
+    issue = DataIssuesManager(database).get_issue(issue_id)
+    assert issue.state == IssueState.OPEN
+    assert issue.auto_remediation_attempts == []
+
+
+def test_earlier_customized_transaction_in_negative_bucket_is_compared(
+        database: DBHandler,
+) -> None:
+    customized_tx_hash, failing_tx_hash = make_evm_tx_hash(), make_evm_tx_hash()
+    dbevents = DBHistoryEvents(database)
+    with database.user_write() as write_cursor:
+        dbevents.add_history_event(
+            write_cursor=write_cursor,
+            event=_make_event(
+                tx_hash=customized_tx_hash,
+                amount='1',
+                event_type=HistoryEventType.RECEIVE,
+            ),
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
+        )
+        failing_event_id = dbevents.add_history_event(
+            write_cursor=write_cursor,
+            event=_make_event(tx_hash=failing_tx_hash, amount='2', timestamp=2_000),
+        )
+    assert failing_event_id is not None
+    issue_id = DataIssuesManager(database).write_issue(
+        kind=IssueKind.NEGATIVE_BALANCE,
+        location=Location.ETHEREUM.serialize_for_db(),
+        location_label=TEST_ADDR1,
+        protocol=None,
+        asset=A_ETH.identifier,
+        payload={
+            'event_identifier': failing_event_id,
+            'in_memory_negative_amount': '-1',
+            'derived_balance_before_event': '1',
+        },
+        ts_start=2_000,
+        ts_end=2_000,
+    )
+
+    with patch(
+        'rotkehlchen.tasks.data_issues._preview_transaction',
+        return_value=[_make_event(
+            tx_hash=customized_tx_hash,
+            amount='2',
+            event_type=HistoryEventType.RECEIVE,
+        )],
+    ) as preview:
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+    preview.assert_called_once()
+    issue = DataIssuesManager(database).get_issue(issue_id)
+    assert issue.state == IssueState.UNRESOLVED
+    assert issue.auto_remediation_attempts[0]['result'] == 'redecoding_would_change_balance'
+
+
+def test_failed_redecode_comparison_preserves_saved_events(database: DBHandler) -> None:
+    issue_id, _tx_hash = _add_negative_balance_issue(database=database, customized=True)
+    saved_rows = _get_saved_event_rows(database)
+    with patch(
+        'rotkehlchen.tasks.data_issues._preview_transaction',
+        side_effect=RuntimeError('receipt unavailable'),
+    ):
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+    issue = DataIssuesManager(database).get_issue(issue_id)
+    assert issue.state == IssueState.UNRESOLVED
+    assert issue.auto_remediation_attempts[0] | {'timestamp': 0} == {
+        'attribution': 'system',
+        'strategy': 'redecode_customized_transactions',
+        'timestamp': 0,
+        'result': 'redecoding_failed',
+        'customized_transaction_count': 1,
+        'changed_transaction_count': 0,
+        'reason': 'receipt unavailable',
+    }
+    assert _get_saved_event_rows(database) == saved_rows

--- a/rotkehlchen/tests/unit/test_data_issue_remediation.py
+++ b/rotkehlchen/tests/unit/test_data_issue_remediation.py
@@ -32,6 +32,7 @@ def _make_event(
         amount: str,
         timestamp: int = 1_000,
         event_type: HistoryEventType = HistoryEventType.SPEND,
+        location_label: str = TEST_ADDR1,
 ) -> EvmEvent:
     return EvmEvent(
         tx_ref=tx_hash,
@@ -42,8 +43,25 @@ def _make_event(
         event_subtype=HistoryEventSubType.NONE,
         asset=A_ETH,
         amount=FVal(amount),
-        location_label=TEST_ADDR1,
+        location_label=location_label,
         notes='saved customized event',
+    )
+
+
+def _make_transaction(tx_hash: EVMTxHash, timestamp: int = 1) -> EvmTransaction:
+    return EvmTransaction(
+        tx_hash=tx_hash,
+        chain_id=ChainID.ETHEREUM,
+        timestamp=Timestamp(timestamp),
+        block_number=1,
+        from_address=TEST_ADDR1,
+        to_address=TEST_ADDR2,
+        value=0,
+        gas=21_000,
+        gas_price=0,
+        gas_used=0,
+        input_data=b'',
+        nonce=0,
     )
 
 
@@ -53,6 +71,11 @@ def _add_negative_balance_issue(
 ) -> tuple[int, EVMTxHash]:
     tx_hash = make_evm_tx_hash()
     with database.user_write() as write_cursor:
+        DBEvmTx(database).add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[_make_transaction(tx_hash)],
+            relevant_address=TEST_ADDR1,
+        )
         event_id = DBHistoryEvents(database).add_history_event(
             write_cursor=write_cursor,
             event=_make_event(tx_hash=tx_hash, amount='2'),
@@ -223,8 +246,13 @@ def test_earlier_customized_transaction_in_negative_bucket_is_compared(
         database: DBHandler,
 ) -> None:
     customized_tx_hash, failing_tx_hash = make_evm_tx_hash(), make_evm_tx_hash()
-    dbevents = DBHistoryEvents(database)
+    dbevents, dbtx = DBHistoryEvents(database), DBEvmTx(database)
     with database.user_write() as write_cursor:
+        dbtx.add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[_make_transaction(customized_tx_hash)],
+            relevant_address=TEST_ADDR1,
+        )
         dbevents.add_history_event(
             write_cursor=write_cursor,
             event=_make_event(
@@ -268,6 +296,88 @@ def test_earlier_customized_transaction_in_negative_bucket_is_compared(
     issue = DataIssuesManager(database).get_issue(issue_id)
     assert issue.state == IssueState.UNRESOLVED
     assert issue.auto_remediation_attempts[0]['result'] == 'redecoding_would_change_balance'
+
+
+@pytest.mark.parametrize(('saved_timestamp', 'saved_location_label'), [
+    (1_000, TEST_ADDR2),
+    (2_000, TEST_ADDR1),
+])
+def test_customized_transaction_with_changed_bucket_scope_is_compared(
+        database: DBHandler,
+        saved_timestamp: int,
+        saved_location_label: str,
+) -> None:
+    customized_tx_hash = make_evm_tx_hash()
+    issue_id, _failing_tx_hash = _add_negative_balance_issue(
+        database=database,
+        customized=False,
+    )
+    with database.user_write() as write_cursor:
+        DBEvmTx(database).add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[_make_transaction(customized_tx_hash)],
+            relevant_address=TEST_ADDR1,
+        )
+        DBHistoryEvents(database).add_history_event(
+            write_cursor=write_cursor,
+            event=_make_event(
+                tx_hash=customized_tx_hash,
+                amount='1',
+                timestamp=saved_timestamp,
+                event_type=HistoryEventType.RECEIVE,
+                location_label=saved_location_label,
+            ),
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
+        )
+
+    with patch(
+        'rotkehlchen.tasks.data_issues._preview_transaction',
+        return_value=[_make_event(
+            tx_hash=customized_tx_hash,
+            amount='1',
+            event_type=HistoryEventType.RECEIVE,
+        )],
+    ) as preview:
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+    preview.assert_called_once()
+    issue = DataIssuesManager(database).get_issue(issue_id)
+    assert issue.state == IssueState.UNRESOLVED
+    assert issue.auto_remediation_attempts[0]['result'] == 'redecoding_would_change_balance'
+    assert issue.auto_remediation_attempts[0]['changed_transaction_count'] == 1
+
+
+def test_customized_transaction_for_unrelated_account_is_not_compared(
+        database: DBHandler,
+) -> None:
+    customized_tx_hash = make_evm_tx_hash()
+    issue_id, _failing_tx_hash = _add_negative_balance_issue(
+        database=database,
+        customized=False,
+    )
+    with database.user_write() as write_cursor:
+        DBEvmTx(database).add_transactions(
+            write_cursor=write_cursor,
+            evm_transactions=[_make_transaction(customized_tx_hash)],
+            relevant_address=TEST_ADDR2,
+        )
+        DBHistoryEvents(database).add_history_event(
+            write_cursor=write_cursor,
+            event=_make_event(
+                tx_hash=customized_tx_hash,
+                amount='1',
+                event_type=HistoryEventType.RECEIVE,
+            ),
+            mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
+        )
+
+    with patch('rotkehlchen.tasks.data_issues._preview_transaction') as preview:
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+    preview.assert_not_called()
+    issue = DataIssuesManager(database).get_issue(issue_id)
+    assert issue.state == IssueState.OPEN
+    assert issue.auto_remediation_attempts == []
 
 
 def test_failed_redecode_comparison_preserves_saved_events(database: DBHandler) -> None:

--- a/rotkehlchen/tests/unit/test_data_issue_remediation.py
+++ b/rotkehlchen/tests/unit/test_data_issue_remediation.py
@@ -1,12 +1,15 @@
+from dataclasses import replace
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.history_events import DBHistoryEvents
+from rotkehlchen.errors.misc import RemoteError
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.data_issues.constants import IssueKind, IssueState
 from rotkehlchen.history.data_issues.manager import DataIssuesManager
@@ -142,7 +145,7 @@ def test_negative_balance_customized_spend_is_compared_with_real_decoder(
             relevant_address=TEST_ADDR1,
         )
         dbtx.add_or_ignore_receipt_data(write_cursor, ChainID.ETHEREUM, {
-            'transactionHash': spend_tx_hash.hex(),
+            'transactionHash': str(spend_tx_hash),
             'type': '0x0',
             'status': 1,
             'contractAddress': None,
@@ -401,3 +404,90 @@ def test_failed_redecode_comparison_preserves_saved_events(database: DBHandler) 
         'reason': 'receipt unavailable',
     }
     assert _get_saved_event_rows(database) == saved_rows
+
+
+@pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1]])
+@pytest.mark.parametrize('rule_stage', [
+    'address', 'input', 'event', 'post_decoding', 'enrichment',
+])
+@pytest.mark.parametrize('error_type', [RemoteError, ValueError])
+def test_decoder_rule_failure_is_reported_as_failed_comparison(
+        database: DBHandler,
+        ethereum_transaction_decoder: EthereumTransactionDecoder,
+        rule_stage: str,
+        error_type: type[Exception],
+) -> None:
+    """A rule failure invalidates previews without changing normal decoding's error tolerance."""
+    issue_id, tx_hash = _add_negative_balance_issue(database, customized=True)
+    dbtx = DBEvmTx(database)
+    with database.user_write() as cursor:
+        dbtx.add_or_ignore_receipt_data(cursor, ChainID.ETHEREUM, {
+            'transactionHash': str(tx_hash),
+            'type': '0x0',
+            'status': 1,
+            'contractAddress': None,
+            'logs': [{
+                'logIndex': 0,
+                'data': '0x' + (1000000).to_bytes(32, 'big').hex(),
+                'address': (
+                    '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+                    if rule_stage == 'enrichment' else TEST_ADDR2
+                ),
+                'topics': [
+                    '0x' + ERC20_OR_ERC721_TRANSFER.hex(),
+                    '0x' + '00' * 12 + TEST_ADDR1[2:],
+                    '0x' + '00' * 12 + TEST_ADDR2[2:],
+                ] if rule_stage == 'enrichment' else ['0x' + '01' * 32],
+            }],
+        })
+    with database.conn.read_ctx() as cursor:
+        receipt = dbtx.get_receipt(cursor, tx_hash, ChainID.ETHEREUM)
+    assert receipt is not None
+    saved_rows = _get_saved_event_rows(database)
+    decoder = ethereum_transaction_decoder
+    failing_rule = Mock(__name__='failing_rule', side_effect=error_type('rule unavailable'))
+    chains_aggregator = MagicMock()
+    chains_aggregator.get_evm_manager.return_value.transactions_decoder = decoder
+
+    with (
+        patch.object(
+            decoder,
+            'rules',
+            replace(
+                decoder.rules,
+                address_mappings=(
+                    {TEST_ADDR2: (failing_rule,)} if rule_stage == 'address' else {}
+                ),
+                input_data_rules=(
+                    {b'': {bytes.fromhex('01' * 32): failing_rule}}
+                    if rule_stage == 'input' else {}
+                ),
+                event_rules=(
+                    [failing_rule] if rule_stage == 'event' else
+                    [decoder._maybe_decode_erc20_721_transfer]
+                ),
+                token_enricher_rules=[failing_rule] if rule_stage == 'enrichment' else [],
+            ),
+        ),
+        patch.object(
+            decoder,
+            '_chain_specific_post_decoding_rules',
+            return_value=[(0, failing_rule)] if rule_stage == 'post_decoding' else [],
+        ),
+    ):
+        run_data_issue_remediation(database, chains_aggregator)
+        issue = DataIssuesManager(database).get_issue(issue_id)
+        assert issue.state == IssueState.UNRESOLVED
+        assert issue.auto_remediation_attempts[0]['result'] == 'redecoding_failed'
+        assert issue.auto_remediation_attempts[0]['reason'] == 'rule unavailable'
+        failing_rule.assert_called_once()
+        assert _get_saved_event_rows(database) == saved_rows
+
+        events, _, _ = decoder._decode_transaction(
+            transaction=_make_transaction(tx_hash),
+            tx_receipt=receipt,
+            write_buffer=[],
+        )
+        assert failing_rule.call_count == 2
+        assert len(events) != 0
+        assert any('failed' in message for message in decoder.msg_aggregator.consume_errors())

--- a/rotkehlchen/tests/unit/test_data_issue_remediation.py
+++ b/rotkehlchen/tests/unit/test_data_issue_remediation.py
@@ -3,9 +3,12 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from freezegun import freeze_time
 
+from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
 from rotkehlchen.constants.assets import A_ETH
+from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
 from rotkehlchen.db.evmtx import DBEvmTx
 from rotkehlchen.db.history_events import DBHistoryEvents
@@ -16,16 +19,17 @@ from rotkehlchen.history.data_issues.manager import DataIssuesManager
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.tasks.data_issues import run_data_issue_remediation
-from rotkehlchen.tasks.historical_balances import process_historical_balances
 from rotkehlchen.tests.utils.ethereum import TEST_ADDR1, TEST_ADDR2
 from rotkehlchen.tests.utils.factories import make_evm_tx_hash
 from rotkehlchen.types import ChainID, EvmTransaction, Location, Timestamp, TimestampMS
+from rotkehlchen.utils.misc import ts_now
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.ethereum.decoding.decoder import EthereumTransactionDecoder
+    from rotkehlchen.concurrency import Task
     from rotkehlchen.db.dbhandler import DBHandler
+    from rotkehlchen.tasks.manager import TaskManager
     from rotkehlchen.types import EVMTxHash
-    from rotkehlchen.user_messages import MessagesAggregator
 
 pytestmark = pytest.mark.accounting_update
 
@@ -116,12 +120,32 @@ def _get_saved_event_rows(database: DBHandler) -> tuple[list[tuple], list[tuple]
         )
 
 
+def _wait_for_background_task(tasks: list[Task] | None) -> None:
+    assert tasks is not None
+    assert len(tasks) == 1
+    task = tasks[0]
+    task.join(timeout=10)
+    assert task.dead, f'{task.task_name} did not finish'
+    task.get()
+
+
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1]])
+@pytest.mark.usefixtures('ethereum_transaction_decoder')
+@pytest.mark.parametrize(('decoded_spend', 'missing_receipt', 'expected_result'), [
+    (5, False, 'redecoding_would_change_balance'),
+    (11, False, 'redecoding_would_not_change_balance'),
+    (5, True, 'redecoding_would_change_balance'),
+])
+@freeze_time('2026-09-07 12:00:00')
 def test_negative_balance_customized_spend_is_compared_with_real_decoder(
         database: DBHandler,
-        messages_aggregator: MessagesAggregator,
-        ethereum_transaction_decoder: EthereumTransactionDecoder,
+        task_manager: TaskManager,
+        request: pytest.FixtureRequest,
+        decoded_spend: int,
+        missing_receipt: bool,
+        expected_result: str,
 ) -> None:
+    """Schedule balance processing and real previews, preserving events across attempts."""
     receive_tx_hash, spend_tx_hash = make_evm_tx_hash(), make_evm_tx_hash()
     spend_transaction = EvmTransaction(
         tx_hash=spend_tx_hash,
@@ -130,13 +154,20 @@ def test_negative_balance_customized_spend_is_compared_with_real_decoder(
         block_number=1,
         from_address=TEST_ADDR1,
         to_address=TEST_ADDR2,
-        value=5 * 10**18,
+        value=decoded_spend * 10**18,
         gas=21_000,
         gas_price=0,
         gas_used=0,
         input_data=b'',
         nonce=0,
     )
+    receipt_data = {
+        'transactionHash': str(spend_tx_hash),
+        'type': '0x0',
+        'status': 1,
+        'contractAddress': None,
+        'logs': [],
+    }
     dbevents, dbtx = DBHistoryEvents(database), DBEvmTx(database)
     with database.user_write() as write_cursor:
         dbtx.add_transactions(
@@ -144,13 +175,8 @@ def test_negative_balance_customized_spend_is_compared_with_real_decoder(
             evm_transactions=[spend_transaction],
             relevant_address=TEST_ADDR1,
         )
-        dbtx.add_or_ignore_receipt_data(write_cursor, ChainID.ETHEREUM, {
-            'transactionHash': str(spend_tx_hash),
-            'type': '0x0',
-            'status': 1,
-            'contractAddress': None,
-            'logs': [],
-        })
+        if missing_receipt is False:
+            dbtx.add_or_ignore_receipt_data(write_cursor, ChainID.ETHEREUM, receipt_data)
         dbevents.add_history_event(
             write_cursor=write_cursor,
             event=_make_event(
@@ -159,14 +185,30 @@ def test_negative_balance_customized_spend_is_compared_with_real_decoder(
                 event_type=HistoryEventType.RECEIVE,
             ),
         )
+        dbevents.add_history_event(write_cursor, EvmEvent(
+            tx_ref=spend_tx_hash,
+            sequence_index=0,
+            timestamp=TimestampMS(2_000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.SPEND,
+            event_subtype=HistoryEventSubType.FEE,
+            asset=A_ETH,
+            amount=FVal(0),
+            location_label=TEST_ADDR1,
+            counterparty=CPT_GAS,
+            notes='Burn 0 ETH for gas',
+        ))
+        saved_spend = _make_event(tx_hash=spend_tx_hash, amount='11', timestamp=2_000)
+        saved_spend.sequence_index = 1
         spend_event_id = dbevents.add_history_event(
             write_cursor=write_cursor,
-            event=_make_event(tx_hash=spend_tx_hash, amount='11', timestamp=2_000),
+            event=saved_spend,
             mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED},
         )
     assert spend_event_id is not None
 
-    process_historical_balances(database=database, msg_aggregator=messages_aggregator)
+    assert task_manager._maybe_run_data_issue_remediation() is None
+    _wait_for_background_task(task_manager._maybe_process_historical_balances())
     issues_manager = DataIssuesManager(database)
     issues = issues_manager.list_issues()
     assert len(issues) == 1
@@ -178,27 +220,66 @@ def test_negative_balance_customized_spend_is_compared_with_real_decoder(
         'derived_balance_before_event': '10',
     }
     saved_rows = _get_saved_event_rows(database)
-
-    chains_aggregator = MagicMock()
-    chains_aggregator.get_evm_manager.return_value.transactions_decoder = (
-        ethereum_transaction_decoder
-    )
-    run_data_issue_remediation(
-        database=database,
-        chains_aggregator=chains_aggregator,
-    )
+    with database.conn.read_ctx() as cursor:
+        saved_tx_mappings = cursor.execute('SELECT * FROM evm_tx_mappings').fetchall()
+        assert database.get_static_cache(
+            cursor, DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
+        ) == ts_now()
+    _wait_for_background_task(task_manager._maybe_run_data_issue_remediation())
 
     issue = issues_manager.get_issue(issues[0].id)
     assert issue.state == IssueState.UNRESOLVED
-    assert issue.auto_remediation_attempts == [{
+    assert len(issue.auto_remediation_attempts) == 1
+    attempt = issue.auto_remediation_attempts[0]
+    assert {key: value for key, value in attempt.items() if key != 'reason'} == {
         'attribution': 'system',
         'strategy': 'redecode_customized_transactions',
-        'timestamp': issue.auto_remediation_attempts[0]['timestamp'],
-        'result': 'redecoding_would_change_balance',
+        'timestamp': ts_now(),
+        'result': 'redecoding_failed' if missing_receipt else expected_result,
         'customized_transaction_count': 1,
-        'changed_transaction_count': 1,
-    }]
+        'changed_transaction_count': int(not missing_receipt and decoded_spend != 11),
+    }
     assert _get_saved_event_rows(database) == saved_rows
+    with database.conn.read_ctx() as cursor:
+        assert cursor.execute('SELECT * FROM evm_tx_mappings').fetchall() == saved_tx_mappings
+        assert database.get_static_cache(
+            cursor, DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
+        ) == ts_now()
+    assert task_manager._maybe_run_data_issue_remediation() is None
+
+    if missing_receipt:
+        assert 'Missing transaction data' in attempt['reason']
+        with database.user_write() as cursor:
+            dbtx.add_or_ignore_receipt_data(cursor, ChainID.ETHEREUM, receipt_data)
+
+    with freeze_time('2026-09-08 12:00:01'):
+        _wait_for_background_task(task_manager._maybe_run_data_issue_remediation())
+        issue = issues_manager.get_issue(issue.id)
+        assert issue.state == IssueState.UNRESOLVED
+        assert _get_saved_event_rows(database) == saved_rows
+        with database.conn.read_ctx() as cursor:
+            assert cursor.execute('SELECT * FROM evm_tx_mappings').fetchall() == saved_tx_mappings
+            assert database.get_static_cache(
+                cursor, DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
+            ) == ts_now()
+
+        if missing_receipt:
+            request.applymarker(pytest.mark.xfail(
+                strict=True,
+                reason='Step 5: unresolved failed comparisons are not retried yet',
+            ))
+            assert len(issue.auto_remediation_attempts) == 2
+            assert issue.auto_remediation_attempts[0] == attempt
+            assert issue.auto_remediation_attempts[1] == {
+                'attribution': 'system',
+                'strategy': 'redecode_customized_transactions',
+                'timestamp': ts_now(),
+                'result': expected_result,
+                'customized_transaction_count': 1,
+                'changed_transaction_count': 1,
+            }
+        else:
+            assert issue.auto_remediation_attempts == [attempt]
 
 
 @pytest.mark.parametrize(('preview_amount', 'expected_result', 'expected_changed'), [

--- a/rotkehlchen/tests/unit/test_data_issue_remediation.py
+++ b/rotkehlchen/tests/unit/test_data_issue_remediation.py
@@ -140,7 +140,6 @@ def _wait_for_background_task(tasks: list[Task] | None) -> None:
 def test_negative_balance_customized_spend_is_compared_with_real_decoder(
         database: DBHandler,
         task_manager: TaskManager,
-        request: pytest.FixtureRequest,
         decoded_spend: int,
         missing_receipt: bool,
         expected_result: str,
@@ -264,10 +263,6 @@ def test_negative_balance_customized_spend_is_compared_with_real_decoder(
             ) == ts_now()
 
         if missing_receipt:
-            request.applymarker(pytest.mark.xfail(
-                strict=True,
-                reason='Step 5: unresolved failed comparisons are not retried yet',
-            ))
             assert len(issue.auto_remediation_attempts) == 2
             assert issue.auto_remediation_attempts[0] == attempt
             assert issue.auto_remediation_attempts[1] == {
@@ -313,6 +308,22 @@ def test_customized_transaction_redecode_comparison_preserves_saved_events(
         'changed_transaction_count': expected_changed,
     }]
     assert _get_saved_event_rows(database) == saved_rows
+
+
+def test_redecode_comparison_ignores_sequence_index_changes(database: DBHandler) -> None:
+    issue_id, tx_hash = _add_negative_balance_issue(database=database, customized=True)
+    preview_event = _make_event(tx_hash=tx_hash, amount='2')
+    preview_event.sequence_index = 7
+
+    with patch(
+        'rotkehlchen.tasks.data_issues._preview_transaction',
+        return_value=[preview_event],
+    ):
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+    attempt = DataIssuesManager(database).get_issue(issue_id).auto_remediation_attempts[0]
+    assert attempt['result'] == 'redecoding_would_not_change_balance'
+    assert attempt['changed_transaction_count'] == 0
 
 
 def test_normal_transaction_is_not_redecoded_for_negative_balance(database: DBHandler) -> None:

--- a/rotkehlchen/tests/unit/test_data_issue_remediation.py
+++ b/rotkehlchen/tests/unit/test_data_issue_remediation.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.evm.decoding.constants import ERC20_OR_ERC721_TRANSFER
+from rotkehlchen.concurrency import TaskCancelledError
 from rotkehlchen.constants.assets import A_ETH
 from rotkehlchen.db.cache import DBCacheStatic
 from rotkehlchen.db.constants import HISTORY_MAPPING_KEY_STATE, HistoryMappingState
@@ -496,6 +497,52 @@ def test_failed_redecode_comparison_preserves_saved_events(database: DBHandler) 
         'reason': 'receipt unavailable',
     }
     assert _get_saved_event_rows(database) == saved_rows
+
+
+def test_repeated_failed_comparison_keeps_one_attempt(database: DBHandler) -> None:
+    issue_id, _tx_hash = _add_negative_balance_issue(database=database, customized=True)
+    with patch(
+        'rotkehlchen.tasks.data_issues._preview_transaction',
+        side_effect=RuntimeError('receipt unavailable'),
+    ) as preview:
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+    assert preview.call_count == 2
+    issue = DataIssuesManager(database).get_issue(issue_id)
+    assert issue.state == IssueState.UNRESOLVED
+    assert len(issue.auto_remediation_attempts) == 1
+
+
+def test_cancelled_comparison_is_retried(database: DBHandler) -> None:
+    issue_id, tx_hash = _add_negative_balance_issue(database=database, customized=True)
+    with patch(
+        'rotkehlchen.tasks.data_issues._preview_transaction',
+        side_effect=(
+            TaskCancelledError(),
+            [_make_event(tx_hash=tx_hash, amount='2')],
+        ),
+    ) as preview:
+        with pytest.raises(TaskCancelledError):
+            run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+        issue = DataIssuesManager(database).get_issue(issue_id)
+        assert issue.state == IssueState.UNRESOLVED
+        assert len(issue.auto_remediation_attempts) == 1
+        assert issue.auto_remediation_attempts[0]['result'] == 'redecoding_failed'
+        assert issue.auto_remediation_attempts[0]['reason'] == (
+            'Remediation was cancelled before the comparison finished'
+        )
+
+        run_data_issue_remediation(database=database, chains_aggregator=MagicMock())
+
+    assert preview.call_count == 2
+    issue = DataIssuesManager(database).get_issue(issue_id)
+    assert issue.state == IssueState.UNRESOLVED
+    assert len(issue.auto_remediation_attempts) == 2
+    assert issue.auto_remediation_attempts[1]['result'] == (
+        'redecoding_would_not_change_balance'
+    )
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1]])

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -45,7 +45,11 @@ from rotkehlchen.history.events.structures.base import (
 )
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
 from rotkehlchen.tests.utils.ethereum import INFURA_ETH_NODE, get_decoded_events_of_transaction
-from rotkehlchen.tests.utils.factories import make_evm_address, make_evm_tx_hash
+from rotkehlchen.tests.utils.factories import (
+    make_ethereum_transaction,
+    make_evm_address,
+    make_evm_tx_hash,
+)
 from rotkehlchen.types import (
     ChainID,
     ChecksumEvmAddress,
@@ -763,6 +767,48 @@ def test_write_events_relocates_sequence_index_collision(
         (3, 'first at 3'),
         (4, 'second at 3'),  # relocated past the max used index instead of being dropped
     ]
+
+
+def test_decode_transaction_without_persistence_discards_write_buffer(
+        ethereum_transaction_decoder: EthereumTransactionDecoder,
+) -> None:
+    transaction = make_ethereum_transaction()
+    receipt = EvmTxReceipt(
+        tx_hash=transaction.tx_hash,
+        chain_id=ChainID.ETHEREUM,
+        contract_address=None,
+        status=True,
+        tx_type=0,
+    )
+    expected_events = [EvmEvent(
+        tx_ref=transaction.tx_hash,
+        sequence_index=0,
+        timestamp=TimestampMS(0),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_ETH,
+        amount=ZERO,
+    )]
+    with (
+        patch.object(ethereum_transaction_decoder, 'reload_data') as reload_data,
+        patch.object(
+            ethereum_transaction_decoder,
+            '_decode_transaction',
+            return_value=(expected_events, False, None),
+        ) as decode_transaction,
+    ):
+        assert ethereum_transaction_decoder.decode_transaction_without_persistence(
+            transaction=transaction,
+            tx_receipt=receipt,
+        ) == expected_events
+
+    reload_data.assert_called_once()
+    decode_transaction.assert_called_once_with(
+        transaction=transaction,
+        tx_receipt=receipt,
+        write_buffer=[],
+    )
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -933,6 +933,7 @@ def test_decode_transaction_without_persistence_discards_write_buffer(
         transaction=transaction,
         tx_receipt=receipt,
         write_buffer=[],
+        strict=True,
     )
 
 

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -43,8 +43,14 @@ from rotkehlchen.history.events.structures.base import (
     HistoryEventSubType,
     HistoryEventType,
 )
+from rotkehlchen.history.events.structures.eth2 import EthBlockEvent
 from rotkehlchen.history.events.structures.evm_event import EvmEvent
-from rotkehlchen.tests.utils.ethereum import INFURA_ETH_NODE, get_decoded_events_of_transaction
+from rotkehlchen.tests.utils.ethereum import (
+    INFURA_ETH_NODE,
+    TEST_ADDR1,
+    TEST_ADDR2,
+    get_decoded_events_of_transaction,
+)
 from rotkehlchen.tests.utils.factories import (
     make_ethereum_transaction,
     make_evm_address,
@@ -767,6 +773,125 @@ def test_write_events_relocates_sequence_index_collision(
         (3, 'first at 3'),
         (4, 'second at 3'),  # relocated past the max used index instead of being dropped
     ]
+
+
+@pytest.mark.parametrize('ethereum_accounts', [[TEST_ADDR1]])
+@pytest.mark.parametrize('existing_mev_reward', [False, True])
+def test_reward_fallback_only_persists_after_normal_decoding(
+        database: DBHandler,
+        ethereum_transaction_decoder: EthereumTransactionDecoder,
+        existing_mev_reward: bool,
+) -> None:
+    """Preview preserves customized events and rewards; fresh decoding persists the fallback."""
+    decoder = ethereum_transaction_decoder
+    transaction = EvmTransaction(
+        tx_hash=make_evm_tx_hash(),
+        chain_id=ChainID.ETHEREUM,
+        timestamp=Timestamp(1739574323),
+        block_number=21847848,
+        from_address=TEST_ADDR2,
+        to_address=TEST_ADDR1,
+        value=2 * 10**18,
+        gas=21000,
+        gas_price=0,
+        gas_used=21000,
+        input_data=b'',
+        nonce=0,
+    )
+    receipt = EvmTxReceipt(
+        tx_hash=transaction.tx_hash,
+        chain_id=ChainID.ETHEREUM,
+        contract_address=None,
+        status=True,
+        tx_type=0,
+    )
+    dbevents = DBHistoryEvents(database)
+    with database.user_write() as cursor:
+        DBEvmTx(database).add_transactions(cursor, [transaction], relevant_address=TEST_ADDR1)
+        cursor.execute(
+            'INSERT INTO eth2_validators(validator_index, public_key, validator_type, '
+            'ownership_proportion, activation_timestamp) VALUES(?, ?, ?, ?, ?)',
+            (397160, '0xaabb', 1, '1', 0),
+        )
+        dbevents.add_history_event(cursor, EvmEvent(
+            tx_ref=transaction.tx_hash,
+            sequence_index=0,
+            timestamp=TimestampMS(transaction.timestamp * 1000),
+            location=Location.ETHEREUM,
+            event_type=HistoryEventType.RECEIVE,
+            event_subtype=HistoryEventSubType.NONE,
+            asset=A_ETH,
+            amount=FVal(3),
+            location_label=TEST_ADDR1,
+            notes='Customized receive',
+        ), mapping_values={HISTORY_MAPPING_KEY_STATE: HistoryMappingState.CUSTOMIZED})
+        if existing_mev_reward:
+            dbevents.add_history_event(cursor, EthBlockEvent(
+                validator_index=397160,
+                timestamp=TimestampMS(transaction.timestamp * 1000),
+                amount=FVal(1),
+                fee_recipient=TEST_ADDR1,
+                fee_recipient_tracked=True,
+                block_number=transaction.block_number,
+                is_mev_reward=True,
+                extra_data={'tx_hashes': []},
+            ))
+
+    tables = (
+        'history_events', 'chain_events_info', 'history_events_mappings',
+        'eth_staking_events_info', 'evm_tx_mappings',
+    )
+    with database.conn.read_ctx() as cursor:
+        before_preview = [cursor.execute(f'SELECT * FROM {table}').fetchall() for table in tables]
+
+    with (
+        patch.object(decoder, 'beacon_chain', Mock(has_api_key=Mock(return_value=False))),
+        patch.object(decoder, '_get_beacon_node', return_value=Mock(
+            query_block_proposer=Mock(return_value=397160),
+        )),
+        patch.object(decoder.evm_inquirer, '_try_indexers', return_value={
+            'blockMiner': TEST_ADDR1,
+            'blockReward': str(10**18),
+        }),
+    ):
+        preview = decoder.decode_transaction_without_persistence(transaction, receipt)
+        assert len(preview) == 1
+        assert preview[0].amount == FVal(2)
+        with database.conn.read_ctx() as cursor:
+            assert [cursor.execute(f'SELECT * FROM {table}').fetchall() for table in tables] == before_preview  # noqa: E501
+
+        write_buffer: list[tuple[list[EvmEvent], str, int]] = []
+        events, _, _ = decoder._get_or_decode_transaction_events(
+            transaction, receipt, ignore_cache=True, delete_customized=True,
+            write_buffer=write_buffer,
+        )
+        assert events == preview
+        assert write_buffer == []
+
+    with database.conn.read_ctx() as cursor:
+        rewards = cursor.execute(
+            'SELECT amount, extra_data FROM history_events WHERE subtype=?',
+            (HistoryEventSubType.MEV_REWARD.serialize(),),
+        ).fetchall()
+        assert len(rewards) == 1
+        assert FVal(rewards[0][0]) == FVal(3)
+        assert transaction.tx_hash.hex() in rewards[0][1]
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM history_events WHERE subtype=?',
+            (HistoryEventSubType.BLOCK_PRODUCTION.serialize(),),
+        ).fetchone()[0] == (0 if existing_mev_reward else 1)
+        assert cursor.execute(
+            'SELECT COUNT(*) FROM evm_tx_mappings WHERE value=?', (TX_DECODED,),
+        ).fetchone()[0] == 1
+
+    with patch.object(decoder, '_maybe_create_produced_block_event_from_eth_receive') as fallback:
+        cached_events, _, _ = decoder._get_or_decode_transaction_events(
+            transaction, receipt, ignore_cache=False,
+        )
+        assert len(cached_events) == 1
+        assert cached_events[0].tx_ref == transaction.tx_hash
+        assert cached_events[0].amount == FVal(2)
+        fallback.assert_not_called()
 
 
 def test_decode_transaction_without_persistence_discards_write_buffer(

--- a/rotkehlchen/tests/unit/test_evm_tx_decoding.py
+++ b/rotkehlchen/tests/unit/test_evm_tx_decoding.py
@@ -927,14 +927,21 @@ def test_decode_transaction_without_persistence_discards_write_buffer(
             transaction=transaction,
             tx_receipt=receipt,
         ) == expected_events
+        reload_data.assert_called_once()
+        decode_transaction.assert_called_once_with(
+            transaction=transaction,
+            tx_receipt=receipt,
+            write_buffer=[],
+            strict=True,
+        )
 
-    reload_data.assert_called_once()
-    decode_transaction.assert_called_once_with(
-        transaction=transaction,
-        tx_receipt=receipt,
-        write_buffer=[],
-        strict=True,
-    )
+        reload_data.reset_mock()
+        assert ethereum_transaction_decoder.decode_transaction_without_persistence(
+            transaction=transaction,
+            tx_receipt=receipt,
+            reload=False,
+        ) == expected_events
+        reload_data.assert_not_called()
 
 
 @pytest.mark.parametrize('ethereum_accounts', [[

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -45,7 +45,9 @@ from rotkehlchen.premium.premium import (
 from rotkehlchen.premium.sync import PremiumSyncManager
 from rotkehlchen.serialization.deserialize import deserialize_timestamp
 from rotkehlchen.tasks.assets import _find_missing_tokens, maybe_detect_new_tokens
+from rotkehlchen.tasks.data_issues import run_data_issue_remediation
 from rotkehlchen.tasks.manager import (
+    DATA_ISSUE_REMEDIATION_TASK_NAME,
     HISTORICAL_BALANCE_PROCESSING_TASK_NAME,
     PREMIUM_STATUS_CHECK,
     TaskManager,
@@ -104,6 +106,7 @@ def test_potential_maybe_schedule_task(task_manager: TaskManager):
     }
     if is_accounting_update_enabled() is False:
         expected_tasks.remove('_maybe_process_historical_balances')
+        expected_tasks.remove('_maybe_run_data_issue_remediation')
 
     assert expected_tasks == tasks
     assert [function.__name__ for function in task_manager.priority_tasks_queue] == [
@@ -118,11 +121,89 @@ def test_periodic_historical_balances_skip_active_remediation(task_manager: Task
             'is_history_fetching',
             return_value=False,
         ),
-        patch.object(task_manager.task_supervisor, 'has_task', return_value=True) as has_task,
+        patch.object(
+            task_manager.task_supervisor,
+            'has_task',
+            side_effect=lambda name: name == DATA_ISSUE_REMEDIATION_TASK_NAME,
+        ) as has_task,
     ):
         assert task_manager._maybe_process_historical_balances() is None
 
-    has_task.assert_called_once_with(HISTORICAL_BALANCE_PROCESSING_TASK_NAME)
+    assert has_task.call_args_list == [
+        ((HISTORICAL_BALANCE_PROCESSING_TASK_NAME,), {}),
+        ((DATA_ISSUE_REMEDIATION_TASK_NAME,), {}),
+    ]
+
+
+def test_data_issue_remediation_runs_daily_after_initial_processing(
+        task_manager: TaskManager,
+) -> None:
+    with patch.object(task_manager.task_supervisor, 'spawn_and_track') as spawn_task:
+        assert task_manager._maybe_run_data_issue_remediation() is None
+        spawn_task.assert_not_called()
+
+        with task_manager.database.user_write() as write_cursor:
+            task_manager.database.set_static_cache(
+                write_cursor=write_cursor,
+                name=DBCacheStatic.LAST_HISTORICAL_BALANCE_PROCESSING_TS,
+                value=ts_now(),
+            )
+
+        assert task_manager._maybe_run_data_issue_remediation() == [spawn_task.return_value]
+        assert spawn_task.call_args.kwargs == {
+            'after_seconds': None,
+            'task_name': DATA_ISSUE_REMEDIATION_TASK_NAME,
+            'exception_is_error': True,
+            'method': run_data_issue_remediation,
+            'database': task_manager.database,
+        }
+
+        with task_manager.database.user_write() as write_cursor:
+            task_manager.database.set_static_cache(
+                write_cursor=write_cursor,
+                name=DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
+                value=ts_now(),
+            )
+
+        spawn_task.reset_mock()
+        assert task_manager._maybe_run_data_issue_remediation() is None
+        spawn_task.assert_not_called()
+
+        with task_manager.database.user_write() as write_cursor:
+            task_manager.database.set_static_cache(
+                write_cursor=write_cursor,
+                name=DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
+                value=Timestamp(ts_now() - DAY_IN_SECONDS),
+            )
+
+        assert task_manager._maybe_run_data_issue_remediation() == [spawn_task.return_value]
+
+
+def test_data_issue_remediation_skips_active_historical_processing(
+        task_manager: TaskManager,
+) -> None:
+    with (
+        patch.object(
+            task_manager.task_supervisor,
+            'has_task',
+            side_effect=lambda name: name == HISTORICAL_BALANCE_PROCESSING_TASK_NAME,
+        ),
+        patch.object(task_manager.task_supervisor, 'spawn_and_track') as spawn_task,
+    ):
+        assert task_manager._maybe_run_data_issue_remediation() is None
+
+    spawn_task.assert_not_called()
+
+
+def test_data_issue_remediation_records_completed_run(database: DBHandler) -> None:
+    with freeze_time('2026-09-04 12:00:00'):
+        run_data_issue_remediation(database)
+
+        with database.conn.read_ctx() as cursor:
+            assert database.get_static_cache(
+                cursor=cursor,
+                name=DBCacheStatic.LAST_DATA_ISSUE_REMEDIATION_TS,
+            ) == ts_now()
 
 
 @pytest.mark.parametrize('max_tasks_num', [5])

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -156,6 +156,7 @@ def test_data_issue_remediation_runs_daily_after_initial_processing(
             'exception_is_error': True,
             'method': run_data_issue_remediation,
             'database': task_manager.database,
+            'chains_aggregator': task_manager.chains_aggregator,
         }
 
         with task_manager.database.user_write() as write_cursor:
@@ -197,7 +198,7 @@ def test_data_issue_remediation_skips_active_historical_processing(
 
 def test_data_issue_remediation_records_completed_run(database: DBHandler) -> None:
     with freeze_time('2026-09-04 12:00:00'):
-        run_data_issue_remediation(database)
+        run_data_issue_remediation(database, MagicMock())
 
         with database.conn.read_ctx() as cursor:
             assert database.get_static_cache(

--- a/rotkehlchen/tests/unit/test_tasks_manager.py
+++ b/rotkehlchen/tests/unit/test_tasks_manager.py
@@ -140,6 +140,7 @@ def test_data_issue_remediation_runs_daily_after_initial_processing(
 ) -> None:
     with patch.object(task_manager.task_supervisor, 'spawn_and_track') as spawn_task:
         assert task_manager._maybe_run_data_issue_remediation() is None
+        assert task_manager._maybe_run_data_issue_remediation(force=True) is None
         spawn_task.assert_not_called()
 
         with task_manager.database.user_write() as write_cursor:
@@ -170,6 +171,10 @@ def test_data_issue_remediation_runs_daily_after_initial_processing(
         assert task_manager._maybe_run_data_issue_remediation() is None
         spawn_task.assert_not_called()
 
+        assert task_manager._maybe_run_data_issue_remediation(force=True) == [
+            spawn_task.return_value,
+        ]
+
         with task_manager.database.user_write() as write_cursor:
             task_manager.database.set_static_cache(
                 write_cursor=write_cursor,
@@ -180,18 +185,25 @@ def test_data_issue_remediation_runs_daily_after_initial_processing(
         assert task_manager._maybe_run_data_issue_remediation() == [spawn_task.return_value]
 
 
-def test_data_issue_remediation_skips_active_historical_processing(
+@pytest.mark.parametrize('force', [False, True])
+@pytest.mark.parametrize('active_task', [
+    HISTORICAL_BALANCE_PROCESSING_TASK_NAME,
+    DATA_ISSUE_REMEDIATION_TASK_NAME,
+])
+def test_data_issue_remediation_skips_active_history_tasks(
         task_manager: TaskManager,
+        force: bool,
+        active_task: str,
 ) -> None:
     with (
         patch.object(
             task_manager.task_supervisor,
             'has_task',
-            side_effect=lambda name: name == HISTORICAL_BALANCE_PROCESSING_TASK_NAME,
+            side_effect=lambda name: name == active_task,
         ),
         patch.object(task_manager.task_supervisor, 'spawn_and_track') as spawn_task,
     ):
-        assert task_manager._maybe_run_data_issue_remediation() is None
+        assert task_manager._maybe_run_data_issue_remediation(force=force) is None
 
     spawn_task.assert_not_called()
 


### PR DESCRIPTION
Part of https://github.com/rotki/rotki/issues/12289

Add background diagnostics for negative-balance data issues. The first strategy checks whether redecoding customized EVM transactions with the current decoders would change the affected balance, without replacing the user's saved events or customizations.

- Add the task interface and daily scheduling for data issue remediation, gated by the accounting update feature. Wait until historical balance processing has completed, track the last remediation run, and prevent scheduling it alongside history fetching, periodic historical balance processing, or another remediation run.
- Add virtual decoding of customized transactions using a discarded write buffer. Compare the ordered balance effects of saved events with freshly decoded events for the issue's account, asset, location, and protocol, respecting the ETH/ETH2 balance setting. Preserve saved history events and transaction decoded markers.
- Scope candidate transactions to the issue's account and time range using transaction-account associations, so customizations that change an event's asset or account label are still considered. Reuse transaction previews across issues within a run.
- Separate Ethereum produced-block fallback reward persistence from decoding through a post-decoding hook. Normal decoding still persists these staking rewards, while virtual decoding avoids that persistence step.
- Add strict error propagation for virtual decoding through input, address, event, transfer-enrichment, and post-decoding rules. A decoder failure produces a failed diagnostic instead of comparing partial results; regular decoding retains its existing error handling.
- Persist remediation attempts and show their outcome in the data issue timeline: redecoding would change the balance, would not change it, or failed. Record transaction counts and failure reasons. Issues pass through the auto-remediating state and remain unresolved for user review; the diagnostic does not automatically repair the balance.
- Add a debug-only `data_issue_remediation` option to the task-trigger API for on-demand runs. It bypasses the daily cooldown while preserving the feature gate and history-processing prerequisites.
- Add scheduler, API, decoder isolation/error propagation, account-scoping, persistence, and frontend timeline tests. Include a real flow test that creates a negative balance from a customized spend, runs scheduled remediation, and checks that the diagnostic is recorded without changing saved events.

The detailed before-and-after event comparison UI is in the stacked follow-up: https://github.com/yabirgb/rotki/pull/6.
