### PR TITLE
fix: clear exchange query cursors on removal

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Coinbase conversions no longer get a made-up fee consisting of the difference between the two legs' fiat valuations.
-* :bug:`-` Removing a Coinbase or Bitstamp connection, or renaming them and Bitstamp now also forgets how far its history had been queried.
+* :bug:`-` Removing a Coinbase, Bitstamp or Binance connection now forgets how far its history had been queried, renaming one carries that progress over to the new name, and a connection added under the name of a previously removed one starts querying from scratch.
 * :bug:`-` Swaps through any newer 0x Settler deployment are now decoded, including any future ones.
 * :bug:`12795` When every RPC node of one chain fails, blockchain balances of the other chains are no longer discarded from balance snapshot.
 * :bug:`13034` Withdrawals from a validator whose withdrawal address you do not track no longer show up in your history or count as staking income.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 =========
 
 * :bug:`-` Coinbase conversions no longer get a made-up fee consisting of the difference between the two legs' fiat valuations.
+* :bug:`-` Removing a Coinbase or Bitstamp connection, or renaming them and Bitstamp now also forgets how far its history had been queried.
 * :bug:`-` Swaps through any newer 0x Settler deployment are now decoded, including any future ones.
 * :bug:`12795` When every RPC node of one chain fails, blockchain balances of the other chains are no longer discarded from balance snapshot.
 * :bug:`13034` Withdrawals from a validator whose withdrawal address you do not track no longer show up in your history or count as staking income.

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from threading import Semaphore
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Unpack, cast, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, Unpack, cast, overload
 
 from sqlcipher3 import dbapi2 as sqlcipher
 
@@ -177,6 +177,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
+
+EXCHANGE_INSTANCE_CACHE_KEY_PREFIX: Final = '{location}_{location_name}_'
+# Regexes for the tail of every DBCacheDynamic key scoped to a single exchange instance.
+# Each placeholder is a single underscore-free segment so that the name of one exchange can't
+# swallow the keys of another exchange whose name starts with it (`main` vs `main_backup`).
+EXCHANGE_INSTANCE_CACHE_KEY_TAILS: Final = tuple(
+    re.compile('[^_]+'.join(
+        re.escape(part)
+        for part in re.split(r'\{\w+\}', template.removeprefix(EXCHANGE_INSTANCE_CACHE_KEY_PREFIX))
+    ))
+    for template in (member.value[0] for member in DBCacheDynamic)
+    if template.startswith(EXCHANGE_INSTANCE_CACHE_KEY_PREFIX)
+)
 
 DBINFO_FILENAME = 'dbinfo.json'
 TRANSIENT_DB_NAME = 'rotkehlchen_transient.db'
@@ -1119,7 +1132,7 @@ class DBHandler:
             self,
             write_cursor: DBCursor,
             name: Literal[DBCacheDynamic.LAST_QUERY_ID],
-            value: int,
+            value: str,
             **kwargs: Unpack[LabeledLocationIdArgsType],
     ) -> None:
         ...
@@ -1742,15 +1755,38 @@ class DBHandler:
         return Timestamp(int(result[0])), Timestamp(int(result[1]))
 
     @staticmethod
-    def _is_binance_pair_cache_key(key: str, prefix: str) -> bool:
-        """Return whether key is a Binance pair ID or pair query timestamp cache.
+    def _is_exchange_instance_cache_key(key: str, prefix: str) -> bool:
+        """Return whether key is a key_value_cache entry scoped to one exchange instance,
+        such as a Coinbase per-account cursor, a Bitstamp offset or Binance per-pair progress.
 
