### PR TITLE
Skip an account's queries from the accounts table

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :feature:`13033` You can now stop rotki querying an account from the accounts table itself, on one of its chains or on all of them, instead of having to remember the address and find it again in the chain settings. The chains that are skipped are marked on the account's row.
 * :feature:`13050` Robinhood Chain is now a supported EVM chain. Balances and transactions can be tracked on it. Transaction history on it needs a Blockscout API key.
 * :feature:`1981` Deposits to and withdrawals from the 1inch Liquidity Protocol and Mooniswap pools are now decoded.
 * :feature:`1988` Transactions going through the zerion SDK router are now understood properly.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -68,7 +68,19 @@
       "chain": "Chain"
     },
     "per_chain": "Per chain",
-    "refresh_tooltip": "Refresh {blockchain} balances ignoring any cached entries"
+    "refresh_tooltip": "Refresh {blockchain} balances ignoring any cached entries",
+    "skip_queries": {
+      "chain_marker": "rotki does not query this account on {chain}",
+      "chain_skipped": "skipped",
+      "chain_whole": "entire chain",
+      "entire_chain": "Skipped in Settings → Chains as an entire chain",
+      "error": "Skipped chains and addresses",
+      "menu": "Choose which chains rotki skips for this account",
+      "resume": "Query this account again on {chains}",
+      "resume_all": "Query this chain again | Query all {count} chains again",
+      "skip": "Skip balance and history queries for this account on {chains}",
+      "skip_all": "Skip queries on this chain | Skip all {count} chains"
+    }
   },
   "account_form": {
     "advanced_tooltip": "Display the advanced xpub options | Hide the advanced xpub options",

--- a/frontend/app/src/modules/accounts/AccountChains.spec.ts
+++ b/frontend/app/src/modules/accounts/AccountChains.spec.ts
@@ -1,0 +1,138 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it } from 'vitest';
+import AccountChains from '@/modules/accounts/AccountChains.vue';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
+
+describe('modules/accounts/AccountChains', () => {
+  const ADDRESS = '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c';
+
+  let wrapper: VueWrapper;
+
+  function setDisabled(value: Record<string, string[]>): void {
+    const store = useSettingsRepo();
+    store.updateGeneral({ ...store.general, disabledChainQueries: value });
+  }
+
+  function createWrapper(props: { address?: string; row: { chains: string[]; id: string } }): VueWrapper {
+    return mount(AccountChains, {
+      global: {
+        stubs: {
+          ChainIcon: true,
+          RuiTooltip: { template: '<div><slot name="activator" /><slot /></div>' },
+        },
+      },
+      props: { chainFilter: {}, ...props },
+    });
+  }
+
+  function markedChains(): string[] {
+    return Array.from(wrapper.findAll('[data-testid=account-chain-skipped]'), el => el.attributes('data-chain') ?? '');
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('should mark only the chains the address is excluded on', () => {
+    setDisabled({ optimism: [ADDRESS] });
+
+    wrapper = createWrapper({ address: ADDRESS, row: { chains: ['eth', 'optimism'], id: ADDRESS } });
+
+    expect(markedChains()).toEqual(['optimism']);
+  });
+
+  it('should mark a chain that is switched off whole, which has no rule of its own', () => {
+    setDisabled({ eth: [] });
+
+    wrapper = createWrapper({ address: ADDRESS, row: { chains: ['eth', 'optimism'], id: ADDRESS } });
+
+    expect(markedChains()).toEqual(['eth']);
+  });
+
+  it('should mark nothing when the row carries no address, as an xpub group does not', () => {
+    setDisabled({ eth: [], optimism: [ADDRESS] });
+
+    wrapper = createWrapper({ row: { chains: ['eth', 'optimism'], id: 'xpub1' } });
+
+    expect(markedChains()).toEqual([]);
+  });
+
+  it('should say why the chain is marked, in place of the bare chain name', () => {
+    setDisabled({ eth: [ADDRESS] });
+
+    wrapper = createWrapper({ address: ADDRESS, row: { chains: ['eth'], id: ADDRESS } });
+
+    expect(wrapper.find('[data-testid=account-chain-skipped-tooltip]').text())
+      .toContain('account_balances.skip_queries.chain_marker');
+    const tooltip = wrapper.find('[data-testid=account-chain-skipped-tooltip]').element.parentElement;
+    expect(tooltip?.textContent?.replace('lu-ban', '').trim()).toBe('account_balances.skip_queries.chain_marker::Eth');
+  });
+
+  it('should not mark a chain the row merely filtered out of its totals', async () => {
+    wrapper = createWrapper({ address: ADDRESS, row: { chains: ['eth', 'optimism'], id: ADDRESS } });
+
+    await wrapper.find('[data-chain=eth][data-testid=account-chain]').trigger('click');
+
+    expect(wrapper.emitted('update:chainFilter')).toBeDefined();
+    expect(markedChains()).toEqual([]);
+  });
+
+  describe('the display filter', () => {
+    async function clickChain(chain: string): Promise<void> {
+      await wrapper.find(`[data-chain=${chain}][data-testid=account-chain]`).trigger('click');
+    }
+
+    function isFilter(value: unknown): value is Record<string, string[]> {
+      return typeof value === 'object' && value !== null;
+    }
+
+    function lastFilter(): Record<string, string[]> | undefined {
+      const payload = wrapper.emitted('update:chainFilter')?.at(-1)?.[0];
+      return isFilter(payload) ? payload : undefined;
+    }
+
+    it('should exclude a chain the row shows', async () => {
+      wrapper = createWrapper({ row: { chains: ['eth', 'optimism'], id: 'row-1' } });
+
+      await clickChain('eth');
+
+      expect(lastFilter()).toEqual({ 'row-1': ['eth'] });
+    });
+
+    it('should drop the row from the filter once its last exclusion goes', async () => {
+      wrapper = createWrapper({ row: { chains: ['eth', 'optimism'], id: 'row-1' } });
+      await clickChain('eth');
+      await wrapper.setProps({ chainFilter: { 'row-1': ['eth'] } });
+
+      await clickChain('eth');
+
+      expect(lastFilter()).toEqual({});
+    });
+
+    it('should keep the other exclusions when one chain comes back', async () => {
+      wrapper = createWrapper({ row: { chains: ['eth', 'optimism', 'base'], id: 'row-1' } });
+      await wrapper.setProps({ chainFilter: { 'row-1': ['eth', 'base'] } });
+
+      await clickChain('eth');
+
+      expect(lastFilter()).toEqual({ 'row-1': ['base'] });
+    });
+
+    it('should leave a single-chain row alone, having nothing to filter against', async () => {
+      wrapper = createWrapper({ row: { chains: ['eth'], id: 'row-1' } });
+
+      await clickChain('eth');
+
+      expect(wrapper.emitted('update:chainFilter')).toBeUndefined();
+    });
+
+    it('should clear every exclusion of the row at once', async () => {
+      wrapper = createWrapper({ row: { chains: ['eth', 'optimism'], id: 'row-1' } });
+      await wrapper.setProps({ chainFilter: { 'row-1': ['eth'] } });
+
+      await wrapper.find('[data-testid=account-chain-filter-clear]').trigger('click');
+
+      expect(lastFilter()).toEqual({ 'row-1': [] });
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/AccountChains.vue
+++ b/frontend/app/src/modules/accounts/AccountChains.vue
@@ -1,24 +1,39 @@
 <script lang="ts" setup>
 import { uniqueStrings } from '@/modules/core/common/data/data';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
 import ChainIcon from '@/modules/shell/components/ChainIcon.vue';
 
 type Row = ({ chain: string } | { chains: string[] }) & { id: string };
 
 const chainFilter = defineModel<Record<string, string[]>>('chainFilter', { required: true });
 
-const { row } = defineProps<{ row: Row }>();
+const { address, row } = defineProps<{ address?: string; row: Row }>();
 
 const { t } = useI18n({ useScope: 'global' });
 
 const chains = computed<string[]>(() => 'chains' in row ? row.chains : [row.chain]);
 
 const { getChainName } = useSupportedChains();
+const { isAddressExcluded } = useDisabledChains();
 
-const chainStatus = computed<{ chain: string; enabled: boolean }[]>(() => {
+/**
+ * Per chain: `enabled` is this row's local display filter, `skipped` is the saved setting.
+ *
+ * @remarks
+ * Two unrelated states on one icon, so they are drawn differently: the filter dims the icon, while
+ * a skip adds the ban badge that Settings uses for the same thing. `isAddressExcluded` answers for
+ * a chain switched off whole as well, which is why a row can be marked on a chain it has no rule of
+ * its own for.
+ */
+const chainStatus = computed<{ chain: string; enabled: boolean; skipped: boolean }[]>(() => {
   const activated = get(chains);
   const filter = get(chainFilter)[row.id] ?? [];
-  return activated.map(chain => ({ chain, enabled: !filter.includes(chain) })).reverse();
+  return activated.map(chain => ({
+    chain,
+    enabled: !filter.includes(chain),
+    skipped: address !== undefined && isAddressExcluded(chain, address),
+  })).reverse();
 });
 
 function updateChain(chain: string, enabled: boolean) {
@@ -65,6 +80,7 @@ function reset() {
         <RuiButton
           size="sm"
           icon
+          data-testid="account-chain-filter-clear"
           class="opacity-0 transition invisible"
           :class="{
             'group-hover:opacity-100 group-hover:visible': anyDisabled,
@@ -86,24 +102,44 @@ function reset() {
         :class-names="{ tooltip: '!-ml-1' }"
       >
         <template #activator>
-          <div
-            class="rounded-full w-8 h-8 bg-rui-grey-300 dark:bg-white flex items-center justify-center border-2 border-white dark:border-rui-grey-300 -ml-2 relative z-[0] hover:z-[1] cursor-pointer transition-all overflow-hidden"
-            :class="{ '!border-0': !item.enabled }"
-            :data-chain="item.chain"
-            data-testid="account-chain"
-            @click="updateChain(item.chain, !item.enabled)"
-          >
-            <ChainIcon
-              :chain="item.chain"
-              class="!bg-transparent"
-              size="1"
-            />
+          <div class="relative -ml-2 z-[0] hover:z-[1]">
             <div
-              class="absolute top-0 left-0 w-full h-full opacity-0 bg-black z-[2] transition-all"
-              :class="{ 'opacity-40 dark:opacity-60': !item.enabled } "
-            />
+              class="rounded-full w-8 h-8 bg-rui-grey-300 dark:bg-white flex items-center justify-center border-2 border-white dark:border-rui-grey-300 relative cursor-pointer transition-all overflow-hidden"
+              :class="{ '!border-0': !item.enabled }"
+              :data-chain="item.chain"
+              data-testid="account-chain"
+              @click="updateChain(item.chain, !item.enabled)"
+            >
+              <ChainIcon
+                :chain="item.chain"
+                class="!bg-transparent"
+                size="1"
+              />
+              <div
+                class="absolute top-0 left-0 w-full h-full opacity-0 bg-black z-[2] transition-all"
+                :class="{ 'opacity-40 dark:opacity-60': !item.enabled } "
+              />
+            </div>
+            <div
+              v-if="item.skipped"
+              class="absolute -bottom-0.5 -right-0.5 flex items-center justify-center rounded-full bg-rui-error text-white p-[2px] border border-rui-bg z-[3]"
+              data-testid="account-chain-skipped"
+              :data-chain="item.chain"
+            >
+              <RuiIcon
+                name="lu-ban"
+                size="10"
+              />
+            </div>
           </div>
         </template>
+
+        <div
+          v-if="item.skipped"
+          data-testid="account-chain-skipped-tooltip"
+        >
+          {{ t('account_balances.skip_queries.chain_marker', { chain: getChainName(item.chain) }) }}
+        </div>
 
         <template v-if="chains.length > 1">
           <i18n-t
@@ -127,7 +163,7 @@ function reset() {
             </template>
           </i18n-t>
         </template>
-        <template v-else>
+        <template v-else-if="!item.skipped">
           {{ getChainName(item.chain) }}
         </template>
       </RuiTooltip>

--- a/frontend/app/src/modules/accounts/table/AccountBalancesTable.vue
+++ b/frontend/app/src/modules/accounts/table/AccountBalancesTable.vue
@@ -3,6 +3,7 @@ import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
 import type { BlockchainAccountBalance } from '@/modules/accounts/blockchain-accounts';
 import type { AccountManageState } from '@/modules/accounts/blockchain/use-account-manage';
 import type { Collection } from '@/modules/core/common/collection';
+import { getAccountAddress } from '@/modules/accounts/account-utils';
 import AccountChains from '@/modules/accounts/AccountChains.vue';
 import AccountTopTokens from '@/modules/accounts/AccountTopTokens.vue';
 import { FiatDisplay } from '@/modules/assets/amount-display/components';
@@ -104,6 +105,7 @@ defineExpose({
     <template #item.chain="{ row }">
       <AccountChains
         v-model:chain-filter="chainFilter"
+        :address="getAccountAddress(row)"
         :row="row"
       />
     </template>

--- a/frontend/app/src/modules/accounts/table/components/table/AccountActions.spec.ts
+++ b/frontend/app/src/modules/accounts/table/components/table/AccountActions.spec.ts
@@ -82,6 +82,7 @@ describe('modules/accounts/table/components/table/AccountActions', () => {
       global: {
         plugins: [pinia],
         stubs: {
+          AccountSkipQueriesToggle: true,
           RuiButton: true,
           RuiIcon: true,
           RuiProgress: true,
@@ -333,6 +334,82 @@ describe('modules/accounts/table/components/table/AccountActions', () => {
 
       const rowActions = wrapper.findComponent({ name: 'RowActions' });
       expect(rowActions.props('disabled')).toBe(false);
+    });
+  });
+
+  describe('skip queries toggle', () => {
+    beforeEach(() => {
+      supportsTransactionsMock.mockReturnValue(true);
+    });
+
+    it('should scope it to every chain the group stands for', () => {
+      wrapper = createWrapper({
+        accountOperation: false,
+        group: 'evm',
+        isSectionLoading: false,
+        isVirtual: false,
+        row: createGroupRow(['eth', 'optimism', 'base']),
+      });
+
+      const toggle = wrapper.findComponent({ name: 'AccountSkipQueriesToggle' });
+      expect(toggle.props('chains')).toEqual(['eth', 'optimism', 'base']);
+      expect(toggle.props('address')).toBe('0x1234567890abcdef1234567890abcdef12345678');
+    });
+
+    it('should scope it to the one chain of an account row', () => {
+      wrapper = createWrapper({
+        accountOperation: false,
+        isSectionLoading: false,
+        isVirtual: false,
+        row: createAccountRow('optimism'),
+      });
+
+      expect(wrapper.findComponent({ name: 'AccountSkipQueriesToggle' }).props('chains')).toEqual(['optimism']);
+    });
+
+    it('should hide it on a virtual row, which carries no actions', () => {
+      wrapper = createWrapper({
+        accountOperation: false,
+        group: 'xpub',
+        isSectionLoading: false,
+        isVirtual: true,
+        row: createAccountRow('btc'),
+      });
+
+      expect(wrapper.findComponent({ name: 'AccountSkipQueriesToggle' }).exists()).toBe(false);
+    });
+
+    it('should hide it for a validator, whose public key no rule matches', () => {
+      const row: AccountDataRow<BlockchainAccountWithBalance> = {
+        ...createAccountRow('eth2'),
+        data: {
+          index: 1,
+          publicKey: '0xa1d1ad0714035353258038e964ae9675dc0252ee22cea896825c01458e1807bfad2f9969338798548d9858a571f7425c',
+          status: 'active',
+          type: 'validator',
+        },
+      };
+
+      wrapper = createWrapper({
+        accountOperation: false,
+        isSectionLoading: false,
+        isVirtual: false,
+        row,
+      });
+
+      expect(wrapper.findComponent({ name: 'AccountSkipQueriesToggle' }).exists()).toBe(false);
+    });
+
+    it('should disable it while an account operation is running', () => {
+      wrapper = createWrapper({
+        accountOperation: true,
+        group: 'evm',
+        isSectionLoading: false,
+        isVirtual: false,
+        row: createAccountRow('eth'),
+      });
+
+      expect(wrapper.findComponent({ name: 'AccountSkipQueriesToggle' }).props('disabled')).toBe(true);
     });
   });
 

--- a/frontend/app/src/modules/accounts/table/components/table/AccountActions.vue
+++ b/frontend/app/src/modules/accounts/table/components/table/AccountActions.vue
@@ -3,6 +3,7 @@ import type { AccountDataRow } from '../../types';
 import type { BlockchainAccountBalance } from '@/modules/accounts/blockchain-accounts';
 import { getAccountAddress } from '@/modules/accounts/account-utils';
 import TokenDetection from '@/modules/accounts/blockchain/TokenDetection.vue';
+import AccountSkipQueriesToggle from '@/modules/accounts/table/components/table/AccountSkipQueriesToggle.vue';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import RowActions from '@/modules/shell/components/RowActions.vue';
 
@@ -19,7 +20,7 @@ export interface Props<T extends BlockchainAccountBalance> {
   row: AccountDataRow<T>;
 }
 
-defineProps<Props<T>>();
+const { isVirtual, row } = defineProps<Props<T>>();
 
 const emit = defineEmits<{
   delete: [row: AccountDataRow<T>];
@@ -35,6 +36,28 @@ function showTokenDetection(row: AccountDataRow<T>): boolean {
 
   return supportsTransactions(row.chain);
 }
+
+/**
+ * The chains a skip rule from this row applies to: every chain the row stands for.
+ *
+ * @remarks
+ * Deliberately not the chains the Chains column currently *shows*. Its icons are a display filter -
+ * clicking one drops that chain from the row's totals - so scoping the action to what survives it
+ * would make the same control mean two things, and dimming a chain to read the value without it
+ * would then skip every chain except that one. The page's own chain filter still narrows the row,
+ * because it narrows what the row is.
+ */
+const skipChains = computed<string[]>(() => row.type === 'group' ? row.chains : [row.chain]);
+
+/**
+ * Skipping is keyed on an address, so it is offered for address accounts only.
+ *
+ * @remarks
+ * A validator row carries a public key and an xpub group its xpub, neither of which the backend
+ * matches a rule against. The addresses derived from an xpub are reachable on its virtual rows,
+ * which carry no actions at all, for the same reason edit and delete skip them.
+ */
+const canSkipQueries = computed<boolean>(() => !isVirtual && row.data.type === 'address' && get(skipChains).length > 0);
 
 function getTokenDetectionChains(row: AccountDataRow<T>): string[] {
   if (row.type === 'group')
@@ -52,6 +75,12 @@ function getTokenDetectionChains(row: AccountDataRow<T>): string[] {
       :address="getAccountAddress(row)"
       :loading="isSectionLoading"
       :chains="getTokenDetectionChains(row)"
+    />
+    <AccountSkipQueriesToggle
+      v-if="canSkipQueries"
+      :address="getAccountAddress(row)"
+      :chains="skipChains"
+      :disabled="accountOperation"
     />
     <RowActions
       v-if="!isVirtual"

--- a/frontend/app/src/modules/accounts/table/components/table/AccountSkipQueriesToggle.spec.ts
+++ b/frontend/app/src/modules/accounts/table/components/table/AccountSkipQueriesToggle.spec.ts
@@ -1,0 +1,213 @@
+import type { MaybeRefOrGetter } from 'vue';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AccountSkipQueriesToggle from '@/modules/accounts/table/components/table/AccountSkipQueriesToggle.vue';
+import { type SkipChainItem, SkipState } from '@/modules/accounts/table/use-account-skip-queries';
+
+const ADDRESS = '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c';
+
+const toggleAll = vi.fn<() => Promise<void>>(async () => {});
+const toggleChain = vi.fn<(chain: string) => Promise<void>>(async () => {});
+const scope = vi.fn<(address: string, chains: string[]) => void>();
+
+const items = ref<SkipChainItem[]>([]);
+const state = ref<SkipState>(SkipState.NONE);
+const locked = ref<boolean>(false);
+
+/**
+ * Only the composable is replaced; `SkipState` comes from the real module, so the states this spec
+ * drives stay the ones the component compares against.
+ */
+vi.mock('@/modules/accounts/table/use-account-skip-queries', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/accounts/table/use-account-skip-queries')>(),
+  useAccountSkipQueries: (address: MaybeRefOrGetter<string>, chains: MaybeRefOrGetter<string[]>): {
+    items: typeof items;
+    locked: typeof locked;
+    pending: Ref<boolean>;
+    state: typeof state;
+    toggleAll: typeof toggleAll;
+    toggleChain: typeof toggleChain;
+  } => {
+    scope(toValue(address), toValue(chains));
+    return { items, locked, pending: ref(false), state, toggleAll, toggleChain };
+  },
+}));
+
+function chain(name: string, overrides: Partial<SkipChainItem> = {}): SkipChainItem {
+  return { chain: name, name: name.toUpperCase(), skipped: false, wholeChain: false, ...overrides };
+}
+
+describe('modules/accounts/table/components/table/AccountSkipQueriesToggle', () => {
+  let wrapper: VueWrapper;
+
+  function createWrapper(props: { address: string; chains: string[]; disabled?: boolean }): VueWrapper {
+    return mount(AccountSkipQueriesToggle, {
+      global: {
+        stubs: {
+          ChainIcon: true,
+          RuiMenu: { props: ['disabled'], template: '<div><slot name="activator" v-bind="{ attrs: {} }" /><slot v-if="!disabled" /></div>' },
+          RuiTooltip: { template: '<div><slot name="activator" /><slot /></div>' },
+        },
+      },
+      props,
+    });
+  }
+
+  function button(): ReturnType<VueWrapper['find']> {
+    return wrapper.find('[data-testid=account-skip-queries]');
+  }
+
+  function chainItems(): ReturnType<VueWrapper['findAll']> {
+    return wrapper.findAll('[data-testid=account-skip-queries-chain]');
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(items, [chain('eth')]);
+    set(state, SkipState.NONE);
+    set(locked, false);
+  });
+
+  it('should ask about the account and chains it was given', () => {
+    wrapper = createWrapper({ address: ADDRESS, chains: ['eth', 'optimism'] });
+
+    expect(scope).toHaveBeenCalledWith(ADDRESS, ['eth', 'optimism']);
+  });
+
+  describe('a row standing for one chain', () => {
+    it('should toggle it directly, with no menu to open', async () => {
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth'] });
+
+      expect(chainItems()).toHaveLength(0);
+      await button().trigger('click');
+
+      expect(toggleAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should name the chain in the tooltip', () => {
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth'] });
+
+      expect(wrapper.text()).toContain('account_balances.skip_queries.skip::ETH');
+    });
+
+    it('should offer to query it again once it is skipped', () => {
+      set(items, [chain('eth', { skipped: true })]);
+      set(state, SkipState.ALL);
+
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth'] });
+
+      expect(wrapper.text()).toContain('account_balances.skip_queries.resume::ETH');
+    });
+  });
+
+  describe('a row standing for several chains', () => {
+    beforeEach(() => {
+      set(items, [chain('eth', { skipped: true }), chain('optimism'), chain('base', { wholeChain: true })]);
+      set(state, SkipState.PARTIAL);
+    });
+
+    it('should offer one entry per chain, and act on that chain alone', async () => {
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth', 'optimism', 'base'] });
+
+      expect(chainItems()).toHaveLength(3);
+      await wrapper.find('[data-testid=account-skip-queries-chain][data-chain=optimism]').trigger('click');
+
+      expect(toggleChain).toHaveBeenCalledWith('optimism');
+      expect(toggleAll).not.toHaveBeenCalled();
+    });
+
+    it('should not act on a chain that is switched off whole', () => {
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth', 'optimism', 'base'] });
+
+      const wholeChain = wrapper.find('[data-testid=account-skip-queries-chain][data-chain=base]');
+      expect(wholeChain.attributes('disabled')).toBeDefined();
+      expect(wholeChain.text()).toContain('account_balances.skip_queries.chain_whole');
+    });
+
+    it('should say which chains are already skipped', () => {
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth', 'optimism', 'base'] });
+
+      expect(wrapper.find('[data-testid=account-skip-queries-chain][data-chain=eth]').text())
+        .toContain('account_balances.skip_queries.chain_skipped');
+      expect(wrapper.find('[data-testid=account-skip-queries-chain][data-chain=optimism]').text())
+        .not
+        .toContain('account_balances.skip_queries.chain_skipped');
+    });
+
+    it('should offer to skip them all while some are still queried, counting only the chains it can act on', async () => {
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth', 'optimism', 'base'] });
+
+      const all = wrapper.find('[data-testid=account-skip-queries-all]');
+      expect(all.text()).toContain('account_balances.skip_queries.skip_all::2');
+      await all.trigger('click');
+
+      expect(toggleAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('should offer to query them all again once every chain is skipped', () => {
+      set(state, SkipState.ALL);
+
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth', 'optimism', 'base'] });
+
+      expect(wrapper.find('[data-testid=account-skip-queries-all]').text())
+        .toContain('account_balances.skip_queries.resume_all::2');
+    });
+
+    it('should not toggle anything when the button only opens the menu', async () => {
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth', 'optimism', 'base'] });
+
+      await button().trigger('click');
+
+      expect(toggleAll).not.toHaveBeenCalled();
+      expect(toggleChain).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('state colour', () => {
+    it.each<[SkipState, boolean, boolean]>([
+      [SkipState.NONE, false, false],
+      [SkipState.PARTIAL, false, true],
+      [SkipState.ALL, true, false],
+    ])('should draw %s with error=%s and warning=%s', (value, error, warning) => {
+      set(state, value);
+
+      wrapper = createWrapper({ address: ADDRESS, chains: ['eth'] });
+
+      const classes = button().classes();
+      expect(classes.includes('text-rui-error')).toBe(error);
+      expect(classes.includes('text-rui-warning')).toBe(warning);
+    });
+  });
+
+  describe('when every chain is switched off whole', () => {
+    beforeEach(() => {
+      set(locked, true);
+    });
+
+    it('should stay hoverable so the tooltip can explain why, rather than go natively disabled', async () => {
+      wrapper = createWrapper({ address: ADDRESS, chains: ['base'] });
+
+      expect(button().attributes('disabled')).toBeUndefined();
+      expect(button().attributes('aria-disabled')).toBe('true');
+      expect(wrapper.text()).toContain('account_balances.skip_queries.entire_chain');
+
+      await button().trigger('click');
+
+      expect(toggleAll).not.toHaveBeenCalled();
+    });
+
+    it('should offer no menu to open', () => {
+      set(items, [chain('base', { wholeChain: true }), chain('gnosis', { wholeChain: true })]);
+
+      wrapper = createWrapper({ address: ADDRESS, chains: ['base', 'gnosis'] });
+
+      expect(chainItems()).toHaveLength(0);
+    });
+  });
+
+  it('should disable itself while an account operation is running', () => {
+    wrapper = createWrapper({ address: ADDRESS, chains: ['eth'], disabled: true });
+
+    expect(button().attributes('disabled')).toBeDefined();
+  });
+});

--- a/frontend/app/src/modules/accounts/table/components/table/AccountSkipQueriesToggle.vue
+++ b/frontend/app/src/modules/accounts/table/components/table/AccountSkipQueriesToggle.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { startPromise } from '@shared/utils';
+import { SkipState, useAccountSkipQueries } from '@/modules/accounts/table/use-account-skip-queries';
+import ChainIcon from '@/modules/shell/components/ChainIcon.vue';
+
+const { address, chains, disabled = false } = defineProps<{
+  address: string;
+  chains: string[];
+  disabled?: boolean;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const { items, locked, pending, state, toggleAll, toggleChain } = useAccountSkipQueries(
+  () => address,
+  () => chains,
+);
+
+const perChain = computed<boolean>(() => get(items).length > 1);
+
+/** What "all" means: chains switched off whole are listed, but no row action reaches them. */
+const actionable = computed<number>(() => get(items).filter(item => !item.wholeChain).length);
+
+const color = computed<'error' | 'warning' | undefined>(() => {
+  const current = get(state);
+  if (current === SkipState.ALL)
+    return 'error';
+  return current === SkipState.PARTIAL ? 'warning' : undefined;
+});
+
+const allSkipped = computed<boolean>(() => get(state) === SkipState.ALL);
+
+/**
+ * Inert rather than `disabled` while locked, so the tooltip explaining why still opens.
+ *
+ * @remarks
+ * A natively disabled button dispatches no mouse events, and the tooltip listens on a wrapper drawn
+ * tightly around it, so disabling the one state that exists to be explained is what hides the
+ * explanation. Opening the menu is already blocked on `locked`, and this covers the click.
+ */
+function activate(): void {
+  if (get(locked) || get(perChain))
+    return;
+  startPromise(toggleAll());
+}
+
+const tooltip = computed<string>(() => {
+  if (get(locked))
+    return t('account_balances.skip_queries.entire_chain');
+  if (get(perChain))
+    return t('account_balances.skip_queries.menu');
+
+  const chain = get(items)[0];
+  return chain.skipped
+    ? t('account_balances.skip_queries.resume', { chains: chain.name })
+    : t('account_balances.skip_queries.skip', { chains: chain.name });
+});
+</script>
+
+<template>
+  <RuiMenu
+    :disabled="!perChain || locked"
+    :options="{ placement: 'bottom-end' }"
+  >
+    <template #activator="{ attrs }">
+      <RuiTooltip
+        :options="{ placement: 'top' }"
+        :open-delay="400"
+      >
+        <template #activator>
+          <RuiButton
+            v-bind="perChain ? attrs : {}"
+            variant="text"
+            icon
+            data-testid="account-skip-queries"
+            :disabled="disabled || pending"
+            :aria-disabled="locked || undefined"
+            :class="{ 'opacity-50 cursor-not-allowed': locked }"
+            :color="color"
+            @click="activate()"
+          >
+            <RuiIcon
+              size="16"
+              name="lu-ban"
+            />
+          </RuiButton>
+        </template>
+        {{ tooltip }}
+      </RuiTooltip>
+    </template>
+
+    <div class="min-w-[16rem]">
+      <RuiButton
+        variant="list"
+        size="sm"
+        :disabled="pending"
+        data-testid="account-skip-queries-all"
+        @click="toggleAll()"
+      >
+        <template #prepend>
+          <RuiIcon
+            size="18"
+            :name="allSkipped ? 'lu-circle-check' : 'lu-ban'"
+          />
+        </template>
+        {{ allSkipped
+          ? t('account_balances.skip_queries.resume_all', { count: actionable }, actionable)
+          : t('account_balances.skip_queries.skip_all', { count: actionable }, actionable) }}
+      </RuiButton>
+
+      <RuiDivider class="my-1" />
+
+      <RuiButton
+        v-for="item in items"
+        :key="item.chain"
+        variant="list"
+        size="sm"
+        :disabled="pending || item.wholeChain"
+        data-testid="account-skip-queries-chain"
+        :data-chain="item.chain"
+        @click="toggleChain(item.chain)"
+      >
+        <template #prepend>
+          <ChainIcon
+            :chain="item.chain"
+            size="18px"
+          />
+        </template>
+        <div class="flex items-baseline justify-between gap-6 w-full">
+          <span class="truncate">{{ item.name }}</span>
+          <span
+            v-if="item.wholeChain || item.skipped"
+            class="text-caption font-normal text-rui-text-secondary shrink-0"
+            data-testid="account-skip-queries-chain-state"
+          >
+            {{ item.wholeChain
+              ? t('account_balances.skip_queries.chain_whole')
+              : t('account_balances.skip_queries.chain_skipped') }}
+          </span>
+        </div>
+      </RuiButton>
+    </div>
+  </RuiMenu>
+</template>

--- a/frontend/app/src/modules/accounts/table/use-account-skip-queries.spec.ts
+++ b/frontend/app/src/modules/accounts/table/use-account-skip-queries.spec.ts
@@ -1,0 +1,131 @@
+import type { ActionStatus } from '@/modules/core/common/action';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SkipState, useAccountSkipQueries } from '@/modules/accounts/table/use-account-skip-queries';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
+
+const write = vi.fn<(key: string, value: Record<string, string[]>) => Promise<ActionStatus>>(
+  async () => ({ success: true }),
+);
+const setMessage = vi.fn();
+
+vi.mock('@/modules/settings/settings-writer', () => ({
+  useSettingsWriter: (): { write: typeof write } => ({ write }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): { setMessage: typeof setMessage } => ({ setMessage }),
+}));
+
+describe('useAccountSkipQueries', () => {
+  const ADDRESS = '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c';
+
+  function setDisabled(value: Record<string, string[]>): void {
+    const store = useSettingsRepo();
+    store.updateGeneral({ ...store.general, disabledChainQueries: value });
+  }
+
+  function writtenPayload(): Record<string, string[]> {
+    const call = write.mock.lastCall;
+    expect(call).toBeDefined();
+    return call?.[1] ?? {};
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    write.mockResolvedValue({ success: true });
+  });
+
+  describe('state', () => {
+    it('should be none when no chain of the row is skipped', () => {
+      const { locked, state } = useAccountSkipQueries(ADDRESS, ['eth', 'optimism']);
+      expect(get(state)).toBe(SkipState.NONE);
+      expect(get(locked)).toBe(false);
+    });
+
+    it('should be partial when only some chains are skipped', () => {
+      setDisabled({ optimism: [ADDRESS] });
+      expect(get(useAccountSkipQueries(ADDRESS, ['eth', 'optimism']).state)).toBe(SkipState.PARTIAL);
+    });
+
+    it('should be all when every chain is skipped', () => {
+      setDisabled({ eth: [ADDRESS], optimism: [ADDRESS] });
+      expect(get(useAccountSkipQueries(ADDRESS, ['eth', 'optimism']).state)).toBe(SkipState.ALL);
+    });
+
+    it('should ignore a chain switched off whole, which the row cannot act on', () => {
+      setDisabled({ base: [], eth: [ADDRESS] });
+      expect(get(useAccountSkipQueries(ADDRESS, ['eth', 'base']).state)).toBe(SkipState.ALL);
+    });
+
+    it('should lock the row when every chain in scope is switched off whole', () => {
+      setDisabled({ base: [] });
+      const { locked, state } = useAccountSkipQueries(ADDRESS, ['base']);
+      expect(get(locked)).toBe(true);
+      expect(get(state)).toBe(SkipState.NONE);
+    });
+  });
+
+  describe('items', () => {
+    it('should list every chain of the row, marking the ones off whole', () => {
+      setDisabled({ base: [], eth: [ADDRESS] });
+
+      expect(get(useAccountSkipQueries(ADDRESS, ['eth', 'base', 'optimism']).items)).toEqual([
+        { chain: 'eth', name: 'Eth', skipped: true, wholeChain: false },
+        { chain: 'base', name: 'Base', skipped: false, wholeChain: true },
+        { chain: 'optimism', name: 'Optimism', skipped: false, wholeChain: false },
+      ]);
+    });
+  });
+
+  describe('writes', () => {
+    it('should skip one chain without touching the others', async () => {
+      setDisabled({ eth: [ADDRESS] });
+
+      await useAccountSkipQueries(ADDRESS, ['eth', 'optimism']).toggleChain('optimism');
+
+      expect(writtenPayload()).toEqual({ eth: [ADDRESS], optimism: [ADDRESS] });
+    });
+
+    it('should resume one chain without touching the others', async () => {
+      setDisabled({ eth: [ADDRESS], optimism: [ADDRESS] });
+
+      await useAccountSkipQueries(ADDRESS, ['eth', 'optimism']).toggleChain('eth');
+
+      expect(writtenPayload()).toEqual({ optimism: [ADDRESS] });
+    });
+
+    it('should skip the rest from a partial state, rather than resume', async () => {
+      setDisabled({ optimism: [ADDRESS] });
+
+      await useAccountSkipQueries(ADDRESS, ['eth', 'optimism']).toggleAll();
+
+      expect(writtenPayload()).toEqual({ eth: [ADDRESS], optimism: [ADDRESS] });
+    });
+
+    it('should resume every chain once they are all skipped', async () => {
+      setDisabled({ eth: [ADDRESS], optimism: [ADDRESS] });
+
+      await useAccountSkipQueries(ADDRESS, ['eth', 'optimism']).toggleAll();
+
+      expect(writtenPayload()).toEqual({});
+    });
+
+    it('should report a rejected write', async () => {
+      write.mockResolvedValue({ message: 'nope', success: false });
+
+      await useAccountSkipQueries(ADDRESS, ['eth']).toggleChain('eth');
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ description: 'nope', success: false }));
+    });
+
+    it('should not report a write that succeeded', async () => {
+      const { pending, toggleChain } = useAccountSkipQueries(ADDRESS, ['eth']);
+
+      await toggleChain('eth');
+
+      expect(setMessage).not.toHaveBeenCalled();
+      expect(get(pending)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/table/use-account-skip-queries.ts
+++ b/frontend/app/src/modules/accounts/table/use-account-skip-queries.ts
@@ -1,0 +1,107 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { ActionStatus } from '@/modules/core/common/action';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
+import { useSkipAddressQueries } from '@/modules/settings/general/disabled-chain-queries/use-skip-address-queries';
+
+/** `PARTIAL` is the state a per-chain choice creates, and the reason the row cannot be a checkbox. */
+export const SkipState = {
+  ALL: 'all',
+  NONE: 'none',
+  PARTIAL: 'partial',
+} as const;
+
+export type SkipState = (typeof SkipState)[keyof typeof SkipState];
+
+export interface SkipChainItem {
+  readonly chain: string;
+  readonly name: string;
+  readonly skipped: boolean;
+  /** The chain is switched off whole, so nothing this row does can change it. */
+  readonly wholeChain: boolean;
+}
+
+export interface UseAccountSkipQueriesReturn {
+  /** One entry per chain of the row, in the row's own order, whole-chain ones included. */
+  items: ComputedRef<SkipChainItem[]>;
+  state: ComputedRef<SkipState>;
+  /** No chain in scope can carry a per-address rule, so the row has nothing to offer. */
+  locked: ComputedRef<boolean>;
+  pending: Readonly<Ref<boolean>>;
+  /** Skip every chain the row can act on, or resume them all when they are already skipped. */
+  toggleAll: () => Promise<void>;
+  toggleChain: (chain: string) => Promise<void>;
+}
+
+/**
+ * One account row's view of the `disabledChainQueries` setting: the per-chain state behind the
+ * row's control, and the two writes it offers.
+ *
+ * @remarks
+ * Chains switched off whole are listed but never written to, in either direction: that is a
+ * decision about the chain, and a row lifting it would silently re-enable every other address on
+ * it. They are excluded from {@link SkipState} for the same reason - a row whose only chain is off
+ * whole reads as `none`, with `locked` explaining why nothing can be done about it.
+ *
+ * A failed write reports itself here rather than in the component, because the component would
+ * otherwise have to repeat it for each of the two actions.
+ */
+export function useAccountSkipQueries(
+  address: MaybeRefOrGetter<string>,
+  chains: MaybeRefOrGetter<string[]>,
+): UseAccountSkipQueriesReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const pending = shallowRef<boolean>(false);
+
+  const { setMessage } = useMessageStore();
+  const { getChainName } = useSupportedChains();
+  const { isChainExcluded } = useDisabledChains();
+  const { isSkipped, toggle } = useSkipAddressQueries();
+
+  const items = computed<SkipChainItem[]>(() => toValue(chains).map(chain => ({
+    chain,
+    name: getChainName(chain),
+    skipped: isSkipped(toValue(address), [chain]),
+    wholeChain: isChainExcluded(chain),
+  })));
+
+  const skippable = computed<SkipChainItem[]>(() => get(items).filter(item => !item.wholeChain));
+
+  const locked = computed<boolean>(() => get(skippable).length === 0);
+
+  const state = computed<SkipState>(() => {
+    const actionable = get(skippable);
+    const skipped = actionable.filter(item => item.skipped).length;
+    if (skipped === 0)
+      return SkipState.NONE;
+    return skipped === actionable.length ? SkipState.ALL : SkipState.PARTIAL;
+  });
+
+  const run = async (write: () => Promise<ActionStatus>): Promise<void> => {
+    set(pending, true);
+    const result = await write();
+    set(pending, false);
+    if (!result.success) {
+      setMessage({
+        description: result.message,
+        success: false,
+        title: t('account_balances.skip_queries.error'),
+      });
+    }
+  };
+
+  const toggleAll = async (): Promise<void> => run(async () => toggle(toValue(address), toValue(chains)));
+
+  const toggleChain = async (chain: string): Promise<void> => run(async () => toggle(toValue(address), [chain]));
+
+  return {
+    items,
+    locked,
+    pending: readonly(pending),
+    state,
+    toggleAll,
+    toggleChain,
+  };
+}

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/use-skip-address-queries.spec.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/use-skip-address-queries.spec.ts
@@ -1,0 +1,208 @@
+import type { ActionStatus } from '@/modules/core/common/action';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSettingsRepo } from '@/modules/settings/settings-repo';
+import { skipAddress, unskipAddress, useSkipAddressQueries } from './use-skip-address-queries';
+
+const write = vi.fn<(key: string, value: Record<string, string[]>) => Promise<ActionStatus>>(
+  async () => ({ success: true }),
+);
+
+vi.mock('@/modules/settings/settings-writer', () => ({
+  useSettingsWriter: (): { write: typeof write } => ({ write }),
+}));
+
+describe('useSkipAddressQueries', () => {
+  const ADDRESS = '0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c';
+  const OTHER_ADDRESS = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
+
+  let composable: ReturnType<typeof useSkipAddressQueries>;
+
+  function setDisabled(value: Record<string, string[]>): void {
+    const store = useSettingsRepo();
+    store.updateGeneral({ ...store.general, disabledChainQueries: value });
+  }
+
+  function writtenPayload(): Record<string, string[]> {
+    const call = write.mock.lastCall;
+    assert(call, 'expected a write to disabledChainQueries');
+    expect(call[0]).toBe('disabledChainQueries');
+    return call[1];
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    write.mockClear();
+    composable = useSkipAddressQueries();
+  });
+
+  describe('isSkipped', () => {
+    it('should be true only when every skippable chain excludes the address', () => {
+      setDisabled({ eth: [ADDRESS] });
+      expect(composable.isSkipped(ADDRESS, ['eth'])).toBe(true);
+      expect(composable.isSkipped(ADDRESS, ['eth', 'optimism'])).toBe(false);
+    });
+
+    it('should ignore a chain that is switched off whole', () => {
+      setDisabled({ base: [], eth: [ADDRESS] });
+      expect(composable.isSkipped(ADDRESS, ['eth', 'base'])).toBe(true);
+    });
+
+    it('should be false when the only chains in scope are switched off whole', () => {
+      setDisabled({ base: [] });
+      expect(composable.isSkipped(ADDRESS, ['base'])).toBe(false);
+    });
+  });
+
+  describe('toggle, adding the rule', () => {
+    it('should add the address on every chain in scope', async () => {
+      await composable.toggle(ADDRESS, ['eth', 'optimism']);
+      expect(writtenPayload()).toEqual({ eth: [ADDRESS], optimism: [ADDRESS] });
+    });
+
+    it('should keep the addresses another rule already excludes', async () => {
+      setDisabled({ eth: [OTHER_ADDRESS] });
+      await composable.toggle(ADDRESS, ['eth']);
+      expect(writtenPayload()).toEqual({ eth: [OTHER_ADDRESS, ADDRESS] });
+    });
+
+    it('should write into the existing key when the payload spells the chain differently', async () => {
+      setDisabled({ polygonPos: [OTHER_ADDRESS] });
+      await composable.toggle(ADDRESS, ['polygon_pos']);
+      expect(writtenPayload()).toEqual({ polygonPos: [OTHER_ADDRESS, ADDRESS] });
+    });
+
+    it('should leave a chain that is switched off whole untouched', async () => {
+      setDisabled({ base: [] });
+      await composable.toggle(ADDRESS, ['base', 'eth']);
+      expect(writtenPayload()).toEqual({ base: [], eth: [ADDRESS] });
+    });
+
+    it('should write nothing when every chain in scope is switched off whole', async () => {
+      setDisabled({ base: [] });
+      await composable.toggle(ADDRESS, ['base']);
+      expect(write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggle, lifting the rule', () => {
+    it('should drop the chain key rather than leave an empty array, which would skip the whole chain', async () => {
+      setDisabled({ eth: [ADDRESS] });
+      await composable.toggle(ADDRESS, ['eth']);
+      expect(writtenPayload()).toEqual({});
+    });
+
+    it('should keep the other addresses excluded on the chain', async () => {
+      setDisabled({ eth: [ADDRESS, OTHER_ADDRESS] });
+      await composable.toggle(ADDRESS, ['eth']);
+      expect(writtenPayload()).toEqual({ eth: [OTHER_ADDRESS] });
+    });
+
+    it('should lift the rule from every chain in scope', async () => {
+      setDisabled({ eth: [ADDRESS], optimism: [ADDRESS, OTHER_ADDRESS] });
+      await composable.toggle(ADDRESS, ['eth', 'optimism']);
+      expect(writtenPayload()).toEqual({ optimism: [OTHER_ADDRESS] });
+    });
+
+    it('should match the stored address regardless of case', async () => {
+      setDisabled({ eth: [ADDRESS.toLowerCase()] });
+      await composable.toggle(ADDRESS, ['eth']);
+      expect(writtenPayload()).toEqual({});
+    });
+  });
+
+  it('should not mutate the stored setting when building the payload', async () => {
+    const stored = { eth: [OTHER_ADDRESS] };
+    setDisabled(stored);
+    await composable.toggle(ADDRESS, ['eth']);
+    expect(stored).toEqual({ eth: [OTHER_ADDRESS] });
+  });
+
+  describe('concurrent toggles', () => {
+    /**
+     * Stands in for the real writer, which updates the settings repo before it resolves. The first
+     * call is held open by the returned resolver, so the second toggle is asked for while it is
+     * still in flight.
+     */
+    function writeThroughRepo(): () => void {
+      let release: () => void = () => {};
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      let first = true;
+      write.mockImplementation(async (_key, value) => {
+        if (first) {
+          first = false;
+          await held;
+        }
+        setDisabled(value);
+        return { success: true };
+      });
+      return release;
+    }
+
+    it('should not let a second row erase what the first one wrote', async () => {
+      const release = writeThroughRepo();
+
+      const first = composable.toggle(ADDRESS, ['eth']);
+      const second = composable.toggle(OTHER_ADDRESS, ['optimism']);
+      await nextTick();
+      release();
+      await Promise.all([first, second]);
+
+      expect(writtenPayload()).toEqual({ eth: [ADDRESS], optimism: [OTHER_ADDRESS] });
+    });
+
+    it('should keep the queue alive when a write throws rather than answering', async () => {
+      write.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(composable.toggle(ADDRESS, ['eth'])).rejects.toThrow('boom');
+
+      expect((await composable.toggle(OTHER_ADDRESS, ['optimism'])).success).toBe(true);
+      expect(writtenPayload()).toEqual({ optimism: [OTHER_ADDRESS] });
+    });
+
+    it('should keep writing after one of them is rejected', async () => {
+      write.mockResolvedValueOnce({ message: 'nope', success: false });
+      const release = writeThroughRepo();
+      release();
+
+      const [rejected] = await Promise.all([
+        composable.toggle(ADDRESS, ['eth']),
+        composable.toggle(OTHER_ADDRESS, ['optimism']),
+      ]);
+
+      expect(rejected.success).toBe(false);
+      expect(writtenPayload()).toEqual({ optimism: [OTHER_ADDRESS] });
+    });
+  });
+
+  describe('unskipAddress, on payloads the composable never hands it', () => {
+    it('should leave a chain with no rule of its own untouched', () => {
+      expect(unskipAddress({ eth: [OTHER_ADDRESS] }, ADDRESS, ['optimism']))
+        .toEqual({ eth: [OTHER_ADDRESS] });
+    });
+
+    it('should keep the empty array of a chain switched off whole, never emptying it further', () => {
+      expect(unskipAddress({ eth: [] }, ADDRESS, ['eth'])).toEqual({ eth: [] });
+    });
+
+    it('should leave a rule that does not name this address', () => {
+      expect(unskipAddress({ eth: [OTHER_ADDRESS] }, ADDRESS, ['eth']))
+        .toEqual({ eth: [OTHER_ADDRESS] });
+    });
+  });
+
+  describe('skipAddress, on payloads the composable never hands it', () => {
+    it('should not narrow a chain that is switched off whole', () => {
+      expect(skipAddress({ eth: [] }, ADDRESS, ['eth'])).toEqual({ eth: [] });
+    });
+
+    it('should not add an address the rule already names', () => {
+      expect(skipAddress({ eth: [ADDRESS] }, ADDRESS, ['eth'])).toEqual({ eth: [ADDRESS] });
+    });
+
+    it('should replace an entry that differs only by case, which the backend would never match', () => {
+      expect(skipAddress({ eth: [ADDRESS.toLowerCase()] }, ADDRESS, ['eth'])).toEqual({ eth: [ADDRESS] });
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/disabled-chain-queries/use-skip-address-queries.ts
+++ b/frontend/app/src/modules/settings/general/disabled-chain-queries/use-skip-address-queries.ts
@@ -1,0 +1,165 @@
+import type { ActionStatus } from '@/modules/core/common/action';
+import type { DisabledChainQueries } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chain-queries-state';
+import { get } from '@vueuse/core';
+import { toChainKey } from '@/modules/core/common/chains';
+import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
+import { useSettingsWriter } from '@/modules/settings/settings-writer';
+import { useSetting } from '@/modules/settings/use-setting';
+
+export interface UseSkipAddressQueriesReturn {
+  /** True when every skippable chain already excludes this address. False when none are skippable. */
+  isSkipped: (address: string, chains: string[]) => boolean;
+  /** Add the address rule on every skippable chain, or lift it from all of them when it is set. */
+  toggle: (address: string, chains: string[]) => Promise<ActionStatus>;
+}
+
+/**
+ * The key `payload` stores `chain` under, whatever its spelling, or `undefined` when it has none.
+ *
+ * @remarks
+ * Written by the settings dialog, by this composable and by the backend, so `polygon_pos` and
+ * `polygonPos` both occur. Adding a second key for a chain that already has one leaves two rules
+ * the reader folds together but the writer keeps overwriting one of.
+ */
+function findChainKey(payload: DisabledChainQueries, chain: string): string | undefined {
+  const target = toChainKey(chain);
+  return Object.keys(payload).find(key => toChainKey(key) === target);
+}
+
+function sameAddress(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function clonePayload(payload: DisabledChainQueries): DisabledChainQueries {
+  return Object.fromEntries(Object.entries(payload).map(([chain, addresses]) => [chain, [...addresses]]));
+}
+
+/**
+ * `payload` with `address` excluded on each of `chains`.
+ *
+ * @remarks
+ * A chain whose entry is empty is switched off whole, which already covers every address on it, so
+ * it is left alone rather than given a narrower rule that would read as a downgrade.
+ *
+ * An entry that differs from `address` only by case is **replaced** rather than left as it is: the
+ * backend compares addresses exactly, so a lower-cased entry written by hand or by an older client
+ * never matches the checksummed address the row carries, and the rule silently does nothing while
+ * this module - which folds case - reports the account as skipped.
+ *
+ * Exported for its spec: {@link useSkipAddressQueries} only ever calls it under conditions it has
+ * already established, which leaves the guards that make it total untestable through the composable.
+ */
+export function skipAddress(payload: DisabledChainQueries, address: string, chains: string[]): DisabledChainQueries {
+  const next = clonePayload(payload);
+  for (const chain of chains) {
+    const key = findChainKey(next, chain);
+    if (key === undefined) {
+      next[chain] = [address];
+      continue;
+    }
+    const addresses = next[key];
+    if (addresses.length === 0)
+      continue;
+    const existing = addresses.findIndex(entry => sameAddress(entry, address));
+    if (existing === -1)
+      addresses.push(address);
+    else
+      addresses[existing] = address;
+  }
+  return next;
+}
+
+/**
+ * `payload` without `address` on any of `chains`.
+ *
+ * @remarks
+ * The chain's key is **deleted** once its last address goes, never left as an empty array: an empty
+ * array is the payload's spelling for "this entire chain is switched off", so lifting the last
+ * address rule that way would silently skip the whole chain instead of nothing.
+ *
+ * Exported for its spec, as {@link skipAddress} is.
+ */
+export function unskipAddress(payload: DisabledChainQueries, address: string, chains: string[]): DisabledChainQueries {
+  const next = clonePayload(payload);
+  for (const chain of chains) {
+    const key = findChainKey(next, chain);
+    if (key === undefined)
+      continue;
+    const addresses = next[key];
+    if (addresses.length === 0)
+      continue;
+    const remaining = addresses.filter(existing => !sameAddress(existing, address));
+    if (remaining.length === addresses.length)
+      continue;
+    if (remaining.length === 0)
+      delete next[key];
+    else
+      next[key] = remaining;
+  }
+  return next;
+}
+
+/**
+ * Serializes every write this module makes, across all of its callers.
+ *
+ * @remarks
+ * A toggle is a read-modify-write of one shared setting, and each row holds its own composable. Two
+ * rows toggled before the first write lands would otherwise both build a payload from the state
+ * before either, and the second would erase the first with no error to show for it. Queued, each
+ * payload is built once the previous write has updated the settings repo, which
+ * `useSettingsOperations.update` does before it resolves.
+ *
+ * A rejected write must not stall the queue, so the chain is kept on its settled form.
+ */
+let writeQueue: Promise<unknown> = Promise.resolve();
+
+async function queued<T>(task: () => Promise<T>): Promise<T> {
+  const run = writeQueue.then(task, task);
+  writeQueue = run.catch(() => undefined);
+  return run;
+}
+
+/**
+ * Write side of the `disabledChainQueries` setting for one address, as the accounts table needs it:
+ * skip this address on the chains the row shows, or stop skipping it, in a single call.
+ *
+ * @remarks
+ * The settings dialog edits the same setting through {@link useDisabledChainQueriesState}, which
+ * models it as a list of rules with ids so a row can be edited in place. A quick action has no rule
+ * to edit - it knows an address and some chains - so it works on the payload directly and shares
+ * only the read side, {@link useDisabledChains}.
+ *
+ * A chain switched off whole is never touched here, in either direction: it is a decision about the
+ * chain rather than about this account, and undoing it from a single row would silently re-enable
+ * every other address on it.
+ */
+export function useSkipAddressQueries(): UseSkipAddressQueriesReturn {
+  const disabledChainQueries = useSetting('disabledChainQueries');
+  const { isAddressExcluded, isChainExcluded } = useDisabledChains();
+  const { write } = useSettingsWriter();
+
+  const skippableChains = (chains: string[]): string[] => chains.filter(chain => !isChainExcluded(chain));
+
+  const isSkipped = (address: string, chains: string[]): boolean => {
+    const skippable = skippableChains(chains);
+    return skippable.length > 0 && skippable.every(chain => isAddressExcluded(chain, address));
+  };
+
+  const toggle = async (address: string, chains: string[]): Promise<ActionStatus> => queued(async () => {
+    const skippable = skippableChains(chains);
+    if (skippable.length === 0)
+      return { success: true };
+
+    const current = get(disabledChainQueries);
+    const payload = isSkipped(address, chains)
+      ? unskipAddress(current, address, skippable)
+      : skipAddress(current, address, skippable);
+
+    return write('disabledChainQueries', payload);
+  });
+
+  return {
+    isSkipped,
+    toggle,
+  };
+}


### PR DESCRIPTION
Closes #13033.

Ignoring an address on a chain meant remembering it, going to Settings → Chains and searching for it there. The accounts table now carries the action on the row.

## What it does

- A ban icon in the row's actions. One chain toggles directly; several open a menu that skips or resumes each chain on its own, above an item for all of them at once.
- The control's colour carries the row's state: red once every chain is skipped, amber while only some are.
- Skipped chains are marked in the **Chains** column with the same greyscale + ban badge Settings uses, so which chains are skipped is legible where the chains are named. The badge answers for entire-chain rules too, so a row on a chain you switched off whole is marked even though it has no rule of its own.
- It works on the group row and on the per-chain rows inside an expanded group, since both render through `AccountBalancesTable`.

No backend change: enforcement already exists, since `useDisabledChains` is read by balances, token detection, history and the sync panel.

## Decisions worth reviewing

**Scope is every chain the row stands for, not the chains its Chains column shows.** Those icons are a display filter (`chainFilter`), so reading them would give one control two meanings — dimming a chain to see the value without it would then skip every *other* chain. The page's own chain filter still narrows the action, because it narrows what the row is.

**A chain switched off whole is never written to, in either direction.** That is a decision about the chain, and a row lifting it would silently re-enable every other address on it. Such chains are listed in the menu but inert, excluded from the "all" count, and a row that has nothing else left is inert rather than `disabled`, so its tooltip can still explain why.

**Address accounts only.** A validator's public key and an xpub are not what the backend matches a rule against.

**Balances are not re-read after a write.** A skipped account keeps its stored value until the next query. Happy to add a cached refresh (the backend strips disabled addresses even on the `from_cache` path) if you would rather it settle immediately.

## The payload rules, which are the subtle part

`disabledChainQueries` is `Record<chain, address[]>` where an **empty array disables the entire chain**. Three properties follow, each with a test:

- lifting the last address rule on a chain **deletes its key**; leaving `[]` would silently skip the whole chain;
- a chain already present under a different spelling (`polygonPos` vs `polygon_pos`) keeps its key rather than gaining a second one the reader folds together and the writer keeps overwriting;
- an entry differing only in case is replaced by the row's own spelling, since the backend compares addresses exactly while the read side folds case.

Writes are also queued across callers: two rows toggled before the first landed would otherwise both build a payload from the state before either, and the second would erase the first with nothing to show for it.

## Tests

829 tests pass across `modules/accounts` and the setting. New code is fully covered:

| file | statements | branches |
|---|---|---|
| `use-skip-address-queries.ts` | 61/61 | 20/20 |
| `use-account-skip-queries.ts` | 34/34 | 6/6 |
| `AccountSkipQueriesToggle.vue` | 41/41 | 38/38 |
| `AccountActions.vue` | 19/19 | 16/16 |
| `AccountChains.vue` | 38/40 | 23/24 |

`AccountChains.vue` had no spec before this branch; its display-filter logic is now covered too, and the two remaining lines are interpolation slots inside the filter tooltips.

Every assertion was checked with a negative control. Two of them passed at first and had to be re-aimed — one guard in `unskipAddress` turns out to be redundant with the guard after it, and an assertion on the chain tooltip matched both the correct and the duplicated output.

Driven in the running app as well: the rule shape the quick action writes matches what the settings dialog produces, the entire-chain rule survives a "skip all", and un-skipping the last chain leaves no empty key behind.
