### PR TITLE
Add 1inch Liquidity Protocol pool decoder

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`1981` Deposits to and withdrawals from the 1inch Liquidity Protocol and Mooniswap pools are now decoded.
 * :feature:`1988` Transactions going through the zerion SDK router are now understood properly.
 * :feature:`-` Flying Tulip activity is now decoded on Ethereum: ftUSD mints and redemptions, sftUSD staking with its FT reward claims, lending deposits, withdrawals, borrows and repayments, and ftPUT invests, divests and FT withdrawals. Open lending positions, outstanding debt and claimable staking rewards are also included in your on-chain balances. The lending market is also supported on Binance Smart Chain.
 * :feature:`6206` A deposit or withdrawal on an exchange whose counterpart is not tracked can now be marked as income or payment.

--- a/rotkehlchen/chain/ethereum/modules/oneinch/liquidity/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/liquidity/constants.py
@@ -1,0 +1,18 @@
+from typing import Final
+
+from rotkehlchen.chain.decoding.types import CounterpartyDetails
+from rotkehlchen.chain.evm.decoding.oneinch.constants import ONEINCH_ICON
+
+CPT_ONEINCH_LIQUIDITY: Final = '1inch-liquidity'
+ONEINCH_LIQUIDITY_LABEL: Final = '1inch Liquidity Protocol'
+ONEINCH_LIQUIDITY_CPT_DETAILS: Final = CounterpartyDetails(
+    identifier=CPT_ONEINCH_LIQUIDITY,
+    label=ONEINCH_LIQUIDITY_LABEL,
+    image=ONEINCH_ICON,
+)
+
+# Events emitted by the pools of both the Mooniswap and the 1inch Liquidity Protocol factories
+# topic of the Deposited(address,address,uint256,uint256,uint256) event
+DEPOSITED: Final = b'\x8b\xabj\xedZP\x897\x05\x1a\x14Na\xd6\xe6\x136\x83Jf\xaa\xee%\n\x00a:\xe6\xf7D\xc4"'  # noqa: E501
+# topic of the Withdrawn(address,address,uint256,uint256,uint256) event
+WITHDRAWN: Final = b'<\xae\x99#\xfd</F\x8a\xa2Z\x8e\xf6\x87\x92>7\xf9WE\x95W\xc08\x0f\xd0e&\xc0\xb8\xcd\xbc'  # noqa: E501