-        Binance symbols are concatenated alphanumeric asset symbols. Checking the suffix keeps
-        exchange names such as ``main`` and ``main_backup`` unambiguous despite the legacy
-        underscore-delimited cache format.
+        The key's tail after ``{location}_{name}_`` has to match one of the DBCacheDynamic
+        templates with every placeholder (a Coinbase account UUID, a Binance pair) free of
+        underscores. That keeps exchange names such as ``main`` and ``main_backup``
+        unambiguous despite the legacy underscore-delimited cache format.
         """
-        suffix = key.removeprefix(prefix).removesuffix('_last_query_ts')
-        return suffix.isalnum()
+        tail = key.removeprefix(prefix)
+        return any(pattern.fullmatch(tail) for pattern in EXCHANGE_INSTANCE_CACHE_KEY_TAILS)
+
+    def _get_exchange_instance_cache_keys(
+            self,
+            cursor: DBCursor,
+            location: Location,
+            exchange_name: str,
+    ) -> list[str]:
+        """Return the key_value_cache keys holding the query progress of one exchange
+        instance. They are named {location}_{name}_... so a LIKE on the name alone would
+        also return the keys of any exchange whose name starts with this one."""
+        escaped_name = exchange_name.replace(
+            '\\',
+            '\\\\',
+        ).replace('%', '\\%').replace('_', '\\_')
+        prefix = f'{location!s}_{exchange_name}_'
+        return [
+            key for key, in cursor.execute(
+                'SELECT name FROM key_value_cache WHERE name LIKE ? ESCAPE ?;',
+                (f'{location!s}\\_{escaped_name}\\_%', '\\'),
+            ) if self._is_exchange_instance_cache_key(key=key, prefix=prefix)
+        ]
 
     def delete_used_query_range_for_exchange(
             self,
@@ -1762,34 +1798,22 @@ class DBHandler:
         """Delete the query ranges for the given exchange name"""
         if data_type == ExchangePurgeType.ALL:
             ranges_to_delete = [f'{location!s}\\_%']
-            escaped_name: str | None = None
             if exchange_name is not None:
                 escaped_name = exchange_name.replace(
                     '\\',
                     '\\\\',
                 ).replace('%', '\\%').replace('_', '\\_')
                 ranges_to_delete = [f'{location!s}\\_%\\_{escaped_name}']
-            write_cursor.execute(
-                'DELETE FROM key_value_cache WHERE name LIKE ? ESCAPE ?;',
-                (ranges_to_delete[0], '\\'),
-            )
-            if (
-                    exchange_name is not None and
-                    escaped_name is not None and
-                    location in (Location.BINANCE, Location.BINANCEUS)
-            ):
-                cache_prefix = f'{location!s}_{exchange_name}_'
-                cache_keys = write_cursor.execute(
-                    'SELECT name FROM key_value_cache WHERE name LIKE ? ESCAPE ?;',
-                    (f'{location!s}\\_{escaped_name}\\_%', '\\'),
-                ).fetchall()
+                # The pattern above only catches keys ending in the exchange name. The
+                # per-instance caches (Coinbase account cursors, Bitstamp offset, Binance
+                # pair progress) are named {location}_{name}_... so match them separately.
                 write_cursor.executemany(
                     'DELETE FROM key_value_cache WHERE name=?;',
-                    [
-                        (key,)
-                        for key, in cache_keys
-                        if self._is_binance_pair_cache_key(key=key, prefix=cache_prefix)
-                    ],
+                    [(key,) for key in self._get_exchange_instance_cache_keys(
+                        cursor=write_cursor,
+                        location=location,
+                        exchange_name=exchange_name,
+                    )],
                 )
         elif data_type == ExchangePurgeType.TRADES:
             ranges_to_delete = [
@@ -2736,7 +2760,7 @@ class DBHandler:
                 raise InputError(f'Could not update DB user_credentials_mappings due to {e!s}') from e  # noqa: E501
 
         if new_name is not None:
-            exchange_re = re.compile(r'(.*?)_(margins|history_events).*')
+            exchange_re = re.compile(r'(.*?)_(margins|history_events|lending_history).*')
             used_ranges = write_cursor.execute(
                 'SELECT * from used_query_ranges WHERE name LIKE ?',
                 (f'{location!s}_%_{name}',),
@@ -2753,6 +2777,20 @@ class DBHandler:
                 [
                     (f'{location!s}_{entry_type}_{new_name}', f'{location!s}_{entry_type}_{name}')
                     for entry_type in entry_types
+                ],
+            )
+            # move the per-instance query progress (Coinbase account cursors, Bitstamp
+            # offset, Binance pair progress) to the new name so history isn't re-queried
+            cache_prefix = f'{location!s}_{name}_'
+            write_cursor.executemany(
+                'UPDATE key_value_cache SET name=? WHERE name=?',
+                [
+                    (f'{location!s}_{new_name}_{key.removeprefix(cache_prefix)}', key)
+                    for key in self._get_exchange_instance_cache_keys(
+                        cursor=write_cursor,
+                        location=location,
+                        exchange_name=name,
+                    )
                 ],
             )
 

--- a/rotkehlchen/db/dbhandler.py
+++ b/rotkehlchen/db/dbhandler.py
@@ -2576,6 +2576,17 @@ class DBHandler:
                 '(name, location, api_key, api_secret, passphrase) VALUES (?, ?, ?, ?, ?)',
                 (name, location.serialize_for_db(), api_key, api_secret.decode() if api_secret is not None else None, passphrase),  # noqa: E501
             )
+            # Older versions did not clear the per-instance query progress (Coinbase account
+            # cursors, Bitstamp offset, Binance pair progress and lending range) when an
+            # exchange was removed or renamed, so stale progress under this name would make
+            # the new connection skip everything before it. Nothing can legitimately exist
+            # under the name of an exchange that is only now being added, so drop it. Has
+            # to happen before the binance history start range is written below.
+            self.delete_used_query_range_for_exchange(
+                write_cursor=cursor,
+                location=location,
+                exchange_name=name,
+            )
 
             if location == Location.KRAKEN:
                 if kraken_account_type is not None:
@@ -2780,10 +2791,13 @@ class DBHandler:
                 ],
             )
             # move the per-instance query progress (Coinbase account cursors, Bitstamp
-            # offset, Binance pair progress) to the new name so history isn't re-queried
+            # offset, Binance pair progress) to the new name so history isn't re-queried.
+            # OR REPLACE since older versions left the keys of removed or renamed exchanges
+            # behind and no live exchange can hold the new name (user_credentials PK), so
+            # anything already under it is stale and must not block the rename.
             cache_prefix = f'{location!s}_{name}_'
             write_cursor.executemany(
-                'UPDATE key_value_cache SET name=? WHERE name=?',
+                'UPDATE OR REPLACE key_value_cache SET name=? WHERE name=?',
                 [
                     (f'{location!s}_{new_name}_{key.removeprefix(cache_prefix)}', key)
                     for key in self._get_exchange_instance_cache_keys(

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -2231,6 +2231,193 @@ def test_delete_binance_exchange_clears_pair_query_progress(
             ) is not None
 
 
+@pytest.mark.parametrize(('deleted_name', 'remaining_name'), [
+    ('coinbase_1', 'coinbase_1_backup'),
+    ('coinbase_1_backup', 'coinbase_1'),
+])
+def test_delete_exchange_clears_instance_cache(
+        database: DBHandler,
+        deleted_name: str,
+        remaining_name: str,
+) -> None:
+    """Deleting one Coinbase/Bitstamp key clears only that key's query cursors.
+
+    Regression test: the by-name purge only matched cache keys ending in the exchange
+    name, but the Coinbase per-account cursors and the Bitstamp offset are named
+    {location}_{name}_..., so removing and re-adding an exchange under the same name never
+    re-fetched the transactions before the old cursor.
+    """
+    account_id = '3c04e35e-8e5a-5ff1-9155-00675db4ac02'
+    exchange_names = (deleted_name, remaining_name)
+    with database.user_write() as write_cursor:
+        for location_name in exchange_names:
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.LAST_QUERY_ID,
+                value='tx_id',
+                location=Location.COINBASE.serialize(),
+                location_name=location_name,
+                account_id=account_id,
+            )
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.LAST_QUERY_TS,
+                value=Timestamp(1800000000),
+                location=Location.COINBASE.serialize(),
+                location_name=location_name,
+                account_id=account_id,
+            )
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.LAST_CRYPTOTX_OFFSET,
+                value=7,
+                location=Location.BITSTAMP.serialize(),
+                location_name=location_name,
+            )
+
+        for location in (Location.COINBASE, Location.BITSTAMP):
+            database.delete_used_query_range_for_exchange(
+                write_cursor=write_cursor,
+                location=location,
+                exchange_name=deleted_name,
+            )
+
+    with database.conn.read_ctx() as cursor:
+        for cache_name in (DBCacheDynamic.LAST_QUERY_ID, DBCacheDynamic.LAST_QUERY_TS):
+            assert database.get_dynamic_cache(
+                cursor=cursor,
+                name=cache_name,
+                location=Location.COINBASE.serialize(),
+                location_name=deleted_name,
+                account_id=account_id,
+            ) is None
+            assert database.get_dynamic_cache(
+                cursor=cursor,
+                name=cache_name,
+                location=Location.COINBASE.serialize(),
+                location_name=remaining_name,
+                account_id=account_id,
+            ) is not None
+        assert database.get_dynamic_cache(
+            cursor=cursor,
+            name=DBCacheDynamic.LAST_CRYPTOTX_OFFSET,
+            location=Location.BITSTAMP.serialize(),
+            location_name=deleted_name,
+        ) is None
+        assert database.get_dynamic_cache(
+            cursor=cursor,
+            name=DBCacheDynamic.LAST_CRYPTOTX_OFFSET,
+            location=Location.BITSTAMP.serialize(),
+            location_name=remaining_name,
+        ) == 7
+
+
+@pytest.mark.parametrize(('renamed_name', 'sibling_name'), [
+    ('main', 'main_backup'),
+    ('main_backup', 'main'),
+])
+def test_rename_exchange_moves_instance_cache(
+        database: DBHandler,
+        renamed_name: str,
+        sibling_name: str,
+) -> None:
+    """Renaming an exchange moves its query progress to the new name and leaves alone
+    a sibling whose name shares a prefix with it.
+
+    Regression test: edit_exchange renamed the used_query_ranges rows but not the
+    key_value_cache cursors (Coinbase per-account, Bitstamp offset, Binance per-pair), so a
+    renamed exchange re-queried its whole history and the old keys were orphaned. The
+    Binance lending history range was not renamed either.
+    """
+    new_name = 'renamed'
+    account_id = '3c04e35e-8e5a-5ff1-9155-00675db4ac02'
+    for location in (Location.COINBASE, Location.BITSTAMP, Location.BINANCE):
+        for name in (renamed_name, sibling_name):
+            database.add_exchange(
+                name=name,
+                location=location,
+                api_key=ApiKey(f'{location!s}_{name}_key'),
+                api_secret=ApiSecret(f'{location!s}_{name}_secret'.encode()),
+            )
+
+    with database.user_write() as write_cursor:
+        for name in (renamed_name, sibling_name):
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.LAST_QUERY_ID,
+                value=f'tx_of_{name}',
+                location=Location.COINBASE.serialize(),
+                location_name=name,
+                account_id=account_id,
+            )
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.LAST_CRYPTOTX_OFFSET,
+                value=7,
+                location=Location.BITSTAMP.serialize(),
+                location_name=name,
+            )
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.BINANCE_PAIR_LAST_ID,
+                value=42,
+                location=Location.BINANCE.serialize(),
+                location_name=name,
+                queried_pair='ETHBTC',
+            )
+            database.update_used_query_range(
+                write_cursor=write_cursor,
+                name=f'{Location.BINANCE!s}_lending_history_{name}',
+                start_ts=Timestamp(0),
+                end_ts=Timestamp(1500000000),
+            )
+
+        for location in (Location.COINBASE, Location.BITSTAMP, Location.BINANCE):
+            database.edit_exchange(
+                write_cursor,
+                name=renamed_name,
+                location=location,
+                new_name=new_name,
+                api_key=None,
+                api_secret=None,
+                passphrase=None,
+                kraken_account_type=None,
+                kraken_futures_api_key=None,
+                kraken_futures_api_secret=None,
+                binance_selected_trade_pairs=None,
+                okx_location=None,
+            )
+
+    with database.conn.read_ctx() as cursor:
+        for name, expected_tx in ((renamed_name, None), (new_name, f'tx_of_{renamed_name}'), (sibling_name, f'tx_of_{sibling_name}')):  # noqa: E501
+            assert database.get_dynamic_cache(
+                cursor=cursor,
+                name=DBCacheDynamic.LAST_QUERY_ID,
+                location=Location.COINBASE.serialize(),
+                location_name=name,
+                account_id=account_id,
+            ) == expected_tx
+        for name, expected in ((renamed_name, None), (new_name, 7), (sibling_name, 7)):
+            assert database.get_dynamic_cache(
+                cursor=cursor,
+                name=DBCacheDynamic.LAST_CRYPTOTX_OFFSET,
+                location=Location.BITSTAMP.serialize(),
+                location_name=name,
+            ) == expected
+        for name, expected in ((renamed_name, None), (new_name, 42), (sibling_name, 42)):
+            assert database.get_dynamic_cache(
+                cursor=cursor,
+                name=DBCacheDynamic.BINANCE_PAIR_LAST_ID,
+                location=Location.BINANCE.serialize(),
+                location_name=name,
+                queried_pair='ETHBTC',
+            ) == expected
+            assert (database.get_used_query_range(
+                cursor,
+                f'{Location.BINANCE!s}_lending_history_{name}',
+            ) is None) == (expected is None)
+
+
 def test_remove_multichain_address_keeps_tags_on_other_chains(database: DBHandler) -> None:
     """Removing a multi-chain address from one chain must not delete its tags while
     the same address is still tracked on another chain.

