### PR TITLE
fix: coinbase conversion fee

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Coinbase conversions no longer get a made-up fee consisting of the difference between the two legs' fiat valuations.
 * :bug:`-` Swaps through any newer 0x Settler deployment are now decoded, including any future ones.
 * :bug:`12795` When every RPC node of one chain fails, blockchain balances of the other chains are no longer discarded from balance snapshot.
 * :bug:`13034` Withdrawals from a validator whose withdrawal address you do not track no longer show up in your history or count as staking income.

--- a/rotkehlchen/exchanges/coinbase.py
+++ b/rotkehlchen/exchanges/coinbase.py
@@ -655,79 +655,42 @@ class Coinbase(ExchangeInterface):
             formatstr='iso8601',
             location='coinbase',
         )
-        fee = None
         if tx_b is not None:
             # Trade b will represent the asset we are converting to
             if tx_b['amount']['amount'].startswith('-'):
                 tx_a, tx_b = tx_b, tx_a
 
-            tx_amount = abs(deserialize_fval(tx_a['amount']['amount']))
-            tx_asset = asset_from_coinbase(tx_a['amount']['currency'], time=timestamp)
             native_amount = abs(deserialize_fval(tx_b['amount']['amount']))
             native_asset = asset_from_coinbase(tx_b['amount']['currency'], time=timestamp)
-
-            amount_after_fee = deserialize_fval(tx_b['native_amount']['amount'])
-            amount_before_fee = deserialize_fval(tx_a['native_amount']['amount'])
-            if (
-                    (fee_a := tx_a['trade'].get('fee')) is not None and
-                    (fee_b := tx_b['trade'].get('fee')) is not None and
-                    fee_a['amount'] == fee_b['amount']
-            ):
-                # Lefteris mentioned that conversions for him didn't have at least in the past the
-                # fee section. I've kept both of them but we might have to revisit this part of the logic.  # noqa: E501
-                # Using the fee field as value for the fee the rate that calculates rotki is correct  # noqa: E501
-                # and displays the exact same amounts that the accounting report from coinbase.
-                conversion_native_fee_amount = deserialize_fval(
-                    value=tx_a['trade']['fee']['amount'],
-                    name='conversion fee',
-                    location='coinbase conversion',
-                )
-            else:
-                # Obtain fee amount in the native currency using data from both trades
-                # amount_after_fee + amount_before_fee is a negative amount and the fee needs to be positive  # noqa: E501
-                conversion_native_fee_amount = abs(amount_after_fee + amount_before_fee)
-
-            if ZERO not in {tx_amount, conversion_native_fee_amount, amount_before_fee, amount_after_fee}:  # noqa: E501
-                # To get the asset in which the fee is nominated we pay attention to the creation
-                # date of each event. As per our hypothesis the fee is nominated in the asset
-                # for which the first transaction part was initialized
-                time_created_a = deserialize_timestamp_from_date(
-                    date=tx_a['created_at'],
-                    formatstr='iso8601',
-                    location='coinbase',
-                )
-                time_created_b = deserialize_timestamp_from_date(
-                    date=tx_b['created_at'],
-                    formatstr='iso8601',
-                    location='coinbase',
-                )
-                if time_created_a < time_created_b:
-                    # We have the fee amount in the native currency. To get it in the
-                    # converted asset we have to get the rate
-                    asset_native_rate = tx_amount / abs(amount_before_fee)
-                    fee = AssetAmount(
-                        amount=conversion_native_fee_amount * asset_native_rate,
-                        asset=asset_from_coinbase(tx_a['amount']['currency'], time=timestamp),
-                    )
-                else:
-                    tx_b_amount = abs(deserialize_fval(tx_b['amount']['amount']))
-                    asset_native_rate = tx_b_amount / abs(amount_after_fee)
-                    fee = AssetAmount(
-                        amount=conversion_native_fee_amount * asset_native_rate,
-                        asset=asset_from_coinbase(tx_b['amount']['currency'], time=timestamp),
-                    )
-
+            fee_data = tx_a['trade'].get('fee') or tx_b['trade'].get('fee')
         else:  # only one transaction
