### PR TITLE
Remove the retry hack for issue 5432

### DIFF
--- a/rotkehlchen/chain/ethereum/modules/nft/nfts.py
+++ b/rotkehlchen/chain/ethereum/modules/nft/nfts.py
@@ -198,7 +198,7 @@ class Nfts(EthereumModule, CacheableMixIn, LockableQueryMixIn):
 
         query, bindings = filter_query.prepare()
         with self.db.conn.read_ctx() as cursor:
-            cursor.execute(  # this sometimes causes https://github.com/rotki/rotki/issues/5432
+            cursor.execute(
                 'SELECT identifier, name, last_price, last_price_asset, manual_price, is_lp, '
                 'image_url, collection_name FROM nfts ' + query,
                 bindings,

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -2057,7 +2057,7 @@ class DBHandler:
             "value = evm_accounts_details.value)"
         )
         bindings = (address, blockchain.to_chain_id().serialize_for_db(), EVM_ACCOUNTS_DETAILS_LAST_QUERIED_TS, EVM_ACCOUNTS_DETAILS_TOKENS)  # noqa: E501
-        cursor.execute(querystr, bindings)  # original place https://github.com/rotki/rotki/issues/5432 was seen # noqa: E501
+        cursor.execute(querystr, bindings)
 
         returned_list = []
         for (key, value) in cursor:

--- a/rotkehlchen/db/drivers/sqlite.py
+++ b/rotkehlchen/db/drivers/sqlite.py
@@ -145,12 +145,7 @@ class DBCursor:
         self._prefetched_rows.clear()  # a new statement discards the previous result set
         try:
             with self.connection.statement_lock:
-                try:
-                    self._cursor.execute(statement, *bindings)
-                except (sqlcipher.InterfaceError, rsqlite.InterfaceError) as e:  # pylint: disable=no-member
-                    # Long story. Don't judge me. https://github.com/rotki/rotki/issues/5432
-                    logger.debug('%s with %s failed due to %s. Probably https://github.com/rotki/rotki/issues/5432. Retrying', statement, bindings, e)  # noqa: E501
-                    self._cursor.execute(statement, *bindings)
+                self._cursor.execute(statement, *bindings)
         except (sqlcipher.OperationalError, rsqlite.OperationalError) as e:  # pylint: disable=no-member
             _maybe_raise_cancelled(e)
             raise

--- a/rotkehlchen/tests/unit/test_tokens.py
+++ b/rotkehlchen/tests/unit/test_tokens.py
@@ -1,6 +1,4 @@
 import datetime
-import threading
-import time
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, get_args
 from unittest.mock import MagicMock, call, patch
@@ -21,7 +19,6 @@ from rotkehlchen.chain.evm.tokens import (
 )
 from rotkehlchen.chain.evm.types import string_to_evm_address
 from rotkehlchen.chain.structures import EvmTokenDetectionData
-from rotkehlchen.concurrency import spawn
 from rotkehlchen.constants import ONE, ZERO
 from rotkehlchen.constants.assets import A_CRV, A_DAI, A_ETH, A_OMG, A_WETH
 from rotkehlchen.constants.resolver import evm_address_to_identifier
@@ -768,76 +765,6 @@ def test_cache_is_per_token_type(ethereum_inquirer):
 
     assert erc20_token_data == erc20_cached_data == ('Tether USD', 'USDT', 6, TokenKind.ERC20)
     assert erc721_token_data == erc721_cached_data == ('Art Blocks', 'BLOCKS', 0, TokenKind.ERC721)
-
-
-def _do_read(database):
-    with database.conn.read_ctx() as cursor:
-        database.get_settings(cursor)
-        database.get_all_external_service_credentials()
-        database.get_blockchain_accounts(cursor)
-
-
-def _do_spawn(database, stop_event):
-    while not stop_event.is_set():
-        spawn(_do_read, database)
-        with database.user_write() as write_cursor:
-            database.set_setting(write_cursor, 'last_write_ts', 15)
-            time.sleep(0.1)
-            database.set_setting(write_cursor, 'last_write_ts', 15)
-
-
-@pytest.mark.parametrize('number_of_eth_accounts', [100])
-@pytest.mark.parametrize('sql_vm_instructions_cb', [10])
-def test_flaky_binding_parameter_zero(
-        database: DBHandler,
-        ethereum_accounts: list[ChecksumEvmAddress],
-) -> None:
-    """Test that reproduces https://github.com/rotki/rotki/issues/5432 reliably.
-
-    Seems to be an sqlite driver implementation error that causes a wrong instance of
-    "Error binding parameter 0 - probably unsupported type" flakily. Happened once
-    in a blue moon for our users so was hard to reproduce.
-
-    Happens only if opening a parallel write context in the same connection from which
-    the read only get_tokens_for_address is done. Makes no sense. As a read context
-    should not be affected. Our current fix in the code is to repeat the cursor.execute()
-    without any delay. It works splendid. Same solution the coveragepy people used:
-    https://github.com/nedbat/coveragepy/issues/1010
-    """
-    stuff: list[tuple[Any, ...]] = []
-    # Populate some data in the evm_accounts_details table, since this is what's used in the bug
-    for idx, address in enumerate(ethereum_accounts):
-        if idx % 2 == 0:
-            stuff.append((address, 1, 'last_queried_timestamp', 42))
-        else:
-            stuff.extend((
-                (address, 1, 'tokens', 'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F'),  # noqa: E501
-                (address, 1, 'tokens', 'eip155:1/erc20:0x6810e776880C02933D47DB1b9fc05908e5386b96'),  # noqa: E501
-            ))
-
-    with database.user_write() as write_cursor:
-        write_cursor.executemany(
-            'INSERT OR REPLACE INTO evm_accounts_details '
-            '(account, chain_id, key, value) VALUES (?, ?, ?, ?)',
-            stuff,
-        )
-
-    # Create the conditions for the bug to hit. Can verify by removing the retry in dbhandler.py
-    stop_event = threading.Event()
-    spawner_task = spawn(_do_spawn, database, stop_event)
-    time.sleep(.1)  # give the writer task time to start writing
-    try:
-        with database.conn.read_ctx() as cursor:
-            for address in ethereum_accounts:
-                database.get_tokens_for_address(
-                    cursor=cursor,
-                    address=address,
-                    blockchain=SupportedBlockchain.ETHEREUM,
-                    token_exceptions=set(),
-                )
-    finally:  # stop the writer so it does not keep using the db after the test ends
-        stop_event.set()
-        spawner_task.join(timeout=5)
 
 
 @pytest.mark.parametrize('number_of_eth_accounts', [1])


### PR DESCRIPTION
Closes https://github.com/rotki/rotki/issues/5432

The flaky "Error binding parameter 0 - probably unsupported type" was never a rotki or sqlite bug and the bindings were always correct. It was a pre-2016 pysqlite bug that rotki-pysqlcipher3 (2022.8.1 through 2024.10.1, rotki 1.26-1.41) inherited from the rigglemania/pysqlcipher3 fork and never got the upstream fix for. CPython fixed it in August 2016 for 3.5.3+ as bpo-10513 (https://github.com/python/cpython/issues/54722), where one of the attached reproducers is literally named bug-binding_parameter_0.py.

Mechanism, all on one shared connection:

1. A reader executes a parameterized SELECT and consumes it partially. The statement is busy in sqlite and the binding marks it in_use. With gevent the reader yielded between rows all the time.
2. Another greenlet's write_ctx ends with conn.commit(). The old binding's commit() ran pysqlite_do_all_statements(ACTION_RESET): sqlite3_reset() on every statement of the connection and every in_use flag cleared.
3. The reader keeps iterating. Its next step restarts the query from row zero with whatever bindings were last bound: silent duplicate rows or rows for the wrong parameter.
4. Any cursor executes the same SQL text. The per-connection statement cache returns the same statement and since in_use is zero it looks free. sqlite3_bind_*() on a running statement returns SQLITE_MISUSE ("bind on a busy prepared statement"), which old pysqlite reported as "Error binding parameter 0 - probably unsupported type".
5. The failed execute resets the statement on its error path, which is why the blind retry "worked". It also restarted the other cursor's query underneath it, which is how the 1.39.1 IndexError in get_used_query_range (commit 9394f4925b) came out of the retry path.

This explains every observation in the issue: only under a parallel write context, only for SQL executed repeatedly from several cursors (tokens per address, concurrent nft balance queries, used_query_ranges), correct parameters, and a retry fixing it. It was reproduced deterministically with no concurrency at all by compiling the shipped 2024.10.1 C sources against system sqlite. A randomized interleaving of four cursors and commits hit the bind error in 2445 of 3000 runs and returned rows for the wrong bound parameter in 342 runs, the silent corruption nobody saw.

It never disappeared. Since June 2023 the retry in DBCursor.execute swallowed every occurrence with a DEBUG log.

It cannot happen with the current code for three independent reasons:

- rotki-pysqlcipher3 2026.8.3 and rotki-sqlite are CPython 3.14 code. commit()/rollback() do not touch other statements and cursor sharing asks sqlite via sqlite3_stmt_busy() instead of trusting a flag.
- Readers run on pooled connections and share no statement cache with the writer.
- statement_lock serializes all C calls per connection, which also covers the modern multithreaded cache race gh-118172.

The test that reproduced the bug is removed as well. With threads instead of gevent it could only fail on a microsecond window and would not have been a reliable guard; test_driver_concurrency.py already soaks readers and committing writers on one connection.