--- a/rotkehlchen/chain/ethereum/modules/oneinch/liquidity/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/oneinch/liquidity/decoder.py
@@ -1,0 +1,199 @@
+import logging
+from typing import TYPE_CHECKING
+
+from rotkehlchen.chain.decoding.utils import maybe_reshuffle_events
+from rotkehlchen.chain.evm.constants import ZERO_ADDRESS
+from rotkehlchen.chain.evm.decoding.interfaces import EvmDecoderInterface
+from rotkehlchen.chain.evm.decoding.structures import (
+    FAILED_ENRICHMENT_OUTPUT,
+    EnricherContext,
+    TransferEnrichmentOutput,
+)
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+
+from .constants import (
+    CPT_ONEINCH_LIQUIDITY,
+    DEPOSITED,
+    ONEINCH_LIQUIDITY_CPT_DETAILS,
+    ONEINCH_LIQUIDITY_LABEL,
+    WITHDRAWN,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from rotkehlchen.chain.decoding.types import CounterpartyDetails
+    from rotkehlchen.chain.evm.structures import EvmTxReceiptLog
+    from rotkehlchen.history.events.structures.evm_event import EvmEvent
+    from rotkehlchen.types import ChecksumEvmAddress, EvmTransaction
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
+
+
+class OneinchliquidityDecoder(EvmDecoderInterface):
+    """Decoder for the Mooniswap and 1inch Liquidity Protocol pools.
+
+    The pools are deployed by a factory so their addresses are not known in advance. The LP
+    token of a pool is the pool contract itself, so a mint or burn of a token whose contract
+    also emitted a Deposited/Withdrawn log in the same transaction identifies the pool. That
+    check happens in a transfer enricher, which only runs for transfers of tracked addresses,
+    and the actual event processing happens in a post-decoding rule.
+    """
+
+    @staticmethod
+    def _find_pool_logs(
+            all_logs: list[EvmTxReceiptLog],
+            pool_address: ChecksumEvmAddress | None = None,
+    ) -> list[EvmTxReceiptLog]:
+        """Return the Deposited/Withdrawn logs of the transaction, optionally only for one pool"""
+        return [
+            tx_log for tx_log in all_logs
+            if (
+                len(tx_log.topics) == 3 and
+                tx_log.topics[0] in (DEPOSITED, WITHDRAWN) and
+                (pool_address is None or tx_log.address == pool_address)
+            )
+        ]
+
+    def _maybe_enrich_pool_token_transfer(
+            self,
+            context: EnricherContext,
+    ) -> TransferEnrichmentOutput:
+        """Match the mint or burn of a pool's LP token to trigger the post decoding rule"""
+        if (
+            context.event.address != ZERO_ADDRESS or
+            len(self._find_pool_logs(context.all_logs, pool_address=context.tx_log.address)) == 0
+        ):
+            return FAILED_ENRICHMENT_OUTPUT
+
+        return TransferEnrichmentOutput(matched_counterparty=CPT_ONEINCH_LIQUIDITY)
+
+    def _process_deposit(
+            self,
+            pool_address: ChecksumEvmAddress,
+            decoded_events: list[EvmEvent],
+    ) -> bool:
+        """Turn the transfers of a pool deposit into deposit and receive wrapped events.
+
+        The pool refunds any ETH sent in excess of what it needed, so a receive of ETH
+        from the pool is marked as a refund. Returns whether the events were found.
+        """
+        deposit_events, receive_events = [], []
+        for event in decoded_events:
+            if (
+                event.event_type == HistoryEventType.SPEND and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.address == pool_address
+            ):
+                event.event_type = HistoryEventType.DEPOSIT
+                event.event_subtype = HistoryEventSubType.DEPOSIT_FOR_WRAPPED
+                event.counterparty = CPT_ONEINCH_LIQUIDITY
+                event.notes = f'Deposit {event.amount} {event.asset.resolve_to_asset_with_symbol().symbol} to {ONEINCH_LIQUIDITY_LABEL} pool {pool_address}'  # noqa: E501
+                deposit_events.append(event)
+            elif (
+                event.event_type == HistoryEventType.RECEIVE and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.address == ZERO_ADDRESS and
+                event.asset.identifier.endswith(pool_address)  # the pool's own token
+            ):
+                event.event_subtype = HistoryEventSubType.RECEIVE_WRAPPED
+                event.counterparty = CPT_ONEINCH_LIQUIDITY
+                event.address = pool_address
+                event.notes = f'Receive {event.amount} {event.asset.resolve_to_asset_with_symbol().symbol} from {ONEINCH_LIQUIDITY_LABEL} pool'  # noqa: E501
+                receive_events.append(event)
+            elif (
+                event.event_type == HistoryEventType.RECEIVE and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.address == pool_address and
+                event.asset == self.node_inquirer.native_token
+            ):
+                event.event_type = HistoryEventType.WITHDRAWAL
+                event.event_subtype = HistoryEventSubType.REFUND
+                event.counterparty = CPT_ONEINCH_LIQUIDITY
+                event.notes = f'Refund of {event.amount} {self.node_inquirer.native_token.symbol} from {ONEINCH_LIQUIDITY_LABEL} pool due to price change'  # noqa: E501
+                receive_events.append(event)
+
+        if len(deposit_events) == 0 or len(receive_events) == 0:
+            return False
+
+        maybe_reshuffle_events(
+            ordered_events=deposit_events + receive_events,
+            events_list=decoded_events,
+        )
+        return True
+
+    def _process_withdrawal(
+            self,
+            pool_address: ChecksumEvmAddress,
+            decoded_events: list[EvmEvent],
+    ) -> bool:
+        """Turn the transfers of a pool withdrawal into return wrapped and withdrawal events.
+        Returns whether the events were found.
+        """
+        return_events, withdrawal_events = [], []
+        for event in decoded_events:
+            if (
+                event.event_type == HistoryEventType.SPEND and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.address == ZERO_ADDRESS and
+                event.asset.identifier.endswith(pool_address)  # the pool's own token
+            ):
+                event.event_subtype = HistoryEventSubType.RETURN_WRAPPED
+                event.counterparty = CPT_ONEINCH_LIQUIDITY
+                event.address = pool_address
+                event.notes = f'Return {event.amount} {event.asset.resolve_to_asset_with_symbol().symbol} to {ONEINCH_LIQUIDITY_LABEL} pool'  # noqa: E501
+                return_events.append(event)
+            elif (
+                event.event_type == HistoryEventType.RECEIVE and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.address == pool_address
+            ):
+                event.event_type = HistoryEventType.WITHDRAWAL
+                event.event_subtype = HistoryEventSubType.REDEEM_WRAPPED
+                event.counterparty = CPT_ONEINCH_LIQUIDITY
+                event.notes = f'Withdraw {event.amount} {event.asset.resolve_to_asset_with_symbol().symbol} from {ONEINCH_LIQUIDITY_LABEL} pool {pool_address}'  # noqa: E501
+                withdrawal_events.append(event)
+
+        if len(return_events) == 0 or len(withdrawal_events) == 0:
+            return False
+
+        maybe_reshuffle_events(
+            ordered_events=return_events + withdrawal_events,
+            events_list=decoded_events,
+        )
+        return True
+
+    def _process_pool_events(
+            self,
+            transaction: EvmTransaction,
+            decoded_events: list[EvmEvent],
+            all_logs: list[EvmTxReceiptLog],
+    ) -> list[EvmEvent]:
+        for tx_log in self._find_pool_logs(all_logs):
+            processed = (
+                self._process_deposit(pool_address=tx_log.address, decoded_events=decoded_events)
+                if tx_log.topics[0] == DEPOSITED else
+                self._process_withdrawal(pool_address=tx_log.address, decoded_events=decoded_events)  # noqa: E501
+            )
+            if processed is False:
+                log.error(
+                    'Failed to find the transfers of a 1inch liquidity pool interaction',
+                    tx_hash=transaction.tx_hash.hex(),
+                    pool_address=tx_log.address,
+                )
+
+        return decoded_events
+
+    # -- DecoderInterface methods
+
+    def enricher_rules(self) -> list[Callable]:
+        return [self._maybe_enrich_pool_token_transfer]
+
+    def post_decoding_rules(self) -> dict[str, list[tuple[int, Callable]]]:
+        return {CPT_ONEINCH_LIQUIDITY: [(0, self._process_pool_events)]}
+
+    @staticmethod
+    def counterparties() -> tuple[CounterpartyDetails, ...]:
+        return (ONEINCH_LIQUIDITY_CPT_DETAILS,)

--- a/rotkehlchen/tests/unit/decoders/test_main.py
+++ b/rotkehlchen/tests/unit/decoders/test_main.py
@@ -164,6 +164,7 @@ def test_decoders_initialization(ethereum_transaction_decoder: EthereumTransacti
         'Zerox',
         'WooFi',
         'Zerion',
+        'Oneinchliquidity',
     }
 
     counterparty_ids = {counterparty.identifier for counterparty in ethereum_transaction_decoder.rules.all_counterparties}  # noqa: E501
@@ -292,6 +293,7 @@ def test_decoders_initialization(ethereum_transaction_decoder: EthereumTransacti
         'morpho_blue',
         'clipper',
         'zerion',
+        '1inch-liquidity',
     }
 
 

--- a/rotkehlchen/tests/unit/decoders/test_oneinch_liquidity.py
+++ b/rotkehlchen/tests/unit/decoders/test_oneinch_liquidity.py
@@ -1,0 +1,269 @@
+import pytest
+
+from rotkehlchen.assets.asset import Asset
+from rotkehlchen.chain.decoding.constants import CPT_GAS
+from rotkehlchen.chain.ethereum.modules.oneinch.liquidity.constants import CPT_ONEINCH_LIQUIDITY
+from rotkehlchen.chain.evm.types import string_to_evm_address
+from rotkehlchen.constants.assets import A_ETH, A_USDT
+from rotkehlchen.fval import FVal
+from rotkehlchen.history.events.structures.evm_event import EvmEvent
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.tests.utils.ethereum import get_decoded_events_of_transaction
+from rotkehlchen.types import Location, TimestampMS, deserialize_evm_tx_hash
+
+A_1INCH = Asset('eip155:1/erc20:0x111111111117dC0aa78b770fA6A738034120C302')
+ETH_1INCH_POOL = string_to_evm_address('0x812b40c2cA7fAbBAc756475593fC8B1c313434FA')
+A_1LP_ETH_1INCH = Asset(f'eip155:1/erc20:{ETH_1INCH_POOL}')
+ETH_USDT_POOL = string_to_evm_address('0xbBa17b81aB4193455Be10741512d0E71520F43cB')
+A_1LP_ETH_USDT = Asset(f'eip155:1/erc20:{ETH_USDT_POOL}')
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0xbC75767E2c23fC834379C4599067dbE3174FE5F4']])
+def test_oneinch_liquidity_deposit(ethereum_inquirer, ethereum_accounts):
+    """Test the deposit from https://github.com/rotki/rotki/issues/1981"""
+    tx_hash = deserialize_evm_tx_hash('0x0fc846fdc0343a7aa43447f7cf074d7dcb2ae4283c2c2e53e0477a2cfb196037')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1609102338000)),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount := '0.009274412'),
+        location_label=(user_address := ethereum_accounts[0]),
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=147,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.APPROVE,
+        asset=A_1INCH,
+        amount=FVal(approve_amount := '115792089237316195423570985008687907853269984665640564038051.821129519885804696'),  # noqa: E501
+        location_label=user_address,
+        notes=f'Set 1INCH spending approval of {user_address} by {ETH_1INCH_POOL} to {approve_amount}',  # noqa: E501
+        address=ETH_1INCH_POOL,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=148,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.DEPOSIT,
+        event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
+        asset=A_ETH,
+        amount=FVal(eth_amount := '2.517948895660343739'),
+        location_label=user_address,
+        notes=f'Deposit {eth_amount} ETH to 1inch Liquidity Protocol pool {ETH_1INCH_POOL}',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_1INCH_POOL,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=149,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.DEPOSIT,
+        event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
+        asset=A_1INCH,
+        amount=FVal(oneinch_amount := '1405.762878393243835239'),
+        location_label=user_address,
+        notes=f'Deposit {oneinch_amount} 1INCH to 1inch Liquidity Protocol pool {ETH_1INCH_POOL}',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_1INCH_POOL,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=150,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
+        asset=A_1LP_ETH_1INCH,
+        amount=FVal(lp_amount := '688'),
+        location_label=user_address,
+        notes=f'Receive {lp_amount} 1LP-ETH-1INCH from 1inch Liquidity Protocol pool',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_1INCH_POOL,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0xa6CE66f79EBEa1420D71B4B688c652F077Bc1331']])
+def test_oneinch_liquidity_withdrawal(ethereum_inquirer, ethereum_accounts):
+    tx_hash = deserialize_evm_tx_hash('0x97ebe63649b077a6c5f490274431f428e67ded267bec686e49012e4adba053b2')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1780991039000)),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount := '0.000120824534327907'),
+        location_label=(user_address := ethereum_accounts[0]),
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=1,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+        asset=A_1LP_ETH_1INCH,
+        amount=FVal(lp_amount := '2.628872543480759388'),
+        location_label=user_address,
+        notes=f'Return {lp_amount} 1LP-ETH-1INCH to 1inch Liquidity Protocol pool',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_1INCH_POOL,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=2,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
+        asset=A_ETH,
+        amount=FVal(eth_amount := '0.001729244160134287'),
+        location_label=user_address,
+        notes=f'Withdraw {eth_amount} ETH from 1inch Liquidity Protocol pool {ETH_1INCH_POOL}',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_1INCH_POOL,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=3,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
+        asset=A_1INCH,
+        amount=FVal(oneinch_amount := '40.799694177311019181'),
+        location_label=user_address,
+        notes=f'Withdraw {oneinch_amount} 1INCH from 1inch Liquidity Protocol pool {ETH_1INCH_POOL}',  # noqa: E501
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_1INCH_POOL,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0x4b0429F3db75dbA6B82c32a200C9C298ffC05839']])
+def test_mooniswap_deposit(ethereum_inquirer, ethereum_accounts):
+    """Test a deposit to a pool of the older Mooniswap factory"""
+    tx_hash = deserialize_evm_tx_hash('0x1f736d92563259ae1feeec90f8109e31a30801e8303483750ee15817bba5e735')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1679479991000)),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount := '0.002885261256994148'),
+        location_label=(user_address := ethereum_accounts[0]),
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=1,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.DEPOSIT,
+        event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
+        asset=A_ETH,
+        amount=FVal(eth_amount := '0.00728986527436188'),
+        location_label=user_address,
+        notes=f'Deposit {eth_amount} ETH to 1inch Liquidity Protocol pool {ETH_USDT_POOL}',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_USDT_POOL,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=2,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.DEPOSIT,
+        event_subtype=HistoryEventSubType.DEPOSIT_FOR_WRAPPED,
+        asset=A_USDT,
+        amount=FVal(usdt_amount := '12.899385'),
+        location_label=user_address,
+        notes=f'Deposit {usdt_amount} USDT to 1inch Liquidity Protocol pool {ETH_USDT_POOL}',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_USDT_POOL,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=3,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.RECEIVE,
+        event_subtype=HistoryEventSubType.RECEIVE_WRAPPED,
+        asset=A_1LP_ETH_USDT,
+        amount=FVal(lp_amount := '0.007351124014184462'),
+        location_label=user_address,
+        notes=f'Receive {lp_amount} 1LP-ETH-USDT from 1inch Liquidity Protocol pool',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_USDT_POOL,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('ethereum_accounts', [['0x188B2d6ac1A8752Ea4Ef4ADB582646F074096aeE']])
+def test_mooniswap_withdrawal(ethereum_inquirer, ethereum_accounts):
+    """Test a withdrawal from a pool of the older Mooniswap factory"""
+    tx_hash = deserialize_evm_tx_hash('0x6cc9a9795819e6f2ec58a0c8a640a5bf09626e504d8900c990712a3a28b5d790')  # noqa: E501
+    events, _ = get_decoded_events_of_transaction(evm_inquirer=ethereum_inquirer, tx_hash=tx_hash)
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1782410459000)),
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount := '0.00015820347100082'),
+        location_label=(user_address := ethereum_accounts[0]),
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=1,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.RETURN_WRAPPED,
+        asset=A_1LP_ETH_USDT,
+        amount=FVal(lp_amount := '0.002094679797874485'),
+        location_label=user_address,
+        notes=f'Return {lp_amount} 1LP-ETH-USDT to 1inch Liquidity Protocol pool',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_USDT_POOL,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=2,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
+        asset=A_ETH,
+        amount=FVal(eth_amount := '0.002356990500221975'),
+        location_label=user_address,
+        notes=f'Withdraw {eth_amount} ETH from 1inch Liquidity Protocol pool {ETH_USDT_POOL}',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_USDT_POOL,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=3,
+        timestamp=timestamp,
+        location=Location.ETHEREUM,
+        event_type=HistoryEventType.WITHDRAWAL,
+        event_subtype=HistoryEventSubType.REDEEM_WRAPPED,
+        asset=A_USDT,
+        amount=FVal(usdt_amount := '3.69377'),
+        location_label=user_address,
+        notes=f'Withdraw {usdt_amount} USDT from 1inch Liquidity Protocol pool {ETH_USDT_POOL}',
+        counterparty=CPT_ONEINCH_LIQUIDITY,
+        address=ETH_USDT_POOL,
+    )]


### PR DESCRIPTION
Deposits to and withdrawals from the Mooniswap and 1inch Liquidity Protocol pools are decoded. The pools are found through a transfer enricher that matches mints and burns of a token whose contract also emitted a Deposited or Withdrawn log, so no pool list and no per-log rule is needed. Closes #1981