### PR TITLE
test(assets): coverage batch K, the asset admin mapping pages

### DIFF
--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingContent.spec.ts
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingContent.spec.ts
@@ -1,0 +1,146 @@
+import type { CexMapping } from '@/modules/assets/types';
+import type { Collection } from '@/modules/core/common/collection';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import ManageCexMappingContent from '@/modules/assets/admin/cex-mapping/ManageCexMappingContent.vue';
+import ManageCexMappingFormDialog from '@/modules/assets/admin/cex-mapping/ManageCexMappingFormDialog.vue';
+import ManageCexMappingTable from '@/modules/assets/admin/cex-mapping/ManageCexMappingTable.vue';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+
+interface RouteHolder {
+  route?: Ref<{ query: Record<string, string> }>;
+}
+
+let filter: Ref<Record<string, string | string[] | undefined>>;
+
+const { deleteCexMapping, fetchAllCexMapping, held, refetch, replace } = vi.hoisted(() => {
+  const held: RouteHolder = {};
+  return {
+    deleteCexMapping: vi.fn(async () => Promise.resolve(true)),
+    fetchAllCexMapping: vi.fn(),
+    held,
+    refetch: vi.fn(async () => Promise.resolve()),
+    replace: vi.fn(async () => Promise.resolve()),
+  };
+});
+
+vi.mock('vue-router', async () => {
+  const { ref: actualRef } = await vi.importActual<typeof import('vue')>('vue');
+  held.route = actualRef({ query: {} });
+  return {
+    useRoute: (): unknown => held.route,
+    useRouter: (): Record<string, unknown> => ({ replace }),
+  };
+});
+
+vi.mock('@/modules/assets/api/use-asset-cex-mapping-api', () => ({
+  useAssetCexMappingApi: (): Record<string, unknown> => ({ deleteCexMapping, fetchAllCexMapping }),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', () => ({
+  useServerTable: (): Record<string, unknown> => ({
+    collection: ref<Collection<CexMapping>>({ data: [], found: 0, limit: -1, total: 0, totalValue: undefined }),
+    filter,
+    isLoading: ref<boolean>(false),
+    pagination: ref({ limit: 10, page: 1, total: 0 }),
+    refetch,
+  }),
+}));
+
+const MAPPING: CexMapping = { asset: 'BTC', location: 'kraken', locationSymbol: 'XBT' };
+
+function createWrapper(): VueWrapper {
+  return mount(ManageCexMappingContent, {
+    global: {
+      plugins: [createCustomPinia()],
+      stubs: {
+        ManageCexMappingFormDialog: true,
+        ManageCexMappingTable: true,
+        TablePageLayout: { template: '<div><slot name="buttons" /><slot /></div>' },
+      },
+    },
+  });
+}
+
+describe('modules/assets/admin/cex-mapping/ManageCexMappingContent.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    filter = ref<Record<string, string | string[] | undefined>>({});
+    held.route = ref({ query: {} });
+  });
+
+  it('should read the mappings when it opens', async () => {
+    createWrapper();
+    await flushPromises();
+
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  it('should open the dialog on a blank mapping from the add button', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    await wrapper.find('[data-testid=managed-cex-mapping-add-btn]').trigger('click');
+
+    expect(wrapper.findComponent(ManageCexMappingFormDialog).props('modelValue'))
+      .toEqual({ asset: '', location: '', locationSymbol: '' });
+  });
+
+  it('should seed the new mapping from the filter', async () => {
+    set(filter, { location: 'kraken', locationSymbol: 'XBT' });
+
+    const wrapper = createWrapper();
+    await flushPromises();
+    await wrapper.find('[data-testid=managed-cex-mapping-add-btn]').trigger('click');
+
+    expect(wrapper.findComponent(ManageCexMappingFormDialog).props('modelValue'))
+      .toEqual({ asset: '', location: 'kraken', locationSymbol: 'XBT' });
+  });
+
+  it('should hand the table a row to edit straight to the dialog', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(ManageCexMappingTable).vm.$emit('edit', MAPPING);
+    await flushPromises();
+
+    const dialog = wrapper.findComponent(ManageCexMappingFormDialog);
+    expect(dialog.props('modelValue')).toEqual(MAPPING);
+    expect(dialog.props('editMode')).toBe(true);
+  });
+
+  it('should ask before deleting a row the table asked to remove', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(ManageCexMappingTable).vm.$emit('delete', MAPPING);
+    await flushPromises();
+
+    expect(get(useConfirmStore().visible)).toBe(true);
+    expect(deleteCexMapping).not.toHaveBeenCalled();
+  });
+
+  it('should delete the row once the dialog is confirmed, without its asset', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(ManageCexMappingTable).vm.$emit('delete', MAPPING);
+    await useConfirmStore().confirm();
+    await flushPromises();
+
+    expect(deleteCexMapping).toHaveBeenCalledWith({ location: 'kraken', locationSymbol: 'XBT' });
+  });
+
+  it('should open the dialog seeded from an ?add= link', async () => {
+    held.route = ref({ query: { add: 'true', location: 'coinbase', locationSymbol: 'ETH' } });
+
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    expect(wrapper.findComponent(ManageCexMappingFormDialog).props('modelValue'))
+      .toEqual({ asset: '', location: 'coinbase', locationSymbol: 'ETH' });
+    expect(replace).toHaveBeenCalledWith({ query: {} });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingContent.vue
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingContent.vue
@@ -4,23 +4,17 @@ import { omit } from 'es-toolkit';
 import ManageCexMappingFormDialog from '@/modules/assets/admin/cex-mapping/ManageCexMappingFormDialog.vue';
 import ManageCexMappingTable from '@/modules/assets/admin/cex-mapping/ManageCexMappingTable.vue';
 import { useCexMappingFields } from '@/modules/assets/admin/cex-mapping/use-cex-mapping-fields';
-import { type CexMappingFilterKey, CexMappingFilterKeys, type Filters } from '@/modules/assets/admin/cex-mapping/use-cex-mapping-filter';
+import { CexMappingFilterKeys, type Filters } from '@/modules/assets/admin/cex-mapping/use-cex-mapping-filter';
+import { useMappingAdmin } from '@/modules/assets/admin/use-mapping-admin';
 import { useAssetCexMappingApi } from '@/modules/assets/api/use-asset-cex-mapping-api';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { firstQueryValue } from '@/modules/core/table/route';
 import { useServerTable } from '@/modules/core/table/use-server-table';
 import { useTableRowDeletion } from '@/modules/core/table/use-table-row-deletion';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
 const { t } = useI18n({ useScope: 'global' });
-const router = useRouter();
-const route = useRoute();
 
 const { deleteCexMapping, fetchAllCexMapping } = useAssetCexMappingApi();
-
-const editMode = ref<boolean>(false);
-
-const modelValue = ref<CexMapping>();
 
 const fields = useCexMappingFields();
 
@@ -40,47 +34,20 @@ const {
   urlState: { mode: 'route' },
 });
 
-/** The bag types every value as one-or-many; both of these fields are single-valued. */
-function filterValue(key: CexMappingFilterKey): string {
-  const picked = get(filter)[key];
-  return (Array.isArray(picked) ? picked[0] : picked)?.toString() ?? '';
-}
-
-onMounted(async () => {
-  const { query } = get(route);
-  if (query.add) {
-    await router.replace({ query: {} });
-    add({
-      location: firstQueryValue(query.location),
-      locationSymbol: firstQueryValue(query.locationSymbol),
-    });
-  }
-
-  await refetch();
+const { add, consumeAddQuery, edit, editMode, modelValue } = useMappingAdmin<CexMapping, Filters>({
+  blank: () => ({ asset: '', location: '', locationSymbol: '' }),
+  filter,
+  seedFromFilter: {
+    location: CexMappingFilterKeys.LOCATION,
+    locationSymbol: CexMappingFilterKeys.LOCATION_SYMBOL,
+  },
+  seedFromQuery: { location: 'location', locationSymbol: 'locationSymbol' },
 });
 
-/**
- * Opens the form dialog on a blank mapping, seeded from whatever the pill bar is narrowed to.
- *
- * @remarks
- * Adding while filtered to an exchange should not ask for that exchange again, so the location
- * fields come from the filter. `payload` is spread last and wins, which is how the `?location=`
- * and `?locationSymbol=` query handled on mount reaches the form.
- */
-function add(payload?: Partial<CexMapping>) {
-  set(modelValue, {
-    asset: '',
-    location: filterValue(CexMappingFilterKeys.LOCATION),
-    locationSymbol: filterValue(CexMappingFilterKeys.LOCATION_SYMBOL),
-    ...payload,
-  });
-  set(editMode, false);
-}
-
-function edit(editMapping: CexMapping) {
-  set(modelValue, editMapping);
-  set(editMode, true);
-}
+onMounted(async () => {
+  await consumeAddQuery();
+  await refetch();
+});
 
 const { showDeleteConfirmation } = useTableRowDeletion<CexMapping>({
   confirm: item => ({

--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingFormDialog.vue
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingFormDialog.vue
@@ -2,9 +2,8 @@
 import type { CexMapping } from '@/modules/assets/types';
 import { useTemplateRef } from 'vue';
 import ManageCexMappingForm from '@/modules/assets/admin/cex-mapping/ManageCexMappingForm.vue';
+import { useMappingFormDialog } from '@/modules/assets/admin/use-mapping-form-dialog';
 import { useAssetCexMappingApi } from '@/modules/assets/api/use-asset-cex-mapping-api';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 
 const modelValue = defineModel<CexMapping | undefined>({ required: true });
@@ -20,61 +19,23 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 const form = useTemplateRef<InstanceType<typeof ManageCexMappingForm>>('form');
-const loading = ref(false);
-const stateUpdated = ref(false);
-const errorMessages = ref<Record<string, string[]>>({});
+const stateUpdated = ref<boolean>(false);
 const forAllExchanges = ref<boolean>(false);
 
-const dialogTitle = computed<string>(() =>
-  editMode
-    ? t('asset_management.cex_mapping.edit_title')
-    : t('asset_management.cex_mapping.add_title'),
-);
-
 const { addCexMapping, editCexMapping } = useAssetCexMappingApi();
-const { setMessage } = useMessageStore();
 
-async function save(): Promise<boolean> {
-  if (!isDefined(modelValue))
-    return false;
-
-  const formRef = get(form);
-  const valid = formRef?.validate();
-  if (!valid)
-    return false;
-
-  const data = get(modelValue);
-  let success;
-  const payload = {
-    ...data,
-    location: get(forAllExchanges) ? null : data.location,
-  };
-
-  set(loading, true);
-  try {
-    if (editMode)
-      success = await editCexMapping(payload);
-    else
-      success = await addCexMapping(payload);
-  }
-  catch (error: unknown) {
-    success = false;
-    const obj = { message: getErrorMessage(error) };
-    setMessage({
-      description: editMode
-        ? t('asset_management.cex_mapping.add_error', obj)
-        : t('asset_management.cex_mapping.edit_error', obj),
-    });
-  }
-
-  set(loading, false);
-  if (success) {
-    const mapping = get(modelValue);
-    set(modelValue, undefined);
-    emit('refresh', mapping);
-  }
-  return success;
-}
+const { dialogTitle, loading, modelErrorMessages, save } = useMappingFormDialog({
+  add: addCexMapping,
+  edit: editCexMapping,
+  editMode: () => editMode ?? false,
+  form,
+  modelValue,
+  onSaved: (mapping): void => emit('refresh', mapping),
+  toPayload: (mapping): CexMapping => ({
+    ...mapping,
+    location: get(forAllExchanges) ? null : mapping.location,
+  }),
+});
 </script>
 
 <template>
@@ -91,7 +52,7 @@ async function save(): Promise<boolean> {
       v-if="modelValue"
       ref="form"
       v-model="modelValue"
-      v-model:error-messages="errorMessages"
+      v-model:error-messages="modelErrorMessages"
       v-model:state-updated="stateUpdated"
       v-model:for-all-exchanges="forAllExchanges"
       :edit-mode="editMode"

--- a/frontend/app/src/modules/assets/admin/cex-mapping/use-cex-mapping-filter.ts
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/use-cex-mapping-filter.ts
@@ -6,6 +6,6 @@ export const CexMappingFilterKeys = {
   LOCATION_SYMBOL: 'locationSymbol',
 } as const;
 
-export type CexMappingFilterKey = typeof CexMappingFilterKeys[keyof typeof CexMappingFilterKeys];
+type CexMappingFilterKey = typeof CexMappingFilterKeys[keyof typeof CexMappingFilterKeys];
 
 export type Filters = MatchedKeyword<CexMappingFilterKey>;

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.spec.ts
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.spec.ts
@@ -1,0 +1,145 @@
+import type { CounterpartyMapping } from '@/modules/assets/admin/counterparty-mapping/schema';
+import type { Collection } from '@/modules/core/common/collection';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import ManageCounterpartyMapping from '@/modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.vue';
+import ManageCounterpartyMappingFormDialog from '@/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingFormDialog.vue';
+import ManageCounterpartyMappingTable from '@/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingTable.vue';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+
+interface RouteHolder {
+  route?: Ref<{ query: Record<string, string> }>;
+}
+
+let filter: Ref<Record<string, string | string[] | undefined>>;
+
+const { deleteCounterpartyMapping, fetchAllCounterpartyMapping, held, refetch, replace } = vi.hoisted(() => {
+  const held: RouteHolder = {};
+  return {
+    deleteCounterpartyMapping: vi.fn(async () => Promise.resolve(true)),
+    fetchAllCounterpartyMapping: vi.fn(),
+    held,
+    refetch: vi.fn(async () => Promise.resolve()),
+    replace: vi.fn(async () => Promise.resolve()),
+  };
+});
+
+vi.mock('vue-router', async () => {
+  const { ref: actualRef } = await vi.importActual<typeof import('vue')>('vue');
+  held.route = actualRef({ query: {} });
+  return {
+    useRoute: (): unknown => held.route,
+    useRouter: (): Record<string, unknown> => ({ replace }),
+  };
+});
+
+vi.mock('@/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-api', () => ({
+  useCounterpartyMappingApi: (): Record<string, unknown> => ({
+    deleteCounterpartyMapping,
+    fetchAllCounterpartyMapping,
+  }),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', () => ({
+  useServerTable: (): Record<string, unknown> => ({
+    collection: ref<Collection<CounterpartyMapping>>({
+      data: [],
+      found: 0,
+      limit: -1,
+      total: 0,
+      totalValue: undefined,
+    }),
+    filter,
+    isLoading: ref<boolean>(false),
+    pagination: ref({ limit: 10, page: 1, total: 0 }),
+    refetch,
+  }),
+}));
+
+const MAPPING: CounterpartyMapping = { asset: 'ETH', counterparty: 'uniswap', counterpartySymbol: 'WETH' };
+
+function createWrapper(): VueWrapper {
+  return mount(ManageCounterpartyMapping, {
+    global: {
+      plugins: [createCustomPinia()],
+      stubs: {
+        ManageCounterpartyMappingFormDialog: true,
+        ManageCounterpartyMappingTable: true,
+        TablePageLayout: { template: '<div><slot name="buttons" /><slot /></div>' },
+      },
+    },
+  });
+}
+
+describe('modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    filter = ref<Record<string, string | string[] | undefined>>({});
+    held.route = ref({ query: {} });
+  });
+
+  it('should read the mappings when it opens', async () => {
+    createWrapper();
+    await flushPromises();
+
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  it('should seed the new mapping from the filter', async () => {
+    set(filter, { counterparty: 'uniswap', counterpartySymbol: 'WETH' });
+
+    const wrapper = createWrapper();
+    await flushPromises();
+    await wrapper.find('[data-testid=managed-counterparty-mapping-add-btn]').trigger('click');
+
+    expect(wrapper.findComponent(ManageCounterpartyMappingFormDialog).props('modelValue'))
+      .toEqual({ asset: '', counterparty: 'uniswap', counterpartySymbol: 'WETH' });
+  });
+
+  it('should hand the table a row to edit straight to the dialog', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(ManageCounterpartyMappingTable).vm.$emit('edit', MAPPING);
+    await flushPromises();
+
+    const dialog = wrapper.findComponent(ManageCounterpartyMappingFormDialog);
+    expect(dialog.props('modelValue')).toEqual(MAPPING);
+    expect(dialog.props('editMode')).toBe(true);
+  });
+
+  it('should ask before deleting a row the table asked to remove', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(ManageCounterpartyMappingTable).vm.$emit('delete', MAPPING);
+    await flushPromises();
+
+    expect(get(useConfirmStore().visible)).toBe(true);
+    expect(deleteCounterpartyMapping).not.toHaveBeenCalled();
+  });
+
+  it('should delete the row once the dialog is confirmed, without its asset', async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    wrapper.findComponent(ManageCounterpartyMappingTable).vm.$emit('delete', MAPPING);
+    await useConfirmStore().confirm();
+    await flushPromises();
+
+    expect(deleteCounterpartyMapping).toHaveBeenCalledWith({ counterparty: 'uniswap', counterpartySymbol: 'WETH' });
+  });
+
+  it('should open the dialog seeded from an ?add= link', async () => {
+    held.route = ref({ query: { add: 'true', counterparty: 'curve', counterpartySymbol: 'CRV' } });
+
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    expect(wrapper.findComponent(ManageCounterpartyMappingFormDialog).props('modelValue'))
+      .toEqual({ asset: '', counterparty: 'curve', counterpartySymbol: 'CRV' });
+    expect(replace).toHaveBeenCalledWith({ query: {} });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.vue
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.vue
@@ -6,22 +6,16 @@ import ManageCounterpartyMappingFormDialog
 import ManageCounterpartyMappingTable from '@/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingTable.vue';
 import { useCounterpartyMappingApi } from '@/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-api';
 import { useCounterpartyMappingFields } from '@/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-fields';
-import { type CounterpartyMappingFilterKey, CounterpartyMappingFilterKeys, type Filters } from '@/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-filter';
+import { CounterpartyMappingFilterKeys, type Filters } from '@/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-filter';
+import { useMappingAdmin } from '@/modules/assets/admin/use-mapping-admin';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { firstQueryValue } from '@/modules/core/table/route';
 import { useServerTable } from '@/modules/core/table/use-server-table';
 import { useTableRowDeletion } from '@/modules/core/table/use-table-row-deletion';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
 const { t } = useI18n({ useScope: 'global' });
-const router = useRouter();
-const route = useRoute();
 
 const { deleteCounterpartyMapping, fetchAllCounterpartyMapping } = useCounterpartyMappingApi();
-
-const editMode = ref<boolean>(false);
-
-const modelValue = ref<CounterpartyMapping>();
 
 const fields = useCounterpartyMappingFields();
 
@@ -41,46 +35,20 @@ const {
   urlState: { mode: 'route' },
 });
 
-/** The bag types every value as one-or-many; both of these fields are single-valued. */
-function filterValue(key: CounterpartyMappingFilterKey): string {
-  const picked = get(filter)[key];
-  return (Array.isArray(picked) ? picked[0] : picked)?.toString() ?? '';
-}
-
-onMounted(async () => {
-  const { query } = get(route);
-  if (query.add) {
-    await router.replace({ query: {} });
-    add({
-      counterparty: firstQueryValue(query.counterparty),
-      counterpartySymbol: firstQueryValue(query.counterpartySymbol),
-    });
-  }
-
-  await refetch();
+const { add, consumeAddQuery, edit, editMode, modelValue } = useMappingAdmin<CounterpartyMapping, Filters>({
+  blank: () => ({ asset: '', counterparty: '', counterpartySymbol: '' }),
+  filter,
+  seedFromFilter: {
+    counterparty: CounterpartyMappingFilterKeys.COUNTERPARTY,
+    counterpartySymbol: CounterpartyMappingFilterKeys.COUNTERPARTY_SYMBOL,
+  },
+  seedFromQuery: { counterparty: 'counterparty', counterpartySymbol: 'counterpartySymbol' },
 });
 
-/**
- * Opens the mapping dialog on a new mapping, seeded from the filter bar.
- *
- * @remarks
- * The counterparty and its symbol default to whatever the bar is narrowed to, so adding a mapping
- * while filtered does not make the user pick the same values again; `payload` overrides them.
- */
-function add(payload?: Partial<CounterpartyMapping>) {
-  set(modelValue, {
-    asset: '',
-    counterparty: filterValue(CounterpartyMappingFilterKeys.COUNTERPARTY),
-    counterpartySymbol: filterValue(CounterpartyMappingFilterKeys.COUNTERPARTY_SYMBOL),
-    ...payload,
-  });
-  set(editMode, false);
-}
-
-function edit(editMapping: CounterpartyMapping) {
-  set(modelValue, editMapping);
-  set(editMode, true);
-}
+onMounted(async () => {
+  await consumeAddQuery();
+  await refetch();
+});
 
 const { showDeleteConfirmation } = useTableRowDeletion<CounterpartyMapping>({
   confirm: item => ({

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingFormDialog.vue
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingFormDialog.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import type { CounterpartyMapping } from '@/modules/assets/admin/counterparty-mapping/schema';
 import { useTemplateRef } from 'vue';
-import ManageCounterpartyMappingForm from '@/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.vue';
+import ManageCounterpartyMappingForm
+  from '@/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingForm.vue';
 import { useCounterpartyMappingApi } from '@/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-api';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useMappingFormDialog } from '@/modules/assets/admin/use-mapping-form-dialog';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 
 const modelValue = defineModel<CounterpartyMapping | undefined>({ required: true });
@@ -20,56 +20,19 @@ const emit = defineEmits<{
 const { t } = useI18n({ useScope: 'global' });
 
 const form = useTemplateRef<InstanceType<typeof ManageCounterpartyMappingForm>>('form');
-const loading = ref(false);
-const stateUpdated = ref(false);
-const errorMessages = ref<Record<string, string[]>>({});
-
-const dialogTitle = computed<string>(() =>
-  editMode
-    ? t('asset_management.cex_mapping.edit_title')
-    : t('asset_management.cex_mapping.add_title'),
-);
+const stateUpdated = ref<boolean>(false);
 
 const { addCounterpartyMapping, editCounterpartyMapping } = useCounterpartyMappingApi();
-const { setMessage } = useMessageStore();
 
-async function save(): Promise<boolean> {
-  if (!isDefined(modelValue))
-    return false;
-
-  const formRef = get(form);
-  const valid = formRef?.validate();
-  if (!valid)
-    return false;
-
-  const data = get(modelValue);
-  let success;
-
-  set(loading, true);
-  try {
-    if (editMode)
-      success = await editCounterpartyMapping(data);
-    else
-      success = await addCounterpartyMapping(data);
-  }
-  catch (error: unknown) {
-    success = false;
-    const obj = { message: getErrorMessage(error) };
-    setMessage({
-      description: editMode
-        ? t('asset_management.cex_mapping.add_error', obj)
-        : t('asset_management.cex_mapping.edit_error', obj),
-    });
-  }
-
-  set(loading, false);
-  if (success) {
-    const mapping = get(modelValue);
-    set(modelValue, undefined);
-    emit('refresh', mapping);
-  }
-  return success;
-}
+const { dialogTitle, loading, modelErrorMessages, save } = useMappingFormDialog({
+  add: addCounterpartyMapping,
+  edit: editCounterpartyMapping,
+  editMode: () => editMode ?? false,
+  form,
+  modelValue,
+  onSaved: (mapping): void => emit('refresh', mapping),
+  toPayload: (mapping): CounterpartyMapping => mapping,
+});
 </script>
 
 <template>
@@ -86,7 +49,7 @@ async function save(): Promise<boolean> {
       v-if="modelValue"
       ref="form"
       v-model="modelValue"
-      v-model:error-messages="errorMessages"
+      v-model:error-messages="modelErrorMessages"
       v-model:state-updated="stateUpdated"
       :edit-mode="editMode"
     />

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-filter.ts
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/use-counterparty-mapping-filter.ts
@@ -6,7 +6,7 @@ export const CounterpartyMappingFilterKeys = {
   COUNTERPARTY_SYMBOL: 'counterpartySymbol',
 } as const;
 
-export type CounterpartyMappingFilterKey =
+type CounterpartyMappingFilterKey =
   typeof CounterpartyMappingFilterKeys[keyof typeof CounterpartyMappingFilterKeys];
 
 export type Filters = MatchedKeyword<CounterpartyMappingFilterKey>;

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetFormDialog.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetFormDialog.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
 import type { SupportedAsset } from '@rotki/common';
-import { omit } from 'es-toolkit';
 import { useTemplateRef } from 'vue';
 import ManagedAssetForm from '@/modules/assets/admin/managed/ManagedAssetForm.vue';
-import { useAssetInfoCache } from '@/modules/assets/use-asset-info-cache';
-import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useManagedAssetFormDialog } from '@/modules/assets/admin/managed/use-managed-asset-form-dialog';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 
 const modelValue = defineModel<SupportedAsset | undefined>({ required: true });
@@ -22,90 +18,15 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const loading = ref<boolean>(false);
 const stateUpdated = ref<boolean>(false);
-const errorMessages = ref<Record<string, string[]>>({});
 const form = useTemplateRef<InstanceType<typeof ManagedAssetForm>>('form');
 
-const dialogTitle = computed<string>(() =>
-  editMode ? t('asset_management.edit_title') : t('asset_management.add_title'),
-);
-
-const { setMessage } = useMessageStore();
-const { deleteCacheKey } = useAssetInfoCache();
-
-function handleValidationErrors(errors: ValidationErrors): void {
-  if ('underlyingTokens' in errors) {
-    const underlyingTokens = errors.underlyingTokens;
-    if (underlyingTokens) {
-      const messages = Array.isArray(underlyingTokens) ? underlyingTokens : [underlyingTokens];
-      setMessage({
-        description: messages.join(','),
-        title: t('asset_form.underlying_tokens'),
-      });
-    }
-  }
-  else {
-    const schema = '_schema' in errors ? errors._schema : errors.Schema;
-    if (Array.isArray(schema)) {
-      setMessage({
-        description: schema[0],
-        title: t('asset_form.underlying_tokens'),
-      });
-    }
-  }
-}
-
-function handleSaveError(error: unknown): void {
-  let errors: string | ValidationErrors = getErrorMessage(error);
-  if (error instanceof ApiValidationError)
-    errors = error.getValidationErrors({});
-
-  if (typeof errors === 'string') {
-    setMessage({
-      description: errors,
-      title: editMode ? t('asset_form.edit_error') : t('asset_form.add_error'),
-    });
-    return;
-  }
-
-  if ('underlyingTokens' in errors || '_schema' in errors || 'Schema' in errors)
-    handleValidationErrors(errors);
-
-  set(errorMessages, omit(errors, ['underlyingTokens', '_schema', 'Schema']));
-  get(form)?.validate();
-}
-
-async function save(): Promise<boolean> {
-  if (!isDefined(modelValue))
-    return false;
-
-  const formRef = get(form);
-  const valid = formRef?.validate();
-  if (!valid)
-    return false;
-
-  set(loading, true);
-  try {
-    const identifier = await formRef?.saveAsset();
-    if (!identifier) {
-      return false;
-    }
-
-    deleteCacheKey(identifier);
-    formRef?.saveIcon(identifier);
-    set(modelValue, undefined);
-    emit('refresh');
-    return true;
-  }
-  catch (error: unknown) {
-    handleSaveError(error);
-    return false;
-  }
-  finally {
-    set(loading, false);
-  }
-}
+const { dialogTitle, loading, modelErrorMessages, save } = useManagedAssetFormDialog({
+  editMode: () => editMode,
+  form,
+  modelValue,
+  onSaved: (): void => emit('refresh'),
+});
 </script>
 
 <template>
@@ -122,7 +43,7 @@ async function save(): Promise<boolean> {
       v-if="modelValue"
       ref="form"
       v-model="modelValue"
-      v-model:error-messages="errorMessages"
+      v-model:error-messages="modelErrorMessages"
       v-model:state-updated="stateUpdated"
       :asset-types="assetTypes"
       :loading="loading"

--- a/frontend/app/src/modules/assets/admin/managed/use-managed-asset-form-dialog.spec.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-managed-asset-form-dialog.spec.ts
@@ -1,0 +1,265 @@
+import type { SupportedAsset } from '@rotki/common';
+import { createMock } from '@test/utils/create-mock';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref, shallowRef } from 'vue';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import { useManagedAssetFormDialog } from './use-managed-asset-form-dialog';
+
+const { deleteCacheKey, saveAsset, saveIcon, setMessage, validate } = vi.hoisted(() => ({
+  deleteCacheKey: vi.fn(),
+  saveAsset: vi.fn(),
+  saveIcon: vi.fn(),
+  setMessage: vi.fn(),
+  validate: vi.fn(() => true),
+}));
+
+vi.mock('@/modules/assets/use-asset-info-cache', () => ({
+  useAssetInfoCache: (): Record<string, unknown> => ({ deleteCacheKey }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+const ASSET = createMock<SupportedAsset>({ identifier: 'eip155:1/erc20:0xABC', name: 'Token' });
+
+let modelValue: Ref<SupportedAsset | undefined>;
+let editMode: Ref<boolean>;
+let form: Ref<{ saveAsset: typeof saveAsset; saveIcon: typeof saveIcon; validate: typeof validate } | null>;
+let onSaved: ReturnType<typeof vi.fn<() => void>>;
+let scope: ReturnType<typeof effectScope>;
+
+function dialog(): ReturnType<typeof useManagedAssetFormDialog> {
+  scope = effectScope();
+  return scope.run(() => useManagedAssetFormDialog({
+    editMode,
+    form,
+    modelValue,
+    onSaved,
+  }))!;
+}
+
+describe('modules/assets/admin/managed/useManagedAssetFormDialog', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    modelValue = ref<SupportedAsset | undefined>(ASSET);
+    editMode = shallowRef<boolean>(false);
+    onSaved = vi.fn<() => void>();
+    validate.mockReturnValue(true);
+    saveAsset.mockResolvedValue('eip155:1/erc20:0xABC');
+    form = shallowRef({ saveAsset, saveIcon, validate });
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the title', () => {
+    it('should say add while creating', () => {
+      const { dialogTitle } = dialog();
+
+      expect(get(dialogTitle)).toBe('asset_management.add_title');
+    });
+
+    it('should say edit while editing', () => {
+      set(editMode, true);
+
+      const { dialogTitle } = dialog();
+
+      expect(get(dialogTitle)).toBe('asset_management.edit_title');
+    });
+  });
+
+  describe('before it writes anything', () => {
+    it('should write nothing without an asset', async () => {
+      set(modelValue, undefined);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(saveAsset).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing while the form is invalid', async () => {
+      validate.mockReturnValue(false);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(saveAsset).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing when the form is not mounted', async () => {
+      set(form, null);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(saveAsset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a write that lands', () => {
+    it('should drop the stale cache entry and upload the icon', async () => {
+      const { save } = dialog();
+
+      expect(await save()).toBe(true);
+      expect(deleteCacheKey).toHaveBeenCalledWith('eip155:1/erc20:0xABC');
+      expect(saveIcon).toHaveBeenCalledWith('eip155:1/erc20:0xABC');
+    });
+
+    it('should close the dialog and ask the caller to refresh', async () => {
+      const { save } = dialog();
+      await save();
+
+      expect(get(modelValue)).toBeUndefined();
+      expect(onSaved).toHaveBeenCalledOnce();
+    });
+
+    it('should mark itself loading only while the write runs', async () => {
+      const { loading, save } = dialog();
+
+      const pending = save();
+      expect(get(loading)).toBe(true);
+
+      await pending;
+      expect(get(loading)).toBe(false);
+    });
+  });
+
+  describe('a write the form refuses', () => {
+    it('should keep the dialog open when no identifier comes back', async () => {
+      saveAsset.mockResolvedValue(undefined);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(deleteCacheKey).not.toHaveBeenCalled();
+      expect(saveIcon).not.toHaveBeenCalled();
+      expect(onSaved).not.toHaveBeenCalled();
+      expect(get(modelValue)).toBeDefined();
+    });
+
+    it('should stop loading so the user can try again', async () => {
+      saveAsset.mockRejectedValue(new Error('boom'));
+
+      const { loading, save } = dialog();
+      await save();
+
+      expect(get(loading)).toBe(false);
+    });
+  });
+
+  describe('reporting a failure', () => {
+    it('should report a plain failure with the adding wording', async () => {
+      saveAsset.mockRejectedValue(new Error('the backend is down'));
+
+      const { save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'the backend is down',
+        title: 'asset_form.add_error',
+      });
+    });
+
+    it('should report a plain failure with the editing wording', async () => {
+      set(editMode, true);
+      saveAsset.mockRejectedValue(new Error('the backend is down'));
+
+      const { save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ title: 'asset_form.edit_error' }));
+    });
+
+    it('should put field errors on the form and re-validate so they surface', async () => {
+      saveAsset.mockRejectedValue(new ApiValidationError(JSON.stringify({ name: ['is required'] })));
+
+      const { modelErrorMessages, save } = dialog();
+      validate.mockClear();
+      await save();
+
+      expect(get(modelErrorMessages)).toEqual({ name: ['is required'] });
+      expect(validate).toHaveBeenCalledTimes(2);
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a failure with no single field to blame', () => {
+    it('should report underlying tokens as a message, not on a field', async () => {
+      saveAsset.mockRejectedValue(
+        new ApiValidationError(JSON.stringify({ underlyingTokens: ['weights must add up to 100'] })),
+      );
+
+      const { modelErrorMessages, save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'weights must add up to 100',
+        title: 'asset_form.underlying_tokens',
+      });
+      expect(get(modelErrorMessages)).toEqual({});
+    });
+
+    it('should join several underlying-token failures into one message', async () => {
+      saveAsset.mockRejectedValue(
+        new ApiValidationError(JSON.stringify({ underlyingTokens: ['too many', 'bad weight'] })),
+      );
+
+      const { save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ description: 'too many,bad weight' }));
+    });
+
+    it('should report a whole-payload failure, which arrives camelCased as Schema', async () => {
+      saveAsset.mockRejectedValue(new ApiValidationError(JSON.stringify({ _schema: ['the payload is wrong'] })));
+
+      const { modelErrorMessages, save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'the payload is wrong',
+        title: 'asset_form.underlying_tokens',
+      });
+      expect(get(modelErrorMessages)).toEqual({});
+    });
+
+    it('should report a single underlying-token failure that is not a list', async () => {
+      saveAsset.mockRejectedValue(
+        new ApiValidationError(JSON.stringify({ underlyingTokens: 'weights must add up to 100' })),
+      );
+
+      const { save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({
+        description: 'weights must add up to 100',
+      }));
+    });
+
+    it('should report nothing when the payload failure is not a list', async () => {
+      saveAsset.mockRejectedValue(new ApiValidationError(JSON.stringify({ _schema: 'the payload is wrong' })));
+
+      const { save } = dialog();
+      await save();
+
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+
+    it('should keep the field errors while reporting the payload one', async () => {
+      saveAsset.mockRejectedValue(
+        new ApiValidationError(JSON.stringify({ name: ['is required'], _schema: ['the payload is wrong'] })),
+      );
+
+      const { modelErrorMessages, save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledOnce();
+      expect(get(modelErrorMessages)).toEqual({ name: ['is required'] });
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/managed/use-managed-asset-form-dialog.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-managed-asset-form-dialog.ts
@@ -1,0 +1,152 @@
+import type { SupportedAsset } from '@rotki/common';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { omit } from 'es-toolkit';
+import { useAssetInfoCache } from '@/modules/assets/use-asset-info-cache';
+import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/types/errors';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+
+/**
+ * The error keys the dialog reports as a message rather than on a field.
+ *
+ * @remarks
+ * `underlyingTokens` has no single input to attach to. Marshmallow reports whole-payload failures
+ * under `_schema`, which reaches here as `Schema`: `ApiValidationError` runs the payload through
+ * `camelCaseTransformer`, and both spellings normalise to that one.
+ */
+const MESSAGE_ONLY_KEYS = ['underlyingTokens', 'Schema'] as const;
+
+interface ManagedAssetFormHandle {
+  /** Runs the form's own validation. */
+  validate: () => boolean;
+  /** Writes the asset and resolves its identifier, or nothing when the write failed. */
+  saveAsset: () => Promise<string | undefined>;
+  /** Uploads the pending icon for the saved asset. */
+  saveIcon: (identifier: string) => void;
+}
+
+interface UseManagedAssetFormDialogOptions {
+  /** Whether the dialog is editing rather than creating; it only changes the wording. */
+  editMode: MaybeRefOrGetter<boolean>;
+  /** The asset being edited, cleared once the write lands. */
+  modelValue: Ref<SupportedAsset | undefined>;
+  /** Called after a successful write, so the caller can refresh its list. */
+  onSaved: () => void;
+  /** The form component, which owns validation and the write itself. */
+  form: MaybeRefOrGetter<ManagedAssetFormHandle | null | undefined>;
+}
+
+interface UseManagedAssetFormDialogReturn {
+  /** The dialog's title, which differs between adding and editing. */
+  dialogTitle: ComputedRef<string>;
+  /** Field errors returned by the server. */
+  modelErrorMessages: Ref<ValidationErrors>;
+  /** Whether a write is in flight. */
+  loading: Readonly<Ref<boolean>>;
+  /**
+   * Validates and writes the asset.
+   *
+   * @returns whether it landed; `false` leaves the dialog open with the reason shown
+   */
+  save: () => Promise<boolean>;
+}
+
+/**
+ * Drives the managed asset dialog: validating, writing through the form, and splitting a failure
+ * between the fields it belongs to and a message for the rest.
+ *
+ * @returns the dialog's state and its submit
+ */
+export function useManagedAssetFormDialog(
+  options: UseManagedAssetFormDialogOptions,
+): UseManagedAssetFormDialogReturn {
+  const { editMode, form, modelValue, onSaved } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const loading = shallowRef<boolean>(false);
+  const modelErrorMessages = ref<ValidationErrors>({});
+
+  const { setMessage } = useMessageStore();
+  const { deleteCacheKey } = useAssetInfoCache();
+
+  const dialogTitle = computed<string>(() =>
+    toValue(editMode) ? t('asset_management.edit_title') : t('asset_management.add_title'),
+  );
+
+  function reportWholePayloadFailure(errors: ValidationErrors): void {
+    const underlyingTokens = 'underlyingTokens' in errors ? errors.underlyingTokens : undefined;
+    if (underlyingTokens) {
+      const messages = Array.isArray(underlyingTokens) ? underlyingTokens : [underlyingTokens];
+      setMessage({
+        description: messages.join(','),
+        title: t('asset_form.underlying_tokens'),
+      });
+      return;
+    }
+
+    const schema = errors.Schema;
+    if (Array.isArray(schema)) {
+      setMessage({
+        description: schema[0],
+        title: t('asset_form.underlying_tokens'),
+      });
+    }
+  }
+
+  function handleSaveError(error: unknown): void {
+    let errors: string | ValidationErrors = getErrorMessage(error);
+    if (error instanceof ApiValidationError)
+      errors = error.getValidationErrors({});
+
+    if (typeof errors === 'string') {
+      setMessage({
+        description: errors,
+        title: toValue(editMode) ? t('asset_form.edit_error') : t('asset_form.add_error'),
+      });
+      return;
+    }
+
+    if (MESSAGE_ONLY_KEYS.some(key => key in errors))
+      reportWholePayloadFailure(errors);
+
+    set(modelErrorMessages, omit(errors, [...MESSAGE_ONLY_KEYS]));
+    toValue(form)?.validate();
+  }
+
+  async function save(): Promise<boolean> {
+    if (!isDefined(modelValue))
+      return false;
+
+    const formRef = toValue(form);
+    if (!formRef?.validate())
+      return false;
+
+    set(loading, true);
+    try {
+      const identifier = await formRef.saveAsset();
+      if (!identifier)
+        return false;
+
+      deleteCacheKey(identifier);
+      formRef.saveIcon(identifier);
+      set(modelValue, undefined);
+      onSaved();
+      return true;
+    }
+    catch (error: unknown) {
+      handleSaveError(error);
+      return false;
+    }
+    finally {
+      set(loading, false);
+    }
+  }
+
+  return {
+    dialogTitle,
+    loading: readonly(loading),
+    modelErrorMessages,
+    save,
+  };
+}

--- a/frontend/app/src/modules/assets/admin/use-mapping-admin.spec.ts
+++ b/frontend/app/src/modules/assets/admin/use-mapping-admin.spec.ts
@@ -1,0 +1,218 @@
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { useMappingAdmin } from './use-mapping-admin';
+
+interface RouteHolder {
+  route?: Ref<{ query: Record<string, string> }>;
+}
+
+/**
+ * The global `vue-router` mock exposes `push` but no `replace`, and hands back a plain object rather
+ * than a ref, so `get(route)` reads undefined. This spec needs both, so it mocks locally.
+ */
+const { held, replace } = vi.hoisted(() => {
+  const held: RouteHolder = {};
+  return { held, replace: vi.fn(async () => Promise.resolve()) };
+});
+
+vi.mock('vue-router', async () => {
+  const { ref: actualRef } = await vi.importActual<typeof import('vue')>('vue');
+  held.route = actualRef({ query: {} });
+  return {
+    useRoute: (): unknown => held.route,
+    useRouter: (): Record<string, unknown> => ({ replace }),
+  };
+});
+
+function setQuery(query: Record<string, string>): void {
+  assert(held.route);
+  set(held.route, { query });
+}
+
+interface CexMapping {
+  asset: string;
+  location: string;
+  locationSymbol: string;
+}
+
+interface CexFilters extends Record<string, string | string[] | undefined> {
+  location?: string | string[];
+  locationSymbol?: string | string[];
+}
+
+let filter: Ref<CexFilters>;
+let scope: ReturnType<typeof effectScope>;
+
+function admin(): ReturnType<typeof useMappingAdmin<CexMapping, CexFilters>> {
+  scope = effectScope();
+  return scope.run(() => useMappingAdmin<CexMapping, CexFilters>({
+    blank: () => ({ asset: '', location: '', locationSymbol: '' }),
+    filter,
+    seedFromFilter: { location: 'location', locationSymbol: 'locationSymbol' },
+    seedFromQuery: { location: 'location', locationSymbol: 'locationSymbol' },
+  }))!;
+}
+
+describe('modules/assets/admin/useMappingAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    filter = ref<CexFilters>({});
+    setQuery({});
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('adding a mapping', () => {
+    it('should open the dialog closed to editing', () => {
+      const { add, editMode, modelValue } = admin();
+      add();
+
+      expect(get(editMode)).toBe(false);
+      expect(get(modelValue)).toEqual({ asset: '', location: '', locationSymbol: '' });
+    });
+
+    it('should seed from whatever the filter is narrowed to', () => {
+      set(filter, { location: 'kraken', locationSymbol: 'XBT' });
+
+      const { add, modelValue } = admin();
+      add();
+
+      expect(get(modelValue)).toEqual({ asset: '', location: 'kraken', locationSymbol: 'XBT' });
+    });
+
+    it('should take the first value when the filter holds a list', () => {
+      set(filter, { location: ['kraken', 'binance'] });
+
+      const { add, modelValue } = admin();
+      add();
+
+      expect(get(modelValue)?.location).toBe('kraken');
+    });
+
+    it('should leave a field the filter does not narrow empty', () => {
+      set(filter, { location: 'kraken' });
+
+      const { add, modelValue } = admin();
+      add();
+
+      expect(get(modelValue)?.locationSymbol).toBe('');
+    });
+
+    it('should leave a field out when its seed maps nowhere', () => {
+      set(filter, { location: 'kraken', locationSymbol: 'XBT' });
+
+      scope = effectScope();
+      const { add, modelValue } = scope.run(() => useMappingAdmin<CexMapping, CexFilters>({
+        blank: () => ({ asset: '', location: '', locationSymbol: '' }),
+        filter,
+        seedFromFilter: { location: 'location', locationSymbol: undefined },
+        seedFromQuery: { location: undefined },
+      }))!;
+      add();
+
+      expect(get(modelValue)).toEqual({ asset: '', location: 'kraken', locationSymbol: '' });
+    });
+
+    it('should let the caller override a seeded field', () => {
+      set(filter, { location: 'kraken' });
+
+      const { add, modelValue } = admin();
+      add({ location: 'binance' });
+
+      expect(get(modelValue)?.location).toBe('binance');
+    });
+
+    it('should start from a fresh blank each time', () => {
+      const { add, modelValue } = admin();
+      add({ asset: 'BTC' });
+      add();
+
+      expect(get(modelValue)?.asset).toBe('');
+    });
+  });
+
+  describe('editing a mapping', () => {
+    it('should open the dialog on the mapping, in edit mode', () => {
+      const existing: CexMapping = { asset: 'BTC', location: 'kraken', locationSymbol: 'XBT' };
+
+      const { edit, editMode, modelValue } = admin();
+      edit(existing);
+
+      expect(get(editMode)).toBe(true);
+      expect(get(modelValue)).toEqual(existing);
+    });
+
+    it('should go back to adding after an edit', () => {
+      const { add, edit, editMode } = admin();
+      edit({ asset: 'BTC', location: 'kraken', locationSymbol: 'XBT' });
+      add();
+
+      expect(get(editMode)).toBe(false);
+    });
+  });
+
+  describe('an ?add= link', () => {
+    it('should do nothing when the query does not ask for it', async () => {
+      const { consumeAddQuery, modelValue } = admin();
+
+      expect(await consumeAddQuery()).toBe(false);
+      expect(get(modelValue)).toBeUndefined();
+      expect(replace).not.toHaveBeenCalled();
+    });
+
+    it('should open the dialog seeded from the query', async () => {
+      setQuery({ add: 'true', location: 'coinbase', locationSymbol: 'ETH' });
+
+      const { consumeAddQuery, modelValue } = admin();
+
+      expect(await consumeAddQuery()).toBe(true);
+      expect(get(modelValue)).toEqual({ asset: '', location: 'coinbase', locationSymbol: 'ETH' });
+    });
+
+    it('should clear the query so a reload does not reopen it', async () => {
+      setQuery({ add: 'true', location: 'coinbase' });
+
+      const { consumeAddQuery } = admin();
+      await consumeAddQuery();
+
+      expect(replace).toHaveBeenCalledWith({ query: {} });
+    });
+
+    it('should let the query win over the filter', async () => {
+      set(filter, { location: 'kraken', locationSymbol: 'XBT' });
+      setQuery({ add: 'true', location: 'coinbase', locationSymbol: 'ETH' });
+
+      const { consumeAddQuery, modelValue } = admin();
+      await consumeAddQuery();
+
+      expect(get(modelValue)).toEqual({ asset: '', location: 'coinbase', locationSymbol: 'ETH' });
+    });
+
+    it('should leave a field out when its query seed maps nowhere', async () => {
+      setQuery({ add: 'true', location: 'coinbase', locationSymbol: 'ETH' });
+
+      scope = effectScope();
+      const { consumeAddQuery, modelValue } = scope.run(() => useMappingAdmin<CexMapping, CexFilters>({
+        blank: () => ({ asset: '', location: '', locationSymbol: '' }),
+        filter,
+        seedFromFilter: {},
+        seedFromQuery: { location: 'location', locationSymbol: undefined },
+      }))!;
+      await consumeAddQuery();
+
+      expect(get(modelValue)).toEqual({ asset: '', location: 'coinbase', locationSymbol: '' });
+    });
+
+    it('should blank a field the query omits rather than fall back to the filter', async () => {
+      set(filter, { location: 'kraken', locationSymbol: 'XBT' });
+      setQuery({ add: 'true', location: 'coinbase' });
+
+      const { consumeAddQuery, modelValue } = admin();
+      await consumeAddQuery();
+
+      expect(get(modelValue)?.locationSymbol).toBe('');
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/use-mapping-admin.ts
+++ b/frontend/app/src/modules/assets/admin/use-mapping-admin.ts
@@ -1,0 +1,123 @@
+import type { Ref } from 'vue';
+import type { LocationQuery } from 'vue-router';
+import { objectKeys } from '@/modules/core/common/data/array';
+import { firstQueryValue } from '@/modules/core/table/route';
+
+/** A filter bag value: the pill bar types every key as one-or-many, and some keys are toggles. */
+type FilterValue = string | string[] | number | number[] | boolean | undefined;
+
+interface UseMappingAdminOptions<T extends object, TFilters extends Record<string, FilterValue>> {
+  /** A blank mapping, before any seeding. */
+  blank: () => T;
+  /** The pill-bar filter the table is currently narrowed to. */
+  filter: Ref<TFilters>;
+  /**
+   * Mapping fields seeded from the filter, as field name to filter key.
+   *
+   * @remarks
+   * Adding while narrowed to an exchange should not ask for that exchange again.
+   */
+  seedFromFilter: Partial<Record<keyof T, keyof TFilters>>;
+  /** Mapping fields seeded from the `?add=` query, as field name to query parameter. */
+  seedFromQuery: Partial<Record<keyof T, string>>;
+}
+
+interface UseMappingAdminReturn<T> {
+  /**
+   * Opens the dialog on a blank mapping seeded from the filter.
+   *
+   * @remarks
+   * `payload` is applied last and wins, so a caller can override any seeded field.
+   */
+  add: (payload?: Partial<T>) => void;
+  /**
+   * Consumes an `?add=` query, opening the dialog seeded from its parameters.
+   *
+   * @remarks
+   * The query is cleared first, so a reload does not reopen the dialog.
+   *
+   * @returns whether the query asked for the dialog
+   */
+  consumeAddQuery: () => Promise<boolean>;
+  /** Opens the dialog on an existing mapping. */
+  edit: (mapping: T) => void;
+  /** Whether the dialog is editing rather than creating. */
+  editMode: Readonly<Ref<boolean>>;
+  /** The mapping the dialog is editing or creating, or undefined while it is closed. */
+  modelValue: Ref<T | undefined>;
+}
+
+/**
+ * The add-and-edit flow the asset-mapping admin pages share: a new mapping is seeded from whatever
+ * the pill bar is narrowed to, and an `?add=` link seeds it from the url instead.
+ *
+ * @returns the dialog's mapping and the three ways it opens
+ */
+export function useMappingAdmin<T extends object, TFilters extends Record<string, FilterValue>>(
+  options: UseMappingAdminOptions<T, TFilters>,
+): UseMappingAdminReturn<T> {
+  const { blank, filter, seedFromFilter, seedFromQuery } = options;
+
+  const router = useRouter();
+  const route = useRoute();
+
+  const modelValue = ref<T>();
+  const editMode = shallowRef<boolean>(false);
+
+  function filterValue(key: keyof TFilters): string {
+    const picked = get(filter)[key];
+    return (Array.isArray(picked) ? picked[0] : picked)?.toString() ?? '';
+  }
+
+  function seededFromFilter(): Partial<T> {
+    const seeded: Partial<T> = {};
+    for (const field of objectKeys(seedFromFilter)) {
+      const key = seedFromFilter[field];
+      if (key !== undefined)
+        Reflect.set(seeded, field, filterValue(key));
+    }
+    return seeded;
+  }
+
+  function seededFromQuery(query: LocationQuery): Partial<T> {
+    const seeded: Partial<T> = {};
+    for (const field of objectKeys(seedFromQuery)) {
+      const param = seedFromQuery[field];
+      if (param !== undefined)
+        Reflect.set(seeded, field, firstQueryValue(query[param]));
+    }
+    return seeded;
+  }
+
+  function add(payload?: Partial<T>): void {
+    set(modelValue, {
+      ...blank(),
+      ...seededFromFilter(),
+      ...payload,
+    });
+    set(editMode, false);
+  }
+
+  function edit(mapping: T): void {
+    set(modelValue, mapping);
+    set(editMode, true);
+  }
+
+  async function consumeAddQuery(): Promise<boolean> {
+    const { query } = get(route);
+    if (!query.add)
+      return false;
+
+    await router.replace({ query: {} });
+    add(seededFromQuery(query));
+    return true;
+  }
+
+  return {
+    add,
+    consumeAddQuery,
+    edit,
+    editMode: readonly(editMode),
+    modelValue,
+  };
+}

--- a/frontend/app/src/modules/assets/admin/use-mapping-form-dialog.spec.ts
+++ b/frontend/app/src/modules/assets/admin/use-mapping-form-dialog.spec.ts
@@ -1,0 +1,208 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref, shallowRef } from 'vue';
+import { useMappingFormDialog } from './use-mapping-form-dialog';
+
+const { add, edit, setMessage, validate } = vi.hoisted(() => ({
+  add: vi.fn(async () => Promise.resolve(true)),
+  edit: vi.fn(async () => Promise.resolve(true)),
+  setMessage: vi.fn(),
+  validate: vi.fn(() => true),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+interface Mapping {
+  asset: string;
+  location: string | null;
+  locationSymbol: string;
+}
+
+const MAPPING: Mapping = { asset: 'BTC', location: 'kraken', locationSymbol: 'XBT' };
+
+let modelValue: Ref<Mapping | undefined>;
+let editMode: Ref<boolean>;
+let form: Ref<{ validate: typeof validate } | null>;
+let onSaved: ReturnType<typeof vi.fn<(mapping: Mapping) => void>>;
+let toPayload: ReturnType<typeof vi.fn<(mapping: Mapping) => Mapping>>;
+let scope: ReturnType<typeof effectScope>;
+
+function dialog(): ReturnType<typeof useMappingFormDialog<Mapping, Mapping>> {
+  scope = effectScope();
+  return scope.run(() => useMappingFormDialog<Mapping, Mapping>({
+    add,
+    edit,
+    editMode,
+    form,
+    modelValue,
+    onSaved,
+    toPayload,
+  }))!;
+}
+
+describe('modules/assets/admin/useMappingFormDialog', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    modelValue = ref<Mapping | undefined>({ ...MAPPING });
+    editMode = shallowRef<boolean>(false);
+    form = shallowRef({ validate });
+    onSaved = vi.fn<(mapping: Mapping) => void>();
+    toPayload = vi.fn<(mapping: Mapping) => Mapping>(mapping => mapping);
+    validate.mockReturnValue(true);
+    add.mockResolvedValue(true);
+    edit.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the title', () => {
+    it('should say add while creating', () => {
+      const { dialogTitle } = dialog();
+
+      expect(get(dialogTitle)).toBe('asset_management.cex_mapping.add_title');
+    });
+
+    it('should say edit while editing', () => {
+      set(editMode, true);
+
+      const { dialogTitle } = dialog();
+
+      expect(get(dialogTitle)).toBe('asset_management.cex_mapping.edit_title');
+    });
+  });
+
+  describe('before it writes anything', () => {
+    it('should write nothing without a mapping', async () => {
+      set(modelValue, undefined);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(add).not.toHaveBeenCalled();
+      expect(edit).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing while the form is invalid', async () => {
+      validate.mockReturnValue(false);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(add).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing when the form is not mounted', async () => {
+      set(form, null);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('writing', () => {
+    it('should add a new mapping', async () => {
+      const { save } = dialog();
+
+      expect(await save()).toBe(true);
+      expect(add).toHaveBeenCalledWith(MAPPING);
+      expect(edit).not.toHaveBeenCalled();
+    });
+
+    it('should edit an existing mapping', async () => {
+      set(editMode, true);
+
+      const { save } = dialog();
+      await save();
+
+      expect(edit).toHaveBeenCalledWith(MAPPING);
+      expect(add).not.toHaveBeenCalled();
+    });
+
+    it('should send what the caller turns the mapping into', async () => {
+      toPayload.mockImplementation(mapping => ({ ...mapping, location: null }));
+
+      const { save } = dialog();
+      await save();
+
+      expect(add).toHaveBeenCalledWith({ asset: 'BTC', location: null, locationSymbol: 'XBT' });
+    });
+
+    it('should close the dialog and hand the mapping back once it lands', async () => {
+      const { save } = dialog();
+      await save();
+
+      expect(get(modelValue)).toBeUndefined();
+      expect(onSaved).toHaveBeenCalledWith(MAPPING);
+    });
+
+    it('should hand back the mapping as edited, not the payload it sent', async () => {
+      toPayload.mockImplementation(mapping => ({ ...mapping, location: null }));
+
+      const { save } = dialog();
+      await save();
+
+      expect(onSaved).toHaveBeenCalledWith(MAPPING);
+    });
+
+    it('should mark itself loading only while the write runs', async () => {
+      const { loading, save } = dialog();
+
+      const pending = save();
+      expect(get(loading)).toBe(true);
+
+      await pending;
+      expect(get(loading)).toBe(false);
+    });
+  });
+
+  describe('a write that does not land', () => {
+    it('should keep the dialog open when the endpoint refuses', async () => {
+      add.mockResolvedValue(false);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(get(modelValue)).toBeDefined();
+      expect(onSaved).not.toHaveBeenCalled();
+    });
+
+    it('should report a failure while adding as an add failure', async () => {
+      add.mockRejectedValue(new Error('the backend is down'));
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'asset_management.cex_mapping.add_error::the backend is down',
+      });
+    });
+
+    it('should report a failure while editing as an edit failure', async () => {
+      set(editMode, true);
+      edit.mockRejectedValue(new Error('the backend is down'));
+
+      const { save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'asset_management.cex_mapping.edit_error::the backend is down',
+      });
+    });
+
+    it('should stop loading so the user can try again', async () => {
+      add.mockRejectedValue(new Error('boom'));
+
+      const { loading, save } = dialog();
+      await save();
+
+      expect(get(loading)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/use-mapping-form-dialog.ts
+++ b/frontend/app/src/modules/assets/admin/use-mapping-form-dialog.ts
@@ -1,0 +1,110 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+
+interface MappingFormHandle {
+  /** Runs the form's own validation. */
+  validate: () => boolean;
+}
+
+interface UseMappingFormDialogOptions<T, TPayload> {
+  /** Writes a new mapping. */
+  add: (payload: TPayload) => Promise<boolean>;
+  /** Whether the dialog is editing rather than creating. */
+  editMode: MaybeRefOrGetter<boolean>;
+  /** Writes an existing mapping. */
+  edit: (payload: TPayload) => Promise<boolean>;
+  /** The form component, which owns validation. */
+  form: MaybeRefOrGetter<MappingFormHandle | null | undefined>;
+  /** The mapping being edited, cleared once the write lands. */
+  modelValue: Ref<T | undefined>;
+  /** Called with the mapping that was written, so the caller can refresh its list. */
+  onSaved: (mapping: T) => void;
+  /** Turns the edited mapping into what the endpoint takes. */
+  toPayload: (mapping: T) => TPayload;
+}
+
+interface UseMappingFormDialogReturn {
+  /** The dialog's title, which differs between adding and editing. */
+  dialogTitle: ComputedRef<string>;
+  /** Whether a write is in flight. */
+  loading: Readonly<Ref<boolean>>;
+  /** Field errors, which the form binds. */
+  modelErrorMessages: Ref<ValidationErrors>;
+  /**
+   * Validates and writes the mapping.
+   *
+   * @returns whether it landed; `false` leaves the dialog open with the reason shown
+   */
+  save: () => Promise<boolean>;
+}
+
+/**
+ * The write flow the asset-mapping dialogs share: validate, add or edit, then close and hand the
+ * mapping back on success.
+ *
+ * @returns the dialog's state and its submit
+ */
+export function useMappingFormDialog<T, TPayload = T>(
+  options: UseMappingFormDialogOptions<T, TPayload>,
+): UseMappingFormDialogReturn {
+  const { add, edit, editMode, form, modelValue, onSaved, toPayload } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const loading = shallowRef<boolean>(false);
+  const modelErrorMessages = ref<ValidationErrors>({});
+
+  const { setMessage } = useMessageStore();
+
+  const dialogTitle = computed<string>(() =>
+    toValue(editMode)
+      ? t('asset_management.cex_mapping.edit_title')
+      : t('asset_management.cex_mapping.add_title'),
+  );
+
+  function reportFailure(error: unknown): void {
+    const obj = { message: getErrorMessage(error) };
+    setMessage({
+      description: toValue(editMode)
+        ? t('asset_management.cex_mapping.edit_error', obj)
+        : t('asset_management.cex_mapping.add_error', obj),
+    });
+  }
+
+  async function save(): Promise<boolean> {
+    if (!isDefined(modelValue))
+      return false;
+
+    if (!toValue(form)?.validate())
+      return false;
+
+    const mapping = get(modelValue);
+    const payload = toPayload(mapping);
+
+    set(loading, true);
+    let success: boolean;
+    try {
+      success = toValue(editMode) ? await edit(payload) : await add(payload);
+    }
+    catch (error: unknown) {
+      success = false;
+      reportFailure(error);
+    }
+    set(loading, false);
+
+    if (success) {
+      set(modelValue, undefined);
+      onSaved(mapping);
+    }
+    return success;
+  }
+
+  return {
+    dialogTitle,
+    loading: readonly(loading),
+    modelErrorMessages,
+    save,
+  };
+}


### PR DESCRIPTION
Follows #12964, after batch J (#13061). Three asset-admin surfaces extracted to composables and covered there, with component specs for the wiring that remains.

70.01% → **70.35%** lines. Suite green at 1024 files / 11,014 tests.

## What is in it

One commit per tested module.

| Component(s) | Extracted to | Tests | Script lines |
|---|---|---|---|
| `cex-mapping/ManageCexMappingContent.vue` **+** `counterparty-mapping/ManageCounterpartyMapping.vue` | one `use-mapping-admin.ts` | 15 composable + 7 / 6 component | 85 → 45, 85 → 46 |
| `managed/ManagedAssetFormDialog.vue` | `use-managed-asset-form-dialog.ts` | 19 | 91 → 29 |
| `cex-mapping/ManageCexMappingFormDialog.vue` **+** `counterparty-mapping/ManageCounterpartyMappingFormDialog.vue` | one `use-mapping-form-dialog.ts` | 15 | 64 → 36, 59 → 33 |

All three composables are at full statement and branch coverage.

## The cex and counterparty surfaces were the same code twice

Both pairs were duplicates, down to an identical `filterValue` helper carrying identical TSDoc. They differ only in the entity, the two fields seeded from the filter, and the api — so each pair now shares one composable, parameterised by those.

The deletion half of that duplication had already been factored out into `useTableRowDeletion`, whose own docs note it "was copy-pasted across the mapping and asset content components". This is the rest of it.

## A wording bug both mapping dialogs carried

The failure message picked its string with the ternary the wrong way round:

```ts
description: editMode
  ? t('asset_management.cex_mapping.add_error', obj)    // editing reported "Could not add"
  : t('asset_management.cex_mapping.edit_error', obj),  // adding reported "Could not edit"
```

`dialogTitle`, five lines above, has the same condition the right way round, and the strings themselves are correct — so only which one is shown was wrong. Two tests pin the wording now; reinstating the inversion turns exactly those two red.

It was only visible with the two files side by side. Neither reads as wrong on its own.

## A dead check in the managed dialog

The whole-payload error was read as `'_schema' in errors ? errors._schema : errors.Schema`. `ApiValidationError` runs the payload through `camelCaseTransformer`, which normalises **both** `_schema` and `Schema` to `Schema`, so the first arm never ran and `_schema` in the message-only key list never matched. Removed; `errors.Schema` is what was already executing.

Left as it is, and asserted as behaviour rather than changed: a whole-payload error arriving as a bare string rather than a list is dropped without a message, unlike `underlyingTokens`, which accepts both shapes. Nothing here shows the backend sends that shape.

## Conventions

Extraction before testing; a component is a seam rather than a screen; `data-testid` selectors; every behavioural claim negative-controlled by breaking it and watching the named test go red; comment-free specs with TSDoc on the consumer-facing interface members.

`pnpm run test:unit`, `lint`, `typecheck`, `lint:style`, `check:linked-keys` and `knip` are all green. Knip is worth calling out: extracting the `filterValue` helpers left two filter-key types exported but unused, and it was the only gate that caught it.
