### PR TITLE
Drop help cursor on dashboard last-queried time

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Hovering the last-queried time in the dashboard sync bar no longer turns the cursor into a question mark.
 * :bug:`-` Coinbase conversions no longer get a made-up fee consisting of the difference between the two legs' fiat valuations.
 * :bug:`-` Swaps through any newer 0x Settler deployment are now decoded, including any future ones.
 * :bug:`12795` When every RPC node of one chain fails, blockchain balances of the other chains are no longer discarded from balance snapshot.

--- a/frontend/app/src/modules/dashboard/progress/components/IdleQuerySection.vue
+++ b/frontend/app/src/modules/dashboard/progress/components/IdleQuerySection.vue
@@ -32,7 +32,7 @@ const [DefineTimeTooltip, ReuseTimeTooltip] = createReusableTemplate();
         persist-on-tooltip-hover
       >
         <template #activator>
-          <span class="underline decoration-dotted cursor-help">
+          <span class="underline decoration-dotted">
             {{ lastQueriedDisplay }}
           </span>
         </template>

--- a/frontend/app/tests/e2e/fixtures/history-events.ts
+++ b/frontend/app/tests/e2e/fixtures/history-events.ts
@@ -147,11 +147,17 @@ export const ethBlockEventFixture: EthBlockEventFixture = {
   validatorIndex: '100000',
 };
 
+/**
+ * The withdrawal address has to be tracked for the event to be visible at all, and tracking it
+ * makes rotki query the chain for it. An address with no history keeps that query short, where a
+ * well-known one (the fee recipient above, say) has a transaction list that outlives the test.
+ * Checksummed, since the backend rejects anything else.
+ */
 export const ethWithdrawalEventFixture: EthWithdrawalEventFixture = {
   amount: '32',
   isExit: false,
   validatorIndex: '100001',
-  withdrawalAddress: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+  withdrawalAddress: '0xe2e7a1c0B7ec06e1C2Eae0a5FFBf5f2d3b6c4915',
 };
 
 export interface EthDepositEventFixture {

--- a/frontend/app/tests/e2e/helpers/blockchain-accounts-api.ts
+++ b/frontend/app/tests/e2e/helpers/blockchain-accounts-api.ts
@@ -1,0 +1,34 @@
+import type { APIRequestContext } from '@playwright/test';
+import { backendUrl } from '../../../playwright.config';
+import { waitForAsyncQuery } from './api';
+
+/**
+ * Tracks a blockchain account via API, waiting for the balance query it starts.
+ *
+ * Adding an account here rather than seeding it into the database keeps it out of the fetch lane
+ * that runs at login, whose transaction query outlives the test timeout for any address with a
+ * history worth speaking of.
+ */
+export async function apiAddBlockchainAccount(
+  request: APIRequestContext,
+  address: string,
+  blockchain: string = 'eth',
+): Promise<void> {
+  const response = await request.put(`${backendUrl}/api/1/blockchains/${blockchain}/accounts`, {
+    failOnStatusCode: false,
+    data: {
+      accounts: [{ address }],
+      async_query: true,
+    },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to track ${address} on ${blockchain}: ${response.status()} ${await response.text()}`);
+  }
+
+  const body = await response.json();
+
+  if (body.result?.task_id) {
+    await waitForAsyncQuery(request, body.result.task_id);
+  }
+}

--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../../fixtures/history-events';
 import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { waitForNoRunningTasks } from '../../helpers/api';
+import { apiAddBlockchainAccount } from '../../helpers/blockchain-accounts-api';
 import { TIMEOUT_MEDIUM } from '../../helpers/constants';
 import { seedEvmTransaction, seedHistoricPrices } from '../../helpers/seed-db';
 import { EVENT_ROW, MOVEMENT_ROW, SWAP_ROW } from '../../pages/history-event-rows';
@@ -56,7 +57,19 @@ test.describe.serial('history events', () => {
 
   test.beforeAll(async ({ browser, request }) => {
     seedHistoricPrices(TEST_PRICE_ENTRIES, TEST_EVENT_TIMESTAMP);
-    ctx = await createLoggedInContext(browser, request);
+    ctx = await createLoggedInContext(browser, request, {
+      // A tracked account pulls in the NFT query, which retries against opensea for as long as the
+      // suite lasts, and a balance query that would otherwise reach real nodes.
+      disableModules: true,
+      rpcMockCassette: 'history-events',
+    });
+
+    // The events query drops an eth withdrawal event whose withdrawal address is not a tracked
+    // ethereum account, so the withdrawal this block adds only reaches the table if the address it
+    // pays out to is tracked. It is added after login, not seeded: an address the fetch lane sees
+    // at login is one it queries transactions for, and that outlives the test timeout.
+    await apiAddBlockchainAccount(request, ethWithdrawalEventFixture.withdrawalAddress);
+
     page = new HistoryEventsPage(ctx.sharedPage);
   });
 


### PR DESCRIPTION
The time-ago in the dashboard sync bar was styled with `cursor-help`, which renders as a question mark on hover. Its tooltip only restates the same value as a full date, so the default cursor is correct here, matching `DataIssueDetectedTime` and `BlockchainBalanceStalenessIndicator`.