-            tx_amount = abs(deserialize_fval(tx_a['amount']['amount']))
-            tx_asset = asset_from_coinbase(tx_a['amount']['currency'], time=timestamp)
             native_amount = abs(deserialize_fval(tx_a['native_amount']['amount']))
             native_asset = asset_from_coinbase(tx_a['native_amount']['currency'], time=timestamp)
-            # For a single transaction fee may or may not exist in the transaction.
-            if (fee_data := tx_a['trade'].get('fee')) is not None:
-                fee = AssetAmount(
-                    asset=asset_from_coinbase(fee_data['currency']),
-                    amount=abs(deserialize_fval(fee_data['amount'])),
-                )
+            fee_data = tx_a['trade'].get('fee')
+
+        tx_amount = abs(deserialize_fval(tx_a['amount']['amount']))
+        tx_asset = asset_from_coinbase(tx_a['amount']['currency'], time=timestamp)
+        # The fee is only ever the one coinbase reports explicitly under trade.fee. The difference
+        # between the two legs' native_amount valuations is coinbase's spread, i.e. a worse rate,
+        # and not an amount that leaves the user's wallets, so it must not become a fee event.
+        fee = None
+        if (
+                fee_data is not None and
+                (fee_amount := abs(deserialize_fval(
+                    value=fee_data['amount'],
+                    name='conversion fee',
+                    location='coinbase conversion',
+                ))) != ZERO
+        ):
+            fee = AssetAmount(
+                asset=asset_from_coinbase(fee_data['currency'], time=timestamp),
+                amount=fee_amount,
+            )
+            if fee.asset == tx_asset:
+                # The wallet transaction amount is the total debit, fee included.
+                # e.g. amount -10.571942 USDC with fee 0.109974 USDC means 10.461968 USDC were
+                # exchanged and 0.109974 USDC were paid as fee, not 10.571942 + 0.109974.
+                tx_amount -= fee_amount
 
         if _is_same_asset_amount_trade(
             spend=(spend := AssetAmount(asset=tx_asset, amount=tx_amount)),

--- a/rotkehlchen/tests/exchanges/test_coinbase.py
+++ b/rotkehlchen/tests/exchanges/test_coinbase.py
@@ -669,7 +669,7 @@ def test_coinbase_query_history_events(
         location=Location.COINBASE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_USDC,
-        amount=FVal('10.482180'),
+        amount=FVal('10.382341'),
         location_label=coinbase.name,
         group_identifier=create_group_identifier_from_unique_id(
             location=Location.COINBASE,
@@ -704,6 +704,8 @@ def test_coinbase_query_history_events(
 
 
 def test_asset_conversion(mock_coinbase):
+    """A conversion without an explicit trade.fee gets no fee event. The difference between
+    the two legs' native valuations (1000 USD vs 910 USD) is coinbase's spread, not a fee."""
     tx_id = '77c5ad72-764e-414b-8bdb-b5aed20fb4b1'
     trade_b = {
         'id': tx_id,
@@ -792,21 +794,13 @@ def test_asset_conversion(mock_coinbase):
             location=Location.COINBASE,
             unique_id='5dceef97-ef34-41e6-9171-3e60cd01639e',
         ),
-    ), SwapEvent(
-        timestamp=TimestampMS(1623119536000),
-        location=Location.COINBASE,
-        event_subtype=HistoryEventSubType.FEE,
-        asset=A_USDC,
-        amount=FVal('90.000000'),
-        location_label='coinbase1',
-        group_identifier=create_group_identifier_from_unique_id(
-            location=Location.COINBASE,
-            unique_id='5dceef97-ef34-41e6-9171-3e60cd01639e',
-        ),
     )]
 
 
 def test_conversion_with_fee(mock_coinbase):
+    """Real payload of a coinbase conversion with an explicit fee. The USDC wallet balance
+    dropped by 10.571942 in total, so the fee of 0.109974 USDC is part of that amount and the
+    spend is what remains after the fee, not the full amount with the fee added on top."""
     tx_id = '61258a99-7e8a-4ece-94cf-485b33d09319'
     trade_b = {'amount': {'amount': '-10.571942', 'currency': 'USDC'}, 'created_at': '2024-12-06T10:27:56Z', 'id': '39073929-386e-58a2-9ec4-d8371a395a9e', 'native_amount': {'amount': '-10.00', 'currency': 'EUR'}, 'resource': 'transaction', 'resource_path': '/v2/accounts/40e03599-5601-534c-95c2-0db5f5c5e652/transactions/39073929-386e-58a2-9ec4-d8371a395a9e', 'status': 'completed', 'trade': {'fee': {'amount': '0.109974', 'currency': 'USDC'}, 'id': '61258a99-7e8a-4ece-94cf-485b33d09319', 'payment_method_name': 'billetera de USDC'}, 'type': 'trade'}  # noqa: E501
     trade_a = {'amount': {'amount': '0.00266121', 'currency': 'ETH'}, 'created_at': '2024-12-06T10:27:57Z', 'id': 'e34548a2-4eec-54fc-a13f-6b48996e9ecf', 'native_amount': {'amount': '9.70', 'currency': 'EUR'}, 'resource': 'transaction', 'resource_path': '/v2/accounts/16ff1367-5834-5827-95f3-f503d891421c/transactions/e34548a2-4eec-54fc-a13f-6b48996e9ecf', 'status': 'completed', 'trade': {'fee': {'amount': '0.109974', 'currency': 'USDC'}, 'id': '61258a99-7e8a-4ece-94cf-485b33d09319', 'payment_method_name': 'billetera de USDC'}, 'type': 'trade'}  # noqa: E501
@@ -818,7 +812,7 @@ def test_conversion_with_fee(mock_coinbase):
         location=Location.COINBASE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_USDC,
-        amount=FVal('10.571942'),
+        amount=FVal('10.461968'),
         location_label='coinbase1',
         group_identifier=create_group_identifier_from_unique_id(
             location=Location.COINBASE,
@@ -840,7 +834,7 @@ def test_conversion_with_fee(mock_coinbase):
         location=Location.COINBASE,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_USDC,
-        amount=FVal('0.1162638749508'),
+        amount=FVal('0.109974'),
         location_label='coinbase1',
         group_identifier=create_group_identifier_from_unique_id(
             location=Location.COINBASE,
@@ -903,7 +897,7 @@ def test_conversion_across_wallets(function_scope_coinbase):
         location=Location.COINBASE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_USDC,
-        amount=FVal('10.571942'),
+        amount=FVal('10.461968'),
         location_label=coinbase.name,
         group_identifier=group_identifier,
     ), SwapEvent(
@@ -919,7 +913,7 @@ def test_conversion_across_wallets(function_scope_coinbase):
         location=Location.COINBASE,
         event_subtype=HistoryEventSubType.FEE,
         asset=A_USDC,
-        amount=FVal('0.1162638749508'),
+        amount=FVal('0.109974'),
         location_label=coinbase.name,
         group_identifier=group_identifier,
     )]
@@ -960,7 +954,7 @@ def test_asset_conversion_no_second_transaction(mock_coinbase):
         location=Location.COINBASE,
         event_subtype=HistoryEventSubType.SPEND,
         asset=A_XTZ,
-        amount=FVal('450'),
+        amount=FVal('449'),
         location_label='coinbase1',
         group_identifier=create_group_identifier_from_unique_id(
             location=Location.COINBASE,
@@ -1081,17 +1075,6 @@ def test_asset_conversion_not_stable_coin(mock_coinbase):
             location=Location.COINBASE,
             unique_id='5dceef97-ef34-41e6-9171-3e60cd01639e',
         ),
-    ), SwapEvent(
-        timestamp=TimestampMS(1623119536000),
-        location=Location.COINBASE,
-        event_subtype=HistoryEventSubType.FEE,
-        asset=A_1INCH,
-        amount=FVal('540.000000'),
-        location_label='coinbase1',
-        group_identifier=create_group_identifier_from_unique_id(
-            location=Location.COINBASE,
-            unique_id='5dceef97-ef34-41e6-9171-3e60cd01639e',
-        ),
     )]
 
 
