### PR TITLE
test(frontend): coverage batch J, nine components to 70%

### DIFF
--- a/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.spec.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.spec.ts
@@ -1,0 +1,87 @@
+import type { SolanaTokenMigrationData } from '@/modules/assets/admin/solana-token-migration/use-solana-token-migration-dialog';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SolanaTokenMigrationDialog from '@/modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.vue';
+import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
+
+const { migrateSolanaToken, removeIdentifier } = vi.hoisted(() => ({
+  migrateSolanaToken: vi.fn(async () => Promise.resolve(true)),
+  removeIdentifier: vi.fn(),
+}));
+
+vi.mock('@/modules/assets/admin/solana-token-migration/solana-token-migration', () => ({
+  useSolanaTokenMigrationApi: (): Record<string, unknown> => ({ migrateSolanaToken }),
+}));
+
+vi.mock('@/modules/assets/admin/solana-token-migration/use-solana-token-migration-store', () => ({
+  useSolanaTokenMigrationStore: (): Record<string, unknown> => ({ removeIdentifier }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage: vi.fn() }),
+}));
+
+const TOKEN: SolanaTokenMigrationData = { address: 'So111', decimals: 9, tokenKind: 'spl-token' };
+
+function createWrapper(modelValue: SolanaTokenMigrationData | undefined = TOKEN): VueWrapper {
+  return mount(SolanaTokenMigrationDialog, {
+    global: {
+      stubs: {
+        BigDialog: {
+          props: ['display', 'loading', 'title', 'action', 'promptOnClose'],
+          template: '<div><slot /></div>',
+        },
+        ExternalLink: true,
+        HintMenuIcon: true,
+        SolanaTokenMigrationForm: {
+          methods: { validate: (): boolean => true },
+          template: '<div data-testid="migration-form" />',
+        },
+      },
+    },
+    props: { modelValue, oldAsset: 'SOL-OLD' },
+  });
+}
+
+describe('modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('should show the dialog while a token is selected', () => {
+    expect(createWrapper().findComponent(BigDialog).props('display')).toBe(true);
+  });
+
+  it('should render the form while a token is selected', () => {
+    expect(createWrapper().find('[data-testid=migration-form]').exists()).toBe(true);
+  });
+
+  it('should clear both selections when cancelled, without migrating', async () => {
+    const wrapper = createWrapper();
+
+    wrapper.findComponent(BigDialog).vm.$emit('cancel');
+    await flushPromises();
+
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([undefined]);
+    expect(wrapper.emitted('update:oldAsset')?.at(-1)).toEqual([undefined]);
+    expect(migrateSolanaToken).not.toHaveBeenCalled();
+  });
+
+  it('should migrate nothing until the dialog is confirmed', () => {
+    createWrapper();
+
+    expect(migrateSolanaToken).not.toHaveBeenCalled();
+  });
+
+  it('should ask the caller to refresh once a confirmed migration lands', async () => {
+    const wrapper = createWrapper();
+
+    wrapper.findComponent(BigDialog).vm.$emit('confirm');
+    await flushPromises();
+
+    expect(migrateSolanaToken).toHaveBeenCalledOnce();
+    expect(wrapper.emitted('refresh')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.vue
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/SolanaTokenMigrationDialog.vue
@@ -1,22 +1,11 @@
 <script setup lang="ts">
 import { externalLinks } from '@shared/external-links';
 import { useTemplateRef } from 'vue';
-import { extractTargetAssetFromError, isUniqueConstraintError } from '@/modules/assets/admin/solana-token-migration/solana-migration-error';
-import { useSolanaTokenMigrationApi } from '@/modules/assets/admin/solana-token-migration/solana-token-migration';
-import { useSolanaTokenMigrationStore } from '@/modules/assets/admin/solana-token-migration/use-solana-token-migration-store';
-import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { type SolanaTokenMigrationData, useSolanaTokenMigrationDialog } from '@/modules/assets/admin/solana-token-migration/use-solana-token-migration-dialog';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 import HintMenuIcon from '@/modules/shell/components/HintMenuIcon.vue';
 import SolanaTokenMigrationForm from './SolanaTokenMigrationForm.vue';
-
-interface SolanaTokenMigrationData {
-  address: string;
-  decimals: number | null;
-  tokenKind: string;
-}
 
 const modelValue = defineModel<SolanaTokenMigrationData | undefined>({ required: true });
 const oldAsset = defineModel<string | undefined>('oldAsset', { required: false });
@@ -28,119 +17,16 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const loading = ref(false);
-const errorMessages = ref<ValidationErrors>({});
 const form = useTemplateRef<InstanceType<typeof SolanaTokenMigrationForm>>('form');
-const stateUpdated = ref(false);
+const stateUpdated = ref<boolean>(false);
 
-const { setMessage } = useMessageStore();
-const { removeIdentifier } = useSolanaTokenMigrationStore();
-const { migrateSolanaToken } = useSolanaTokenMigrationApi();
-
-async function save(): Promise<boolean> {
-  if (!isDefined(modelValue) || !isDefined(oldAsset))
-    return false;
-
-  const formRef = get(form);
-  const valid = formRef?.validate();
-  if (!valid)
-    return false;
-
-  const data = get(modelValue);
-  const assetToMigrate = get(oldAsset);
-
-  if (!data.decimals || !assetToMigrate) {
-    setMessage({
-      description: t('asset_management.solana_token_migration.validation_error'),
-      title: t('asset_management.solana_token_migration.dialog_title'),
-    });
-    return false;
-  }
-
-  set(loading, true);
-
-  try {
-    const result = await migrateSolanaToken({
-      address: data.address,
-      decimals: data.decimals,
-      oldAsset: assetToMigrate,
-      tokenKind: data.tokenKind,
-    });
-
-    if (result) {
-      removeIdentifier(assetToMigrate);
-
-      setMessage({
-        description: t('asset_management.solana_token_migration.migration_success'),
-        success: true,
-        title: t('asset_management.solana_token_migration.dialog_title'),
-      });
-
-      set(modelValue, undefined);
-      set(oldAsset, undefined);
-      emit('refresh');
-      return true;
-    }
-    else {
-      setMessage({
-        description: t('asset_management.solana_token_migration.migration_error'),
-        title: t('asset_management.solana_token_migration.dialog_title'),
-      });
-      return false;
-    }
-  }
-  catch (error: unknown) {
-    return handleSaveException(error, assetToMigrate, formRef);
-  }
-  finally {
-    set(loading, false);
-  }
-}
-
-type MigrationFormRef = InstanceType<typeof SolanaTokenMigrationForm> | null | undefined;
-
-/**
- * Emits a merge suggestion when a failed migration names an asset it collided with.
- *
- * @remarks
- * Recognising the collision also clears the dialog's asset selection, because the merge flow takes
- * over from that point.
- * @returns whether a suggestion was emitted; `false` leaves the error for the caller to report
- */
-function suggestMergeOnConflict(message: string, assetToMigrate: string): boolean {
-  if (!isUniqueConstraintError(message))
-    return false;
-
-  const targetAsset = extractTargetAssetFromError(message);
-  if (!targetAsset)
-    return false;
-
-  emit('suggest-merge', { sourceAsset: assetToMigrate, targetAsset });
-  set(modelValue, undefined);
-  set(oldAsset, undefined);
-  return true;
-}
-
-function handleSaveException(error: unknown, assetToMigrate: string, formRef: MigrationFormRef): boolean {
-  let errors: ValidationErrors | string = getErrorMessage(error);
-  if (error instanceof ApiValidationError)
-    errors = error.getValidationErrors({});
-
-  if (typeof errors === 'string') {
-    if (suggestMergeOnConflict(errors, assetToMigrate))
-      return false;
-
-    setMessage({
-      description: errors,
-      title: t('asset_management.solana_token_migration.migration_error'),
-    });
-  }
-  else {
-    set(errorMessages, errors);
-    formRef?.validate();
-  }
-  return false;
-}
+const { loading, modelErrorMessages, save } = useSolanaTokenMigrationDialog({
+  modelValue,
+  oldAsset,
+  onMigrated: (): void => emit('refresh'),
+  onSuggestMerge: (suggestion): void => emit('suggest-merge', suggestion),
+  validateForm: (): boolean => get(form)?.validate() ?? false,
+});
 </script>
 
 <template>
@@ -179,7 +65,7 @@ function handleSaveException(error: unknown, assetToMigrate: string, formRef: Mi
       v-if="modelValue"
       ref="form"
       v-model="modelValue"
-      v-model:error-messages="errorMessages"
+      v-model:error-messages="modelErrorMessages"
       v-model:state-updated="stateUpdated"
       :old-asset="oldAsset"
       :loading="loading"

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/use-solana-token-migration-dialog.spec.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/use-solana-token-migration-dialog.spec.ts
@@ -1,0 +1,233 @@
+import type { SolanaTokenMigrationData } from '@/modules/assets/admin/solana-token-migration/use-solana-token-migration-dialog';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import { useSolanaTokenMigrationDialog } from './use-solana-token-migration-dialog';
+
+const { migrateSolanaToken, removeIdentifier, setMessage } = vi.hoisted(() => ({
+  migrateSolanaToken: vi.fn(),
+  removeIdentifier: vi.fn(),
+  setMessage: vi.fn(),
+}));
+
+vi.mock('@/modules/assets/admin/solana-token-migration/solana-token-migration', () => ({
+  useSolanaTokenMigrationApi: (): Record<string, unknown> => ({ migrateSolanaToken }),
+}));
+
+vi.mock('@/modules/assets/admin/solana-token-migration/use-solana-token-migration-store', () => ({
+  useSolanaTokenMigrationStore: (): Record<string, unknown> => ({ removeIdentifier }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+const TARGET = 'solana/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+const UNIQUE_CONSTRAINT = `UNIQUE constraint failed: assets.identifier ${TARGET}`;
+
+let modelValue: Ref<SolanaTokenMigrationData | undefined>;
+let oldAsset: Ref<string | undefined>;
+let onMigrated: ReturnType<typeof vi.fn<() => void>>;
+let onSuggestMerge: ReturnType<typeof vi.fn<(suggestion: { sourceAsset: string; targetAsset: string }) => void>>;
+let validateForm: ReturnType<typeof vi.fn<() => boolean>>;
+let scope: ReturnType<typeof effectScope>;
+
+function dialog(): ReturnType<typeof useSolanaTokenMigrationDialog> {
+  scope = effectScope();
+  return scope.run(() => useSolanaTokenMigrationDialog({
+    modelValue,
+    oldAsset,
+    onMigrated,
+    onSuggestMerge,
+    validateForm,
+  }))!;
+}
+
+describe('modules/assets/admin/solana-token-migration/useSolanaTokenMigrationDialog', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    modelValue = ref<SolanaTokenMigrationData>({ address: 'So111', decimals: 9, tokenKind: 'spl-token' });
+    oldAsset = ref<string>('SOL-OLD');
+    onMigrated = vi.fn<() => void>();
+    onSuggestMerge = vi.fn<(suggestion: { sourceAsset: string; targetAsset: string }) => void>();
+    validateForm = vi.fn<() => boolean>(() => true);
+    migrateSolanaToken.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('before it migrates anything', () => {
+    it('should migrate nothing without a target token', async () => {
+      set(modelValue, undefined);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(migrateSolanaToken).not.toHaveBeenCalled();
+    });
+
+    it('should migrate nothing without an asset to migrate from', async () => {
+      set(oldAsset, undefined);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(migrateSolanaToken).not.toHaveBeenCalled();
+    });
+
+    it('should migrate nothing while the form is invalid', async () => {
+      validateForm.mockReturnValue(false);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(migrateSolanaToken).not.toHaveBeenCalled();
+    });
+
+    it('should migrate nothing without decimals, and say why', async () => {
+      set(modelValue, { address: 'So111', decimals: null, tokenKind: 'spl-token' });
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(migrateSolanaToken).not.toHaveBeenCalled();
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({
+        description: 'asset_management.solana_token_migration.validation_error',
+      }));
+    });
+  });
+
+  describe('a migration that lands', () => {
+    it('should send the token and the asset it replaces', async () => {
+      const { save } = dialog();
+      await save();
+
+      expect(migrateSolanaToken).toHaveBeenCalledWith({
+        address: 'So111',
+        decimals: 9,
+        oldAsset: 'SOL-OLD',
+        tokenKind: 'spl-token',
+      });
+    });
+
+    it('should drop the migrated identifier and tell the caller to refresh', async () => {
+      const { save } = dialog();
+
+      expect(await save()).toBe(true);
+      expect(removeIdentifier).toHaveBeenCalledWith('SOL-OLD');
+      expect(onMigrated).toHaveBeenCalledOnce();
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    });
+
+    it('should clear the dialog', async () => {
+      const { save } = dialog();
+      await save();
+
+      expect(get(modelValue)).toBeUndefined();
+      expect(get(oldAsset)).toBeUndefined();
+    });
+
+    it('should mark itself loading only while the migration runs', async () => {
+      const { loading, save } = dialog();
+
+      const pending = save();
+      expect(get(loading)).toBe(true);
+
+      await pending;
+      expect(get(loading)).toBe(false);
+    });
+  });
+
+  describe('a migration the backend refuses', () => {
+    it('should report it and keep the dialog open', async () => {
+      migrateSolanaToken.mockResolvedValue(false);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(removeIdentifier).not.toHaveBeenCalled();
+      expect(onMigrated).not.toHaveBeenCalled();
+      expect(get(modelValue)).toBeDefined();
+    });
+
+    it('should stop loading so the user can try again', async () => {
+      migrateSolanaToken.mockRejectedValue(new Error('boom'));
+
+      const { loading, save } = dialog();
+      await save();
+
+      expect(get(loading)).toBe(false);
+    });
+
+    it('should report a plain failure as a message', async () => {
+      migrateSolanaToken.mockRejectedValue(new Error('the chain is unreachable'));
+
+      const { save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({
+        description: 'the chain is unreachable',
+      }));
+    });
+
+    it('should put field errors on the form rather than in a message', async () => {
+      migrateSolanaToken.mockRejectedValue(
+        new ApiValidationError(JSON.stringify({ address: ['not a valid address'] })),
+      );
+
+      const { modelErrorMessages, save } = dialog();
+      await save();
+
+      expect(get(modelErrorMessages)).toEqual({ address: ['not a valid address'] });
+      expect(validateForm).toHaveBeenCalledTimes(2);
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a collision with an asset that already exists', () => {
+    it('should offer a merge instead of reporting an error', async () => {
+      migrateSolanaToken.mockRejectedValue(new Error(UNIQUE_CONSTRAINT));
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(onSuggestMerge).toHaveBeenCalledWith({ sourceAsset: 'SOL-OLD', targetAsset: TARGET });
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+
+    it('should hand the dialog over by clearing its selection', async () => {
+      migrateSolanaToken.mockRejectedValue(new Error(UNIQUE_CONSTRAINT));
+
+      const { save } = dialog();
+      await save();
+
+      expect(get(modelValue)).toBeUndefined();
+      expect(get(oldAsset)).toBeUndefined();
+    });
+
+    it('should report the error when the collision names no asset it recognises', async () => {
+      migrateSolanaToken.mockRejectedValue(new Error('UNIQUE constraint failed: assets.identifier'));
+
+      const { save } = dialog();
+      await save();
+
+      expect(onSuggestMerge).not.toHaveBeenCalled();
+      expect(setMessage).toHaveBeenCalledOnce();
+      expect(get(modelValue)).toBeDefined();
+    });
+
+    it('should not read a merge out of an unrelated failure', async () => {
+      migrateSolanaToken.mockRejectedValue(new Error(`something else went wrong ${TARGET}`));
+
+      const { save } = dialog();
+      await save();
+
+      expect(onSuggestMerge).not.toHaveBeenCalled();
+      expect(setMessage).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/use-solana-token-migration-dialog.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/use-solana-token-migration-dialog.ts
@@ -1,0 +1,175 @@
+import type { Ref } from 'vue';
+import {
+  extractTargetAssetFromError,
+  isUniqueConstraintError,
+} from '@/modules/assets/admin/solana-token-migration/solana-migration-error';
+import { useSolanaTokenMigrationApi } from '@/modules/assets/admin/solana-token-migration/solana-token-migration';
+import { useSolanaTokenMigrationStore } from '@/modules/assets/admin/solana-token-migration/use-solana-token-migration-store';
+import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+
+export interface SolanaTokenMigrationData {
+  address: string;
+  decimals: number | null;
+  tokenKind: string;
+}
+
+interface MergeSuggestion {
+  sourceAsset: string;
+  targetAsset: string;
+}
+
+interface UseSolanaTokenMigrationDialogOptions {
+  /** The token being migrated to, cleared once the migration lands or is handed to a merge. */
+  modelValue: Ref<SolanaTokenMigrationData | undefined>;
+  /** The asset being migrated from. */
+  oldAsset: Ref<string | undefined>;
+  /** Called after a successful migration, so the caller can refresh its list. */
+  onMigrated: () => void;
+  /**
+   * Called when the migration collided with an asset that already exists.
+   *
+   * @remarks
+   * The collision is not an error the user can fix in this form: the target already exists, so the
+   * two assets have to be merged instead. The dialog hands the pair over and closes.
+   */
+  onSuggestMerge: (suggestion: MergeSuggestion) => void;
+  /** Re-runs the form's own validation, so server-side errors surface on their fields. */
+  validateForm: () => boolean;
+}
+
+interface UseSolanaTokenMigrationDialogReturn {
+  /** Field errors returned by the server. */
+  modelErrorMessages: Ref<ValidationErrors>;
+  /** Whether the migration is in flight. */
+  loading: Readonly<Ref<boolean>>;
+  /**
+   * Migrates the asset.
+   *
+   * @returns whether the migration landed; `false` leaves the dialog open with the reason shown
+   */
+  save: () => Promise<boolean>;
+}
+
+/**
+ * Drives the Solana token migration dialog: validating, migrating, and turning a collision with an
+ * existing asset into a merge suggestion.
+ *
+ * @returns the dialog's state and its submit
+ */
+export function useSolanaTokenMigrationDialog(
+  options: UseSolanaTokenMigrationDialogOptions,
+): UseSolanaTokenMigrationDialogReturn {
+  const { modelValue, oldAsset, onMigrated, onSuggestMerge, validateForm } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const modelErrorMessages = ref<ValidationErrors>({});
+  const loading = shallowRef<boolean>(false);
+
+  const { setMessage } = useMessageStore();
+  const { removeIdentifier } = useSolanaTokenMigrationStore();
+  const { migrateSolanaToken } = useSolanaTokenMigrationApi();
+
+  function report(description: string, title: string): void {
+    setMessage({ description, title });
+  }
+
+  function clearSelection(): void {
+    set(modelValue, undefined);
+    set(oldAsset, undefined);
+  }
+
+  function suggestMergeOnConflict(message: string, assetToMigrate: string): boolean {
+    if (!isUniqueConstraintError(message))
+      return false;
+
+    const targetAsset = extractTargetAssetFromError(message);
+    if (!targetAsset)
+      return false;
+
+    onSuggestMerge({ sourceAsset: assetToMigrate, targetAsset });
+    clearSelection();
+    return true;
+  }
+
+  function handleSaveException(error: unknown, assetToMigrate: string): boolean {
+    let errors: ValidationErrors | string = getErrorMessage(error);
+    if (error instanceof ApiValidationError)
+      errors = error.getValidationErrors({});
+
+    if (typeof errors === 'string') {
+      if (suggestMergeOnConflict(errors, assetToMigrate))
+        return false;
+
+      report(errors, t('asset_management.solana_token_migration.migration_error'));
+    }
+    else {
+      set(modelErrorMessages, errors);
+      validateForm();
+    }
+    return false;
+  }
+
+  async function save(): Promise<boolean> {
+    if (!isDefined(modelValue) || !isDefined(oldAsset))
+      return false;
+
+    if (!validateForm())
+      return false;
+
+    const data = get(modelValue);
+    const assetToMigrate = get(oldAsset);
+
+    if (!data.decimals || !assetToMigrate) {
+      report(
+        t('asset_management.solana_token_migration.validation_error'),
+        t('asset_management.solana_token_migration.dialog_title'),
+      );
+      return false;
+    }
+
+    set(loading, true);
+
+    try {
+      const result = await migrateSolanaToken({
+        address: data.address,
+        decimals: data.decimals,
+        oldAsset: assetToMigrate,
+        tokenKind: data.tokenKind,
+      });
+
+      if (!result) {
+        report(
+          t('asset_management.solana_token_migration.migration_error'),
+          t('asset_management.solana_token_migration.dialog_title'),
+        );
+        return false;
+      }
+
+      removeIdentifier(assetToMigrate);
+      setMessage({
+        description: t('asset_management.solana_token_migration.migration_success'),
+        success: true,
+        title: t('asset_management.solana_token_migration.dialog_title'),
+      });
+
+      clearSelection();
+      onMigrated();
+      return true;
+    }
+    catch (error: unknown) {
+      return handleSaveException(error, assetToMigrate);
+    }
+    finally {
+      set(loading, false);
+    }
+  }
+
+  return {
+    loading: readonly(loading),
+    modelErrorMessages,
+    save,
+  };
+}

--- a/frontend/app/src/modules/assets/prices/use-editable-missing-prices.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-editable-missing-prices.spec.ts
@@ -1,0 +1,341 @@
+import type { HistoricalPrice } from '@/modules/assets/prices/price-types';
+import type { EditableMissingPrice, MissingPrice } from '@/modules/reports/report-types';
+import { bigNumberify } from '@rotki/common';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import { PriceOracle } from '@/modules/settings/types/price-oracle';
+import { useEditableMissingPrices } from './use-editable-missing-prices';
+
+const {
+  addHistoricalPrice,
+  deleteHistoricalPrice,
+  editHistoricalPrice,
+  fetchHistoricalPrices,
+  getHistoricPrice,
+  resetHistoricalPricesData,
+} = vi.hoisted(() => ({
+  addHistoricalPrice: vi.fn(async () => Promise.resolve(true)),
+  deleteHistoricalPrice: vi.fn(async () => Promise.resolve(true)),
+  editHistoricalPrice: vi.fn(async () => Promise.resolve(true)),
+  fetchHistoricalPrices: vi.fn(),
+  getHistoricPrice: vi.fn(),
+  resetHistoricalPricesData: vi.fn(),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: (): Record<string, unknown> => ({
+    addHistoricalPrice,
+    deleteHistoricalPrice,
+    editHistoricalPrice,
+    fetchHistoricalPrices,
+  }),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: (): Record<string, unknown> => ({ resetHistoricalPricesData }),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
+  usePriceTaskManager: (): Record<string, unknown> => ({ getHistoricPrice }),
+}));
+
+const ETH_AT_NOON: MissingPrice = { fromAsset: 'ETH', time: 1_700_000_000, toAsset: 'USD' };
+
+function keyOf(item: MissingPrice): string {
+  return item.fromAsset + item.toAsset + item.time;
+}
+
+function savedPrice(price: string, overrides: Partial<HistoricalPrice> = {}): HistoricalPrice {
+  return {
+    fromAsset: 'ETH',
+    price: bigNumberify(price),
+    timestamp: 1_700_000_000,
+    toAsset: 'USD',
+    ...overrides,
+  };
+}
+
+let items: Ref<MissingPrice[]>;
+let onPriceUpdated: ReturnType<typeof vi.fn<(item: EditableMissingPrice) => void>>;
+let scope: ReturnType<typeof effectScope>;
+
+function table(): ReturnType<typeof useEditableMissingPrices> {
+  scope = effectScope();
+  return scope.run(() => useEditableMissingPrices({ items, keyOf, onPriceUpdated }))!;
+}
+
+/** The row as the table renders it, after the saved prices have been read. */
+async function firstRow(): Promise<{ api: ReturnType<typeof useEditableMissingPrices>; row: EditableMissingPrice }> {
+  const api = table();
+  await api.getHistoricalPrices();
+  return { api, row: get(api.formattedItems)[0] };
+}
+
+describe('modules/assets/prices/useEditableMissingPrices', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    items = ref<MissingPrice[]>([ETH_AT_NOON]);
+    onPriceUpdated = vi.fn<(item: EditableMissingPrice) => void>();
+    fetchHistoricalPrices.mockResolvedValue([]);
+    getHistoricPrice.mockResolvedValue(bigNumberify(0));
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the rows', () => {
+    it('should offer an empty price for a price nothing knows', async () => {
+      const { row } = await firstRow();
+
+      expect(row).toMatchObject({ price: '', saved: false, useRefreshedHistoricalPrice: false });
+    });
+
+    it('should show a price already saved manually', async () => {
+      fetchHistoricalPrices.mockResolvedValue([savedPrice('1500')]);
+
+      const { row } = await firstRow();
+
+      expect(row).toMatchObject({ price: '1500', saved: true, useRefreshedHistoricalPrice: false });
+    });
+
+    it('should not match a saved price for another asset or another moment', async () => {
+      fetchHistoricalPrices.mockResolvedValue([
+        savedPrice('1500', { fromAsset: 'BTC' }),
+        savedPrice('1600', { toAsset: 'EUR' }),
+        savedPrice('1700', { timestamp: 1 }),
+      ]);
+
+      const { row } = await firstRow();
+
+      expect(row.price).toBe('');
+      expect(row.saved).toBe(false);
+    });
+
+    it('should show a rate fetched from an oracle, marked as not the user\'s own', async () => {
+      getHistoricPrice.mockResolvedValue(bigNumberify(1234));
+
+      const { api } = await firstRow();
+      await api.refreshHistoricalPrice(get(api.formattedItems)[0]);
+
+      expect(get(api.formattedItems)[0]).toMatchObject({ price: '1234', useRefreshedHistoricalPrice: true });
+    });
+
+    it('should prefer a manually saved price over a fetched one', async () => {
+      getHistoricPrice.mockResolvedValue(bigNumberify(1234));
+      fetchHistoricalPrices.mockResolvedValue([savedPrice('1500')]);
+
+      const { api } = await firstRow();
+      await api.refreshHistoricalPrice(get(api.formattedItems)[0]);
+
+      expect(get(api.formattedItems)[0]).toMatchObject({ price: '1500', useRefreshedHistoricalPrice: false });
+    });
+  });
+
+  describe('writing a price', () => {
+    it('should add a price the row did not have', async () => {
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: '1500' });
+
+      expect(addHistoricalPrice).toHaveBeenCalledWith(expect.objectContaining({
+        fromAsset: 'ETH',
+        price: '1500',
+        sourceType: PriceOracle.MANUAL,
+        timestamp: 1_700_000_000,
+        toAsset: 'USD',
+      }));
+      expect(editHistoricalPrice).not.toHaveBeenCalled();
+      expect(deleteHistoricalPrice).not.toHaveBeenCalled();
+    });
+
+    it('should edit a price that was already saved', async () => {
+      fetchHistoricalPrices.mockResolvedValue([savedPrice('1500')]);
+
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: '1600' });
+
+      expect(editHistoricalPrice).toHaveBeenCalledWith(expect.objectContaining({ price: '1600' }));
+      expect(addHistoricalPrice).not.toHaveBeenCalled();
+    });
+
+    it('should delete a saved price the user cleared', async () => {
+      fetchHistoricalPrices.mockResolvedValue([savedPrice('1500')]);
+
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: '' });
+
+      expect(deleteHistoricalPrice).toHaveBeenCalledWith(expect.objectContaining({ fromAsset: 'ETH' }));
+      expect(addHistoricalPrice).not.toHaveBeenCalled();
+      expect(editHistoricalPrice).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing for an empty price that was never saved', async () => {
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: '' });
+
+      expect(addHistoricalPrice).not.toHaveBeenCalled();
+      expect(editHistoricalPrice).not.toHaveBeenCalled();
+      expect(deleteHistoricalPrice).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing for a rate that came from an oracle', async () => {
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: '1234', useRefreshedHistoricalPrice: true });
+
+      expect(addHistoricalPrice).not.toHaveBeenCalled();
+      expect(resetHistoricalPricesData).not.toHaveBeenCalled();
+      expect(onPriceUpdated).not.toHaveBeenCalled();
+    });
+
+    it('should invalidate the cache and re-read the prices after writing', async () => {
+      const { api, row } = await firstRow();
+      fetchHistoricalPrices.mockClear();
+      await api.updatePrice({ ...row, price: '1500' });
+
+      expect(resetHistoricalPricesData).toHaveBeenCalledWith([expect.objectContaining({ fromAsset: 'ETH' })]);
+      expect(fetchHistoricalPrices).toHaveBeenCalledOnce();
+    });
+
+    it('should tell the caller which row was written', async () => {
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: '1500' });
+
+      expect(onPriceUpdated).toHaveBeenCalledWith(expect.objectContaining({ fromAsset: 'ETH', time: 1_700_000_000 }));
+    });
+
+    it('should write a price for a caller that wants no notification', async () => {
+      scope = effectScope();
+      const api = scope.run(() => useEditableMissingPrices({ items, keyOf }))!;
+      await api.getHistoricalPrices();
+
+      await api.updatePrice({ ...get(api.formattedItems)[0], price: '1500' });
+
+      expect(addHistoricalPrice).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('when writing fails', () => {
+    it('should report the message on the row it belongs to', async () => {
+      addHistoricalPrice.mockRejectedValue(new Error('backend is down'));
+
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: '1500' });
+
+      expect(get(api.errorMessages)[keyOf(ETH_AT_NOON)]).toBe('backend is down');
+    });
+
+    it('should unwrap a validation error down to the price field', async () => {
+      addHistoricalPrice.mockRejectedValue(
+        new ApiValidationError(JSON.stringify({ price: ['must be a number'] })),
+      );
+
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: 'abc' });
+
+      expect(get(api.errorMessages)[keyOf(ETH_AT_NOON)]).toBe('must be a number');
+    });
+
+    it('should fall back to the raw message when the validation error names another field', async () => {
+      const raw = JSON.stringify({ timestamp: ['out of range'] });
+      addHistoricalPrice.mockRejectedValue(new ApiValidationError(raw));
+
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: '1500' });
+
+      expect(get(api.errorMessages)[keyOf(ETH_AT_NOON)]).toBe(raw);
+    });
+
+    it('should still invalidate the cache and re-read the prices', async () => {
+      addHistoricalPrice.mockRejectedValue(new Error('backend is down'));
+
+      const { api, row } = await firstRow();
+      fetchHistoricalPrices.mockClear();
+      await api.updatePrice({ ...row, price: '1500' });
+
+      expect(resetHistoricalPricesData).toHaveBeenCalledOnce();
+      expect(fetchHistoricalPrices).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('clearing a failure', () => {
+    it('should forget the failure on the row being corrected, and only that one', async () => {
+      const later: MissingPrice = { ...ETH_AT_NOON, time: 1_700_000_001 };
+      set(items, [ETH_AT_NOON, later]);
+      addHistoricalPrice.mockRejectedValue(new Error('backend is down'));
+
+      const { api } = await firstRow();
+      await api.updatePrice({ ...get(api.formattedItems)[0], price: '1500' });
+      await api.updatePrice({ ...get(api.formattedItems)[1], price: '1500' });
+
+      api.clearError(ETH_AT_NOON);
+
+      expect(get(api.errorMessages)[keyOf(ETH_AT_NOON)]).toBeUndefined();
+      expect(get(api.errorMessages)[keyOf(later)]).toBe('backend is down');
+    });
+
+    it('should leave the failures alone for a row that has none', async () => {
+      addHistoricalPrice.mockRejectedValue(new Error('backend is down'));
+
+      const { api, row } = await firstRow();
+      await api.updatePrice({ ...row, price: '1500' });
+
+      api.clearError({ ...ETH_AT_NOON, time: 999 });
+
+      expect(get(api.errorMessages)[keyOf(ETH_AT_NOON)]).toBe('backend is down');
+    });
+  });
+
+  describe('fetching a rate from the oracles', () => {
+    it('should mark itself busy only while the lookup runs', async () => {
+      const { api, row } = await firstRow();
+
+      const pending = api.refreshHistoricalPrice(row);
+      expect(get(api.refreshing)).toBe(true);
+
+      await pending;
+      expect(get(api.refreshing)).toBe(false);
+    });
+
+    it('should ask for the row\'s own asset pair and moment', async () => {
+      const { api, row } = await firstRow();
+      await api.refreshHistoricalPrice(row);
+
+      expect(getHistoricPrice).toHaveBeenCalledWith({
+        fromAsset: 'ETH',
+        timestamp: 1_700_000_000,
+        toAsset: 'USD',
+      });
+    });
+
+    it.each([
+      ['the oracles have no rate', undefined],
+      ['the rate comes back as zero', bigNumberify(0)],
+    ])('should report a lookup that found nothing when %s', async (_case, rate) => {
+      getHistoricPrice.mockResolvedValue(rate);
+
+      const { api, row } = await firstRow();
+      await api.refreshHistoricalPrice(row);
+
+      expect(get(api.errorMessages)[keyOf(ETH_AT_NOON)])
+        .toBe('profit_loss_report.actionable.missing_prices.price_not_found');
+      expect(get(api.formattedItems)[0].price).toBe('');
+    });
+  });
+
+  describe('keying rows', () => {
+    it('should keep two rows of the same asset at different moments apart', async () => {
+      const later: MissingPrice = { ...ETH_AT_NOON, time: 1_700_000_001 };
+      set(items, [ETH_AT_NOON, later]);
+      addHistoricalPrice.mockRejectedValue(new Error('backend is down'));
+
+      const { api } = await firstRow();
+      await api.updatePrice({ ...get(api.formattedItems)[1], price: '1500' });
+
+      expect(get(api.errorMessages)[keyOf(later)]).toBe('backend is down');
+      expect(get(api.errorMessages)[keyOf(ETH_AT_NOON)]).toBeUndefined();
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/prices/use-editable-missing-prices.ts
+++ b/frontend/app/src/modules/assets/prices/use-editable-missing-prices.ts
@@ -1,0 +1,189 @@
+import type { BigNumber } from '@rotki/common';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { HistoricalPrice, HistoricalPriceDeletePayload, HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
+import type { EditableMissingPrice, MissingPrice } from '@/modules/reports/report-types';
+import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
+import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { PriceOracle } from '@/modules/settings/types/price-oracle';
+
+interface UseEditableMissingPricesOptions {
+  /** The prices the report or the dialog could not resolve. */
+  items: MaybeRefOrGetter<MissingPrice[]>;
+  /**
+   * Identifies a row in the error and refreshed-price maps.
+   *
+   * @remarks
+   * The two callers key differently: a report holds several assets at once and needs the whole
+   * triple, while a single-asset dialog only needs the timestamp.
+   */
+  keyOf: (item: MissingPrice) => string;
+  /** Called after a row's price is written, for bookkeeping the caller owns. */
+  onPriceUpdated?: (item: EditableMissingPrice) => void;
+}
+
+interface UseEditableMissingPricesReturn {
+  /** Forgets the failure shown on a row, once the user starts correcting it. */
+  clearError: (item: MissingPrice) => void;
+  /** Validation and lookup failures, keyed by {@link UseEditableMissingPricesOptions.keyOf}. */
+  errorMessages: Readonly<Ref<Record<string, string>>>;
+  /** The rows, each carrying whatever price is already known for it. */
+  formattedItems: ComputedRef<EditableMissingPrice[]>;
+  /** Re-reads the manually saved prices. */
+  getHistoricalPrices: () => Promise<void>;
+  /** Whether an oracle lookup is in flight. */
+  refreshing: Readonly<Ref<boolean>>;
+  /**
+   * Asks the oracles for a rate the report could not find.
+   *
+   * @remarks
+   * A rate of zero counts as not found, and is reported on the row rather than saved.
+   */
+  refreshHistoricalPrice: (item: EditableMissingPrice) => Promise<void>;
+  /**
+   * Writes a row's price: adds, edits, or deletes the manual price to match what was typed.
+   *
+   * @remarks
+   * A row showing a rate fetched from an oracle is left alone; that price was never the user's to
+   * save. An empty price on a saved row deletes it.
+   */
+  updatePrice: (item: EditableMissingPrice) => Promise<void>;
+}
+
+/**
+ * Drives an editable table of prices rotki could not resolve, shared by the profit and loss
+ * report's missing-prices pane and the failed-daily-prices dialog.
+ *
+ * @returns the rows and the two things a user can do to one
+ */
+export function useEditableMissingPrices(options: UseEditableMissingPricesOptions): UseEditableMissingPricesReturn {
+  const { items, keyOf, onPriceUpdated } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const prices = ref<HistoricalPrice[]>([]);
+  const errorMessages = ref<Record<string, string>>({});
+  const refreshedHistoricalPrices = ref<Record<string, BigNumber>>({});
+  const refreshing = shallowRef<boolean>(false);
+
+  const { resetHistoricalPricesData } = useHistoricPriceCache();
+  const { addHistoricalPrice, deleteHistoricalPrice, editHistoricalPrice, fetchHistoricalPrices } = useAssetPricesApi();
+  const { getHistoricPrice } = usePriceTaskManager();
+
+  const formattedItems = computed<EditableMissingPrice[]>(() =>
+    toValue(items).map((item) => {
+      const savedHistoricalPrice = get(prices).find(
+        price => price.fromAsset === item.fromAsset && price.toAsset === item.toAsset && price.timestamp === item.time,
+      );
+
+      const savedPrice = savedHistoricalPrice?.price;
+      const refreshedHistoricalPrice = get(refreshedHistoricalPrices)[keyOf(item)];
+
+      const useRefreshedHistoricalPrice = !savedPrice && !!refreshedHistoricalPrice;
+
+      const price = (useRefreshedHistoricalPrice ? refreshedHistoricalPrice : savedPrice)?.toFixed() ?? '';
+
+      return {
+        ...item,
+        price,
+        saved: !!savedPrice,
+        useRefreshedHistoricalPrice,
+      };
+    }),
+  );
+
+  async function getHistoricalPrices(): Promise<void> {
+    set(prices, await fetchHistoricalPrices());
+  }
+
+  function reportOn(item: MissingPrice, message: string): void {
+    set(errorMessages, {
+      ...get(errorMessages),
+      [keyOf(item)]: message,
+    });
+  }
+
+  function clearError(item: MissingPrice): void {
+    const { [keyOf(item)]: cleared, ...rest } = get(errorMessages);
+    if (cleared !== undefined)
+      set(errorMessages, rest);
+  }
+
+  async function writePrice(item: EditableMissingPrice, payload: HistoricalPriceDeletePayload): Promise<void> {
+    if (item.price) {
+      const formPayload: HistoricalPriceFormPayload = {
+        ...payload,
+        price: item.price,
+      };
+
+      if (item.saved)
+        await editHistoricalPrice(formPayload);
+      else await addHistoricalPrice(formPayload);
+    }
+    else if (item.saved) {
+      await deleteHistoricalPrice(payload);
+    }
+  }
+
+  async function updatePrice(item: EditableMissingPrice): Promise<void> {
+    if (item.useRefreshedHistoricalPrice)
+      return;
+
+    const payload: HistoricalPriceDeletePayload = {
+      fromAsset: item.fromAsset,
+      sourceType: PriceOracle.MANUAL,
+      timestamp: item.time,
+      toAsset: item.toAsset,
+    };
+
+    try {
+      await writePrice(item, payload);
+    }
+    catch (error: unknown) {
+      let errorMessage = getErrorMessage(error);
+      if (error instanceof ApiValidationError) {
+        const errors = error.getValidationErrors({ price: '' });
+        errorMessage = typeof errors === 'string' ? error.message : errors.price[0];
+      }
+
+      reportOn(item, errorMessage);
+    }
+
+    resetHistoricalPricesData([payload]);
+    onPriceUpdated?.(item);
+
+    await getHistoricalPrices();
+  }
+
+  async function refreshHistoricalPrice(item: EditableMissingPrice): Promise<void> {
+    set(refreshing, true);
+    const rateFromHistoricPrice = await getHistoricPrice({
+      fromAsset: item.fromAsset,
+      timestamp: item.time,
+      toAsset: item.toAsset,
+    });
+
+    if (rateFromHistoricPrice?.gt(0)) {
+      set(refreshedHistoricalPrices, {
+        ...get(refreshedHistoricalPrices),
+        [keyOf(item)]: rateFromHistoricPrice,
+      });
+    }
+    else {
+      reportOn(item, t('profit_loss_report.actionable.missing_prices.price_not_found'));
+    }
+    set(refreshing, false);
+  }
+
+  return {
+    clearError,
+    errorMessages: readonly(errorMessages),
+    formattedItems,
+    getHistoricalPrices,
+    refreshHistoricalPrice,
+    refreshing: readonly(refreshing),
+    updatePrice,
+  };
+}

--- a/frontend/app/src/modules/core/notifications/Notification.spec.ts
+++ b/frontend/app/src/modules/core/notifications/Notification.spec.ts
@@ -1,0 +1,85 @@
+import { type NotificationAction, NotificationCategory, type NotificationData, Severity } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import Notification from '@/modules/core/notifications/Notification.vue';
+
+function notification(overrides: Partial<NotificationData> = {}): NotificationData {
+  return {
+    category: NotificationCategory.DEFAULT,
+    date: new Date('2026-03-04T05:06:07Z'),
+    display: true,
+    duration: 5000,
+    id: 42,
+    message: 'the message',
+    severity: Severity.INFO,
+    title: 'the title',
+    ...overrides,
+  };
+}
+
+function createWrapper(data: NotificationData = notification()): VueWrapper {
+  return mount(Notification, {
+    props: { notification: data },
+  });
+}
+
+describe('modules/core/notifications/Notification.vue', () => {
+  it('should show the title and the message', () => {
+    const wrapper = createWrapper(notification({ message: 'disk is full', title: 'Backup failed' }));
+
+    expect(wrapper.text()).toContain('Backup failed');
+    expect(wrapper.text()).toContain('disk is full');
+  });
+
+  it('should emit the notification id when dismissed', async () => {
+    const wrapper = createWrapper(notification({ id: 11 }));
+
+    await wrapper.find('[data-id=notification_dismiss]').trigger('click');
+
+    expect(wrapper.emitted('dismiss')).toEqual([[11]]);
+  });
+
+  it('should render one button per action', () => {
+    const actions: NotificationAction[] = [
+      { action: vi.fn(), label: 'Retry' },
+      { action: vi.fn(), label: 'Ignore' },
+    ];
+
+    const wrapper = createWrapper(notification({ action: actions }));
+
+    expect(wrapper.text()).toContain('Retry');
+    expect(wrapper.text()).toContain('Ignore');
+  });
+
+  it('should run the action and emit a dismissal when its button is pressed', async () => {
+    const action = vi.fn();
+
+    const wrapper = createWrapper(notification({ action: { action, label: 'Retry' }, id: 3 }));
+    const button = wrapper.findAll('button').find(item => item.text().includes('Retry'));
+    await button?.trigger('click');
+
+    expect(action).toHaveBeenCalledOnce();
+    expect(wrapper.emitted('dismiss')).toEqual([[3]]);
+  });
+
+  it('should offer a copy button only for an error', () => {
+    const error = createWrapper(notification({ severity: Severity.ERROR }));
+    const info = createWrapper(notification({ severity: Severity.INFO }));
+
+    expect(error.text()).toContain('common.actions.copy');
+    expect(info.text()).not.toContain('common.actions.copy');
+  });
+
+  it('should render the missing key notice instead of the raw message', () => {
+    const wrapper = createWrapper(notification({
+      i18nParam: {
+        choice: 1,
+        message: 'notification_messages.missing_api_key',
+        props: { location: 'ethereum', service: 'etherscan', url: 'https://example.com' },
+      },
+      message: 'the untranslated message',
+    }));
+
+    expect(wrapper.text()).not.toContain('the untranslated message');
+  });
+});

--- a/frontend/app/src/modules/core/notifications/Notification.vue
+++ b/frontend/app/src/modules/core/notifications/Notification.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import { type NotificationAction, type NotificationData, Severity } from '@rotki/common';
-import { isRuiIcon, type RuiIcons } from '@rotki/ui-library';
-import dayjs from 'dayjs';
-import { arrayify } from '@/modules/core/common/data/array';
+import { type NotificationData, Severity } from '@rotki/common';
 import MissingKeyNotification from '@/modules/core/notifications/MissingKeyNotification.vue';
+import { useNotificationCard } from '@/modules/core/notifications/use-notification-card';
 
 const { notification, popup = false } = defineProps<{
   notification: NotificationData;
@@ -15,152 +13,31 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const { copy: copyToClipboard } = useClipboard();
 
-const actions = computed<NotificationAction[]>(() => {
-  const action = notification.action;
+const message = useTemplateRef<HTMLDivElement>('message');
+const { height } = useElementSize(message);
 
-  if (!action)
-    return [];
-
-  return arrayify(action);
-});
-
-function dismiss(id: number) {
+function dismiss(id: number): void {
   emit('dismiss', id);
 }
 
-const icon = computed<RuiIcons>(() => {
-  switch (notification.severity) {
-    case Severity.ERROR:
-    case Severity.INFO:
-      return 'lu-circle-alert';
-    case Severity.WARNING:
-      return 'lu-siren';
-    case Severity.REMINDER:
-      return 'lu-alarm-clock';
-    default:
-      return 'lu-circle-alert';
-  }
-});
-
-const color = computed<string>(() => {
-  if (notification.action)
-    return 'warning';
-
-  switch (notification.severity) {
-    case Severity.ERROR:
-      return 'error';
-    case Severity.INFO:
-      return 'info';
-    case Severity.WARNING:
-      return 'warning';
-    case Severity.REMINDER:
-      return 'reminder';
-    default:
-      return '';
-  }
-});
-
-const colorBgClass = computed<string>(() => {
-  switch (get(color)) {
-    case 'warning':
-      return '!bg-rui-warning/10';
-    case 'error':
-      return '!bg-rui-error/10';
-    case 'info':
-      return '!bg-rui-info/10';
-    case 'reminder':
-      return '!bg-rui-secondary/10';
-    default:
-      return '';
-  }
-});
-
-const expandButtonClass = computed<string>(() => {
-  switch (get(color)) {
-    case 'warning':
-      return '!to-rui-warning/10';
-    case 'error':
-      return '!to-rui-error/10';
-    case 'info':
-      return '!to-rui-info/10';
-    case 'reminder':
-      return '!to-rui-secondary/10';
-    default:
-      return '';
-  }
-});
-
-const circleBgClass = computed(() => {
-  switch (notification.severity) {
-    case Severity.ERROR:
-      return 'bg-rui-error';
-    case Severity.INFO:
-      return 'bg-rui-info';
-    case Severity.WARNING:
-      return 'bg-rui-warning';
-    case Severity.REMINDER:
-      return 'bg-rui-secondary';
-    default:
-      return 'bg-rui-success';
-  }
-});
-
-const date = computed(() => dayjs(notification.date).format('LLL'));
-
-async function copy() {
-  const { i18nParam, message } = notification;
-  let messageText = message;
-
-  if (i18nParam) {
-    messageText = t(i18nParam.message, {
-      location: i18nParam.props.location,
-      service: i18nParam.props.service,
-      url: i18nParam.props.url,
-    });
-  }
-  await copyToClipboard(messageText);
-}
-
-function doAction(id: number, action: NotificationAction) {
-  action.action?.();
-  if (!action.persist)
-    dismiss(id);
-}
-
-const message = useTemplateRef<HTMLDivElement>('message');
-const MAX_HEIGHT = 64;
-
-const { height } = useElementSize(message);
-
-const showExpandArrow = computed(() => get(height) > MAX_HEIGHT);
-const expanded = ref<boolean>(false);
-
-const messageWrapperStyle = computed(() => {
-  if (!get(showExpandArrow))
-    return {};
-
-  const usedHeight = get(expanded) ? get(height) + 24 : MAX_HEIGHT;
-  return {
-    height: `${usedHeight}px`,
-  };
-});
-
-function messageClicked() {
-  if (!get(showExpandArrow) && get(expanded))
-    return;
-
-  set(expanded, true);
-}
-
-function buttonClicked() {
-  set(expanded, !get(expanded));
-}
-
-function getIcon(action: NotificationAction): RuiIcons {
-  return isRuiIcon(action.icon) ? action.icon : 'lu-arrow-right';
-}
+const {
+  actions,
+  buttonClicked,
+  circleBgClass,
+  color,
+  colorBgClass,
+  copy,
+  date,
+  doAction,
+  expandButtonClass,
+  expanded,
+  getIcon,
+  icon,
+  messageClicked,
+  messageWrapperStyle,
+  showExpandArrow,
+} = useNotificationCard(() => notification, { dismiss, height });
 </script>
 
 <template>
@@ -264,7 +141,7 @@ function getIcon(action: NotificationAction): RuiIcons {
         :color="action.danger ? 'error' : 'primary'"
         variant="text"
         size="sm"
-        @click="doAction(notification.id, action)"
+        @click="doAction(action)"
       >
         {{ action.label }}
         <template #append>

--- a/frontend/app/src/modules/core/notifications/NotificationSidebar.spec.ts
+++ b/frontend/app/src/modules/core/notifications/NotificationSidebar.spec.ts
@@ -1,0 +1,137 @@
+import { NotificationCategory, type NotificationData, Severity } from '@rotki/common';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { storeToRefs } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import NotificationSidebar from '@/modules/core/notifications/NotificationSidebar.vue';
+import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
+
+interface MockedDependencies {
+  isActive?: Ref<boolean>;
+  silent?: Ref<boolean>;
+}
+
+const { deps, toggleSilent } = vi.hoisted(() => {
+  const deps: MockedDependencies = {};
+  return { deps, toggleSilent: vi.fn(async () => Promise.resolve()) };
+});
+
+let isActive: Ref<boolean>;
+let silent: Ref<boolean>;
+
+vi.mock('@/modules/core/notifications/use-notification-cooldown', () => ({
+  useNotificationCooldown: vi.fn(() => ({
+    recordDisplay: vi.fn(),
+    resetSchedule: vi.fn(),
+    shouldSuppress: vi.fn(() => false),
+  })),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', () => ({
+  useTaskCenter: (): Record<string, unknown> => ({ isActive: deps.isActive }),
+}));
+
+vi.mock('@/modules/core/notifications/use-silent-notifications', () => ({
+  useSilentNotifications: (): Record<string, unknown> => ({
+    silent: deps.silent,
+    toggle: toggleSilent,
+  }),
+}));
+
+function notification(overrides: Partial<NotificationData> = {}): NotificationData {
+  return {
+    category: NotificationCategory.DEFAULT,
+    date: new Date('2026-03-04T05:06:07Z'),
+    display: true,
+    duration: 5000,
+    id: 1,
+    message: 'the message',
+    severity: Severity.INFO,
+    title: 'the title',
+    ...overrides,
+  };
+}
+
+const passThrough = { template: '<div><slot /></div>' };
+
+function createWrapper(notifications: NotificationData[] = []): VueWrapper {
+  const pinia = createCustomPinia();
+  const wrapper = mount(NotificationSidebar, {
+    global: {
+      plugins: [pinia],
+      stubs: {
+        LazyLoader: passThrough,
+        PendingTasks: true,
+        RouterLink: passThrough,
+        RuiNavigationDrawer: passThrough,
+      },
+    },
+    props: { modelValue: true },
+  });
+  set(storeToRefs(useNotificationsStore(pinia)).data, notifications);
+  return wrapper;
+}
+
+describe('modules/core/notifications/NotificationSidebar.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isActive = ref<boolean>(false);
+    silent = ref<boolean>(false);
+    deps.isActive = isActive;
+    deps.silent = silent;
+  });
+
+  it('should render one card per notification', async () => {
+    const wrapper = createWrapper([notification({ id: 1 }), notification({ id: 2 })]);
+    await nextTick();
+
+    expect(wrapper.findAll('[data-id=notification]')).toHaveLength(2);
+  });
+
+  it('should dismiss the notification a card asks it to, and only that one', async () => {
+    const wrapper = createWrapper([
+      notification({ id: 1, title: 'first' }),
+      notification({ id: 2, title: 'second' }),
+    ]);
+    await nextTick();
+
+    const cards = wrapper.findAll('[data-id=notification]');
+    const dismissFirst = cards.find(card => card.text().includes('first'))!;
+    await dismissFirst.find('[data-id=notification_dismiss]').trigger('click');
+    await nextTick();
+
+    const remaining = wrapper.findAll('[data-id=notification]');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].text()).toContain('second');
+  });
+
+  it('should offer nothing to clear while the list is empty', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.find('[data-testid=clear-notifications]').attributes('disabled')).toBeDefined();
+  });
+
+  it('should allow clearing once there is something to clear', async () => {
+    const wrapper = createWrapper([notification()]);
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=clear-notifications]').attributes('disabled')).toBeUndefined();
+  });
+
+  it('should toggle silent mode from its button', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=silent-notifications-toggle]').trigger('click');
+
+    expect(toggleSilent).toHaveBeenCalledOnce();
+  });
+
+  it('should close the drawer when asked', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=close-notifications]').trigger('click');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+});

--- a/frontend/app/src/modules/core/notifications/NotificationSidebar.vue
+++ b/frontend/app/src/modules/core/notifications/NotificationSidebar.vue
@@ -1,106 +1,36 @@
 <script setup lang="ts">
-import { type NotificationData, Priority, Severity } from '@rotki/common';
-import { startPromise } from '@shared/utils';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import Notification from '@/modules/core/notifications/Notification.vue';
 import PendingTasks from '@/modules/core/notifications/PendingTasks.vue';
-import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
-import { useSilentNotifications } from '@/modules/core/notifications/use-silent-notifications';
+import { TAB_ORDER, useNotificationSidebar } from '@/modules/core/notifications/use-notification-sidebar';
 import LazyLoader from '@/modules/shell/components/LazyLoader.vue';
-import { useTaskCenter } from '@/modules/task-center/use-task-center';
 
 const display = defineModel<boolean>({ required: true });
 
-enum TabCategory {
-  VIEW_ALL = 'view_all',
-  NEEDS_ACTION = 'needs_action',
-  REMINDER = 'reminder',
-  ERROR = 'error',
-}
-
-const contentWrapper = useTemplateRef<HTMLDivElement>('contentWrapper');
-const selectedTab = ref<TabCategory>(TabCategory.VIEW_ALL);
-const initialAppear = ref<boolean>(false);
-const pendingTasksExpanded = ref<boolean>(false);
-
 const { t } = useI18n({ useScope: 'global' });
 
-const confirmStore = useConfirmStore();
-const { visible: dialogVisible } = storeToRefs(confirmStore);
-const { show } = confirmStore;
-
-const notificationStore = useNotificationsStore();
-const { messageOverflow, prioritized: allNotifications } = storeToRefs(notificationStore);
-const { remove } = notificationStore;
-const { isActive: hasRunningTasks } = useTaskCenter();
-const { silent, toggle: toggleSilent } = useSilentNotifications();
-const [DefineNoMessages, ReuseNoMessages] = createReusableTemplate();
+const contentWrapper = useTemplateRef<HTMLDivElement>('contentWrapper');
 const { y } = useScroll(contentWrapper);
 
-const tabCategoriesLabel = computed(() => ({
-  [TabCategory.ERROR]: t('notification_sidebar.tabs.error'),
-  [TabCategory.NEEDS_ACTION]: t('notification_sidebar.tabs.needs_action'),
-  [TabCategory.REMINDER]: t('notification_sidebar.tabs.reminder'),
-  [TabCategory.VIEW_ALL]: t('notification_sidebar.tabs.view_all'),
-}));
+const { visible: dialogVisible } = storeToRefs(useConfirmStore());
 
-const selectedNotifications = computed(() => {
-  const all = get(allNotifications);
-  const tab = get(selectedTab);
-  const filters: Partial<Record<TabCategory, (item: NotificationData) => boolean>> = {
-    [TabCategory.ERROR]: (item: NotificationData) => item.severity === Severity.ERROR,
-    [TabCategory.NEEDS_ACTION]: (item: NotificationData) => item.priority === Priority.ACTION,
-    [TabCategory.REMINDER]: (item: NotificationData) => item.severity === Severity.REMINDER,
-  };
+const [DefineNoMessages, ReuseNoMessages] = createReusableTemplate();
 
-  const filterBy = filters[tab];
-  if (filterBy) {
-    return all.filter(filterBy);
-  }
-
-  return all;
-});
-
-function close() {
-  set(display, false);
-}
-
-function toggleSilentMode(): void {
-  startPromise(toggleSilent());
-}
-
-function clear() {
-  notificationStore.$reset();
-  close();
-}
-
-function showConfirmation() {
-  show({
-    message: t('notification_sidebar.confirmation.message'),
-    title: t('notification_sidebar.confirmation.title'),
-    type: 'info',
-  }, clear);
-}
-
-watchDebounced(hasRunningTasks, (running) => {
-  if (!running)
-    set(pendingTasksExpanded, false);
-}, { debounce: 1000 });
-
-watch(
-  [y, selectedTab, selectedNotifications],
-  ([currentY, currSelectedTab, currNotifications], [_, prevSelectedTab, prevNotifications]) => {
-    if (currSelectedTab !== prevSelectedTab || (prevNotifications.length === 0 && currNotifications.length > 0)) {
-      set(initialAppear, false);
-      nextTick(() => {
-        set(initialAppear, true);
-      });
-    }
-    else {
-      set(initialAppear, currentY <= 0);
-    }
-  },
-);
+const {
+  allNotifications,
+  close,
+  hasRunningTasks,
+  initialAppear,
+  messageOverflow,
+  modelPendingTasksExpanded,
+  modelSelectedTab,
+  remove,
+  selectedNotifications,
+  showConfirmation,
+  silent,
+  tabCategoriesLabel,
+  toggleSilentMode,
+} = useNotificationSidebar({ display, scrollY: y });
 </script>
 
 <template>
@@ -146,6 +76,7 @@ watch(
           <RuiButton
             variant="text"
             icon
+            data-testid="close-notifications"
             @click="close()"
           >
             <RuiIcon name="lu-x" />
@@ -158,14 +89,14 @@ watch(
         v-else
         class="flex flex-col h-[calc(100%-133px)]"
       >
-        <PendingTasks v-model="pendingTasksExpanded" />
+        <PendingTasks v-model="modelPendingTasksExpanded" />
         <div class="border-b border-default mx-4">
           <RuiTabs
-            v-model="selectedTab"
+            v-model="modelSelectedTab"
             color="primary"
           >
             <RuiTab
-              v-for="item in Object.values(TabCategory)"
+              v-for="item in TAB_ORDER"
               :key="item"
               size="sm"
               class="!min-w-0"
@@ -218,6 +149,7 @@ watch(
           variant="text"
           color="primary"
           :disabled="allNotifications.length === 0"
+          data-testid="clear-notifications"
           @click="showConfirmation()"
         >
           {{ t('notification_sidebar.clear_tooltip') }}

--- a/frontend/app/src/modules/core/notifications/use-notification-card.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-notification-card.spec.ts
@@ -1,0 +1,264 @@
+import { type NotificationAction, NotificationCategory, type NotificationData, Severity } from '@rotki/common';
+import dayjs from 'dayjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope } from 'vue';
+import { NOTIFICATION_MAX_HEIGHT, useNotificationCard } from './use-notification-card';
+
+const { copyToClipboard } = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock('@vueuse/core', async () => {
+  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+  return {
+    ...actual,
+    useClipboard: (): Record<string, unknown> => ({ copy: copyToClipboard }),
+  };
+});
+
+function notification(overrides: Partial<NotificationData> = {}): NotificationData {
+  return {
+    category: NotificationCategory.DEFAULT,
+    date: new Date('2026-03-04T05:06:07Z'),
+    display: true,
+    duration: 5000,
+    id: 42,
+    message: 'the message',
+    severity: Severity.INFO,
+    title: 'the title',
+    ...overrides,
+  };
+}
+
+const dismiss = vi.fn();
+const height = ref<number>(0);
+let scope: ReturnType<typeof effectScope>;
+
+function card(data: NotificationData = notification()): ReturnType<typeof useNotificationCard> {
+  scope = effectScope();
+  return scope.run(() => useNotificationCard(() => data, { dismiss, height }))!;
+}
+
+describe('modules/core/notifications/useNotificationCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(height, 0);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('actions', () => {
+    it('should be empty when the notification carries none', () => {
+      const { actions } = card();
+
+      expect(get(actions)).toEqual([]);
+    });
+
+    it('should wrap a single action in a list', () => {
+      const action: NotificationAction = { action: vi.fn(), label: 'Retry' };
+
+      const { actions } = card(notification({ action }));
+
+      expect(get(actions)).toEqual([action]);
+    });
+
+    it('should pass a list of actions through unchanged', () => {
+      const first: NotificationAction = { action: vi.fn(), label: 'Retry' };
+      const second: NotificationAction = { action: vi.fn(), label: 'Ignore' };
+
+      const { actions } = card(notification({ action: [first, second] }));
+
+      expect(get(actions)).toEqual([first, second]);
+    });
+  });
+
+  describe('severity styling', () => {
+    it.each([
+      [Severity.ERROR, 'lu-circle-alert', 'bg-rui-error'],
+      [Severity.INFO, 'lu-circle-alert', 'bg-rui-info'],
+      [Severity.WARNING, 'lu-siren', 'bg-rui-warning'],
+      [Severity.REMINDER, 'lu-alarm-clock', 'bg-rui-secondary'],
+    ])('should pick the icon and circle for %s', (severity, expectedIcon, expectedCircle) => {
+      const { circleBgClass, icon } = card(notification({ severity }));
+
+      expect(get(icon)).toBe(expectedIcon);
+      expect(get(circleBgClass)).toBe(expectedCircle);
+    });
+
+    it.each([
+      [Severity.ERROR, 'error', '!bg-rui-error/10', '!to-rui-error/10'],
+      [Severity.INFO, 'info', '!bg-rui-info/10', '!to-rui-info/10'],
+      [Severity.WARNING, 'warning', '!bg-rui-warning/10', '!to-rui-warning/10'],
+      [Severity.REMINDER, 'reminder', '!bg-rui-secondary/10', '!to-rui-secondary/10'],
+    ])('should derive the colour classes for %s', (severity, expectedColor, expectedBg, expectedButton) => {
+      const { color, colorBgClass, expandButtonClass } = card(notification({ severity }));
+
+      expect(get(color)).toBe(expectedColor);
+      expect(get(colorBgClass)).toBe(expectedBg);
+      expect(get(expandButtonClass)).toBe(expectedButton);
+    });
+
+    it('should fall back when the severity is not one it knows', () => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- exercising the defensive default arm
+      const unknown = 'unknown' as Severity;
+
+      const { circleBgClass, color, colorBgClass, expandButtonClass, icon } = card(notification({ severity: unknown }));
+
+      expect(get(icon)).toBe('lu-circle-alert');
+      expect(get(circleBgClass)).toBe('bg-rui-success');
+      expect(get(color)).toBe('');
+      expect(get(colorBgClass)).toBe('');
+      expect(get(expandButtonClass)).toBe('');
+    });
+
+    it('should colour a notification with an action as a warning whatever its severity', () => {
+      const { color, colorBgClass } = card(notification({
+        action: { action: vi.fn(), label: 'Retry' },
+        severity: Severity.ERROR,
+      }));
+
+      expect(get(color)).toBe('warning');
+      expect(get(colorBgClass)).toBe('!bg-rui-warning/10');
+    });
+  });
+
+  describe('the date', () => {
+    it('should render it in the locale long format', () => {
+      const date = new Date('2026-03-04T05:06:07Z');
+
+      const { date: formatted } = card(notification({ date }));
+
+      expect(get(formatted)).toBe(dayjs(date).format('LLL'));
+    });
+  });
+
+  describe('the action icon', () => {
+    it('should use the action icon when the library has it', () => {
+      const { getIcon } = card();
+
+      expect(getIcon({ action: vi.fn(), icon: 'lu-trash-2', label: 'Delete' })).toBe('lu-trash-2');
+    });
+
+    it.each([
+      ['a name the library does not have', 'not-an-icon'],
+      ['no name at all', undefined],
+    ])('should fall back to an arrow given %s', (_case, icon) => {
+      const { getIcon } = card();
+
+      expect(getIcon({ action: vi.fn(), icon, label: 'Go' })).toBe('lu-arrow-right');
+    });
+  });
+
+  describe('running an action', () => {
+    it('should run it and dismiss the notification it belongs to', () => {
+      const action = vi.fn();
+
+      const { doAction } = card(notification({ id: 7 }));
+      doAction({ action, label: 'Retry' });
+
+      expect(action).toHaveBeenCalledOnce();
+      expect(dismiss).toHaveBeenCalledWith(7);
+    });
+
+    it('should leave a persisting action on screen', () => {
+      const action = vi.fn();
+
+      const { doAction } = card();
+      doAction({ action, label: 'Retry', persist: true });
+
+      expect(action).toHaveBeenCalledOnce();
+      expect(dismiss).not.toHaveBeenCalled();
+    });
+
+    it('should still dismiss when the action has nothing to run', () => {
+      const { doAction } = card(notification({ id: 9 }));
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- an action with no callback is what a link-only action looks like
+      doAction({ label: 'Open' } as NotificationAction);
+
+      expect(dismiss).toHaveBeenCalledWith(9);
+    });
+  });
+
+  describe('copying the message', () => {
+    it('should copy the message as written', async () => {
+      const { copy } = card(notification({ message: 'boom' }));
+      await copy();
+
+      expect(copyToClipboard).toHaveBeenCalledWith('boom');
+    });
+
+    it('should resolve the translation parameters before copying', async () => {
+      const { copy } = card(notification({
+        i18nParam: {
+          choice: 1,
+          message: 'notification_messages.missing_api_key',
+          props: { location: 'ethereum', service: 'etherscan', url: 'https://example.com' },
+        },
+        message: 'the untranslated message',
+      }));
+      await copy();
+
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        'notification_messages.missing_api_key::ethereum, etherscan, https://example.com',
+      );
+    });
+  });
+
+  describe('expanding the message', () => {
+    it('should offer no arrow while the message fits', () => {
+      set(height, NOTIFICATION_MAX_HEIGHT);
+
+      const { messageWrapperStyle, showExpandArrow } = card();
+
+      expect(get(showExpandArrow)).toBe(false);
+      expect(get(messageWrapperStyle)).toEqual({});
+    });
+
+    it('should offer the arrow once the message overflows', () => {
+      set(height, NOTIFICATION_MAX_HEIGHT + 1);
+
+      const { messageWrapperStyle, showExpandArrow } = card();
+
+      expect(get(showExpandArrow)).toBe(true);
+      expect(get(messageWrapperStyle)).toEqual({ height: `${NOTIFICATION_MAX_HEIGHT}px` });
+    });
+
+    it('should give the wrapper the full height once expanded', () => {
+      set(height, 200);
+
+      const { buttonClicked, messageWrapperStyle } = card();
+      buttonClicked();
+
+      expect(get(messageWrapperStyle)).toEqual({ height: '224px' });
+    });
+
+    it('should expand when the collapsed message is clicked', () => {
+      set(height, 200);
+
+      const { expanded, messageClicked } = card();
+      messageClicked();
+
+      expect(get(expanded)).toBe(true);
+    });
+
+    it('should stay expanded when a message that fits is clicked again', () => {
+      const { expanded, messageClicked } = card();
+      messageClicked();
+      messageClicked();
+
+      expect(get(expanded)).toBe(true);
+    });
+
+    it('should toggle back to collapsed from the button', () => {
+      set(height, 200);
+
+      const { buttonClicked, expanded } = card();
+      buttonClicked();
+      buttonClicked();
+
+      expect(get(expanded)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/core/notifications/use-notification-card.ts
+++ b/frontend/app/src/modules/core/notifications/use-notification-card.ts
@@ -1,0 +1,223 @@
+import type { ComputedRef, CSSProperties, MaybeRefOrGetter, Ref } from 'vue';
+import { type NotificationAction, type NotificationData, Severity } from '@rotki/common';
+import { isRuiIcon, type RuiIcons } from '@rotki/ui-library';
+import dayjs from 'dayjs';
+import { arrayify } from '@/modules/core/common/data/array';
+
+/** Height in pixels beyond which the message is collapsed behind an expand arrow. */
+export const NOTIFICATION_MAX_HEIGHT = 64;
+
+interface UseNotificationCardOptions {
+  /** Measured height of the message body; drives whether the expand arrow is offered. */
+  height: MaybeRefOrGetter<number>;
+  /** Called when an action asks for the notification to go away. */
+  dismiss: (id: number) => void;
+}
+
+interface UseNotificationCardReturn {
+  /** The notification's actions, always a list even when it carries a single one. */
+  actions: ComputedRef<NotificationAction[]>;
+  /** Toggles the message between collapsed and expanded. */
+  buttonClicked: () => void;
+  /** Background of the severity circle. */
+  circleBgClass: ComputedRef<string>;
+  /** Semantic colour of the card, which an action overrides to a warning. */
+  color: ComputedRef<string>;
+  /** Tinted card background matching {@link UseNotificationCardReturn.color}. */
+  colorBgClass: ComputedRef<string>;
+  /** Puts the message on the clipboard, resolving the i18n parameters first. */
+  copy: () => Promise<void>;
+  /** The notification's date in the locale's long format. */
+  date: ComputedRef<string>;
+  /**
+   * Runs an action and dismisses the notification unless the action persists.
+   *
+   * @remarks
+   * The dismissal is the action's own doing rather than the user's, so a `persist` action is the
+   * only way to leave the card on screen after it runs.
+   */
+  doAction: (action: NotificationAction) => void;
+  /** Gradient target of the expand button, matching the card background. */
+  expandButtonClass: ComputedRef<string>;
+  /** Whether the message is currently showing in full. */
+  expanded: Readonly<Ref<boolean>>;
+  /** Falls back to a generic arrow when an action names an icon the library does not have. */
+  getIcon: (action: NotificationAction) => RuiIcons;
+  /** Severity icon shown in the circle. */
+  icon: ComputedRef<RuiIcons>;
+  /** Expands the message; a message short enough to fit is already showing in full. */
+  messageClicked: () => void;
+  /** Height constraint applied to the message wrapper while it is collapsed. */
+  messageWrapperStyle: ComputedRef<CSSProperties>;
+  /** Whether the message overflows and so offers the expand arrow. */
+  showExpandArrow: ComputedRef<boolean>;
+}
+
+/**
+ * Drives a single notification card: its severity styling, its date, and the expand and action
+ * behaviour behind it.
+ *
+ * @returns the derived presentation and the three things a user can do to the card
+ */
+export function useNotificationCard(
+  notification: MaybeRefOrGetter<NotificationData>,
+  options: UseNotificationCardOptions,
+): UseNotificationCardReturn {
+  const { dismiss, height } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { copy: copyToClipboard } = useClipboard();
+
+  const expanded = shallowRef<boolean>(false);
+
+  const actions = computed<NotificationAction[]>(() => {
+    const action = toValue(notification).action;
+
+    if (!action)
+      return [];
+
+    return arrayify(action);
+  });
+
+  const icon = computed<RuiIcons>(() => {
+    switch (toValue(notification).severity) {
+      case Severity.ERROR:
+      case Severity.INFO:
+        return 'lu-circle-alert';
+      case Severity.WARNING:
+        return 'lu-siren';
+      case Severity.REMINDER:
+        return 'lu-alarm-clock';
+      default:
+        return 'lu-circle-alert';
+    }
+  });
+
+  const color = computed<string>(() => {
+    const data = toValue(notification);
+    if (data.action)
+      return 'warning';
+
+    switch (data.severity) {
+      case Severity.ERROR:
+        return 'error';
+      case Severity.INFO:
+        return 'info';
+      case Severity.WARNING:
+        return 'warning';
+      case Severity.REMINDER:
+        return 'reminder';
+      default:
+        return '';
+    }
+  });
+
+  const colorBgClass = computed<string>(() => {
+    switch (get(color)) {
+      case 'warning':
+        return '!bg-rui-warning/10';
+      case 'error':
+        return '!bg-rui-error/10';
+      case 'info':
+        return '!bg-rui-info/10';
+      case 'reminder':
+        return '!bg-rui-secondary/10';
+      default:
+        return '';
+    }
+  });
+
+  const expandButtonClass = computed<string>(() => {
+    switch (get(color)) {
+      case 'warning':
+        return '!to-rui-warning/10';
+      case 'error':
+        return '!to-rui-error/10';
+      case 'info':
+        return '!to-rui-info/10';
+      case 'reminder':
+        return '!to-rui-secondary/10';
+      default:
+        return '';
+    }
+  });
+
+  const circleBgClass = computed<string>(() => {
+    switch (toValue(notification).severity) {
+      case Severity.ERROR:
+        return 'bg-rui-error';
+      case Severity.INFO:
+        return 'bg-rui-info';
+      case Severity.WARNING:
+        return 'bg-rui-warning';
+      case Severity.REMINDER:
+        return 'bg-rui-secondary';
+      default:
+        return 'bg-rui-success';
+    }
+  });
+
+  const date = computed<string>(() => dayjs(toValue(notification).date).format('LLL'));
+
+  const showExpandArrow = computed<boolean>(() => toValue(height) > NOTIFICATION_MAX_HEIGHT);
+
+  const messageWrapperStyle = computed<CSSProperties>(() => {
+    if (!get(showExpandArrow))
+      return {};
+
+    const usedHeight = get(expanded) ? toValue(height) + 24 : NOTIFICATION_MAX_HEIGHT;
+    return {
+      height: `${usedHeight}px`,
+    };
+  });
+
+  async function copy(): Promise<void> {
+    const { i18nParam, message } = toValue(notification);
+    let messageText = message;
+
+    if (i18nParam) {
+      messageText = t(i18nParam.message, {
+        location: i18nParam.props.location,
+        service: i18nParam.props.service,
+        url: i18nParam.props.url,
+      });
+    }
+    await copyToClipboard(messageText);
+  }
+
+  function doAction(action: NotificationAction): void {
+    action.action?.();
+    if (!action.persist)
+      dismiss(toValue(notification).id);
+  }
+
+  function messageClicked(): void {
+    set(expanded, true);
+  }
+
+  function buttonClicked(): void {
+    set(expanded, !get(expanded));
+  }
+
+  function getIcon(action: NotificationAction): RuiIcons {
+    return isRuiIcon(action.icon) ? action.icon : 'lu-arrow-right';
+  }
+
+  return {
+    actions,
+    buttonClicked,
+    circleBgClass,
+    color,
+    colorBgClass,
+    copy,
+    date,
+    doAction,
+    expandButtonClass,
+    expanded: readonly(expanded),
+    getIcon,
+    icon,
+    messageClicked,
+    messageWrapperStyle,
+    showExpandArrow,
+  };
+}

--- a/frontend/app/src/modules/core/notifications/use-notification-sidebar.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-notification-sidebar.spec.ts
@@ -1,0 +1,268 @@
+import { NotificationCategory, type NotificationData, Priority, Severity } from '@rotki/common';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises } from '@vue/test-utils';
+import { setActivePinia, storeToRefs } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp, effectScope, nextTick, type Ref, ref } from 'vue';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
+import { TAB_ORDER, TabCategory, useNotificationSidebar } from './use-notification-sidebar';
+
+interface MockedDependencies {
+  isActive?: Ref<boolean>;
+  silent?: Ref<boolean>;
+}
+
+const { deps, toggleSilent } = vi.hoisted(() => {
+  const deps: MockedDependencies = {};
+  return { deps, toggleSilent: vi.fn(async () => Promise.resolve()) };
+});
+
+let isActive: Ref<boolean>;
+let silent: Ref<boolean>;
+
+vi.mock('@/modules/core/notifications/use-notification-cooldown', () => ({
+  useNotificationCooldown: vi.fn(() => ({
+    recordDisplay: vi.fn(),
+    resetSchedule: vi.fn(),
+    shouldSuppress: vi.fn(() => false),
+  })),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', () => ({
+  useTaskCenter: (): Record<string, unknown> => ({ isActive: deps.isActive }),
+}));
+
+vi.mock('@/modules/core/notifications/use-silent-notifications', () => ({
+  useSilentNotifications: (): Record<string, unknown> => ({
+    silent: deps.silent,
+    toggle: toggleSilent,
+  }),
+}));
+
+function notification(overrides: Partial<NotificationData> = {}): NotificationData {
+  return {
+    category: NotificationCategory.DEFAULT,
+    date: new Date('2026-03-04T05:06:07Z'),
+    display: true,
+    duration: 5000,
+    id: 1,
+    message: 'the message',
+    severity: Severity.INFO,
+    title: 'the title',
+    ...overrides,
+  };
+}
+
+const display = ref<boolean>(true);
+const scrollY = ref<number>(0);
+let scope: ReturnType<typeof effectScope>;
+
+function sidebar(): ReturnType<typeof useNotificationSidebar> {
+  scope = effectScope();
+  return scope.run(() => useNotificationSidebar({ display, scrollY }))!;
+}
+
+function seed(notifications: NotificationData[]): void {
+  set(storeToRefs(useNotificationsStore()).data, notifications);
+}
+
+/**
+ * `pinia.use()` only queues a plugin; `install(app)` is what moves it into the active list. A spec
+ * that calls `setActivePinia` and never mounts anything therefore runs with no plugins at all, and
+ * `$reset` stays pinia's setup-store version, which throws. Installing into a bare app gives the
+ * store the same `$reset` the application wires up in `main.ts`.
+ */
+function activatePinia(): void {
+  const pinia = createCustomPinia();
+  createApp({}).use(pinia);
+  setActivePinia(pinia);
+}
+
+describe('modules/core/notifications/useNotificationSidebar', () => {
+  beforeEach(() => {
+    activatePinia();
+    vi.clearAllMocks();
+    isActive = ref<boolean>(false);
+    silent = ref<boolean>(false);
+    deps.isActive = isActive;
+    deps.silent = silent;
+    set(display, true);
+    set(scrollY, 0);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the tabs', () => {
+    it('should show the tabs in the order the drawer lays them out', () => {
+      expect(TAB_ORDER).toEqual([
+        TabCategory.VIEW_ALL,
+        TabCategory.NEEDS_ACTION,
+        TabCategory.REMINDER,
+        TabCategory.ERROR,
+      ]);
+    });
+
+    it('should label every tab it offers', () => {
+      const { tabCategoriesLabel } = sidebar();
+
+      for (const tab of TAB_ORDER)
+        expect(get(tabCategoriesLabel)[tab]).toBe(`notification_sidebar.tabs.${tab}`);
+    });
+  });
+
+  describe('filtering by tab', () => {
+    const error = notification({ id: 1, severity: Severity.ERROR });
+    const reminder = notification({ id: 2, severity: Severity.REMINDER });
+    const needsAction = notification({ id: 3, priority: Priority.ACTION, severity: Severity.INFO });
+
+    beforeEach(() => {
+      seed([error, reminder, needsAction]);
+    });
+
+    it('should hold everything back on the view-all tab', () => {
+      const { selectedNotifications } = sidebar();
+
+      expect(get(selectedNotifications)).toHaveLength(3);
+    });
+
+    it.each([
+      [TabCategory.ERROR, 1],
+      [TabCategory.REMINDER, 2],
+      [TabCategory.NEEDS_ACTION, 3],
+    ])('should show only what the %s tab admits', (tab, expectedId) => {
+      const { modelSelectedTab, selectedNotifications } = sidebar();
+      set(modelSelectedTab, tab);
+
+      expect(get(selectedNotifications).map(item => item.id)).toEqual([expectedId]);
+    });
+  });
+
+  describe('clearing every notification', () => {
+    beforeEach(() => {
+      seed([notification({ id: 1 }), notification({ id: 2 })]);
+    });
+
+    it('should discard nothing until the dialog is confirmed', () => {
+      const { allNotifications, showConfirmation } = sidebar();
+      showConfirmation();
+
+      expect(get(useConfirmStore().visible)).toBe(true);
+      expect(get(allNotifications)).toHaveLength(2);
+      expect(get(display)).toBe(true);
+    });
+
+    it('should discard them and close the drawer once confirmed', async () => {
+      const { allNotifications, showConfirmation } = sidebar();
+      showConfirmation();
+      await useConfirmStore().confirm();
+
+      expect(get(allNotifications)).toHaveLength(0);
+      expect(get(display)).toBe(false);
+    });
+
+    it('should discard nothing when the dialog is dismissed', async () => {
+      const { allNotifications, showConfirmation } = sidebar();
+      showConfirmation();
+      await useConfirmStore().dismiss();
+
+      expect(get(allNotifications)).toHaveLength(2);
+      expect(get(display)).toBe(true);
+    });
+  });
+
+  describe('the drawer controls', () => {
+    it('should close the drawer', () => {
+      const { close } = sidebar();
+      close();
+
+      expect(get(display)).toBe(false);
+    });
+
+    it('should toggle silent mode', () => {
+      const { toggleSilentMode } = sidebar();
+      toggleSilentMode();
+
+      expect(toggleSilent).toHaveBeenCalledOnce();
+    });
+
+    it('should read silent mode from the setting', () => {
+      set(silent, true);
+
+      const { silent: isSilent } = sidebar();
+
+      expect(get(isSilent)).toBe(true);
+    });
+  });
+
+  describe('the pending task list', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should collapse it once the tasks have been idle long enough', async () => {
+      set(isActive, true);
+      const { modelPendingTasksExpanded } = sidebar();
+      set(modelPendingTasksExpanded, true);
+
+      set(isActive, false);
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(get(modelPendingTasksExpanded)).toBe(false);
+    });
+
+    it('should leave it expanded while tasks are still running', async () => {
+      const { modelPendingTasksExpanded } = sidebar();
+      set(modelPendingTasksExpanded, true);
+
+      set(isActive, true);
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(get(modelPendingTasksExpanded)).toBe(true);
+    });
+  });
+
+  describe('how rows appear', () => {
+    it('should show a freshly filtered list at once rather than on scroll', async () => {
+      seed([notification({ id: 1, severity: Severity.ERROR })]);
+      const { initialAppear, modelSelectedTab } = sidebar();
+
+      set(modelSelectedTab, TabCategory.ERROR);
+      await flushPromises();
+
+      expect(get(initialAppear)).toBe(true);
+    });
+
+    it('should show the first notifications to arrive at once', async () => {
+      const { initialAppear } = sidebar();
+
+      seed([notification({ id: 1 })]);
+      await flushPromises();
+
+      expect(get(initialAppear)).toBe(true);
+    });
+
+    it('should follow the top of the list once it is scrolled', async () => {
+      seed([notification({ id: 1 }), notification({ id: 2 })]);
+      const { initialAppear } = sidebar();
+
+      set(scrollY, 120);
+      await flushPromises();
+
+      expect(get(initialAppear)).toBe(false);
+
+      set(scrollY, 0);
+      await flushPromises();
+
+      expect(get(initialAppear)).toBe(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/core/notifications/use-notification-sidebar.ts
+++ b/frontend/app/src/modules/core/notifications/use-notification-sidebar.ts
@@ -1,0 +1,184 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { type NotificationData, Priority, Severity } from '@rotki/common';
+import { startPromise } from '@shared/utils';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
+import { useSilentNotifications } from '@/modules/core/notifications/use-silent-notifications';
+import { useTaskCenter } from '@/modules/task-center/use-task-center';
+
+export const TabCategory = {
+  ERROR: 'error',
+  NEEDS_ACTION: 'needs_action',
+  REMINDER: 'reminder',
+  VIEW_ALL: 'view_all',
+} as const;
+
+export type TabCategory = (typeof TabCategory)[keyof typeof TabCategory];
+
+/** Order the tabs appear in, which is not the declaration order of {@link TabCategory}. */
+export const TAB_ORDER: TabCategory[] = [
+  TabCategory.VIEW_ALL,
+  TabCategory.NEEDS_ACTION,
+  TabCategory.REMINDER,
+  TabCategory.ERROR,
+];
+
+const TAB_FILTERS: Partial<Record<TabCategory, (item: NotificationData) => boolean>> = {
+  [TabCategory.ERROR]: (item: NotificationData) => item.severity === Severity.ERROR,
+  [TabCategory.NEEDS_ACTION]: (item: NotificationData) => item.priority === Priority.ACTION,
+  [TabCategory.REMINDER]: (item: NotificationData) => item.severity === Severity.REMINDER,
+};
+
+/** How long the pending-task list stays expanded after the last task finishes. */
+const COLLAPSE_DEBOUNCE = 1000;
+
+interface UseNotificationSidebarOptions {
+  /** Two-way binding for the drawer; closing the sidebar writes `false` to it. */
+  display: Ref<boolean>;
+  /** Vertical scroll offset of the notification list. */
+  scrollY: MaybeRefOrGetter<number>;
+}
+
+interface UseNotificationSidebarReturn {
+  /** Every notification, in priority order, whatever tab is selected. */
+  allNotifications: Readonly<Ref<NotificationData[]>>;
+  /** Closes the drawer. */
+  close: () => void;
+  /** Whether any task is currently running. */
+  hasRunningTasks: ComputedRef<boolean>;
+  /**
+   * Whether newly rendered rows should appear without waiting to be scrolled into view.
+   *
+   * @remarks
+   * It resets on a tab change and on the list going from empty to populated, so a fresh list is
+   * shown at once rather than a column of placeholders; while scrolling it tracks the top of the
+   * list instead.
+   */
+  initialAppear: Readonly<Ref<boolean>>;
+  /** Whether notifications were dropped because the store was full. */
+  messageOverflow: Readonly<Ref<boolean>>;
+  /** Whether the pending-task list is expanded. */
+  modelPendingTasksExpanded: Ref<boolean>;
+  /** The selected tab. */
+  modelSelectedTab: Ref<TabCategory>;
+  /** Dismisses a single notification. */
+  remove: (id: number) => void;
+  /** The notifications the selected tab admits. */
+  selectedNotifications: ComputedRef<NotificationData[]>;
+  /**
+   * Asks for confirmation before discarding every notification.
+   *
+   * @remarks
+   * Clearing is not undoable, so nothing is discarded until the dialog is confirmed.
+   */
+  showConfirmation: () => void;
+  /** Whether popups are suppressed. */
+  silent: Readonly<Ref<boolean>>;
+  /** The tab labels, keyed by tab. */
+  tabCategoriesLabel: ComputedRef<Record<TabCategory, string>>;
+  /** Turns popup suppression on or off. */
+  toggleSilentMode: () => void;
+}
+
+/**
+ * Drives the notification drawer: the tab filtering, the silent-mode toggle, the clear-all
+ * confirmation, and the appearance of rows as the list scrolls.
+ *
+ * @returns the list state the drawer renders and the actions its controls call
+ */
+export function useNotificationSidebar(options: UseNotificationSidebarOptions): UseNotificationSidebarReturn {
+  const { display, scrollY } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const modelSelectedTab = shallowRef<TabCategory>(TabCategory.VIEW_ALL);
+  const modelPendingTasksExpanded = shallowRef<boolean>(false);
+  const initialAppear = shallowRef<boolean>(false);
+
+  const notificationStore = useNotificationsStore();
+  const { messageOverflow, prioritized: allNotifications } = storeToRefs(notificationStore);
+  const { remove } = notificationStore;
+  const { show } = useConfirmStore();
+  const { isActive: hasRunningTasks } = useTaskCenter();
+  const { silent, toggle: toggleSilent } = useSilentNotifications();
+
+  const tabCategoriesLabel = computed<Record<TabCategory, string>>(() => ({
+    [TabCategory.ERROR]: t('notification_sidebar.tabs.error'),
+    [TabCategory.NEEDS_ACTION]: t('notification_sidebar.tabs.needs_action'),
+    [TabCategory.REMINDER]: t('notification_sidebar.tabs.reminder'),
+    [TabCategory.VIEW_ALL]: t('notification_sidebar.tabs.view_all'),
+  }));
+
+  const selectedNotifications = computed<NotificationData[]>(() => {
+    const all = get(allNotifications);
+    const filterBy = TAB_FILTERS[get(modelSelectedTab)];
+
+    if (filterBy)
+      return all.filter(filterBy);
+
+    return all;
+  });
+
+  function close(): void {
+    set(display, false);
+  }
+
+  function toggleSilentMode(): void {
+    startPromise(toggleSilent());
+  }
+
+  function clear(): void {
+    notificationStore.$reset();
+    close();
+  }
+
+  function showConfirmation(): void {
+    show({
+      message: t('notification_sidebar.confirmation.message'),
+      title: t('notification_sidebar.confirmation.title'),
+      type: 'info',
+    }, clear);
+  }
+
+  function collapsePendingTasksWhenIdle(running: boolean): void {
+    if (!running)
+      set(modelPendingTasksExpanded, false);
+  }
+
+  watchDebounced(hasRunningTasks, collapsePendingTasksWhenIdle, { debounce: COLLAPSE_DEBOUNCE });
+
+  function trackRowAppearance(
+    [currentY, currentTab, currentNotifications]: [number, TabCategory, NotificationData[]],
+    [, previousTab, previousNotifications]: [number, TabCategory, NotificationData[]],
+  ): void {
+    const listArrived = previousNotifications.length === 0 && currentNotifications.length > 0;
+
+    if (currentTab !== previousTab || listArrived) {
+      set(initialAppear, false);
+      startPromise(nextTick((): void => {
+        set(initialAppear, true);
+      }));
+    }
+    else {
+      set(initialAppear, currentY <= 0);
+    }
+  }
+
+  watch([(): number => toValue(scrollY), modelSelectedTab, selectedNotifications], trackRowAppearance);
+
+  return {
+    allNotifications,
+    close,
+    hasRunningTasks,
+    initialAppear: readonly(initialAppear),
+    messageOverflow,
+    modelPendingTasksExpanded,
+    modelSelectedTab,
+    remove,
+    selectedNotifications,
+    showConfirmation,
+    silent,
+    tabCategoriesLabel,
+    toggleSilentMode,
+  };
+}

--- a/frontend/app/src/modules/notes/UserNotesList.spec.ts
+++ b/frontend/app/src/modules/notes/UserNotesList.spec.ts
@@ -1,0 +1,180 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { UserNote } from '@/modules/core/common/notes';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import UserNotesList from '@/modules/notes/UserNotesList.vue';
+
+interface TableState {
+  collection?: Ref<Collection<UserNote>>;
+  pagination?: Ref<{ limit: number; page: number }>;
+}
+
+let premium: Ref<boolean>;
+let logged: Ref<boolean>;
+let notes: Ref<Collection<UserNote>>;
+
+const {
+  deleteUserNote,
+  refetch,
+  refreshNotesCount,
+  tableState,
+  updateUserNote,
+} = vi.hoisted(() => {
+  const tableState: TableState = {};
+  return {
+    deleteUserNote: vi.fn(async () => Promise.resolve(true)),
+    refetch: vi.fn(async () => Promise.resolve()),
+    refreshNotesCount: vi.fn(async () => Promise.resolve()),
+    tableState,
+    updateUserNote: vi.fn(async () => Promise.resolve(true)),
+  };
+});
+
+vi.mock('@/modules/notes/use-user-notes-api', () => ({
+  useUserNotesApi: (): Record<string, unknown> => ({
+    deleteUserNote,
+    fetchUserNotes: vi.fn(),
+    updateUserNote,
+  }),
+}));
+
+vi.mock('@/modules/notes/use-notes-count', () => ({
+  useNotesCount: (): Record<string, unknown> => ({ refresh: refreshNotesCount }),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', () => ({
+  useServerTable: (): Record<string, unknown> => ({
+    collection: tableState.collection,
+    pagination: tableState.pagination,
+    refetch,
+  }),
+}));
+
+vi.mock('@/modules/premium/use-premium', () => ({
+  usePremium: (): Ref<boolean> => premium,
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: (): Record<string, unknown> => ({ logged }),
+}));
+
+function note(overrides: Partial<UserNote> = {}): UserNote {
+  return {
+    content: 'the content',
+    identifier: 1,
+    isPinned: false,
+    lastUpdateTimestamp: 1_700_000_000,
+    location: 'G',
+    title: 'the title',
+    ...overrides,
+  };
+}
+
+function collection(data: UserNote[]): Collection<UserNote> {
+  return { data, found: data.length, limit: -1, total: data.length, totalValue: undefined };
+}
+
+async function createWrapper(data: UserNote[] = []): Promise<VueWrapper> {
+  notes = ref<Collection<UserNote>>(collection(data));
+  tableState.collection = notes;
+  tableState.pagination = ref({ limit: 10, page: 1 });
+
+  const wrapper = mount(UserNotesList, {
+    global: { stubs: { DateDisplay: true, ExternalLink: true, UserNotesFormDialog: true } },
+    props: { open: false },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('modules/notes/UserNotesList.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    premium = ref<boolean>(true);
+    logged = ref<boolean>(true);
+  });
+
+  it('should fetch the first page when it opens', async () => {
+    await createWrapper();
+
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  it('should render one card per note', async () => {
+    const wrapper = await createWrapper([note({ identifier: 1 }), note({ identifier: 2 })]);
+
+    expect(wrapper.findAll('[data-testid=note-card]')).toHaveLength(2);
+  });
+
+  it('should say so when there are no notes', async () => {
+    const wrapper = await createWrapper();
+
+    expect(wrapper.text()).toContain('notes_menu.empty_notes');
+  });
+
+  it('should open the dialog to add a note', async () => {
+    const wrapper = await createWrapper();
+
+    await wrapper.find('[data-testid=notes-add]').trigger('click');
+
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([true]);
+  });
+
+  it('should pin the note whose pin was pressed', async () => {
+    const wrapper = await createWrapper([
+      note({ identifier: 1, title: 'first' }),
+      note({ identifier: 2, title: 'second' }),
+    ]);
+
+    const cards = wrapper.findAll('[data-testid=note-card]');
+    const second = cards.find(card => card.text().includes('second'))!;
+    await second.find('[data-testid=note-pin]').trigger('click');
+
+    expect(updateUserNote).toHaveBeenCalledWith(expect.objectContaining({ identifier: 2, isPinned: true }));
+  });
+
+  it('should ask before deleting, and delete nothing until confirmed', async () => {
+    const wrapper = await createWrapper([note({ identifier: 5 })]);
+
+    await wrapper.find('[data-testid=note-delete]').trigger('click');
+
+    expect(wrapper.text()).toContain('notes_menu.delete_confirmation');
+    expect(deleteUserNote).not.toHaveBeenCalled();
+  });
+
+  it('should delete the confirmed note', async () => {
+    const wrapper = await createWrapper([note({ identifier: 5 })]);
+
+    await wrapper.find('[data-testid=note-delete]').trigger('click');
+    await wrapper.find('[data-testid=note-delete-confirm]').trigger('click');
+
+    expect(deleteUserNote).toHaveBeenCalledWith(5);
+  });
+
+  it('should delete nothing when the confirmation is dismissed', async () => {
+    const wrapper = await createWrapper([note({ identifier: 5 })]);
+
+    await wrapper.find('[data-testid=note-delete]').trigger('click');
+    await wrapper.find('[data-testid=note-delete-cancel]').trigger('click');
+
+    expect(wrapper.text()).not.toContain('notes_menu.delete_confirmation');
+    expect(deleteUserNote).not.toHaveBeenCalled();
+  });
+
+  it('should confirm against only the note whose delete was pressed', async () => {
+    const wrapper = await createWrapper([
+      note({ identifier: 1, title: 'first' }),
+      note({ identifier: 2, title: 'second' }),
+    ]);
+
+    const cards = wrapper.findAll('[data-testid=note-card]');
+    const second = cards.find(card => card.text().includes('second'))!;
+    await second.find('[data-testid=note-delete]').trigger('click');
+
+    expect(wrapper.findAll('[data-testid=note-delete-confirm]')).toHaveLength(1);
+    expect(second.text()).toContain('notes_menu.delete_confirmation');
+  });
+});

--- a/frontend/app/src/modules/notes/UserNotesList.vue
+++ b/frontend/app/src/modules/notes/UserNotesList.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
-import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
-import { getCollectionData, setupEntryLimit } from '@/modules/core/common/data/collection-utils';
-import { NoteLocation, type UserNote, type UserNoteDraft, type UserNotesRequestPayload } from '@/modules/core/common/notes';
-import { useServerTable } from '@/modules/core/table/use-server-table';
-import { useNotesCount } from '@/modules/notes/use-notes-count';
-import { useUserNotesApi } from '@/modules/notes/use-user-notes-api';
+import { NoteLocation } from '@/modules/core/common/notes';
+import { useUserNotesList } from '@/modules/notes/use-user-notes-list';
 import UserNotesFormDialog from '@/modules/notes/UserNotesFormDialog.vue';
-import { usePremium } from '@/modules/premium/use-premium';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 
@@ -14,186 +9,46 @@ const open = defineModel<boolean>('open', { required: true });
 
 const { location = NoteLocation.GLOBAL } = defineProps<{ location?: string }>();
 
-function getDefaultForm(): UserNoteDraft {
-  return {
-    content: '',
-    isPinned: false,
-    location: NoteLocation.GLOBAL,
-    title: '',
-  };
-}
-
-const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
-
-const showDeleteConfirmation = ref<boolean>(false);
-const idToDelete = ref<number | null>(null);
-const form = ref<UserNoteDraft>(getDefaultForm());
-const editMode = ref<boolean>(false);
-const loading = ref<boolean>(false);
-const search = ref<string>('');
-const titleSubstring = ref<string>('');
-
-const { deleteUserNote, fetchUserNotes, updateUserNote } = useUserNotesApi();
-
-const { refresh: refreshNotesCount } = useNotesCount();
-
-const extraParams = computed(() => ({
-  location,
-  titleSubstring: get(titleSubstring),
-}));
-
-const {
-  collection: notes,
-  pagination,
-  refetch,
-} = useServerTable<UserNote, UserNotesRequestPayload>({
-  fetch: fetchUserNotes,
-  params: [{ to: 'both', values: extraParams }],
-  sort: {
-    default: [{
-      column: 'isPinned',
-      direction: 'desc',
-    }, {
-      column: 'lastUpdateTimestamp',
-      direction: 'desc',
-    }],
-  },
-});
-
-const { data, limit } = getCollectionData(notes);
-
 const { t } = useI18n({ useScope: 'global' });
 
-async function fetchNotes(loadingIndicator = false): Promise<void> {
-  if (loadingIndicator)
-    set(loading, true);
-
-  await refetch();
-  set(loading, false);
-}
-
-async function refreshNotes(): Promise<void> {
-  await fetchNotes();
-  await refreshNotesCount();
-}
-
-const { found, limit: itemsPerPage, total } = getCollectionData<UserNote>(notes);
-
-const { showUpgradeRow } = setupEntryLimit(itemsPerPage, found, total);
-
-const page = ref<number>(1);
-const nextPageDisabled = ref<boolean>(true);
-
-const LIMIT = 10;
-watch(page, (page) => {
-  set(pagination, {
-    ...get(pagination),
-    limit: LIMIT * page,
-    page: 1,
-  });
-});
-
-async function togglePin(note: UserNote) {
-  const payload = {
-    ...note,
-    isPinned: !note.isPinned,
-  };
-
-  await callUpdateNote(payload);
-}
-
-function resetForm() {
-  set(editMode, false);
-  set(form, getDefaultForm());
-  set(open, false);
-}
-
-function addNote() {
-  resetForm();
-  set(open, true);
-}
-
-function editNote(note: UserNote) {
-  set(editMode, true);
-  set(form, { ...note });
-  set(open, true);
-}
-
-async function callUpdateNote(payload: Partial<UserNote>): Promise<void> {
-  await updateUserNote(payload);
-  await refreshNotes();
-}
-
-function deleteNote(identifier: number) {
-  set(showDeleteConfirmation, true);
-  set(idToDelete, identifier);
-}
-
-function clearDeleteDialog(): void {
-  set(showDeleteConfirmation, false);
-  set(idToDelete, null);
-}
-
-async function confirmDelete(): Promise<void> {
-  const id = get(idToDelete);
-  if (id === null)
-    return;
-
-  await deleteUserNote(id);
-  clearDeleteDialog();
-  await refreshNotes();
-}
-
-function onBeforeLeave(el: Element): void {
-  if (!(el instanceof HTMLElement))
-    return;
-
-  el.style.height = `${el.offsetHeight}px`;
-  el.style.width = `${el.offsetWidth}px`;
-}
-
-const premium = usePremium();
-const { logged } = storeToRefs(useSessionAuthStore());
-
-watch([premium], async () => {
-  if (get(logged))
-    await fetchNotes();
-});
-
-watchDebounced(
-  search,
-  (search) => {
-    set(titleSubstring, search);
-  },
-  { debounce: 400 },
-);
-
-onMounted(async () => {
-  await fetchNotes(true);
-});
-
+const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
 const { arrivedState } = useScroll(wrapper);
 
-watch(notes, (notes) => {
-  set(nextPageDisabled, notes.data.length >= notes.found);
+const {
+  addNote,
+  clearDeleteDialog,
+  confirmDelete,
+  data,
+  deleteNote,
+  editMode,
+  editNote,
+  idToDelete,
+  limit,
+  loadInitialNotes,
+  loading,
+  modelForm,
+  modelSearch,
+  onBeforeLeave,
+  refreshNotes,
+  resetForm,
+  showDeleteConfirmation,
+  showUpgradeRow,
+  togglePin,
+} = useUserNotesList({
+  arrivedBottom: () => arrivedState.bottom,
+  location: () => location,
+  open,
 });
 
-const bottom = ref<boolean>(false);
-watch(arrivedState, (arrived) => {
-  set(bottom, arrived.bottom && get(notes).data.length > 0);
-});
-
-const shouldIncreasePage = logicAnd(bottom, logicNot(nextPageDisabled));
-watch(shouldIncreasePage, (increasePage) => {
-  if (increasePage)
-    set(page, get(page) + 1);
+onMounted(async () => {
+  await loadInitialNotes();
 });
 </script>
 
 <template>
   <div class="p-4 flex items-center gap-3">
     <RuiTextField
-      v-model="search"
+      v-model="modelSearch"
       variant="outlined"
       color="primary"
       dense
@@ -202,12 +57,14 @@ watch(shouldIncreasePage, (increasePage) => {
       :label="t('notes_menu.search')"
       clearable
       hide-details
+      data-testid="notes-search"
     />
 
     <RuiButton
       color="primary"
       class="py-2"
       :disabled="showUpgradeRow"
+      data-testid="notes-add"
       @click="addNote()"
     >
       <template #prepend>
@@ -274,6 +131,7 @@ watch(shouldIncreasePage, (increasePage) => {
           :key="note.identifier"
           dense
           class="overflow-hidden group"
+          data-testid="note-card"
         >
           <div class="flex justify-between items-center">
             <div class="font-bold overflow-hidden whitespace-nowrap text-ellipsis flex-1">
@@ -283,6 +141,7 @@ watch(shouldIncreasePage, (increasePage) => {
               class="!p-2"
               variant="text"
               icon
+              data-testid="note-pin"
               @click="togglePin(note)"
             >
               <RuiIcon
@@ -316,6 +175,7 @@ watch(shouldIncreasePage, (increasePage) => {
               icon
               size="sm"
               color="error"
+              data-testid="note-delete-cancel"
               @click="clearDeleteDialog()"
             >
               <RuiIcon
@@ -329,6 +189,7 @@ watch(shouldIncreasePage, (increasePage) => {
               variant="text"
               icon
               size="sm"
+              data-testid="note-delete-confirm"
               @click="confirmDelete()"
             >
               <RuiIcon
@@ -356,6 +217,7 @@ watch(shouldIncreasePage, (increasePage) => {
               variant="text"
               icon
               size="sm"
+              data-testid="note-edit"
               @click="editNote(note)"
             >
               <RuiIcon
@@ -367,6 +229,7 @@ watch(shouldIncreasePage, (increasePage) => {
               variant="text"
               icon
               size="sm"
+              data-testid="note-delete"
               @click="deleteNote(note.identifier)"
             >
               <RuiIcon
@@ -389,7 +252,7 @@ watch(shouldIncreasePage, (increasePage) => {
 
   <UserNotesFormDialog
     v-model:open="open"
-    v-model="form"
+    v-model="modelForm"
     :edit-mode="editMode"
     :location="location"
     @reset="resetForm()"

--- a/frontend/app/src/modules/notes/use-user-notes-list.spec.ts
+++ b/frontend/app/src/modules/notes/use-user-notes-list.spec.ts
@@ -1,0 +1,383 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { UserNote } from '@/modules/core/common/notes';
+import { flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type ComputedRef, effectScope, type Ref, ref } from 'vue';
+import { useUserNotesList } from './use-user-notes-list';
+
+interface NoteFilterParams {
+  location: string;
+  titleSubstring: string;
+}
+
+interface CapturedTableOptions {
+  params: { to: string; values: ComputedRef<NoteFilterParams> }[];
+  sort: { default: { column: string; direction: string }[] };
+}
+
+interface TableState {
+  collection?: Ref<Collection<UserNote>>;
+  options?: CapturedTableOptions;
+  pagination?: Ref<{ limit: number; page: number }>;
+}
+
+let premium: Ref<boolean>;
+let logged: Ref<boolean>;
+let notes: Ref<Collection<UserNote>>;
+let pagination: Ref<{ limit: number; page: number }>;
+let open: Ref<boolean>;
+let arrivedBottom: Ref<boolean>;
+let scope: ReturnType<typeof effectScope>;
+
+const {
+  deleteUserNote,
+  fetchUserNotes,
+  refreshNotesCount,
+  refetch,
+  tableState,
+  updateUserNote,
+} = vi.hoisted(() => {
+  const tableState: TableState = {};
+  return {
+    deleteUserNote: vi.fn(async () => Promise.resolve(true)),
+    fetchUserNotes: vi.fn(),
+    refetch: vi.fn(async () => Promise.resolve()),
+    refreshNotesCount: vi.fn(async () => Promise.resolve()),
+    tableState,
+    updateUserNote: vi.fn(async () => Promise.resolve(true)),
+  };
+});
+
+vi.mock('@/modules/notes/use-user-notes-api', () => ({
+  useUserNotesApi: (): Record<string, unknown> => ({
+    deleteUserNote,
+    fetchUserNotes,
+    updateUserNote,
+  }),
+}));
+
+vi.mock('@/modules/notes/use-notes-count', () => ({
+  useNotesCount: (): Record<string, unknown> => ({ refresh: refreshNotesCount }),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', () => ({
+  useServerTable: (options: CapturedTableOptions): Record<string, unknown> => {
+    tableState.options = options;
+    return {
+      collection: tableState.collection,
+      pagination: tableState.pagination,
+      refetch,
+    };
+  },
+}));
+
+vi.mock('@/modules/premium/use-premium', () => ({
+  usePremium: (): Ref<boolean> => premium,
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: (): Record<string, unknown> => ({ logged }),
+}));
+
+function note(overrides: Partial<UserNote> = {}): UserNote {
+  return {
+    content: 'the content',
+    identifier: 1,
+    isPinned: false,
+    lastUpdateTimestamp: 1_700_000_000,
+    location: 'G',
+    title: 'the title',
+    ...overrides,
+  };
+}
+
+function collection(data: UserNote[], found = data.length): Collection<UserNote> {
+  return {
+    data,
+    found,
+    limit: -1,
+    total: found,
+    totalValue: undefined,
+  };
+}
+
+/** The query the list hands the table, as captured from the stubbed `useServerTable`. */
+function filterParams(): ComputedRef<NoteFilterParams> {
+  assert(tableState.options);
+  return tableState.options.params[0].values;
+}
+
+function list(): ReturnType<typeof useUserNotesList> {
+  scope = effectScope();
+  return scope.run(() => useUserNotesList({ arrivedBottom, location: 'G', open }))!;
+}
+
+describe('modules/notes/useUserNotesList', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    premium = ref<boolean>(false);
+    logged = ref<boolean>(true);
+    notes = ref<Collection<UserNote>>(collection([]));
+    pagination = ref({ limit: 10, page: 1 });
+    open = ref<boolean>(false);
+    arrivedBottom = ref<boolean>(false);
+    tableState.collection = notes;
+    tableState.pagination = pagination;
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('loading the list', () => {
+    it('should show skeletons while the first page is in flight', async () => {
+      const { loadInitialNotes, loading } = list();
+
+      const pending = loadInitialNotes();
+      expect(get(loading)).toBe(true);
+
+      await pending;
+      expect(get(loading)).toBe(false);
+      expect(refetch).toHaveBeenCalledOnce();
+    });
+
+    it('should refetch when premium changes while logged in', async () => {
+      list();
+
+      set(premium, true);
+      await flushPromises();
+
+      expect(refetch).toHaveBeenCalledOnce();
+    });
+
+    it('should not refetch on a premium change while logged out', async () => {
+      set(logged, false);
+      list();
+
+      set(premium, true);
+      await flushPromises();
+
+      expect(refetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the search box', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should not filter on every keystroke', async () => {
+      const { modelSearch } = list();
+
+      set(modelSearch, 'gro');
+      await vi.advanceTimersByTimeAsync(200);
+      set(modelSearch, 'groceries');
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(refetch).not.toHaveBeenCalled();
+    });
+
+    it('should filter once typing settles', async () => {
+      const { modelSearch } = list();
+
+      set(modelSearch, 'groceries');
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(get(filterParams())).toEqual({ location: 'G', titleSubstring: 'groceries' });
+    });
+
+    it('should not narrow the query while typing is still settling', async () => {
+      const { modelSearch } = list();
+
+      set(modelSearch, 'gro');
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(get(filterParams()).titleSubstring).toBe('');
+    });
+  });
+
+  describe('the add and edit dialog', () => {
+    it('should open a blank note to add', () => {
+      const { addNote, editMode, modelForm } = list();
+      addNote();
+
+      expect(get(open)).toBe(true);
+      expect(get(editMode)).toBe(false);
+      expect(get(modelForm)).toEqual({ content: '', isPinned: false, location: 'G', title: '' });
+    });
+
+    it('should open an existing note to edit', () => {
+      const existing = note({ identifier: 4, title: 'shopping' });
+
+      const { editMode, editNote, modelForm } = list();
+      editNote(existing);
+
+      expect(get(open)).toBe(true);
+      expect(get(editMode)).toBe(true);
+      expect(get(modelForm)).toEqual(existing);
+    });
+
+    it('should not hand the dialog the caller\'s own note object', () => {
+      const existing = note({ title: 'shopping' });
+
+      const { editNote, modelForm } = list();
+      editNote(existing);
+      get(modelForm).title = 'edited in the dialog';
+
+      expect(existing.title).toBe('shopping');
+    });
+
+    it('should blank the note and close the dialog on reset', () => {
+      const { editNote, modelForm, resetForm } = list();
+      editNote(note({ title: 'shopping' }));
+      resetForm();
+
+      expect(get(open)).toBe(false);
+      expect(get(modelForm).title).toBe('');
+    });
+  });
+
+  describe('pinning', () => {
+    it('should pin an unpinned note and refresh the list and the count', async () => {
+      const { togglePin } = list();
+      await togglePin(note({ identifier: 3, isPinned: false }));
+
+      expect(updateUserNote).toHaveBeenCalledWith(expect.objectContaining({ identifier: 3, isPinned: true }));
+      expect(refetch).toHaveBeenCalledOnce();
+      expect(refreshNotesCount).toHaveBeenCalledOnce();
+    });
+
+    it('should unpin a pinned note', async () => {
+      const { togglePin } = list();
+      await togglePin(note({ identifier: 3, isPinned: true }));
+
+      expect(updateUserNote).toHaveBeenCalledWith(expect.objectContaining({ identifier: 3, isPinned: false }));
+    });
+  });
+
+  describe('deleting a note', () => {
+    it('should delete nothing until the confirmation is answered', () => {
+      const { deleteNote, idToDelete, showDeleteConfirmation } = list();
+      deleteNote(7);
+
+      expect(get(showDeleteConfirmation)).toBe(true);
+      expect(get(idToDelete)).toBe(7);
+      expect(deleteUserNote).not.toHaveBeenCalled();
+    });
+
+    it('should delete exactly the note the confirmation names', async () => {
+      const { confirmDelete, deleteNote } = list();
+      deleteNote(7);
+      await confirmDelete();
+
+      expect(deleteUserNote).toHaveBeenCalledWith(7);
+      expect(deleteUserNote).toHaveBeenCalledOnce();
+    });
+
+    it('should close the confirmation and refresh after deleting', async () => {
+      const { confirmDelete, deleteNote, idToDelete, showDeleteConfirmation } = list();
+      deleteNote(7);
+      await confirmDelete();
+
+      expect(get(showDeleteConfirmation)).toBe(false);
+      expect(get(idToDelete)).toBeNull();
+      expect(refreshNotesCount).toHaveBeenCalledOnce();
+    });
+
+    it('should delete nothing when the confirmation is cancelled', () => {
+      const { clearDeleteDialog, deleteNote, idToDelete, showDeleteConfirmation } = list();
+      deleteNote(7);
+      clearDeleteDialog();
+
+      expect(get(showDeleteConfirmation)).toBe(false);
+      expect(get(idToDelete)).toBeNull();
+      expect(deleteUserNote).not.toHaveBeenCalled();
+    });
+
+    it('should delete nothing when confirmed with no note armed', async () => {
+      const { confirmDelete } = list();
+      await confirmDelete();
+
+      expect(deleteUserNote).not.toHaveBeenCalled();
+      expect(refetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('paging as it scrolls', () => {
+    it('should ask for another page at the bottom while more remain', async () => {
+      list();
+      set(notes, collection([note({ identifier: 1 })], 30));
+      await flushPromises();
+
+      set(arrivedBottom, true);
+      await flushPromises();
+
+      expect(get(pagination).limit).toBe(20);
+    });
+
+    it('should not page past the end of the list', async () => {
+      list();
+      set(notes, collection([note({ identifier: 1 })], 1));
+      await flushPromises();
+
+      set(arrivedBottom, true);
+      await flushPromises();
+
+      expect(get(pagination).limit).toBe(10);
+    });
+
+    it('should not page an empty list', async () => {
+      list();
+      set(notes, collection([], 0));
+      await flushPromises();
+
+      set(arrivedBottom, true);
+      await flushPromises();
+
+      expect(get(pagination).limit).toBe(10);
+    });
+
+    it('should keep paging while the user stays at the bottom', async () => {
+      list();
+      set(notes, collection([note({ identifier: 1 })], 30));
+      await flushPromises();
+
+      set(arrivedBottom, true);
+      await flushPromises();
+      set(arrivedBottom, false);
+      await flushPromises();
+      set(arrivedBottom, true);
+      await flushPromises();
+
+      expect(get(pagination).limit).toBe(30);
+    });
+  });
+
+  describe('the leave transition', () => {
+    it('should pin the row box before it animates out', () => {
+      const el = document.createElement('div');
+      Object.defineProperty(el, 'offsetHeight', { value: 48 });
+      Object.defineProperty(el, 'offsetWidth', { value: 300 });
+
+      const { onBeforeLeave } = list();
+      onBeforeLeave(el);
+
+      expect(el.style.height).toBe('48px');
+      expect(el.style.width).toBe('300px');
+    });
+
+    it('should leave anything that is not an element alone', () => {
+      const el = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+      const { onBeforeLeave } = list();
+
+      expect(() => onBeforeLeave(el)).not.toThrow();
+    });
+  });
+});

--- a/frontend/app/src/modules/notes/use-user-notes-list.ts
+++ b/frontend/app/src/modules/notes/use-user-notes-list.ts
@@ -1,0 +1,255 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { getCollectionData, setupEntryLimit } from '@/modules/core/common/data/collection-utils';
+import { NoteLocation, type UserNote, type UserNoteDraft, type UserNotesRequestPayload } from '@/modules/core/common/notes';
+import { useServerTable } from '@/modules/core/table/use-server-table';
+import { useNotesCount } from '@/modules/notes/use-notes-count';
+import { useUserNotesApi } from '@/modules/notes/use-user-notes-api';
+import { usePremium } from '@/modules/premium/use-premium';
+
+/** Notes fetched per page; each scroll to the bottom asks for one more page's worth. */
+const PAGE_SIZE = 10;
+
+/** How long typing settles before the list is filtered. */
+const SEARCH_DEBOUNCE = 400;
+
+function getDefaultForm(): UserNoteDraft {
+  return {
+    content: '',
+    isPinned: false,
+    location: NoteLocation.GLOBAL,
+    title: '',
+  };
+}
+
+interface UseUserNotesListOptions {
+  /** Whether the list is scrolled to the bottom, which is what asks for the next page. */
+  arrivedBottom: MaybeRefOrGetter<boolean>;
+  /** The note location the list is scoped to. */
+  location: MaybeRefOrGetter<string>;
+  /** Two-way binding for the add/edit dialog. */
+  open: Ref<boolean>;
+}
+
+interface UseUserNotesListReturn {
+  /** Opens the dialog on a blank note. */
+  addNote: () => void;
+  /** Closes the delete confirmation without deleting. */
+  clearDeleteDialog: () => void;
+  /** Deletes the note the confirmation names, then refreshes the list and the badge count. */
+  confirmDelete: () => Promise<void>;
+  /** The notes on the current page. */
+  data: ComputedRef<UserNote[]>;
+  /** Arms the inline delete confirmation for one note. */
+  deleteNote: (identifier: number) => void;
+  /** Opens the dialog on an existing note. */
+  editNote: (note: UserNote) => void;
+  /** Whether the dialog is editing rather than creating. */
+  editMode: Readonly<Ref<boolean>>;
+  /** The note the delete confirmation is armed for, or null. */
+  idToDelete: Readonly<Ref<number | null>>;
+  /** The free-tier note cap. */
+  limit: ComputedRef<number>;
+  /** Fetches the first page, showing skeletons while it is in flight. */
+  loadInitialNotes: () => Promise<void>;
+  /** Whether the skeletons are showing. */
+  loading: Readonly<Ref<boolean>>;
+  /** The note the dialog is editing or creating. */
+  modelForm: Ref<UserNoteDraft>;
+  /** The search box contents. */
+  modelSearch: Ref<string>;
+  /**
+   * Fixes a leaving row's box before it animates out.
+   *
+   * @remarks
+   * The row is taken out of flow by the leave transition, so without this it collapses to zero
+   * before it has faded. Anything that is not an element is left alone.
+   */
+  onBeforeLeave: (el: Element) => void;
+  /** Clears the dialog's note and closes it. */
+  resetForm: () => void;
+  /** Refreshes the list and the badge count. */
+  refreshNotes: () => Promise<void>;
+  /** Whether the free-tier cap has been reached. */
+  showUpgradeRow: ComputedRef<boolean>;
+  /** Whether the inline delete confirmation is showing. */
+  showDeleteConfirmation: Readonly<Ref<boolean>>;
+  /** Pins or unpins a note. */
+  togglePin: (note: UserNote) => Promise<void>;
+}
+
+/**
+ * Drives the notes sidebar list: the search, the paging as it scrolls, the add/edit dialog and the
+ * inline delete confirmation.
+ *
+ * @returns the list state and every action its rows offer
+ */
+export function useUserNotesList(options: UseUserNotesListOptions): UseUserNotesListReturn {
+  const { arrivedBottom, location, open } = options;
+
+  const modelSearch = shallowRef<string>('');
+  const modelForm = ref<UserNoteDraft>(getDefaultForm());
+  const titleSubstring = shallowRef<string>('');
+  const showDeleteConfirmation = shallowRef<boolean>(false);
+  const idToDelete = shallowRef<number | null>(null);
+  const editMode = shallowRef<boolean>(false);
+  const loading = shallowRef<boolean>(false);
+  const page = shallowRef<number>(1);
+  const nextPageDisabled = shallowRef<boolean>(true);
+  const atBottom = shallowRef<boolean>(false);
+
+  const { deleteUserNote, fetchUserNotes, updateUserNote } = useUserNotesApi();
+  const { refresh: refreshNotesCount } = useNotesCount();
+  const premium = usePremium();
+  const { logged } = storeToRefs(useSessionAuthStore());
+
+  const extraParams = computed(() => ({
+    location: toValue(location),
+    titleSubstring: get(titleSubstring),
+  }));
+
+  const { collection: notes, pagination, refetch } = useServerTable<UserNote, UserNotesRequestPayload>({
+    fetch: fetchUserNotes,
+    params: [{ to: 'both', values: extraParams }],
+    sort: {
+      default: [{
+        column: 'isPinned',
+        direction: 'desc',
+      }, {
+        column: 'lastUpdateTimestamp',
+        direction: 'desc',
+      }],
+    },
+  });
+
+  const { data, found, limit, total } = getCollectionData<UserNote>(notes);
+  const { showUpgradeRow } = setupEntryLimit(limit, found, total);
+
+  async function fetchNotes(): Promise<void> {
+    await refetch();
+    set(loading, false);
+  }
+
+  async function loadInitialNotes(): Promise<void> {
+    set(loading, true);
+    await fetchNotes();
+  }
+
+  async function refreshNotes(): Promise<void> {
+    await fetchNotes();
+    await refreshNotesCount();
+  }
+
+  async function callUpdateNote(payload: Partial<UserNote>): Promise<void> {
+    await updateUserNote(payload);
+    await refreshNotes();
+  }
+
+  async function togglePin(note: UserNote): Promise<void> {
+    await callUpdateNote({
+      ...note,
+      isPinned: !note.isPinned,
+    });
+  }
+
+  function resetForm(): void {
+    set(editMode, false);
+    set(modelForm, getDefaultForm());
+    set(open, false);
+  }
+
+  function addNote(): void {
+    resetForm();
+    set(open, true);
+  }
+
+  function editNote(note: UserNote): void {
+    set(editMode, true);
+    set(modelForm, { ...note });
+    set(open, true);
+  }
+
+  function deleteNote(identifier: number): void {
+    set(showDeleteConfirmation, true);
+    set(idToDelete, identifier);
+  }
+
+  function clearDeleteDialog(): void {
+    set(showDeleteConfirmation, false);
+    set(idToDelete, null);
+  }
+
+  async function confirmDelete(): Promise<void> {
+    const id = get(idToDelete);
+    if (id === null)
+      return;
+
+    await deleteUserNote(id);
+    clearDeleteDialog();
+    await refreshNotes();
+  }
+
+  function onBeforeLeave(el: Element): void {
+    if (!(el instanceof HTMLElement))
+      return;
+
+    el.style.height = `${el.offsetHeight}px`;
+    el.style.width = `${el.offsetWidth}px`;
+  }
+
+  async function refetchOnPremiumChange(): Promise<void> {
+    if (get(logged))
+      await fetchNotes();
+  }
+
+  watch(page, (page) => {
+    set(pagination, {
+      ...get(pagination),
+      limit: PAGE_SIZE * page,
+      page: 1,
+    });
+  });
+
+  watch(premium, refetchOnPremiumChange);
+
+  watchDebounced(modelSearch, (search) => {
+    set(titleSubstring, search);
+  }, { debounce: SEARCH_DEBOUNCE });
+
+  watch(notes, (notes) => {
+    set(nextPageDisabled, notes.data.length >= notes.found);
+  });
+
+  watch(() => toValue(arrivedBottom), (arrived) => {
+    set(atBottom, arrived && get(data).length > 0);
+  });
+
+  const shouldIncreasePage = logicAnd(atBottom, logicNot(nextPageDisabled));
+
+  watch(shouldIncreasePage, (increasePage) => {
+    if (increasePage)
+      set(page, get(page) + 1);
+  });
+
+  return {
+    addNote,
+    clearDeleteDialog,
+    confirmDelete,
+    data,
+    deleteNote,
+    editMode: readonly(editMode),
+    editNote,
+    idToDelete: readonly(idToDelete),
+    limit,
+    loadInitialNotes,
+    loading: readonly(loading),
+    modelForm,
+    modelSearch,
+    onBeforeLeave,
+    refreshNotes,
+    resetForm,
+    showDeleteConfirmation: readonly(showDeleteConfirmation),
+    showUpgradeRow,
+    togglePin,
+  };
+}

--- a/frontend/app/src/modules/reports/ReportMissingPrices.vue
+++ b/frontend/app/src/modules/reports/ReportMissingPrices.vue
@@ -1,18 +1,11 @@
 <script setup lang="ts">
-import type { BigNumber } from '@rotki/common';
 import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
-import type { HistoricalPrice, HistoricalPriceDeletePayload, HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
 import type { EditableMissingPrice, MissingPrice } from '@/modules/reports/report-types';
-import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
-import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
-import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
-import { ApiValidationError } from '@/modules/core/api/types/errors';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useEditableMissingPrices } from '@/modules/assets/prices/use-editable-missing-prices';
 import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import MissingPriceRefreshButton from '@/modules/reports/MissingPriceRefreshButton.vue';
-import { PriceOracle } from '@/modules/settings/types/price-oracle';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 
@@ -26,89 +19,24 @@ defineSlots<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-const prices = ref<HistoricalPrice[]>([]);
-const errorMessages = ref<Record<string, string[]>>({});
-const refreshing = ref<boolean>(false);
 
-const refreshedHistoricalPrices = ref<Record<string, BigNumber>>({});
 const sort = ref<DataTableSortData<EditableMissingPrice>>([]);
 
-const { resetHistoricalPricesData } = useHistoricPriceCache();
-const { addHistoricalPrice, deleteHistoricalPrice, editHistoricalPrice, fetchHistoricalPrices } = useAssetPricesApi();
-const { getHistoricPrice } = usePriceTaskManager();
+const {
+  clearError,
+  errorMessages,
+  formattedItems,
+  getHistoricalPrices,
+  refreshHistoricalPrice,
+  refreshing,
+  updatePrice,
+} = useEditableMissingPrices({
+  items: () => items,
+  keyOf: createKey,
+});
 
-function createKey(item: MissingPrice) {
+function createKey(item: MissingPrice): string {
   return item.fromAsset + item.toAsset + item.time;
-}
-
-async function getHistoricalPrices(): Promise<void> {
-  set(prices, await fetchHistoricalPrices());
-}
-
-const formattedItems = computed<EditableMissingPrice[]>(() =>
-  items.map((item) => {
-    const savedHistoricalPrice = get(prices).find(
-      price => price.fromAsset === item.fromAsset && price.toAsset === item.toAsset && price.timestamp === item.time,
-    );
-
-    const key = createKey(item);
-    const savedPrice = savedHistoricalPrice?.price;
-    const refreshedHistoricalPrice = get(refreshedHistoricalPrices)[key];
-
-    const useRefreshedHistoricalPrice = !savedPrice && !!refreshedHistoricalPrice;
-
-    const price = (useRefreshedHistoricalPrice ? refreshedHistoricalPrice : savedPrice)?.toFixed() ?? '';
-
-    return {
-      ...item,
-      price,
-      saved: !!savedPrice,
-      useRefreshedHistoricalPrice,
-    };
-  }),
-);
-
-async function updatePrice(item: EditableMissingPrice) {
-  if (item.useRefreshedHistoricalPrice)
-    return;
-
-  const payload: HistoricalPriceDeletePayload = {
-    fromAsset: item.fromAsset,
-    sourceType: PriceOracle.MANUAL,
-    timestamp: item.time,
-    toAsset: item.toAsset,
-  };
-
-  try {
-    if (item.price) {
-      const formPayload: HistoricalPriceFormPayload = {
-        ...payload,
-        price: item.price,
-      };
-
-      if (item.saved)
-        await editHistoricalPrice(formPayload);
-      else await addHistoricalPrice(formPayload);
-    }
-    else if (item.saved) {
-      await deleteHistoricalPrice(payload);
-    }
-  }
-  catch (error: unknown) {
-    let errorMessage = getErrorMessage(error);
-    if (error instanceof ApiValidationError) {
-      const errors = error.getValidationErrors({ price: '' });
-      errorMessage = typeof errors === 'string' ? error.message : errors.price[0];
-    }
-
-    set(errorMessages, {
-      ...get(errorMessages),
-      [createKey(item)]: errorMessage,
-    });
-  }
-
-  resetHistoricalPricesData([payload]);
-  await getHistoricalPrices();
 }
 
 const headers = computed<DataTableColumn<EditableMissingPrice>[]>(() => {
@@ -144,29 +72,6 @@ const headers = computed<DataTableColumn<EditableMissingPrice>[]>(() => {
 });
 
 useRememberTableSorting<EditableMissingPrice>(TableId.REPORTS_MISSING_PRICES, sort, headers);
-
-async function refreshHistoricalPrice(item: EditableMissingPrice) {
-  set(refreshing, true);
-  const rateFromHistoricPrice = await getHistoricPrice({
-    fromAsset: item.fromAsset,
-    timestamp: item.time,
-    toAsset: item.toAsset,
-  });
-
-  const key = createKey(item);
-  if (rateFromHistoricPrice && rateFromHistoricPrice.gt(0)) {
-    const refreshedHistoricalPricesVal = get(refreshedHistoricalPrices);
-    refreshedHistoricalPricesVal[key] = rateFromHistoricPrice;
-    set(refreshedHistoricalPrices, refreshedHistoricalPricesVal);
-  }
-  else {
-    set(errorMessages, {
-      ...get(errorMessages),
-      [key]: t('profit_loss_report.actionable.missing_prices.price_not_found'),
-    });
-  }
-  set(refreshing, false);
-}
 
 onMounted(async () => {
   await getHistoricalPrices();
@@ -229,8 +134,9 @@ onMounted(async () => {
           variant="outlined"
           :success-messages="row.saved ? [t('profit_loss_report.actionable.missing_prices.price_is_saved')] : []"
           :error-messages="errorMessages[createKey(row)]"
-          @focus="delete errorMessages[createKey(row)]"
-          @update:model-value="delete errorMessages[createKey(row)]"
+          data-testid="missing-price-input"
+          @focus="clearError(row)"
+          @update:model-value="clearError(row)"
           @blur="updatePrice(row)"
         >
           <template #append>

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
@@ -1,22 +1,16 @@
 <script lang="ts" setup>
 import type { DataTableColumn } from '@rotki/ui-library';
-import type { ConflictResolution } from '@/modules/assets/types';
-import type { ConflictResolutionStrategy } from '@/modules/core/common/common-types';
 import type {
   AccountingRuleConflict,
-  AccountingRuleConflictRequestPayload,
-  AccountingRuleConflictResolution,
   AccountingTreatment,
 } from '@/modules/settings/types/accounting';
 import { getCollectionData } from '@/modules/core/common/data/collection-utils';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
-import { useServerTable } from '@/modules/core/table/use-server-table';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import HistoryEventTypeCombination from '@/modules/history/events/HistoryEventTypeCombination.vue';
 import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
 import AccountingRuleWithLinkedSettingDisplay
   from '@/modules/settings/accounting/rule/AccountingRuleWithLinkedSettingDisplay.vue';
-import { useAccountingSettings } from '@/modules/settings/accounting/use-accounting-settings';
+import { useAccountingRuleConflictResolution } from '@/modules/settings/accounting/rule/use-accounting-rule-conflict-resolution';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 import CounterpartyDisplay from '@/modules/shell/components/display/CounterpartyDisplay.vue';
 
@@ -25,22 +19,31 @@ const emit = defineEmits<{
   refresh: [];
 }>();
 
-const close = () => emit('close');
-
-const { getAccountingRulesConflicts, resolveAccountingRuleConflicts } = useAccountingSettings();
+const close = (): void => emit('close');
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { collection, isLoading, pagination, refetch } = useServerTable<
-  AccountingRuleConflict,
-  AccountingRuleConflictRequestPayload
->({
-  fetch: getAccountingRulesConflicts,
-  urlState: { mode: 'route' },
+const {
+  collection,
+  isLoading,
+  loading,
+  modelResolution,
+  modelSolveAllUsing,
+  pagination,
+  refetch,
+  remaining,
+  resolutionLength,
+  save,
+  valid,
+} = useAccountingRuleConflictResolution({
+  onResolved: (): void => {
+    emit('refresh');
+    close();
+  },
 });
 
-onMounted(() => {
-  refetch();
+onMounted(async () => {
+  await refetch();
 });
 
 const tableHeaders = computed<DataTableColumn<AccountingRuleConflict>[]>(() => [
@@ -119,60 +122,7 @@ function diffClass(
   return '';
 }
 
-const resolution = ref<ConflictResolution>({});
-const resolutionLength = computed(() => Object.keys(get(resolution)).length);
-
-const solveAllUsing = ref<ConflictResolutionStrategy>();
-
-const { setMessage } = useMessageStore();
-
-const loading = ref<boolean>(false);
-
 const { total } = getCollectionData<AccountingRuleConflict>(collection);
-
-const remaining = computed(() => {
-  const resolved = get(resolutionLength);
-  return get(total) - resolved;
-});
-
-const valid = computed(() => !!get(solveAllUsing) || get(resolutionLength) > 0);
-
-async function save() {
-  set(loading, true);
-  const resolutionVal = get(resolution);
-  const solveAllVal = get(solveAllUsing);
-
-  let payload: AccountingRuleConflictResolution;
-  if (solveAllVal) {
-    payload = { solveAllUsing: solveAllVal };
-  }
-  else {
-    const conflicts = Object.keys(resolutionVal).map(localId => ({
-      localId,
-      solveUsing: resolutionVal[localId],
-    }));
-
-    payload = { conflicts };
-  }
-
-  const result = await resolveAccountingRuleConflicts(payload);
-
-  if (result.success) {
-    emit('refresh');
-    close();
-  }
-  else {
-    setMessage({
-      description: t('accounting_settings.rule.conflicts.error.description', {
-        error: result.message,
-      }),
-      success: false,
-      title: t('accounting_settings.rule.conflicts.error.title'),
-    });
-  }
-
-  set(loading, false);
-}
 </script>
 
 <template>
@@ -189,29 +139,29 @@ async function save() {
     <template #default>
       <div class="flex justify-end items-center gap-8 border border-default rounded p-4 mb-4">
         <RuiCheckbox
-          :model-value="!!solveAllUsing"
+          :model-value="!!modelSolveAllUsing"
           color="primary"
           hide-details
-          @update:model-value="solveAllUsing = $event ? 'local' : undefined"
+          @update:model-value="modelSolveAllUsing = $event ? 'local' : undefined"
         >
           {{ t('conflict_dialog.all_buttons_description') }}
         </RuiCheckbox>
         <RuiButtonGroup
-          v-model="solveAllUsing"
-          :disabled="!solveAllUsing"
+          v-model="modelSolveAllUsing"
+          :disabled="!modelSolveAllUsing"
           color="primary"
           required
           variant="outlined"
         >
           <RuiButton
             model-value="local"
-            @click="solveAllUsing = 'local'"
+            @click="modelSolveAllUsing = 'local'"
           >
             {{ t('conflict_dialog.keep_local') }}
           </RuiButton>
           <RuiButton
             model-value="remote"
-            @click="solveAllUsing = 'remote'"
+            @click="modelSolveAllUsing = 'remote'"
           >
             {{ t('conflict_dialog.keep_remote') }}
           </RuiButton>
@@ -220,7 +170,7 @@ async function save() {
 
       <div class="text-caption pt-4 pb-1">
         <i18n-t
-          v-if="!solveAllUsing"
+          v-if="!modelSolveAllUsing"
           scope="global"
           keypath="conflict_dialog.hint"
           tag="span"
@@ -239,7 +189,7 @@ async function save() {
           tag="span"
         >
           <template #source>
-            <span class="font-medium">{{ solveAllUsing }}</span>
+            <span class="font-medium">{{ modelSolveAllUsing }}</span>
           </template>
         </i18n-t>
       </div>
@@ -402,8 +352,8 @@ async function save() {
         </template>
         <template #item.actions="{ row }">
           <RuiButtonGroup
-            v-model="resolution[row.localId]"
-            :disabled="!!solveAllUsing"
+            v-model="modelResolution[row.localId]"
+            :disabled="!!modelSolveAllUsing"
             class="w-full"
             color="primary"
             required

--- a/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-conflict-resolution.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-conflict-resolution.spec.ts
@@ -1,0 +1,192 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { AccountingRuleConflict } from '@/modules/settings/types/accounting';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { useAccountingRuleConflictResolution } from './use-accounting-rule-conflict-resolution';
+
+interface TableState {
+  collection?: Ref<Collection<AccountingRuleConflict>>;
+}
+
+const {
+  getAccountingRulesConflicts,
+  refetch,
+  resolveAccountingRuleConflicts,
+  setMessage,
+  tableState,
+} = vi.hoisted(() => {
+  const tableState: TableState = {};
+  return {
+    getAccountingRulesConflicts: vi.fn(),
+    refetch: vi.fn(async () => Promise.resolve()),
+    resolveAccountingRuleConflicts: vi.fn(),
+    setMessage: vi.fn(),
+    tableState,
+  };
+});
+
+vi.mock('@/modules/settings/accounting/use-accounting-settings', () => ({
+  useAccountingSettings: (): Record<string, unknown> => ({
+    getAccountingRulesConflicts,
+    resolveAccountingRuleConflicts,
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', () => ({
+  useServerTable: (): Record<string, unknown> => ({
+    collection: tableState.collection,
+    isLoading: ref<boolean>(false),
+    pagination: ref({ limit: 10, page: 1, total: 0 }),
+    refetch,
+  }),
+}));
+
+function collection(total: number): Collection<AccountingRuleConflict> {
+  return { data: [], found: total, limit: -1, total, totalValue: undefined };
+}
+
+let conflicts: Ref<Collection<AccountingRuleConflict>>;
+let onResolved: ReturnType<typeof vi.fn<() => void>>;
+let scope: ReturnType<typeof effectScope>;
+
+function resolution(): ReturnType<typeof useAccountingRuleConflictResolution> {
+  scope = effectScope();
+  return scope.run(() => useAccountingRuleConflictResolution({ onResolved }))!;
+}
+
+describe('modules/settings/accounting/rule/useAccountingRuleConflictResolution', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    conflicts = ref<Collection<AccountingRuleConflict>>(collection(3));
+    tableState.collection = conflicts;
+    onResolved = vi.fn<() => void>();
+    resolveAccountingRuleConflicts.mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('what is left to answer', () => {
+    it('should start with every conflict unanswered', () => {
+      const { remaining, resolutionLength } = resolution();
+
+      expect(get(resolutionLength)).toBe(0);
+      expect(get(remaining)).toBe(3);
+    });
+
+    it('should count down as conflicts are answered', () => {
+      const { modelResolution, remaining } = resolution();
+      set(modelResolution, { a: 'local', b: 'remote' });
+
+      expect(get(remaining)).toBe(1);
+    });
+  });
+
+  describe('what may be submitted', () => {
+    it('should refuse a resolution with nothing chosen', () => {
+      const { valid } = resolution();
+
+      expect(get(valid)).toBe(false);
+    });
+
+    it('should accept one conflict answered individually', () => {
+      const { modelResolution, valid } = resolution();
+      set(modelResolution, { a: 'local' });
+
+      expect(get(valid)).toBe(true);
+    });
+
+    it('should accept a resolve-everything strategy with nothing answered', () => {
+      const { modelSolveAllUsing, valid } = resolution();
+      set(modelSolveAllUsing, 'remote');
+
+      expect(get(valid)).toBe(true);
+    });
+  });
+
+  describe('submitting', () => {
+    it('should send exactly the conflicts the user answered', async () => {
+      const { modelResolution, save } = resolution();
+      set(modelResolution, { a: 'local', b: 'remote' });
+      await save();
+
+      expect(resolveAccountingRuleConflicts).toHaveBeenCalledWith({
+        conflicts: [
+          { localId: 'a', solveUsing: 'local' },
+          { localId: 'b', solveUsing: 'remote' },
+        ],
+      });
+    });
+
+    it('should send an empty list when nothing was answered', async () => {
+      const { save } = resolution();
+      await save();
+
+      expect(resolveAccountingRuleConflicts).toHaveBeenCalledWith({ conflicts: [] });
+    });
+
+    it('should send the strategy alone, discarding the individual answers', async () => {
+      const { modelResolution, modelSolveAllUsing, save } = resolution();
+      set(modelResolution, { a: 'local' });
+      set(modelSolveAllUsing, 'remote');
+      await save();
+
+      expect(resolveAccountingRuleConflicts).toHaveBeenCalledWith({ solveAllUsing: 'remote' });
+    });
+
+    it('should mark itself loading only while the submit is in flight', async () => {
+      const { loading, save } = resolution();
+
+      const pending = save();
+      expect(get(loading)).toBe(true);
+
+      await pending;
+      expect(get(loading)).toBe(false);
+    });
+
+    it('should tell the caller once it succeeds', async () => {
+      const { save } = resolution();
+      await save();
+
+      expect(onResolved).toHaveBeenCalledOnce();
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when submitting fails', () => {
+    beforeEach(() => {
+      resolveAccountingRuleConflicts.mockResolvedValue({ message: 'rule is gone', success: false });
+    });
+
+    it('should report the reason and leave the dialog open', async () => {
+      const { save } = resolution();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+      expect(onResolved).not.toHaveBeenCalled();
+    });
+
+    it('should include the backend message in the report', async () => {
+      const { save } = resolution();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ description: expect.stringContaining('rule is gone') }),
+      );
+    });
+
+    it('should stop loading so the user can try again', async () => {
+      const { loading, save } = resolution();
+      await save();
+
+      expect(get(loading)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-conflict-resolution.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-conflict-resolution.ts
@@ -1,0 +1,136 @@
+import type { TablePaginationData } from '@rotki/ui-library';
+import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import type { ConflictResolution } from '@/modules/assets/types';
+import type { Collection } from '@/modules/core/common/collection';
+import type { ConflictResolutionStrategy } from '@/modules/core/common/common-types';
+import type {
+  AccountingRuleConflict,
+  AccountingRuleConflictRequestPayload,
+  AccountingRuleConflictResolution,
+} from '@/modules/settings/types/accounting';
+import { getCollectionData } from '@/modules/core/common/data/collection-utils';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useServerTable } from '@/modules/core/table/use-server-table';
+import { useAccountingSettings } from '@/modules/settings/accounting/use-accounting-settings';
+
+interface UseAccountingRuleConflictResolutionOptions {
+  /** Called once every conflict has been resolved, so the caller can refresh and close. */
+  onResolved: () => void;
+}
+
+interface UseAccountingRuleConflictResolutionReturn {
+  /** The conflicts on the current page. */
+  collection: Ref<Collection<AccountingRuleConflict>>;
+  /** Whether the page is being read. */
+  isLoading: Ref<boolean>;
+  /** Whether a resolution is being submitted. */
+  loading: Readonly<Ref<boolean>>;
+  /** The per-conflict choices the user has made so far, keyed by local id. */
+  modelResolution: Ref<ConflictResolution>;
+  /**
+   * One strategy applied to every conflict at once.
+   *
+   * @remarks
+   * It overrides the per-conflict choices entirely, so setting it resolves conflicts the user never
+   * looked at. That is why it is a separate deliberate choice rather than a default.
+   */
+  modelSolveAllUsing: Ref<ConflictResolutionStrategy | undefined>;
+  /** Pagination for the conflicts table. */
+  pagination: WritableComputedRef<TablePaginationData>;
+  /** Re-reads the current page. */
+  refetch: () => Promise<void>;
+  /** How many conflicts are still unanswered. */
+  remaining: ComputedRef<number>;
+  /** How many conflicts the user has answered individually. */
+  resolutionLength: ComputedRef<number>;
+  /** Submits the resolution, reporting a failure as a message and leaving the dialog open. */
+  save: () => Promise<void>;
+  /** Whether there is anything to submit. */
+  valid: ComputedRef<boolean>;
+}
+
+/**
+ * Drives the accounting rule conflicts dialog: the conflicts table, the per-conflict and
+ * resolve-everything choices, and submitting them.
+ *
+ * @returns the table state, the resolution the user is building, and the submit
+ */
+export function useAccountingRuleConflictResolution(
+  options: UseAccountingRuleConflictResolutionOptions,
+): UseAccountingRuleConflictResolutionReturn {
+  const { onResolved } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const modelResolution = ref<ConflictResolution>({});
+  const modelSolveAllUsing = ref<ConflictResolutionStrategy>();
+  const loading = shallowRef<boolean>(false);
+
+  const { setMessage } = useMessageStore();
+  const { getAccountingRulesConflicts, resolveAccountingRuleConflicts } = useAccountingSettings();
+
+  const { collection, isLoading, pagination, refetch } = useServerTable<
+    AccountingRuleConflict,
+    AccountingRuleConflictRequestPayload
+  >({
+    fetch: getAccountingRulesConflicts,
+    urlState: { mode: 'route' },
+  });
+
+  const { total } = getCollectionData<AccountingRuleConflict>(collection);
+
+  const resolutionLength = computed<number>(() => Object.keys(get(modelResolution)).length);
+
+  const remaining = computed<number>(() => get(total) - get(resolutionLength));
+
+  const valid = computed<boolean>(() => !!get(modelSolveAllUsing) || get(resolutionLength) > 0);
+
+  function buildPayload(): AccountingRuleConflictResolution {
+    const solveAllVal = get(modelSolveAllUsing);
+    if (solveAllVal)
+      return { solveAllUsing: solveAllVal };
+
+    const resolutionVal = get(modelResolution);
+    const conflicts = Object.keys(resolutionVal).map(localId => ({
+      localId,
+      solveUsing: resolutionVal[localId],
+    }));
+
+    return { conflicts };
+  }
+
+  async function save(): Promise<void> {
+    set(loading, true);
+
+    const result = await resolveAccountingRuleConflicts(buildPayload());
+
+    if (result.success) {
+      onResolved();
+    }
+    else {
+      setMessage({
+        description: t('accounting_settings.rule.conflicts.error.description', {
+          error: result.message,
+        }),
+        success: false,
+        title: t('accounting_settings.rule.conflicts.error.title'),
+      });
+    }
+
+    set(loading, false);
+  }
+
+  return {
+    collection,
+    isLoading,
+    loading: readonly(loading),
+    modelResolution,
+    modelSolveAllUsing,
+    pagination,
+    refetch,
+    remaining,
+    resolutionLength,
+    save,
+    valid,
+  };
+}

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.spec.ts
@@ -1,0 +1,141 @@
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { Blockchain } from '@rotki/common';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import BlockchainRpcNodeManager from '@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue';
+import RowActions from '@/modules/shell/components/RowActions.vue';
+
+let connectedNodes: Ref<Record<string, string[]>>;
+let coolingDownNodes: Ref<Record<string, string[]>>;
+let failedToConnect: Ref<Record<string, string[]>>;
+
+const { deleteEvmNode, editEvmNode, fetchEvmNodes, reConnectNode } = vi.hoisted(() => ({
+  deleteEvmNode: vi.fn(async () => Promise.resolve(true)),
+  editEvmNode: vi.fn(async () => Promise.resolve(true)),
+  fetchEvmNodes: vi.fn(),
+  reConnectNode: vi.fn(async () => Promise.resolve(true)),
+}));
+
+vi.mock('@/modules/settings/api/use-evm-nodes-api', () => ({
+  useEvmNodesApi: (): Record<string, unknown> => ({
+    deleteEvmNode,
+    editEvmNode,
+    fetchEvmNodes,
+    reConnectNode,
+  }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): Record<string, unknown> => ({ notify: vi.fn() }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({
+    useChainName: (): Ref<string> => ref('Ethereum'),
+  }),
+}));
+
+vi.mock('@/modules/session/use-session-metadata-store', () => ({
+  useSessionMetadataStore: (): Record<string, unknown> => ({
+    connectedNodes,
+    coolingDownNodes,
+    failedToConnect,
+  }),
+}));
+
+function node(overrides: Partial<BlockchainRpcNode> = {}): BlockchainRpcNode {
+  return {
+    active: true,
+    blockchain: 'eth',
+    endpoint: 'https://example.com',
+    identifier: 1,
+    name: 'my node',
+    owned: true,
+    weight: 50,
+    ...overrides,
+  };
+}
+
+async function createWrapper(nodes: BlockchainRpcNode[]): Promise<VueWrapper> {
+  fetchEvmNodes.mockResolvedValue(nodes);
+  const wrapper = mount(BlockchainRpcNodeManager, {
+    global: {
+      plugins: [createCustomPinia()],
+      stubs: { BlockchainRpcNodeFormDialog: true, RpcNodeStatusCell: true, RpcReconnectButton: true },
+    },
+    props: { chain: Blockchain.ETH },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('modules/settings/general/rpc/BlockchainRpcNodeManager.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectedNodes = ref<Record<string, string[]>>({});
+    coolingDownNodes = ref<Record<string, string[]>>({});
+    failedToConnect = ref<Record<string, string[]>>({});
+  });
+
+  it('should read the nodes when it opens', async () => {
+    await createWrapper([]);
+
+    expect(fetchEvmNodes).toHaveBeenCalledOnce();
+  });
+
+  it('should render one row per node', async () => {
+    const wrapper = await createWrapper([node({ identifier: 1, name: 'first' }), node({ identifier: 2, name: 'second' })]);
+
+    expect(wrapper.findAll('[data-testid=ethereum-node]')).toHaveLength(2);
+  });
+
+  it('should show the etherscan label in place of an endpoint', async () => {
+    const wrapper = await createWrapper([node({ endpoint: '', name: 'etherscan' })]);
+
+    expect(wrapper.text()).toContain('evm_rpc_node_manager.etherscan');
+  });
+
+  it('should not let the etherscan entry be deleted or switched off', async () => {
+    const wrapper = await createWrapper([node({ endpoint: '', name: 'etherscan' })]);
+
+    expect(wrapper.findComponent(RowActions).props('deleteDisabled')).toBe(true);
+    expect(wrapper.find('[data-testid=node-active] input').attributes('disabled')).toBeDefined();
+  });
+
+  it('should let an ordinary node be deleted', async () => {
+    const wrapper = await createWrapper([node()]);
+
+    expect(wrapper.findComponent(RowActions).props('deleteDisabled')).toBe(false);
+  });
+
+  it('should ask before deleting, and delete nothing until confirmed', async () => {
+    const wrapper = await createWrapper([node({ identifier: 8 })]);
+
+    wrapper.findComponent(RowActions).vm.$emit('delete-click');
+    await flushPromises();
+
+    expect(get(useConfirmStore().visible)).toBe(true);
+    expect(deleteEvmNode).not.toHaveBeenCalled();
+  });
+
+  it('should offer reconnect-all only while an active node is disconnected', async () => {
+    const disconnected = await createWrapper([node({ active: true })]);
+    expect(disconnected.find('[data-testid=reconnect-all]').exists()).toBe(true);
+
+    set(connectedNodes, { eth: ['my node'] });
+    const connected = await createWrapper([node({ active: true })]);
+    expect(connected.find('[data-testid=reconnect-all]').exists()).toBe(false);
+  });
+
+  it('should send the node when its switch is toggled', async () => {
+    const wrapper = await createWrapper([node({ identifier: 4 })]);
+
+    await wrapper.find('[data-testid=node-active] input').setValue(false);
+    await flushPromises();
+
+    expect(editEvmNode).toHaveBeenCalledWith(expect.objectContaining({ active: false, identifier: 4 }));
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
@@ -1,23 +1,9 @@
 <script setup lang="ts">
 import type { Blockchain } from '@rotki/common';
-import { camelCase } from 'es-toolkit';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
-import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
-import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
-import { useEvmNodesApi } from '@/modules/settings/api/use-evm-nodes-api';
 import BlockchainRpcNodeFormDialog from '@/modules/settings/general/rpc/BlockchainRpcNodeFormDialog.vue';
-import { NODE_STATUS, type NodeStatus } from '@/modules/settings/general/rpc/rpc-node-status';
 import RpcNodeStatusCell from '@/modules/settings/general/rpc/RpcNodeStatusCell.vue';
 import RpcReconnectButton from '@/modules/settings/general/rpc/RpcReconnectButton.vue';
-import {
-  type BlockchainRpcNode,
-  type BlockchainRpcNodeList,
-  type BlockchainRpcNodeManageState,
-  getPlaceholderNode,
-} from '@/modules/settings/types/rpc';
+import { useBlockchainRpcNodeManager } from '@/modules/settings/general/rpc/use-blockchain-rpc-node-manager';
 import RowActions from '@/modules/shell/components/RowActions.vue';
 import SimpleTable from '@/modules/shell/components/SimpleTable.vue';
 
@@ -27,137 +13,20 @@ const { chain } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const nodes = ref<BlockchainRpcNodeList>([]);
-const state = ref<BlockchainRpcNodeManageState>();
-const reconnecting = ref<boolean>(false);
-
-const { notify } = useNotificationDispatcher();
-const { setMessage } = useMessageStore();
-
-const { connectedNodes, coolingDownNodes, failedToConnect } = storeToRefs(useSessionMetadataStore());
-const { show } = useConfirmStore();
-const { useChainName } = useSupportedChains();
-const api = useEvmNodesApi(() => chain);
-
-const chainName = useChainName(() => chain);
-const anyDisconnected = computed(() => get(nodes).some(node => !isNodeConnected(node) && node.active));
-
-async function loadNodes(): Promise<void> {
-  try {
-    set(nodes, await api.fetchEvmNodes());
-  }
-  catch (error: unknown) {
-    notify({
-      message: getErrorMessage(error),
-      title: t('evm_rpc_node_manager.loading_error.title', {
-        chain,
-      }),
-    });
-  }
-}
-
-function editRpcNode(node: BlockchainRpcNode) {
-  set(state, {
-    mode: 'edit',
-    node,
-  });
-}
-
-function addNewRpcNode() {
-  set(state, {
-    mode: 'add',
-    node: getPlaceholderNode(chain),
-  });
-}
-
-async function deleteNode(node: BlockchainRpcNode) {
-  try {
-    const identifier = node.identifier;
-    await api.deleteEvmNode(identifier);
-    await loadNodes();
-  }
-  catch (error: unknown) {
-    setMessage({
-      description: getErrorMessage(error),
-      success: false,
-      title: t('evm_rpc_node_manager.delete_error.title', {
-        chain,
-      }),
-    });
-  }
-}
-
-async function onActiveChange(active: boolean, node: BlockchainRpcNode) {
-  const state = { ...node, active };
-  try {
-    await api.editEvmNode(state);
-    await loadNodes();
-  }
-  catch (error: unknown) {
-    setMessage({
-      description: getErrorMessage(error),
-      success: false,
-      title: t('evm_rpc_node_manager.activate_error.title', {
-        node: node.name,
-      }),
-    });
-  }
-}
-
-function isEtherscan(item: BlockchainRpcNode) {
-  return !item.endpoint && item.name.includes('etherscan');
-}
-
-function isNodeInDataset(dataset: Record<string, string[]>, item: BlockchainRpcNode): boolean {
-  const blockchain = camelCase(chain);
-  const nodes = dataset?.[blockchain] || [];
-  return nodes.includes(item.name);
-}
-
-function isNodeConnected(item: BlockchainRpcNode): boolean {
-  return isEtherscan(item) || isNodeInDataset(get(connectedNodes), item);
-}
-
-function getNodeStatus(item: BlockchainRpcNode): NodeStatus {
-  if (isNodeInDataset(get(coolingDownNodes), item)) {
-    return NODE_STATUS.COOLING_DOWN;
-  }
-
-  if (isNodeConnected(item)) {
-    return NODE_STATUS.CONNECTED;
-  }
-
-  if (isNodeInDataset(get(failedToConnect), item)) {
-    return NODE_STATUS.FAILED;
-  }
-
-  return NODE_STATUS.READY;
-}
-
-function showDeleteConfirmation(item: BlockchainRpcNode) {
-  const chainProp = get(chainName);
-  show(
-    {
-      message: t('evm_rpc_node_manager.confirm.message', {
-        chain: chainProp,
-        endpoint: item.endpoint,
-        node: item.name,
-      }),
-      title: t('evm_rpc_node_manager.confirm.title', { chain: chainProp }),
-    },
-    () => deleteNode(item),
-  );
-}
-
-async function reConnect(identifier?: number) {
-  set(reconnecting, true);
-  const success = await api.reConnectNode(identifier);
-  set(reconnecting, false);
-
-  if (success) {
-    await loadNodes();
-  }
-}
+const {
+  addNewRpcNode,
+  anyDisconnected,
+  editRpcNode,
+  getNodeStatus,
+  isEtherscan,
+  loadNodes,
+  modelState,
+  nodes,
+  onActiveChange,
+  reConnect,
+  reconnecting,
+  showDeleteConfirmation,
+} = useBlockchainRpcNodeManager(() => chain);
 
 onMounted(async () => {
   await loadNodes();
@@ -181,6 +50,7 @@ defineExpose({
                 v-if="anyDisconnected"
                 :disabled="reconnecting"
                 :tooltip="t('evm_rpc_node_manager.reconnect.all')"
+                data-testid="reconnect-all"
                 @reconnect="reConnect()"
               />
             </div>
@@ -276,6 +146,7 @@ defineExpose({
               class="mr-4"
               :model-value="item.active"
               :disabled="isEtherscan(item)"
+              data-testid="node-active"
               @update:model-value="onActiveChange($event, item)"
             />
             <RowActions
@@ -291,7 +162,7 @@ defineExpose({
     </tbody>
   </SimpleTable>
   <BlockchainRpcNodeFormDialog
-    v-model="state"
+    v-model="modelState"
     @complete="loadNodes()"
   />
 </template>

--- a/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.spec.ts
@@ -1,0 +1,321 @@
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { Blockchain } from '@rotki/common';
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { NODE_STATUS } from '@/modules/settings/general/rpc/rpc-node-status';
+import { useBlockchainRpcNodeManager } from './use-blockchain-rpc-node-manager';
+
+let connectedNodes: Ref<Record<string, string[]>>;
+let coolingDownNodes: Ref<Record<string, string[]>>;
+let failedToConnect: Ref<Record<string, string[]>>;
+let scope: ReturnType<typeof effectScope>;
+
+const {
+  chainGivenToApi,
+  chainGivenToChainName,
+  deleteEvmNode,
+  editEvmNode,
+  fetchEvmNodes,
+  notify,
+  reConnectNode,
+  setMessage,
+} = vi.hoisted(() => ({
+  chainGivenToApi: vi.fn(),
+  chainGivenToChainName: vi.fn(),
+  deleteEvmNode: vi.fn(async () => Promise.resolve(true)),
+  editEvmNode: vi.fn(async () => Promise.resolve(true)),
+  fetchEvmNodes: vi.fn(),
+  notify: vi.fn(),
+  reConnectNode: vi.fn(async () => Promise.resolve(true)),
+  setMessage: vi.fn(),
+}));
+
+vi.mock('@/modules/settings/api/use-evm-nodes-api', () => ({
+  useEvmNodesApi: (chain: () => string): Record<string, unknown> => {
+    chainGivenToApi(chain());
+    return {
+      deleteEvmNode,
+      editEvmNode,
+      fetchEvmNodes,
+      reConnectNode,
+    };
+  },
+}));
+
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): Record<string, unknown> => ({ notify }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({
+    useChainName: (chain: () => string): Ref<string> => {
+      chainGivenToChainName(chain());
+      return ref('Ethereum');
+    },
+  }),
+}));
+
+vi.mock('@/modules/session/use-session-metadata-store', () => ({
+  useSessionMetadataStore: (): Record<string, unknown> => ({
+    connectedNodes,
+    coolingDownNodes,
+    failedToConnect,
+  }),
+}));
+
+function node(overrides: Partial<BlockchainRpcNode> = {}): BlockchainRpcNode {
+  return {
+    active: true,
+    blockchain: 'eth',
+    endpoint: 'https://example.com',
+    identifier: 1,
+    name: 'my node',
+    owned: true,
+    weight: 50,
+    ...overrides,
+  };
+}
+
+function manager(): ReturnType<typeof useBlockchainRpcNodeManager> {
+  scope = effectScope();
+  return scope.run(() => useBlockchainRpcNodeManager(Blockchain.ETH))!;
+}
+
+describe('modules/settings/general/rpc/useBlockchainRpcNodeManager', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    connectedNodes = ref<Record<string, string[]>>({});
+    coolingDownNodes = ref<Record<string, string[]>>({});
+    failedToConnect = ref<Record<string, string[]>>({});
+    fetchEvmNodes.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('reading the nodes', () => {
+    it('should scope the api and the chain name to the chain it was given', () => {
+      manager();
+
+      expect(chainGivenToApi).toHaveBeenCalledWith('eth');
+      expect(chainGivenToChainName).toHaveBeenCalledWith('eth');
+    });
+
+    it('should read them for the chain it manages', async () => {
+      fetchEvmNodes.mockResolvedValue([node({ name: 'first' })]);
+
+      const { loadNodes, nodes } = manager();
+      await loadNodes();
+
+      expect(get(nodes)).toHaveLength(1);
+      expect(get(nodes)[0].name).toBe('first');
+    });
+
+    it('should report a failure as a notification rather than a message', async () => {
+      fetchEvmNodes.mockRejectedValue(new Error('backend is down'));
+
+      const { loadNodes, nodes } = manager();
+      await loadNodes();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'backend is down' }));
+      expect(setMessage).not.toHaveBeenCalled();
+      expect(get(nodes)).toHaveLength(0);
+    });
+  });
+
+  describe('the etherscan entry', () => {
+    it('should recognise it by having no endpoint', () => {
+      const { isEtherscan } = manager();
+
+      expect(isEtherscan(node({ endpoint: '', name: 'etherscan' }))).toBe(true);
+    });
+
+    it.each([
+      ['it has an endpoint', node({ endpoint: 'https://example.com', name: 'etherscan' })],
+      ['it is not named etherscan', node({ endpoint: '', name: 'my node' })],
+    ])('should not recognise a node when %s', (_case, item) => {
+      const { isEtherscan } = manager();
+
+      expect(isEtherscan(item)).toBe(false);
+    });
+
+    it('should treat it as connected without it appearing in the connected set', () => {
+      const { getNodeStatus } = manager();
+
+      expect(getNodeStatus(node({ endpoint: '', name: 'etherscan' }))).toBe(NODE_STATUS.CONNECTED);
+    });
+  });
+
+  describe('connectivity', () => {
+    it('should read the chain key in camel case', () => {
+      set(connectedNodes, { eth: ['my node'] });
+
+      const { getNodeStatus } = manager();
+
+      expect(getNodeStatus(node())).toBe(NODE_STATUS.CONNECTED);
+    });
+
+    it('should rank cooling down above connected', () => {
+      set(connectedNodes, { eth: ['my node'] });
+      set(coolingDownNodes, { eth: ['my node'] });
+
+      const { getNodeStatus } = manager();
+
+      expect(getNodeStatus(node())).toBe(NODE_STATUS.COOLING_DOWN);
+    });
+
+    it('should report a node that failed to connect', () => {
+      set(failedToConnect, { eth: ['my node'] });
+
+      const { getNodeStatus } = manager();
+
+      expect(getNodeStatus(node())).toBe(NODE_STATUS.FAILED);
+    });
+
+    it('should report a node no set mentions as ready', () => {
+      const { getNodeStatus } = manager();
+
+      expect(getNodeStatus(node())).toBe(NODE_STATUS.READY);
+    });
+
+    it('should offer reconnect-all while an active node is disconnected', async () => {
+      fetchEvmNodes.mockResolvedValue([node({ active: true })]);
+
+      const { anyDisconnected, loadNodes } = manager();
+      await loadNodes();
+
+      expect(get(anyDisconnected)).toBe(true);
+    });
+
+    it('should not offer reconnect-all for a disconnected node that is switched off', async () => {
+      fetchEvmNodes.mockResolvedValue([node({ active: false })]);
+
+      const { anyDisconnected, loadNodes } = manager();
+      await loadNodes();
+
+      expect(get(anyDisconnected)).toBe(false);
+    });
+  });
+
+  describe('the add and edit form', () => {
+    it('should open a blank node for this chain to add', () => {
+      const { addNewRpcNode, modelState } = manager();
+      addNewRpcNode();
+
+      expect(get(modelState)).toEqual({
+        mode: 'add',
+        node: expect.objectContaining({ blockchain: 'eth', identifier: -1, name: '' }),
+      });
+    });
+
+    it('should open an existing node to edit', () => {
+      const existing = node({ identifier: 9 });
+
+      const { editRpcNode, modelState } = manager();
+      editRpcNode(existing);
+
+      expect(get(modelState)).toEqual({ mode: 'edit', node: existing });
+    });
+  });
+
+  describe('activating a node', () => {
+    it('should send the node with its new active flag and re-read the list', async () => {
+      const { onActiveChange } = manager();
+      await onActiveChange(false, node({ identifier: 4 }));
+
+      expect(editEvmNode).toHaveBeenCalledWith(expect.objectContaining({ active: false, identifier: 4 }));
+      expect(fetchEvmNodes).toHaveBeenCalledOnce();
+    });
+
+    it('should report a failure and not re-read the list', async () => {
+      editEvmNode.mockRejectedValue(new Error('rejected'));
+
+      const { onActiveChange } = manager();
+      await onActiveChange(false, node({ name: 'my node' }));
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+      expect(fetchEvmNodes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleting a node', () => {
+    it('should delete nothing until the dialog is confirmed', () => {
+      const { showDeleteConfirmation } = manager();
+      showDeleteConfirmation(node({ identifier: 3 }));
+
+      expect(get(useConfirmStore().visible)).toBe(true);
+      expect(deleteEvmNode).not.toHaveBeenCalled();
+    });
+
+    it('should delete exactly the node the dialog named', async () => {
+      const { showDeleteConfirmation } = manager();
+      showDeleteConfirmation(node({ identifier: 3 }));
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(deleteEvmNode).toHaveBeenCalledWith(3);
+      expect(deleteEvmNode).toHaveBeenCalledOnce();
+      expect(fetchEvmNodes).toHaveBeenCalledOnce();
+    });
+
+    it('should delete nothing when the dialog is dismissed', async () => {
+      const { showDeleteConfirmation } = manager();
+      showDeleteConfirmation(node({ identifier: 3 }));
+      await useConfirmStore().dismiss();
+      await flushPromises();
+
+      expect(deleteEvmNode).not.toHaveBeenCalled();
+    });
+
+    it('should report a failure and not re-read the list', async () => {
+      deleteEvmNode.mockRejectedValue(new Error('still in use'));
+
+      const { showDeleteConfirmation } = manager();
+      showDeleteConfirmation(node({ identifier: 3 }));
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+      expect(fetchEvmNodes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reconnecting', () => {
+    it('should reconnect one node and re-read the list', async () => {
+      const { reConnect, reconnecting } = manager();
+      const pending = reConnect(6);
+      expect(get(reconnecting)).toBe(true);
+
+      await pending;
+
+      expect(reConnectNode).toHaveBeenCalledWith(6);
+      expect(get(reconnecting)).toBe(false);
+      expect(fetchEvmNodes).toHaveBeenCalledOnce();
+    });
+
+    it('should reconnect every node when given no identifier', async () => {
+      const { reConnect } = manager();
+      await reConnect();
+
+      expect(reConnectNode).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should not re-read the list when the reconnect fails', async () => {
+      reConnectNode.mockResolvedValue(false);
+
+      const { reConnect, reconnecting } = manager();
+      await reConnect(6);
+
+      expect(fetchEvmNodes).not.toHaveBeenCalled();
+      expect(get(reconnecting)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
@@ -1,0 +1,206 @@
+import type { Blockchain } from '@rotki/common';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { camelCase } from 'es-toolkit';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
+import { useEvmNodesApi } from '@/modules/settings/api/use-evm-nodes-api';
+import { NODE_STATUS, type NodeStatus } from '@/modules/settings/general/rpc/rpc-node-status';
+import {
+  type BlockchainRpcNode,
+  type BlockchainRpcNodeList,
+  type BlockchainRpcNodeManageState,
+  getPlaceholderNode,
+} from '@/modules/settings/types/rpc';
+
+interface UseBlockchainRpcNodeManagerReturn {
+  /** Opens the form on a blank node for this chain. */
+  addNewRpcNode: () => void;
+  /** Whether any active node is not currently connected, which is what offers "reconnect all". */
+  anyDisconnected: ComputedRef<boolean>;
+  /** Opens the form on an existing node. */
+  editRpcNode: (node: BlockchainRpcNode) => void;
+  /** The connectivity a row should show for a node. */
+  getNodeStatus: (item: BlockchainRpcNode) => NodeStatus;
+  /**
+   * Whether a node is the built-in etherscan entry.
+   *
+   * @remarks
+   * It has no endpoint of its own and cannot be deleted or deactivated, so rows use this to
+   * disable those controls.
+   */
+  isEtherscan: (item: BlockchainRpcNode) => boolean;
+  /** Reads the chain's nodes, reporting a failure as a notification rather than a message. */
+  loadNodes: () => Promise<void>;
+  /** The form's node, or undefined while the form is closed. */
+  modelState: Ref<BlockchainRpcNodeManageState | undefined>;
+  /** The chain's nodes, in the order the backend returns them. */
+  nodes: Readonly<Ref<BlockchainRpcNodeList>>;
+  /** Activates or deactivates a node, then re-reads the list. */
+  onActiveChange: (active: boolean, node: BlockchainRpcNode) => Promise<void>;
+  /** Reconnects one node, or every node when given no identifier. */
+  reConnect: (identifier?: number) => Promise<void>;
+  /** Whether a reconnect is in flight. */
+  reconnecting: Readonly<Ref<boolean>>;
+  /**
+   * Asks for confirmation before removing a node.
+   *
+   * @remarks
+   * Removing a node is not undoable, so nothing is deleted until the dialog is confirmed.
+   */
+  showDeleteConfirmation: (item: BlockchainRpcNode) => void;
+}
+
+/**
+ * Drives the per-chain RPC node table: reading the nodes, their connectivity, and the add, edit,
+ * activate, reconnect and delete actions on them.
+ *
+ * @param chain - the chain whose nodes are managed
+ * @returns the table state and every action its rows offer
+ */
+export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>): UseBlockchainRpcNodeManagerReturn {
+  const nodes = ref<BlockchainRpcNodeList>([]);
+  const modelState = ref<BlockchainRpcNodeManageState>();
+  const reconnecting = shallowRef<boolean>(false);
+
+  const { t } = useI18n({ useScope: 'global' });
+  const { notify } = useNotificationDispatcher();
+  const { setMessage } = useMessageStore();
+  const { connectedNodes, coolingDownNodes, failedToConnect } = storeToRefs(useSessionMetadataStore());
+  const { show } = useConfirmStore();
+  const { useChainName } = useSupportedChains();
+  const api = useEvmNodesApi(() => toValue(chain));
+
+  const chainName = useChainName(() => toValue(chain));
+
+  function isEtherscan(item: BlockchainRpcNode): boolean {
+    return !item.endpoint && item.name.includes('etherscan');
+  }
+
+  function isNodeInDataset(dataset: Record<string, string[]>, item: BlockchainRpcNode): boolean {
+    const blockchain = camelCase(toValue(chain));
+    const nodes = dataset?.[blockchain] || [];
+    return nodes.includes(item.name);
+  }
+
+  function isNodeConnected(item: BlockchainRpcNode): boolean {
+    return isEtherscan(item) || isNodeInDataset(get(connectedNodes), item);
+  }
+
+  function getNodeStatus(item: BlockchainRpcNode): NodeStatus {
+    if (isNodeInDataset(get(coolingDownNodes), item))
+      return NODE_STATUS.COOLING_DOWN;
+
+    if (isNodeConnected(item))
+      return NODE_STATUS.CONNECTED;
+
+    if (isNodeInDataset(get(failedToConnect), item))
+      return NODE_STATUS.FAILED;
+
+    return NODE_STATUS.READY;
+  }
+
+  const anyDisconnected = computed<boolean>(() => get(nodes).some(node => !isNodeConnected(node) && node.active));
+
+  async function loadNodes(): Promise<void> {
+    try {
+      set(nodes, await api.fetchEvmNodes());
+    }
+    catch (error: unknown) {
+      notify({
+        message: getErrorMessage(error),
+        title: t('evm_rpc_node_manager.loading_error.title', {
+          chain: toValue(chain),
+        }),
+      });
+    }
+  }
+
+  function editRpcNode(node: BlockchainRpcNode): void {
+    set(modelState, {
+      mode: 'edit',
+      node,
+    });
+  }
+
+  function addNewRpcNode(): void {
+    set(modelState, {
+      mode: 'add',
+      node: getPlaceholderNode(toValue(chain)),
+    });
+  }
+
+  async function deleteNode(node: BlockchainRpcNode): Promise<void> {
+    try {
+      await api.deleteEvmNode(node.identifier);
+      await loadNodes();
+    }
+    catch (error: unknown) {
+      setMessage({
+        description: getErrorMessage(error),
+        success: false,
+        title: t('evm_rpc_node_manager.delete_error.title', {
+          chain: toValue(chain),
+        }),
+      });
+    }
+  }
+
+  async function onActiveChange(active: boolean, node: BlockchainRpcNode): Promise<void> {
+    try {
+      await api.editEvmNode({ ...node, active });
+      await loadNodes();
+    }
+    catch (error: unknown) {
+      setMessage({
+        description: getErrorMessage(error),
+        success: false,
+        title: t('evm_rpc_node_manager.activate_error.title', {
+          node: node.name,
+        }),
+      });
+    }
+  }
+
+  function showDeleteConfirmation(item: BlockchainRpcNode): void {
+    const chainProp = get(chainName);
+    show(
+      {
+        message: t('evm_rpc_node_manager.confirm.message', {
+          chain: chainProp,
+          endpoint: item.endpoint,
+          node: item.name,
+        }),
+        title: t('evm_rpc_node_manager.confirm.title', { chain: chainProp }),
+      },
+      async () => deleteNode(item),
+    );
+  }
+
+  async function reConnect(identifier?: number): Promise<void> {
+    set(reconnecting, true);
+    const success = await api.reConnectNode(identifier);
+    set(reconnecting, false);
+
+    if (success)
+      await loadNodes();
+  }
+
+  return {
+    addNewRpcNode,
+    anyDisconnected,
+    editRpcNode,
+    getNodeStatus,
+    isEtherscan,
+    loadNodes,
+    modelState,
+    nodes: shallowReadonly(nodes),
+    onActiveChange,
+    reConnect,
+    reconnecting: readonly(reconnecting),
+    showDeleteConfirmation,
+  };
+}

--- a/frontend/app/src/modules/shell/sync-progress/SyncIndicator.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/SyncIndicator.spec.ts
@@ -1,0 +1,160 @@
+import type { DatabaseUploadProgress, DbUploadResult } from '@/modules/core/messaging/types';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref, shallowRef } from 'vue';
+import { SYNC_UPLOAD, type SyncAction } from '@/modules/session/sync';
+import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
+import MenuTooltipButton from '@/modules/shell/components/MenuTooltipButton.vue';
+import SyncIndicator from '@/modules/shell/sync-progress/SyncIndicator.vue';
+
+let cloudBackupAllowed: Ref<boolean>;
+let syncAction: Ref<SyncAction | undefined>;
+let uploadProgress: Ref<DatabaseUploadProgress | undefined>;
+let uploadStatus: Ref<DbUploadResult | null>;
+let displaySyncConfirmation: Ref<boolean>;
+let confirmChecked: Ref<boolean>;
+let isSyncing: Ref<boolean>;
+let premium: Ref<boolean>;
+
+const { cancelSync, forceSync, showSyncConfirmation } = vi.hoisted(() => ({
+  cancelSync: vi.fn(),
+  forceSync: vi.fn(async () => Promise.resolve()),
+  showSyncConfirmation: vi.fn(),
+}));
+
+vi.mock('@/modules/session/use-session-sync', () => ({
+  useSync: (): Record<string, unknown> => ({
+    cancelSync,
+    clearUploadStatus: vi.fn(),
+    confirmChecked,
+    displaySyncConfirmation,
+    forceSync,
+    showSyncConfirmation,
+    syncAction,
+    uploadProgress,
+    uploadStatus,
+  }),
+}));
+
+vi.mock('@/modules/premium/use-feature-access', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/premium/use-feature-access')>(
+    '@/modules/premium/use-feature-access',
+  );
+  return {
+    ...actual,
+    useFeatureAccess: (): Record<string, unknown> => ({ allowed: cloudBackupAllowed }),
+  };
+});
+
+vi.mock('@/modules/premium/use-premium-store', () => ({
+  usePremiumStore: (): Record<string, unknown> => ({
+    premium,
+    premiumSync: ref<boolean>(false),
+  }),
+}));
+
+vi.mock('@/modules/session/use-session-metadata-store', () => ({
+  useSessionMetadataStore: (): Record<string, unknown> => ({
+    lastDataUpload: ref<number>(),
+  }),
+}));
+
+vi.mock('@/modules/task-center/use-native-task', () => ({
+  useNativeTask: (): Record<string, unknown> => ({ cancelActivity: vi.fn() }),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', () => ({
+  useTaskCenter: (): Record<string, unknown> => ({ useIsActive: (): Ref<boolean> => isSyncing }),
+}));
+
+vi.mock('@/modules/auth/use-logout', () => ({
+  useLogout: (): Record<string, unknown> => ({ logout: vi.fn() }),
+}));
+
+vi.mock('@/modules/shell/layout/use-links', () => ({
+  useLinks: (): Record<string, unknown> => ({ href: ref('https://rotki.com'), onLinkClick: vi.fn() }),
+}));
+
+function createWrapper(): VueWrapper {
+  return mount(SyncIndicator, {
+    global: {
+      plugins: [createCustomPinia()],
+      stubs: {
+        AskUserUponSizeDiscrepancySetting: true,
+        ConfirmDialog: true,
+        DateDisplay: true,
+        MenuTooltipButton: true,
+        SyncButtons: true,
+        SyncSettings: true,
+        SyncUploadStatusAlert: true,
+      },
+    },
+  });
+}
+
+describe('modules/shell/sync-progress/SyncIndicator.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cloudBackupAllowed = ref<boolean>(true);
+    syncAction = shallowRef<SyncAction>(SYNC_UPLOAD);
+    uploadProgress = ref<DatabaseUploadProgress>();
+    uploadStatus = ref<DbUploadResult | null>(null);
+    displaySyncConfirmation = ref<boolean>(false);
+    confirmChecked = ref<boolean>(false);
+    isSyncing = ref<boolean>(false);
+    premium = ref<boolean>(true);
+  });
+
+  it('should keep the confirmed action disabled until the box is ticked', async () => {
+    const wrapper = createWrapper();
+    const dialog = wrapper.findComponent(ConfirmDialog);
+
+    expect(dialog.props('disabled')).toBe(true);
+
+    set(confirmChecked, true);
+    await flushPromises();
+
+    expect(dialog.props('disabled')).toBe(false);
+  });
+
+  it('should sync nothing while the dialog only sits there', () => {
+    createWrapper();
+
+    expect(forceSync).not.toHaveBeenCalled();
+  });
+
+  it('should sync when the dialog is confirmed', async () => {
+    const wrapper = createWrapper();
+
+    wrapper.findComponent(ConfirmDialog).vm.$emit('confirm');
+    await flushPromises();
+
+    expect(forceSync).toHaveBeenCalledOnce();
+  });
+
+  it('should sync nothing when the dialog is cancelled', async () => {
+    const wrapper = createWrapper();
+
+    wrapper.findComponent(ConfirmDialog).vm.$emit('cancel');
+    await flushPromises();
+
+    expect(cancelSync).toHaveBeenCalledOnce();
+    expect(forceSync).not.toHaveBeenCalled();
+  });
+
+  it('should offer the upgrade link instead of the menu without premium', () => {
+    set(premium, false);
+
+    const wrapper = createWrapper();
+
+    expect(wrapper.find('#balances-saved-dropdown').exists()).toBe(false);
+    expect(wrapper.findComponent(MenuTooltipButton).props('tooltip')).toBe('sync_indicator.menu_tooltip');
+  });
+
+  it('should offer the menu with premium', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.find('#balances-saved-dropdown').exists()).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/shell/sync-progress/SyncIndicator.vue
+++ b/frontend/app/src/modules/shell/sync-progress/SyncIndicator.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
-import { useLogout } from '@/modules/auth/use-logout';
-import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
 import { usePremiumStore } from '@/modules/premium/use-premium-store';
-import { SYNC_DOWNLOAD, SYNC_UPLOAD, type SyncAction } from '@/modules/session/sync';
 import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
-import { useSync } from '@/modules/session/use-session-sync';
 import AskUserUponSizeDiscrepancySetting from '@/modules/settings/general/AskUserUponSizeDiscrepancySetting.vue';
 import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
@@ -13,163 +9,46 @@ import { useLinks } from '@/modules/shell/layout/use-links';
 import SyncButtons from '@/modules/shell/sync-progress/SyncButtons.vue';
 import SyncSettings from '@/modules/shell/sync-progress/SyncSettings.vue';
 import SyncUploadStatusAlert from '@/modules/shell/sync-progress/SyncUploadStatusAlert.vue';
-import { ActivityKind } from '@/modules/task-center/core/types';
-import { useNativeTask } from '@/modules/task-center/use-native-task';
-import { useTaskCenter } from '@/modules/task-center/use-task-center';
-
-const syncSettingMenuOpen = ref<boolean>(false);
-const pending = ref<boolean>(false);
-const visible = ref<boolean>(false);
+import { useSyncIndicator } from '@/modules/shell/sync-progress/use-sync-indicator';
 
 const { t } = useI18n({ useScope: 'global' });
 
 const { premium, premiumSync } = storeToRefs(usePremiumStore());
 const { lastDataUpload } = storeToRefs(useSessionMetadataStore());
-const { allowed: cloudBackupAllowed } = useFeatureAccess(PremiumFeature.CLOUD_BACKUP);
-
-const {
-  cancelSync,
-  clearUploadStatus,
-  confirmChecked,
-  displaySyncConfirmation,
-  forceSync,
-  showSyncConfirmation,
-  syncAction,
-  uploadProgress,
-  uploadStatus,
-} = useSync();
-const { cancelActivity } = useNativeTask();
-const { useIsActive } = useTaskCenter();
-const { logout } = useLogout();
 const { href, onLinkClick } = useLinks();
 
-const isSyncing = useIsActive(ActivityKind.SYNC);
-
-const isDownload = computed<boolean>(() => get(syncAction) === SYNC_DOWNLOAD);
-
-const textChoice = computed<number>(() => (get(syncAction) === SYNC_UPLOAD ? 1 : 2));
-
-const message = computed<string>(() =>
-  get(syncAction) === SYNC_UPLOAD
-    ? t('sync_indicator.upload_confirmation.message_upload')
-    : t('sync_indicator.upload_confirmation.message_download'),
-);
-
-const { counter, pause, resume } = useInterval(600, {
-  controls: true,
-  immediate: false,
-});
-
-const icon = computed(() => {
-  const tick = get(counter) % 2 === 0;
-  if (get(isDownload))
-    return tick ? 'lu-cloud-download-2-fill' : 'lu-cloud-download-fill';
-
-  return tick ? 'lu-cloud-upload-2-fill' : 'lu-cloud-upload-fill';
-});
-
-const uploadProgressIcon = computed<string>(() => {
-  const progress = get(uploadProgress);
-  if (!progress)
-    return 'lu-cloud-fill';
-
-  const tick = get(counter) % 2 === 0;
-
-  switch (progress.type) {
-    case 'compressing':
-      return tick ? 'lu-folder-shrink-1' : 'lu-folder-shrink-2';
-    case 'encrypting':
-      return 'lu-shield';
-    case 'uploading': {
-      return tick ? 'lu-cloud-upload-2-fill' : 'lu-cloud-upload-fill';
-    }
-    default:
-      return 'lu-cloud-fill';
-  }
-});
-
-const tooltip = computed<string>(() => {
-  if (!get(cloudBackupAllowed))
-    return t('sync_indicator.cloud_backup_unavailable');
-
-  if (get(uploadStatus)) {
-    const title = t('sync_indicator.db_upload_result.title');
-    const message = t('sync_indicator.db_upload_result.message', {
-      reason: get(uploadStatus)?.message,
-    });
-    return `${title}: ${message}`;
-  }
-  return t('sync_indicator.menu_tooltip');
-});
-
-const currentProgressText = computed<string>(() => {
-  if (!isDefined(uploadProgress)) {
-    return '';
-  }
-
-  const type = get(uploadProgress).type;
-  switch (type) {
-    case 'compressing':
-      return t('sync_indicator.upload_progress.compressing');
-    case 'encrypting':
-      return t('sync_indicator.upload_progress.encrypting');
-    case 'uploading':
-      return t('sync_indicator.upload_progress.uploading');
-    default:
-      return '';
-  }
-});
-
-function showConfirmation(action: SyncAction) {
-  set(visible, false);
-  showSyncConfirmation(action);
-}
-
-async function performSync() {
-  if (get(syncAction) === SYNC_UPLOAD)
-    clearUploadStatus();
-
-  set(pending, true);
-  await forceSync(logout);
-  set(pending, false);
-}
-
-async function cancelForceSync() {
-  cancelActivity(ActivityKind.SYNC);
-  await nextTick(() => clearUploadStatus());
-}
-
-const runCounter = computed(() => {
-  if (get(pending)) {
-    return true;
-  }
-
-  const type = get(uploadProgress)?.type;
-  return type && ['compressing', 'uploading'].includes(type);
-});
-
-watch(isSyncing, (current, prev) => {
-  if (current !== prev && !current)
-    cancelSync();
-});
-
-watchImmediate(runCounter, (runCounter) => {
-  if (runCounter) {
-    resume();
-  }
-  else {
-    pause();
-  }
-});
+const {
+  cancelForceSync,
+  cancelSync,
+  clearUploadStatus,
+  cloudBackupAllowed,
+  confirmChecked,
+  currentProgressText,
+  displaySyncConfirmation,
+  icon,
+  isDownload,
+  isSyncing,
+  message,
+  modelSyncSettingMenuOpen,
+  modelVisible,
+  pending,
+  performSync,
+  showConfirmation,
+  textChoice,
+  tooltip,
+  uploadProgress,
+  uploadProgressIcon,
+  uploadStatus,
+} = useSyncIndicator();
 </script>
 
 <template>
   <template v-if="premium">
     <RuiMenu
       id="balances-saved-dropdown"
-      v-model="visible"
+      v-model="modelVisible"
       :class-names="{ menu: 'z-[215]' }"
-      :persistent="syncSettingMenuOpen"
+      :persistent="modelSyncSettingMenuOpen"
     >
       <template #activator="{ attrs }">
         <MenuTooltipButton
@@ -238,7 +117,7 @@ watchImmediate(runCounter, (runCounter) => {
             </div>
           </div>
           <SyncSettings
-            v-model="syncSettingMenuOpen"
+            v-model="modelSyncSettingMenuOpen"
             :disabled="!cloudBackupAllowed"
           />
         </div>
@@ -298,6 +177,7 @@ watchImmediate(runCounter, (runCounter) => {
             <RuiButton
               variant="text"
               color="primary"
+              data-testid="cancel-force-sync"
               @click="cancelForceSync()"
             >
               {{ t('common.actions.cancel') }}

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-indicator.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-indicator.spec.ts
@@ -1,0 +1,319 @@
+import type { DatabaseUploadProgress, DbUploadResult } from '@/modules/core/messaging/types';
+import { createMock } from '@test/utils/create-mock';
+import { flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref, shallowRef } from 'vue';
+import { SYNC_DOWNLOAD, SYNC_UPLOAD, type SyncAction } from '@/modules/session/sync';
+import { ActivityKind } from '@/modules/task-center/core/types';
+import { useSyncIndicator } from './use-sync-indicator';
+
+let cloudBackupAllowed: Ref<boolean>;
+let syncAction: Ref<SyncAction | undefined>;
+let uploadProgress: Ref<DatabaseUploadProgress | undefined>;
+let uploadStatus: Ref<DbUploadResult | null>;
+let displaySyncConfirmation: Ref<boolean>;
+let confirmChecked: Ref<boolean>;
+let isSyncing: Ref<boolean>;
+let scope: ReturnType<typeof effectScope>;
+
+const {
+  cancelActivity,
+  cancelSync,
+  clearUploadStatus,
+  forceSync,
+  logout,
+  showSyncConfirmation,
+} = vi.hoisted(() => ({
+  cancelActivity: vi.fn(),
+  cancelSync: vi.fn(),
+  clearUploadStatus: vi.fn(),
+  forceSync: vi.fn(async () => Promise.resolve()),
+  logout: vi.fn(),
+  showSyncConfirmation: vi.fn(),
+}));
+
+vi.mock('@/modules/session/use-session-sync', () => ({
+  useSync: (): Record<string, unknown> => ({
+    cancelSync,
+    clearUploadStatus,
+    confirmChecked,
+    displaySyncConfirmation,
+    forceSync,
+    showSyncConfirmation,
+    syncAction,
+    uploadProgress,
+    uploadStatus,
+  }),
+}));
+
+vi.mock('@/modules/premium/use-feature-access', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/premium/use-feature-access')>(
+    '@/modules/premium/use-feature-access',
+  );
+  return {
+    ...actual,
+    useFeatureAccess: (): Record<string, unknown> => ({ allowed: cloudBackupAllowed }),
+  };
+});
+
+vi.mock('@/modules/task-center/use-native-task', () => ({
+  useNativeTask: (): Record<string, unknown> => ({ cancelActivity }),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', () => ({
+  useTaskCenter: (): Record<string, unknown> => ({ useIsActive: (): Ref<boolean> => isSyncing }),
+}));
+
+vi.mock('@/modules/auth/use-logout', () => ({
+  useLogout: (): Record<string, unknown> => ({ logout }),
+}));
+
+function progressOf(type: DatabaseUploadProgress['type']): DatabaseUploadProgress {
+  return type === 'uploading' ? { currentChunk: 1, totalChunks: 4, type } : { type };
+}
+
+function uploadFailure(message: string): DbUploadResult {
+  return { actionable: true, message, uploaded: false };
+}
+
+function indicator(): ReturnType<typeof useSyncIndicator> {
+  scope = effectScope();
+  return scope.run(() => useSyncIndicator())!;
+}
+
+describe('modules/shell/sync-progress/useSyncIndicator', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    cloudBackupAllowed = ref<boolean>(true);
+    syncAction = shallowRef<SyncAction>();
+    uploadProgress = ref<DatabaseUploadProgress>();
+    uploadStatus = ref<DbUploadResult | null>(null);
+    displaySyncConfirmation = ref<boolean>(false);
+    confirmChecked = ref<boolean>(false);
+    isSyncing = ref<boolean>(false);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+    vi.useRealTimers();
+  });
+
+  describe('the confirmation before a sync', () => {
+    it('should sync nothing when the confirmation is only opened', () => {
+      const { showConfirmation } = indicator();
+      showConfirmation(SYNC_DOWNLOAD);
+
+      expect(showSyncConfirmation).toHaveBeenCalledWith(SYNC_DOWNLOAD);
+      expect(forceSync).not.toHaveBeenCalled();
+    });
+
+    it('should close the menu when it opens the confirmation', () => {
+      const { modelVisible, showConfirmation } = indicator();
+      set(modelVisible, true);
+      showConfirmation(SYNC_UPLOAD);
+
+      expect(get(modelVisible)).toBe(false);
+    });
+
+    it('should sync nothing when the confirmation is cancelled', () => {
+      const { cancelSync: cancel, showConfirmation } = indicator();
+      showConfirmation(SYNC_DOWNLOAD);
+      cancel();
+
+      expect(cancelSync).toHaveBeenCalledOnce();
+      expect(forceSync).not.toHaveBeenCalled();
+    });
+
+    it('should run the sync only once confirmed, and hand it the logout', async () => {
+      const { performSync, showConfirmation } = indicator();
+      showConfirmation(SYNC_DOWNLOAD);
+      expect(forceSync).not.toHaveBeenCalled();
+
+      await performSync();
+
+      expect(forceSync).toHaveBeenCalledWith(logout);
+    });
+
+    it('should mark the sync pending only while it runs', async () => {
+      const { pending, performSync } = indicator();
+
+      const running = performSync();
+      expect(get(pending)).toBe(true);
+
+      await running;
+      expect(get(pending)).toBe(false);
+    });
+
+    it('should forget a previous upload failure before uploading again', async () => {
+      set(syncAction, SYNC_UPLOAD);
+
+      const { performSync } = indicator();
+      await performSync();
+
+      expect(clearUploadStatus).toHaveBeenCalledOnce();
+    });
+
+    it('should keep the upload failure showing when the sync is a download', async () => {
+      set(syncAction, SYNC_DOWNLOAD);
+
+      const { performSync } = indicator();
+      await performSync();
+
+      expect(clearUploadStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the confirmation wording', () => {
+    it.each([
+      [SYNC_UPLOAD, 1, 'sync_indicator.upload_confirmation.message_upload', false],
+      [SYNC_DOWNLOAD, 2, 'sync_indicator.upload_confirmation.message_download', true],
+    ])('should describe a %s', (action, choice, expectedMessage, download) => {
+      set(syncAction, action);
+
+      const { isDownload, message, textChoice } = indicator();
+
+      expect(get(textChoice)).toBe(choice);
+      expect(get(message)).toBe(expectedMessage);
+      expect(get(isDownload)).toBe(download);
+    });
+  });
+
+  describe('cancelling a running sync', () => {
+    it('should cancel the sync activity and clear what it left behind', async () => {
+      const { cancelForceSync } = indicator();
+      await cancelForceSync();
+      await flushPromises();
+
+      expect(cancelActivity).toHaveBeenCalledWith(ActivityKind.SYNC);
+      expect(clearUploadStatus).toHaveBeenCalledOnce();
+    });
+
+    it('should abandon the pending sync when a running one finishes', async () => {
+      set(isSyncing, true);
+      indicator();
+
+      set(isSyncing, false);
+      await flushPromises();
+
+      expect(cancelSync).toHaveBeenCalledOnce();
+    });
+
+    it('should not abandon anything when a sync starts', async () => {
+      indicator();
+
+      set(isSyncing, true);
+      await flushPromises();
+
+      expect(cancelSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the tooltip', () => {
+    it('should say cloud backup is unavailable before anything else', () => {
+      set(cloudBackupAllowed, false);
+      set(uploadStatus, uploadFailure('too big'));
+
+      const { tooltip } = indicator();
+
+      expect(get(tooltip)).toBe('sync_indicator.cloud_backup_unavailable');
+    });
+
+    it('should report the reason the last upload failed', () => {
+      set(uploadStatus, uploadFailure('too big'));
+
+      const { tooltip } = indicator();
+
+      expect(get(tooltip)).toContain('too big');
+    });
+
+    it('should otherwise name the menu', () => {
+      const { tooltip } = indicator();
+
+      expect(get(tooltip)).toBe('sync_indicator.menu_tooltip');
+    });
+  });
+
+  describe('the progress text', () => {
+    it('should be empty while nothing is uploading', () => {
+      const { currentProgressText } = indicator();
+
+      expect(get(currentProgressText)).toBe('');
+    });
+
+    it.each([
+      ['compressing', 'sync_indicator.upload_progress.compressing'],
+      ['encrypting', 'sync_indicator.upload_progress.encrypting'],
+      ['uploading', 'sync_indicator.upload_progress.uploading'],
+    ] as const)('should name the %s phase', (type, expected) => {
+      set(uploadProgress, progressOf(type));
+
+      const { currentProgressText } = indicator();
+
+      expect(get(currentProgressText)).toBe(expected);
+    });
+  });
+
+  describe('the animated icons', () => {
+    it('should point the arrow down for a download and up for an upload', () => {
+      set(syncAction, SYNC_DOWNLOAD);
+      const download = indicator();
+      expect(get(download.icon)).toContain('cloud-download');
+
+      scope.stop();
+      set(syncAction, SYNC_UPLOAD);
+      const upload = indicator();
+      expect(get(upload.icon)).toContain('cloud-upload');
+    });
+
+    it('should show a still cloud while nothing is uploading', () => {
+      const { uploadProgressIcon } = indicator();
+
+      expect(get(uploadProgressIcon)).toBe('lu-cloud-fill');
+    });
+
+    it('should not animate the encrypting phase', () => {
+      set(uploadProgress, progressOf('encrypting'));
+
+      const { uploadProgressIcon } = indicator();
+
+      expect(get(uploadProgressIcon)).toBe('lu-shield');
+      vi.advanceTimersByTime(1200);
+      expect(get(uploadProgressIcon)).toBe('lu-shield');
+    });
+
+    it.each(['compressing', 'uploading'] as const)('should alternate the icon while %s', async (type) => {
+      set(uploadProgress, progressOf(type));
+
+      const { uploadProgressIcon } = indicator();
+      const first = get(uploadProgressIcon);
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(get(uploadProgressIcon)).not.toBe(first);
+    });
+
+    it('should fall back to a still cloud for a phase it does not know', () => {
+      set(uploadProgress, createMock<DatabaseUploadProgress>());
+
+      const { currentProgressText, uploadProgressIcon } = indicator();
+
+      expect(get(uploadProgressIcon)).toBe('lu-cloud-fill');
+      expect(get(currentProgressText)).toBe('');
+    });
+
+    it('should hold the icon still once the upload finishes', async () => {
+      set(uploadProgress, progressOf('compressing'));
+
+      const { uploadProgressIcon } = indicator();
+      set(uploadProgress, undefined);
+      await flushPromises();
+
+      const still = get(uploadProgressIcon);
+      await vi.advanceTimersByTimeAsync(1200);
+
+      expect(get(uploadProgressIcon)).toBe(still);
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-indicator.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-indicator.ts
@@ -1,0 +1,237 @@
+import type { RuiIcons } from '@rotki/ui-library';
+import type { ComputedRef, Ref } from 'vue';
+import type { DatabaseUploadProgress, DbUploadResult } from '@/modules/core/messaging/types';
+import { useLogout } from '@/modules/auth/use-logout';
+import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
+import { SYNC_DOWNLOAD, SYNC_UPLOAD, type SyncAction } from '@/modules/session/sync';
+import { useSync } from '@/modules/session/use-session-sync';
+import { ActivityKind } from '@/modules/task-center/core/types';
+import { useNativeTask } from '@/modules/task-center/use-native-task';
+import { useTaskCenter } from '@/modules/task-center/use-task-center';
+
+/** How often the cloud icon alternates while a sync is in flight, in milliseconds. */
+const ICON_TICK = 600;
+
+/** The upload phases worth animating; encrypting is too brief to be worth a moving icon. */
+const ANIMATED_PHASES = ['compressing', 'uploading'];
+
+interface UseSyncIndicatorReturn {
+  /** Cancels a running force sync and clears whatever status it left behind. */
+  cancelForceSync: () => Promise<void>;
+  /** Abandons the pending confirmation without syncing. */
+  cancelSync: () => void;
+  /** Forgets the outcome of the last upload, and any progress it left behind. */
+  clearUploadStatus: () => void;
+  /** Whether the user's plan includes cloud backup. */
+  cloudBackupAllowed: Ref<boolean>;
+  /** Two-way binding for the confirmation's acknowledgement checkbox. */
+  confirmChecked: Ref<boolean>;
+  /** What the upload is currently doing, as a sentence. */
+  currentProgressText: ComputedRef<string>;
+  /** Whether the confirmation dialog is showing. */
+  displaySyncConfirmation: Ref<boolean>;
+  /** The animated cloud icon for the direction being synced. */
+  icon: ComputedRef<RuiIcons>;
+  /** Whether the pending sync pulls the remote database down over the local one. */
+  isDownload: ComputedRef<boolean>;
+  /** Whether a sync is running. */
+  isSyncing: ComputedRef<boolean>;
+  /** The confirmation's body text, which differs by direction. */
+  message: ComputedRef<string>;
+  /** Whether the menu is open. */
+  modelVisible: Ref<boolean>;
+  /** Whether the sync settings submenu is open, which pins the menu open. */
+  modelSyncSettingMenuOpen: Ref<boolean>;
+  /** Whether a force sync is in flight from this menu. */
+  pending: Readonly<Ref<boolean>>;
+  /** Runs the confirmed sync, logging out afterwards when it replaced the local database. */
+  performSync: () => Promise<void>;
+  /**
+   * Opens the confirmation for a direction.
+   *
+   * @remarks
+   * A sync overwrites one side wholesale, so nothing runs until {@link UseSyncIndicatorReturn.performSync}
+   * is called from the confirmed dialog.
+   */
+  showConfirmation: (action: SyncAction) => void;
+  /** Pluralisation choice for the confirmation's title and action, by direction. */
+  textChoice: ComputedRef<number>;
+  /** The activator's tooltip, which reports a failed upload ahead of anything else. */
+  tooltip: ComputedRef<string>;
+  /** How far the running upload has got, or undefined when none is running. */
+  uploadProgress: Ref<DatabaseUploadProgress | undefined>;
+  /** The icon for the current upload phase. */
+  uploadProgressIcon: ComputedRef<RuiIcons>;
+  /** The outcome of the last upload, or null when it succeeded or none has run. */
+  uploadStatus: Ref<DbUploadResult | null>;
+}
+
+/**
+ * Drives the cloud sync menu: its icons and tooltip, the confirmation before a sync, and cancelling
+ * one that is running.
+ *
+ * @returns the menu state and the actions its controls call
+ */
+export function useSyncIndicator(): UseSyncIndicatorReturn {
+  const modelSyncSettingMenuOpen = shallowRef<boolean>(false);
+  const modelVisible = shallowRef<boolean>(false);
+  const pending = shallowRef<boolean>(false);
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const { allowed: cloudBackupAllowed } = useFeatureAccess(PremiumFeature.CLOUD_BACKUP);
+  const {
+    cancelSync,
+    clearUploadStatus,
+    confirmChecked,
+    displaySyncConfirmation,
+    forceSync,
+    showSyncConfirmation,
+    syncAction,
+    uploadProgress,
+    uploadStatus,
+  } = useSync();
+  const { cancelActivity } = useNativeTask();
+  const { useIsActive } = useTaskCenter();
+  const { logout } = useLogout();
+
+  const isSyncing = useIsActive(ActivityKind.SYNC);
+
+  const isDownload = computed<boolean>(() => get(syncAction) === SYNC_DOWNLOAD);
+
+  const textChoice = computed<number>(() => (get(syncAction) === SYNC_UPLOAD ? 1 : 2));
+
+  const message = computed<string>(() =>
+    get(syncAction) === SYNC_UPLOAD
+      ? t('sync_indicator.upload_confirmation.message_upload')
+      : t('sync_indicator.upload_confirmation.message_download'),
+  );
+
+  const { counter, pause, resume } = useInterval(ICON_TICK, {
+    controls: true,
+    immediate: false,
+  });
+
+  const icon = computed<RuiIcons>(() => {
+    const tick = get(counter) % 2 === 0;
+    if (get(isDownload))
+      return tick ? 'lu-cloud-download-2-fill' : 'lu-cloud-download-fill';
+
+    return tick ? 'lu-cloud-upload-2-fill' : 'lu-cloud-upload-fill';
+  });
+
+  const uploadProgressIcon = computed<RuiIcons>(() => {
+    const progress = get(uploadProgress);
+    if (!progress)
+      return 'lu-cloud-fill';
+
+    const tick = get(counter) % 2 === 0;
+
+    switch (progress.type) {
+      case 'compressing':
+        return tick ? 'lu-folder-shrink-1' : 'lu-folder-shrink-2';
+      case 'encrypting':
+        return 'lu-shield';
+      case 'uploading':
+        return tick ? 'lu-cloud-upload-2-fill' : 'lu-cloud-upload-fill';
+      default:
+        return 'lu-cloud-fill';
+    }
+  });
+
+  const tooltip = computed<string>(() => {
+    if (!get(cloudBackupAllowed))
+      return t('sync_indicator.cloud_backup_unavailable');
+
+    if (get(uploadStatus)) {
+      const title = t('sync_indicator.db_upload_result.title');
+      const message = t('sync_indicator.db_upload_result.message', {
+        reason: get(uploadStatus)?.message,
+      });
+      return `${title}: ${message}`;
+    }
+    return t('sync_indicator.menu_tooltip');
+  });
+
+  const currentProgressText = computed<string>(() => {
+    if (!isDefined(uploadProgress))
+      return '';
+
+    switch (get(uploadProgress).type) {
+      case 'compressing':
+        return t('sync_indicator.upload_progress.compressing');
+      case 'encrypting':
+        return t('sync_indicator.upload_progress.encrypting');
+      case 'uploading':
+        return t('sync_indicator.upload_progress.uploading');
+      default:
+        return '';
+    }
+  });
+
+  function showConfirmation(action: SyncAction): void {
+    set(modelVisible, false);
+    showSyncConfirmation(action);
+  }
+
+  async function performSync(): Promise<void> {
+    if (get(syncAction) === SYNC_UPLOAD)
+      clearUploadStatus();
+
+    set(pending, true);
+    await forceSync(logout);
+    set(pending, false);
+  }
+
+  async function cancelForceSync(): Promise<void> {
+    cancelActivity(ActivityKind.SYNC);
+    await nextTick(() => clearUploadStatus());
+  }
+
+  const runCounter = computed<boolean>(() => {
+    if (get(pending))
+      return true;
+
+    const type = get(uploadProgress)?.type;
+    return !!type && ANIMATED_PHASES.includes(type);
+  });
+
+  function stopSyncWhenItFinishes(current: boolean, previous: boolean): void {
+    if (current !== previous && !current)
+      cancelSync();
+  }
+
+  function animateWhileWorking(running: boolean): void {
+    if (running)
+      resume();
+    else
+      pause();
+  }
+
+  watch(isSyncing, stopSyncWhenItFinishes);
+  watchImmediate(runCounter, animateWhileWorking);
+
+  return {
+    cancelForceSync,
+    cancelSync,
+    clearUploadStatus,
+    cloudBackupAllowed,
+    confirmChecked,
+    currentProgressText,
+    displaySyncConfirmation,
+    icon,
+    isDownload,
+    isSyncing,
+    message,
+    modelSyncSettingMenuOpen,
+    modelVisible,
+    pending: readonly(pending),
+    performSync,
+    showConfirmation,
+    textChoice,
+    tooltip,
+    uploadProgress,
+    uploadProgressIcon,
+    uploadStatus,
+  };
+}

--- a/frontend/app/src/modules/statistics/MissingDailyPrices.spec.ts
+++ b/frontend/app/src/modules/statistics/MissingDailyPrices.spec.ts
@@ -1,0 +1,121 @@
+import type { FailedHistoricalAssetPriceResponse } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import MissingDailyPrices from '@/modules/statistics/MissingDailyPrices.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { addHistoricalPrice, fetchHistoricalPrices } = vi.hoisted(() => ({
+  addHistoricalPrice: vi.fn(async () => Promise.resolve(true)),
+  fetchHistoricalPrices: vi.fn(),
+}));
+
+let failedDailyPrices: Ref<Record<string, FailedHistoricalAssetPriceResponse>>;
+let resolvedFailedDailyPrices: Ref<Record<string, number[]>>;
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: (): Record<string, unknown> => ({
+    addHistoricalPrice,
+    deleteHistoricalPrice: vi.fn(),
+    editHistoricalPrice: vi.fn(),
+    fetchHistoricalPrices,
+  }),
+}));
+
+vi.mock('@/modules/assets/prices/use-historic-price-cache', () => ({
+  useHistoricPriceCache: (): Record<string, unknown> => ({
+    failedDailyPrices,
+    resetHistoricalPricesData: vi.fn(),
+    resolvedFailedDailyPrices,
+  }),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
+  usePriceTaskManager: (): Record<string, unknown> => ({ getHistoricPrice: vi.fn() }),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: (): Record<string, unknown> => ({
+    useAssetField: (): Ref<string> => ref('Ethereum'),
+  }),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (): Ref<string> => ref('USD'),
+}));
+
+function failures(overrides: Partial<FailedHistoricalAssetPriceResponse> = {}): FailedHistoricalAssetPriceResponse {
+  return {
+    noPricesTimestamps: [],
+    rateLimitedPricesTimestamps: [],
+    ...overrides,
+  };
+}
+
+async function createWrapper(failed: FailedHistoricalAssetPriceResponse): Promise<VueWrapper> {
+  set(failedDailyPrices, { ETH: failed });
+  const wrapper = mount(MissingDailyPrices, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: { DateDisplay: true },
+    },
+    props: { asset: 'ETH' },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('modules/statistics/MissingDailyPrices.vue', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    failedDailyPrices = ref<Record<string, FailedHistoricalAssetPriceResponse>>({});
+    resolvedFailedDailyPrices = ref<Record<string, number[]>>({});
+    fetchHistoricalPrices.mockResolvedValue([]);
+  });
+
+  it('should read the saved prices when it opens', async () => {
+    await createWrapper(failures({ noPricesTimestamps: [1_700_000_000] }));
+
+    expect(fetchHistoricalPrices).toHaveBeenCalledOnce();
+  });
+
+  it('should offer one editable row per unpriced day', async () => {
+    const wrapper = await createWrapper(failures({ noPricesTimestamps: [1_700_000_000, 1_700_086_400] }));
+
+    expect(wrapper.findAll('[data-testid=missing-daily-price-input]')).toHaveLength(2);
+  });
+
+  it('should offer a rate-limited tab only when days were rate limited', async () => {
+    const withoutLimit = await createWrapper(failures({ noPricesTimestamps: [1_700_000_000] }));
+    expect(withoutLimit.text()).not.toContain('failed_daily_prices.rate_limited.title');
+
+    const withLimit = await createWrapper(failures({
+      noPricesTimestamps: [1_700_000_000],
+      rateLimitedPricesTimestamps: [1_700_086_400],
+    }));
+    expect(withLimit.text()).toContain('failed_daily_prices.rate_limited.title');
+  });
+
+  it('should offer a missing-prices tab only when days had no price', async () => {
+    const wrapper = await createWrapper(failures({ rateLimitedPricesTimestamps: [1_700_086_400] }));
+
+    expect(wrapper.text()).not.toContain('failed_daily_prices.missing_prices.title');
+    expect(wrapper.findAll('[data-testid=missing-daily-price-input]')).toHaveLength(0);
+  });
+
+  it('should name the asset it is reporting on', async () => {
+    const wrapper = await createWrapper(failures({ noPricesTimestamps: [1_700_000_000] }));
+
+    expect(wrapper.text()).toContain('Ethereum');
+  });
+
+  it('should ask to be closed', async () => {
+    const wrapper = await createWrapper(failures({ noPricesTimestamps: [1_700_000_000] }));
+
+    await wrapper.find('[data-testid=close-missing-daily-prices]').trigger('click');
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/statistics/MissingDailyPrices.vue
+++ b/frontend/app/src/modules/statistics/MissingDailyPrices.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
-import type { BigNumber, FailedHistoricalAssetPriceResponse } from '@rotki/common';
+import type { FailedHistoricalAssetPriceResponse } from '@rotki/common';
 import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
-import type { HistoricalPrice, HistoricalPriceDeletePayload, HistoricalPriceFormPayload } from '@/modules/assets/prices/price-types';
-import type { EditableMissingPrice } from '@/modules/reports/report-types';
-import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import type { EditableMissingPrice, MissingPrice } from '@/modules/reports/report-types';
+import { useEditableMissingPrices } from '@/modules/assets/prices/use-editable-missing-prices';
 import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
-import { ApiValidationError } from '@/modules/core/api/types/errors';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { PriceOracle } from '@/modules/settings/types/price-oracle';
 import { useSetting } from '@/modules/settings/use-setting';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
@@ -23,21 +19,46 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const prices = ref<HistoricalPrice[]>([]);
-const errorMessages = ref<Record<string, string[]>>({});
-
-const refreshedHistoricalPrices = ref<Record<string, BigNumber>>({});
 const sort = ref<DataTableSortData<EditableMissingPrice>>([]);
-const tab = ref(0);
+const tab = ref<number>(0);
 
 const { useAssetField } = useAssetInfoRetrieval();
-const { failedDailyPrices, resetHistoricalPricesData, resolvedFailedDailyPrices } = useHistoricPriceCache();
+const { failedDailyPrices, resolvedFailedDailyPrices } = useHistoricPriceCache();
 const currencySymbol = useSetting('currencySymbol');
-const { addHistoricalPrice, deleteHistoricalPrice, editHistoricalPrice, fetchHistoricalPrices } = useAssetPricesApi();
 
 const name = useAssetField(() => asset, 'name');
 
 const failedPrices = computed<FailedHistoricalAssetPriceResponse>(() => get(failedDailyPrices)[asset]);
+
+const missingPrices = computed<MissingPrice[]>(() => get(failedPrices).noPricesTimestamps.map(time => ({
+  fromAsset: asset,
+  time,
+  toAsset: get(currencySymbol),
+})));
+
+function markResolved(item: EditableMissingPrice): void {
+  const resolved = { ...get(resolvedFailedDailyPrices) };
+  const assetResolved = resolved[item.fromAsset];
+  if (assetResolved) {
+    assetResolved.push(item.time);
+  }
+  else {
+    resolved[item.fromAsset] = [item.time];
+  }
+  set(resolvedFailedDailyPrices, resolved);
+}
+
+const {
+  clearError,
+  errorMessages,
+  formattedItems,
+  getHistoricalPrices,
+  updatePrice,
+} = useEditableMissingPrices({
+  items: missingPrices,
+  keyOf: item => item.time.toString(),
+  onPriceUpdated: markResolved,
+});
 
 const headers = computed<DataTableColumn<EditableMissingPrice>[]>(() => [
   {
@@ -50,90 +71,6 @@ const headers = computed<DataTableColumn<EditableMissingPrice>[]>(() => [
     label: t('common.price'),
   },
 ]);
-
-const formattedItems = computed<EditableMissingPrice[]>(() => {
-  const fromAsset = asset;
-  const toAsset = get(currencySymbol);
-
-  return get(failedPrices).noPricesTimestamps.map((time) => {
-    const savedHistoricalPrice = get(prices).find(
-      price => price.fromAsset === fromAsset && price.toAsset === toAsset && price.timestamp === time,
-    );
-
-    const savedPrice = savedHistoricalPrice?.price;
-    const refreshedHistoricalPrice = get(refreshedHistoricalPrices)[time];
-
-    const useRefreshedHistoricalPrice = !savedPrice && !!refreshedHistoricalPrice;
-
-    const price = (useRefreshedHistoricalPrice ? refreshedHistoricalPrice : savedPrice)?.toFixed() ?? '';
-
-    return {
-      fromAsset,
-      price,
-      saved: !!savedPrice,
-      time,
-      toAsset,
-      useRefreshedHistoricalPrice,
-    };
-  });
-});
-
-async function getHistoricalPrices() {
-  set(prices, await fetchHistoricalPrices());
-}
-
-async function updatePrice(item: EditableMissingPrice) {
-  if (item.useRefreshedHistoricalPrice)
-    return;
-
-  const payload: HistoricalPriceDeletePayload = {
-    fromAsset: item.fromAsset,
-    sourceType: PriceOracle.MANUAL,
-    timestamp: item.time,
-    toAsset: item.toAsset,
-  };
-
-  try {
-    if (item.price) {
-      const formPayload: HistoricalPriceFormPayload = {
-        ...payload,
-        price: item.price,
-      };
-
-      if (item.saved)
-        await editHistoricalPrice(formPayload);
-      else await addHistoricalPrice(formPayload);
-    }
-    else if (item.saved) {
-      await deleteHistoricalPrice(payload);
-    }
-  }
-  catch (error: unknown) {
-    let errorMessage = getErrorMessage(error);
-    if (error instanceof ApiValidationError) {
-      const errors = error.getValidationErrors({ price: '' });
-      errorMessage = typeof errors === 'string' ? error.message : errors.price[0];
-    }
-
-    set(errorMessages, {
-      ...get(errorMessages),
-      [item.time]: errorMessage,
-    });
-  }
-
-  resetHistoricalPricesData([payload]);
-  const resolved = { ...get(resolvedFailedDailyPrices) };
-  const assetResolved = resolved[item.fromAsset];
-  if (assetResolved) {
-    assetResolved.push(item.time);
-  }
-  else {
-    resolved[item.fromAsset] = [item.time];
-  }
-  set(resolvedFailedDailyPrices, resolved);
-
-  await getHistoricalPrices();
-}
 
 onMounted(async () => {
   await getHistoricalPrices();
@@ -196,8 +133,9 @@ onMounted(async () => {
                 variant="outlined"
                 :success-messages="row.saved ? [t('profit_loss_report.actionable.missing_prices.price_is_saved')] : []"
                 :error-messages="errorMessages[row.time]"
-                @focus="delete errorMessages[row.time]"
-                @update:model-value="delete errorMessages[row.time]"
+                data-testid="missing-daily-price-input"
+                @focus="clearError(row)"
+                @update:model-value="clearError(row)"
                 @blur="updatePrice(row)"
               />
             </template>
@@ -229,6 +167,7 @@ onMounted(async () => {
       <RuiButton
         color="primary"
         class="mt-2"
+        data-testid="close-missing-daily-prices"
         @click="emit('close')"
       >
         {{ t('common.actions.close') }}


### PR DESCRIPTION
Follows #12964, after batch I (#13025 / #13026). Nine components whose logic lived in `<script setup>` are extracted to composables and covered there, with component specs for the seam that remains.

**This takes the project past the issue's 70% line target: 68.81% → 70.01%** (34,420 / 49,164 lines). Suite green at 1019 files / 10,952 tests.

## What is in it

One commit per tested module.

| Component | Extracted to | Composable / component tests | Script lines |
|---|---|---|---|
| `core/notifications/Notification.vue` | `use-notification-card.ts` | 28 / 6 | 136 → 40 |
| `core/notifications/NotificationSidebar.vue` | `use-notification-sidebar.ts` | 17 / 6 | 86 → 30 |
| `notes/UserNotesList.vue` | `use-user-notes-list.ts` | 23 / 9 | 151 → 45 |
| `settings/general/rpc/BlockchainRpcNodeManager.vue` | `use-blockchain-rpc-node-manager.ts` | 24 / 8 | 144 → 37 |
| `shell/sync-progress/SyncIndicator.vue` | `use-sync-indicator.ts` | 26 / 6 | 136 → 40 |
| `reports/ReportMissingPrices.vue` **+** `statistics/MissingDailyPrices.vue` | one `assets/prices/use-editable-missing-prices.ts` | 24 / 6 | 149 → 74, 115 → 71 |
| `settings/accounting/rule/AccountingRuleConflictsDialog.vue` | `use-accounting-rule-conflict-resolution.ts` | 13 / – | 150 → 47 |
| `assets/admin/.../SolanaTokenMigrationDialog.vue` | `use-solana-token-migration-dialog.ts` | 16 / 5 | 120 → 26 |

Every new composable is at full statement and branch coverage.

## Two components held the same algorithm

`ReportMissingPrices` and `MissingDailyPrices` had identical `formattedItems` and `updatePrice`, differing only in the key a row is stored under: the whole `fromAsset + toAsset + time` triple in a report, which holds several assets at once, and the timestamp alone in a single-asset dialog. They now share one composable parameterised by `keyOf`, with an optional `onPriceUpdated` hook for the resolved-prices bookkeeping only the dialog does.

While doing that, the two templates were mutating the composable's error map directly with `delete errorMessages[key]`. It now returns a readonly map and a `clearError(item)`, which is what the templates call.

## One dead guard removed

`Notification.vue`'s `messageClicked` had an early return that fired only when `expanded` was already `true`, and the function's only assignment sets it to `true` — so it could not change anything observable. A negative control confirmed it: removing the guard failed no test, because no test can distinguish it. Deleting it preserves behaviour exactly.

If the intent was that a message short enough to fit should not respond to a click at all, that is a different guard and wants its own change.

## Conventions

Extraction before testing; a component is a seam rather than a screen; `data-testid` selectors; every behavioural claim negative-controlled by breaking it and watching the named test go red; comment-free specs with TSDoc on the consumer-facing interface members.

`pnpm run test:unit`, `lint`, `typecheck`, `lint:style`, `check:linked-keys` and `knip` are all green.