--- a/rotkehlchen/tests/db/test_db.py
+++ b/rotkehlchen/tests/db/test_db.py
@@ -2418,6 +2418,141 @@ def test_rename_exchange_moves_instance_cache(
             ) is None) == (expected is None)
 
 
+def test_rename_exchange_replaces_orphan_instance_cache(database: DBHandler) -> None:
+    """Renaming an exchange onto a name whose query progress an older version left
+    behind replaces the orphan keys instead of failing the whole rename.
+
+    Regression test: older versions did not clear key_value_cache on exchange removal or
+    rename, so a plain UPDATE to the new name hit the key_value_cache.name primary key
+    with an IntegrityError that nothing caught.
+    """
+    database.add_exchange(
+        name=(name := 'current'),
+        location=Location.COINBASE,
+        api_key=ApiKey('key'),
+        api_secret=ApiSecret(b'secret'),
+    )
+    with database.user_write() as write_cursor:
+        for location_name in (name, (orphan_name := 'orphan')):
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.LAST_QUERY_ID,
+                value=f'tx_of_{location_name}',
+                location=Location.COINBASE.serialize(),
+                location_name=location_name,
+                account_id=(account_id := '3c04e35e-8e5a-5ff1-9155-00675db4ac02'),
+            )
+        database.edit_exchange(
+            write_cursor,
+            name=name,
+            location=Location.COINBASE,
+            new_name=orphan_name,
+            api_key=None,
+            api_secret=None,
+            passphrase=None,
+            kraken_account_type=None,
+            kraken_futures_api_key=None,
+            kraken_futures_api_secret=None,
+            binance_selected_trade_pairs=None,
+            okx_location=None,
+        )
+
+    with database.conn.read_ctx() as cursor:
+        assert database.get_dynamic_cache(
+            cursor=cursor,
+            name=DBCacheDynamic.LAST_QUERY_ID,
+            location=Location.COINBASE.serialize(),
+            location_name=orphan_name,
+            account_id=account_id,
+        ) == f'tx_of_{name}'
+        assert database.get_dynamic_cache(
+            cursor=cursor,
+            name=DBCacheDynamic.LAST_QUERY_ID,
+            location=Location.COINBASE.serialize(),
+            location_name=name,
+            account_id=account_id,
+        ) is None
+
+
+def test_add_exchange_clears_stale_instance_cache(database: DBHandler) -> None:
+    """Adding an exchange drops any query progress an older version left under its
+    name, so the new connection queries its history from scratch, while the keys of an
+    exchange whose name merely starts with the same prefix are kept."""
+    with database.user_write() as write_cursor:
+        for location_name in ((name := 'main'), (sibling_name := 'main_backup')):
+            database.update_used_query_range(
+                write_cursor=write_cursor,
+                name=f'{Location.BINANCE!s}_lending_history_{location_name}',
+                start_ts=Timestamp(0),
+                end_ts=Timestamp(1500000000),
+            )
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.LAST_QUERY_ID,
+                value=f'tx_of_{location_name}',
+                location=Location.COINBASE.serialize(),
+                location_name=location_name,
+                account_id=(account_id := '3c04e35e-8e5a-5ff1-9155-00675db4ac02'),
+            )
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.LAST_CRYPTOTX_OFFSET,
+                value=7,
+                location=Location.BITSTAMP.serialize(),
+                location_name=location_name,
+            )
+            database.set_dynamic_cache(
+                write_cursor=write_cursor,
+                name=DBCacheDynamic.BINANCE_PAIR_LAST_ID,
+                value=42,
+                location=Location.BINANCE.serialize(),
+                location_name=location_name,
+                queried_pair='ETHBTC',
+            )
+
+    for location in (Location.COINBASE, Location.BITSTAMP, Location.BINANCE):
+        database.add_exchange(
+            name=name,
+            location=location,
+            api_key=ApiKey(f'{location!s}_key'),
+            api_secret=ApiSecret(f'{location!s}_secret'.encode()),
+        )
+
+    with database.conn.read_ctx() as cursor:
+        for location_name, expected_tx in ((name, None), (sibling_name, f'tx_of_{sibling_name}')):
+            assert database.get_dynamic_cache(
+                cursor=cursor,
+                name=DBCacheDynamic.LAST_QUERY_ID,
+                location=Location.COINBASE.serialize(),
+                location_name=location_name,
+                account_id=account_id,
+            ) == expected_tx
+        for location_name, expected in ((name, None), (sibling_name, 7)):
+            assert database.get_dynamic_cache(
+                cursor=cursor,
+                name=DBCacheDynamic.LAST_CRYPTOTX_OFFSET,
+                location=Location.BITSTAMP.serialize(),
+                location_name=location_name,
+            ) == expected
+        for location_name, expected in ((name, None), (sibling_name, 42)):
+            assert database.get_dynamic_cache(
+                cursor=cursor,
+                name=DBCacheDynamic.BINANCE_PAIR_LAST_ID,
+                location=Location.BINANCE.serialize(),
+                location_name=location_name,
+                queried_pair='ETHBTC',
+            ) == expected
+            assert (database.get_used_query_range(
+                cursor,
+                f'{Location.BINANCE!s}_lending_history_{location_name}',
+            ) is None) == (expected is None)
+        # the binance history start range written by add_exchange itself must survive
+        assert database.get_used_query_range(
+            cursor,
+            f'{Location.BINANCE!s}_history_events_{name}',
+        ) is not None
+
+
 def test_remove_multichain_address_keeps_tags_on_other_chains(database: DBHandler) -> None:
     """Removing a multi-chain address from one chain must not delete its tags while
     the same address is still tracked on another chain.


### PR DESCRIPTION
Removing a named Coinbase or Bitstamp connection kept its key_value_cache progress (per-account cursors, cryptotx offset) because the by-name purge only matched keys ending in the exchange name. Match the {location}_{name}_ keys generically from the DBCacheDynamic templates instead of the Binance-only special case.

fix: keep exchange query progress on rename

Renaming an exchange moved its used_query_ranges rows but left the per-instance key_value_cache keys (Coinbase account cursors, Bitstamp offset, Binance pair progress) under the old name, so the renamed exchange re-downloaded its whole history. Move them with the rename, share the key lookup with the removal path and also rename the Binance lending_history range.