@@ -1184,114 +1167,6 @@ def test_asset_conversion_zero_fee(mock_coinbase):
         group_identifier=create_group_identifier_from_unique_id(
             location=Location.COINBASE,
             unique_id='5dceef97-ef34-41e6-9171-3e60cd01639e',
-        ),
-    )]
-
-
-def test_asset_conversion_choosing_fee_asset(mock_coinbase):
-    """Test that the fee asset is correctly chosen when the received asset transaction
-    is created before the giving transaction.
-    """
-    tx_id = '77c5ad72-764e-414b-8bdb-b5aed20fb4b1'
-    trade_a = {
-        'id': tx_id,
-        'type': 'trade',
-        'status': 'completed',
-        'amount': {
-            'amount': '-37734.034561',
-            'currency': 'ETH',
-        },
-        'native_amount': {
-            'amount': '-79362.22',
-            'currency': 'USD',
-        },
-        'description': None,
-        'created_at': '2021-10-12T13:23:56Z',
-        'updated_at': '2021-10-12T13:23:56Z',
-        'resource': 'transaction',
-        'resource_path': f'/v2/accounts/sd5af/transactions/{tx_id}',
-        'instant_exchange': False,
-        'trade': {
-            'id': 'id_of_trade',
-            'resource': 'trade',
-            'resource_path': '/v2/accounts/REDACTED/trades/id_of_trade',
-        },
-        'details': {
-            'title': 'Converted from ETH',
-            'subtitle': 'Using ETH Wallet',
-            'header': 'Converted 37,734.034561 ETH ($79,362.22)',
-            'health': 'positive',
-            'payment_method_name': 'ETH Wallet',
-        },
-        'hide_native_amount': False,
-    }
-    trade_b = {
-        'id': tx_id,
-        'type': 'trade',
-        'status': 'completed',
-        'amount': {
-            'amount': '552.315885836',
-            'currency': 'BTC',
-        },
-        'native_amount': {
-            'amount': '77827.94',
-            'currency': 'USD',
-        },
-        'description': None,
-        'created_at': '2021-10-12T13:23:55Z',
-        'updated_at': '2021-10-12T13:23:57Z',
-        'resource': 'transaction',
-        'resource_path': f'/v2/accounts/sd5af/transactions/{tx_id}',
-        'instant_exchange': False,
-        'trade': {
-            'id': 'id_of_trade',
-            'resource': 'trade',
-            'resource_path': '/v2/accounts/REDACTED/trades/id_of_trade',
-        },
-        'details': {
-            'title': 'Converted to BTC',
-            'subtitle': 'Using ETH Wallet',
-            'header': 'Converted 552.31588584 BTC ($77,827.94)',
-            'health': 'positive',
-            'payment_method_name': 'ETH Wallet',
-        },
-        'hide_native_amount': False,
-    }
-
-    assert mock_coinbase._process_trades_from_conversion(
-        transaction_pairs={tx_id: [trade_a, trade_b]},
-    ) == [SwapEvent(
-        timestamp=TimestampMS(1634045036000),
-        location=Location.COINBASE,
-        event_subtype=HistoryEventSubType.SPEND,
-        asset=A_ETH,
-        amount=FVal('37734.034561'),
-        location_label='coinbase1',
-        group_identifier=create_group_identifier_from_unique_id(
-            location=Location.COINBASE,
-            unique_id='id_of_trade',
-        ),
-    ), SwapEvent(
-        timestamp=TimestampMS(1634045036000),
-        location=Location.COINBASE,
-        event_subtype=HistoryEventSubType.RECEIVE,
-        asset=A_BTC,
-        amount=FVal('552.315885836'),
-        location_label='coinbase1',
-        group_identifier=create_group_identifier_from_unique_id(
-            location=Location.COINBASE,
-            unique_id='id_of_trade',
-        ),
-    ), SwapEvent(
-        timestamp=TimestampMS(1634045036000),
-        location=Location.COINBASE,
-        event_subtype=HistoryEventSubType.FEE,
-        asset=A_BTC,
-        amount=FVal('10.8882133758192505159458158599598036386418553542596656162298526724464247672494'),
-        location_label='coinbase1',
-        group_identifier=create_group_identifier_from_unique_id(
-            location=Location.COINBASE,
-            unique_id='id_of_trade',
         ),
     )]
 


### PR DESCRIPTION
Stop synthesizing a fee from the difference between the two legs' native valuations of a Coinbase conversion. That difference is Coinbase's spread, not an amount leaving the wallet, so it over-debited the spent asset and made its acquisitions go missing from the PnL report.

An explicit trade.fee is now used in its own currency and, when that is the spend asset, subtracted from the wallet amount since Coinbase already includes the fee in the debit, as verified with a real payload.
