### PR TITLE
Use balance scanner for Robinhood native balances

### DIFF
--- a/rotkehlchen/chain/robinhood/node_inquirer.py
+++ b/rotkehlchen/chain/robinhood/node_inquirer.py
@@ -6,10 +6,8 @@ from rotkehlchen.chain.evm.constants import BALANCE_SCANNER_ADDRESS
 from rotkehlchen.chain.evm.contracts import EvmContracts
 from rotkehlchen.chain.evm.node_inquirer import EvmNodeInquirer
 from rotkehlchen.constants.assets import A_ETH
-from rotkehlchen.fval import FVal
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 from rotkehlchen.types import ChainID, ChecksumEvmAddress, EVMTxHash, SupportedBlockchain
-from rotkehlchen.utils.misc import from_wei
 
 from .constants import (
     ARCHIVE_NODE_CHECK_ADDRESS,
@@ -20,13 +18,11 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-
-    from rotkehlchen.chain.evm.types import WeightedNode
     from rotkehlchen.db.dbhandler import DBHandler
     from rotkehlchen.externalapis.blockscout import Blockscout
     from rotkehlchen.externalapis.etherscan import Etherscan
     from rotkehlchen.externalapis.routescan import Routescan
+    from rotkehlchen.fval import FVal
     from rotkehlchen.tasks.supervisor import TaskSupervisor
 
 logger = logging.getLogger(__name__)
@@ -57,42 +53,6 @@ class RobinhoodInquirer(EvmNodeInquirer):
             contract_scan=contracts.contract(BALANCE_SCANNER_ADDRESS),
             native_token=A_ETH.resolve_to_crypto_asset(),
         )
-
-    def get_multi_balance(
-            self,
-            accounts: Sequence[ChecksumEvmAddress],
-            call_order: Sequence[WeightedNode] | None = None,
-    ) -> dict[ChecksumEvmAddress, FVal]:
-        """Query native balances through Multicall3's getEthBalance.
-
-        The rotki balance scanner is not deployed on Robinhood chain yet. Once it is,
-        drop this override so the default scanner path in the base class is used.
-
-        May raise:
-        - RemoteError if the multicall fails on all nodes.
-        """
-        if len(accounts) == 0:
-            return {}
-
-        log.debug(
-            'Querying Robinhood chain for ETH balances via multicall',
-            eth_addresses=accounts,
-        )
-        results = self.multicall(
-            calls=[(
-                self.contract_multicall.address,
-                self.contract_multicall.encode(method_name='getEthBalance', arguments=[account]),
-            ) for account in accounts],
-            call_order=call_order,
-        )
-        return {
-            account: from_wei(FVal(self.contract_multicall.decode(
-                result=result,
-                method_name='getEthBalance',
-                arguments=[account],
-            )[0]))
-            for account, result in zip(accounts, results, strict=True)
-        }
 
     # -- Implementation of EvmNodeInquirer base methods --
 

--- a/rotkehlchen/tests/unit/decoders/test_robinhood.py
+++ b/rotkehlchen/tests/unit/decoders/test_robinhood.py
@@ -151,9 +151,9 @@ def test_weth_unwrap(robinhood_inquirer, robinhood_accounts):
 
 @pytest.mark.vcr(filter_query_parameters=['apikey'])
 @pytest.mark.parametrize('robinhood_manager_connect_at_start', [(ROBINHOOD_MAINNET_NODE,)])
-def test_native_balances_via_multicall(robinhood_inquirer):
-    """The balance scanner is not deployed on Robinhood chain, so native balances
-    go through Multicall3's getEthBalance. The WETH contract holds the wrapped supply."""
+def test_native_balances_via_scanner(robinhood_inquirer):
+    """Native balances go through the rotki balance scanner deployed on Robinhood chain.
+    The WETH contract holds the wrapped supply."""
     balances = robinhood_inquirer.get_multi_balance(
         accounts=[WETH_ROBINHOOD_ADDRESS, (user := '0x5149Ae7F9445E70331608EA03C592c078aE7399D')],
     )


### PR DESCRIPTION
The rotki balance scanner is now deployed on Robinhood Chain at the usual address, so drop the Multicall3 getEthBalance override in RobinhoodInquirer and let the base class contract_scan path handle native balances like every other chain. The contract_data row for chain 4663 was already seeded in the packaged global DB.