### PR TITLE
test(assets): cover the assets admin surfaces

### DIFF
--- a/frontend/app/src/modules/assets/admin/RestoreAssetDbButton.vue
+++ b/frontend/app/src/modules/assets/admin/RestoreAssetDbButton.vue
@@ -1,94 +1,14 @@
 <script setup lang="ts">
-import { Severity } from '@rotki/common';
-import { useAssets } from '@/modules/assets/use-assets';
-import { DialogType } from '@/modules/core/common/dialogs';
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
-import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
-import { useBackendReload } from '@/modules/shell/app/use-backend-reload';
+import { useRestoreAssetDb } from '@/modules/assets/admin/use-restore-asset-db';
 import ListItem from '@/modules/shell/components/ListItem.vue';
-import { ActivityPart } from '@/modules/task-center/core/types';
-import { ActivityKind, useTaskCenter } from '@/modules/task-center/use-task-center';
 
 const { dropdown = false } = defineProps<{
   dropdown?: boolean;
 }>();
 
-type ResetType = 'soft' | 'hard';
-
-const { notify } = useNotificationDispatcher();
-const { restoreAssetsDatabase } = useAssets();
-const { reload } = useBackendReload();
-
 const { t } = useI18n({ useScope: 'global' });
 
-const { useIsActive } = useTaskCenter();
-const loading = useIsActive(ActivityKind.ASSETS, ActivityPart.RESET);
-
-async function restoreAssets(resetType: ResetType) {
-  if (get(loading))
-    return;
-
-  const result = await restoreAssetsDatabase(resetType);
-
-  if (result.success) {
-    showDoneConfirmation();
-  }
-  else {
-    const { message } = result;
-    const title = t('asset_update.restore.title');
-    if (message.includes('There are assets that can not'))
-      showDoubleConfirmation(resetType);
-
-    notify({
-      display: true,
-      message,
-      severity: Severity.ERROR,
-      title,
-    });
-  }
-}
-
-async function updateComplete() {
-  await reload();
-}
-
-const { show } = useConfirmStore();
-
-function showRestoreConfirmation(type: ResetType) {
-  show(
-    {
-      message:
-        type === 'soft'
-          ? t('asset_update.restore.delete_confirmation.soft_reset_message')
-          : t('asset_update.restore.delete_confirmation.hard_reset_message'),
-      title: t('asset_update.restore.delete_confirmation.title'),
-    },
-    () => restoreAssets(type),
-  );
-}
-
-function showDoubleConfirmation(type: ResetType) {
-  show(
-    {
-      message: t('asset_update.restore.hard_restore_confirmation.message'),
-      title: t('asset_update.restore.hard_restore_confirmation.title'),
-    },
-    () => restoreAssets(type),
-  );
-}
-
-function showDoneConfirmation() {
-  show(
-    {
-      message: t('asset_update.restore.success.description'),
-      primaryAction: t('common.actions.ok'),
-      singleAction: true,
-      title: t('asset_update.restore.success.title'),
-      type: DialogType.SUCCESS,
-    },
-    updateComplete,
-  );
-}
+const { loading, showRestoreConfirmation } = useRestoreAssetDb();
 </script>
 
 <template>

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.spec.ts
@@ -1,0 +1,109 @@
+import type { CustomAsset } from '@/modules/assets/types';
+import type { Collection } from '@/modules/core/common/collection';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises, shallowMount } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import CustomAssetContent from './CustomAssetContent.vue';
+import CustomAssetFormDialog from './CustomAssetFormDialog.vue';
+import CustomAssetTable from './CustomAssetTable.vue';
+
+let collection: Ref<Collection<CustomAsset>>;
+
+const { getCustomAssetTypes, queryAllCustomAssets } = vi.hoisted(() => ({
+  getCustomAssetTypes: vi.fn(),
+  queryAllCustomAssets: vi.fn(),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-management-api', () => ({
+  useAssetManagementApi: (): Record<string, unknown> => ({
+    deleteCustomAsset: vi.fn(),
+    getCustomAssetTypes,
+    queryAllCustomAssets,
+  }),
+}));
+
+vi.mock('@/modules/assets/admin/custom/use-custom-asset-fields', () => ({
+  useCustomAssetFields: (): Record<string, unknown> => ({}),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', () => ({
+  routeWhen: (): unknown => undefined,
+  useServerTable: (): Record<string, unknown> => ({
+    collection,
+    filter: ref({}),
+    isLoading: ref<boolean>(false),
+    pagination: ref({ limit: 10, page: 1, total: 0 }),
+    refetch: vi.fn(async () => Promise.resolve()),
+    sort: ref([]),
+  }),
+}));
+
+function asset(overrides: Partial<CustomAsset> = {}): CustomAsset {
+  return {
+    customAssetType: 'real estate',
+    identifier: 'custom-1',
+    name: 'A house',
+    notes: '',
+    ...overrides,
+  };
+}
+
+function page(data: CustomAsset[]): Collection<CustomAsset> {
+  return { data, found: data.length, limit: -1, total: data.length, totalValue: undefined };
+}
+
+/**
+ * `TablePageLayout` holds the table and the dialog in its default slot, which an auto-stub does not
+ * render, so it needs a pass-through stub for either to exist.
+ */
+function mountContent(props: { identifier?: string } = {}): ReturnType<typeof shallowMount> {
+  return shallowMount(CustomAssetContent, {
+    global: {
+      stubs: {
+        TablePageLayout: { template: '<div><slot name="buttons" /><slot /></div>' },
+      },
+    },
+    props,
+  });
+}
+
+describe('modules/assets/admin/custom/CustomAssetContent', () => {
+  beforeEach(() => {
+    setActivePinia(createCustomPinia());
+    vi.clearAllMocks();
+    getCustomAssetTypes.mockResolvedValue(['real estate']);
+    collection = ref<Collection<CustomAsset>>(page([]));
+  });
+
+  it('should hand the loaded page to the dialog, so a routed identifier can be found', async () => {
+    const wanted = asset({ identifier: 'custom-2', name: 'A boat' });
+    set(collection, page([asset(), wanted]));
+
+    const wrapper = mountContent({ identifier: 'custom-2' });
+    await flushPromises();
+
+    const dialog = wrapper.findComponent(CustomAssetFormDialog);
+    expect(dialog.props('open')).toBe(true);
+    expect(dialog.props('editableItem')).toEqual(wanted);
+  });
+
+  it('should leave the dialog closed when the route names no asset', async () => {
+    set(collection, page([asset()]));
+
+    const wrapper = mountContent();
+    await flushPromises();
+
+    expect(wrapper.findComponent(CustomAssetFormDialog).props('open')).toBe(false);
+  });
+
+  it('should render the loaded page in the table', async () => {
+    set(collection, page([asset({ name: 'A house' })]));
+
+    const wrapper = mountContent();
+    await flushPromises();
+
+    expect(wrapper.findComponent(CustomAssetTable).props('assets')).toEqual(get(collection).data);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.vue
@@ -1,15 +1,8 @@
 <script setup lang="ts">
-import type { Nullable } from '@rotki/common';
-import type { Filters } from '@/modules/assets/admin/custom/use-custom-assets-filter';
-import type { CustomAsset, CustomAssetRequestPayload } from '@/modules/assets/types';
 import CustomAssetFormDialog from '@/modules/assets/admin/custom/CustomAssetFormDialog.vue';
 import CustomAssetTable from '@/modules/assets/admin/custom/CustomAssetTable.vue';
-import { useCustomAssetFields } from '@/modules/assets/admin/custom/use-custom-asset-fields';
-import { useAssetManagementApi } from '@/modules/assets/api/use-asset-management-api';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useCommonTableProps } from '@/modules/core/table/use-common-table-props';
-import { routeWhen, useServerTable } from '@/modules/core/table/use-server-table';
-import { useTableRowDeletion } from '@/modules/core/table/use-table-row-deletion';
+import { useCustomAssetDialog } from '@/modules/assets/admin/custom/use-custom-asset-dialog';
+import { useCustomAssetsTable } from '@/modules/assets/admin/custom/use-custom-assets-table';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
 const { identifier = null, mainPage = false } = defineProps<{
@@ -19,92 +12,37 @@ const { identifier = null, mainPage = false } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const types = ref<string[]>([]);
-
-const router = useRouter();
-const route = useRoute();
-
-const { deleteCustomAsset, getCustomAssetTypes, queryAllCustomAssets } = useAssetManagementApi();
-const { editableItem, expanded } = useCommonTableProps<CustomAsset>();
-const openCustomAssetDialog = ref<boolean>(false);
-
-const { showDeleteConfirmation } = useTableRowDeletion<CustomAsset>({
-  confirm: item => ({
-    message: t('asset_management.confirm_delete.message', { asset: item?.name ?? '' }),
-    title: t('asset_management.confirm_delete.title'),
-  }),
-  deleteItem: item => deleteCustomAsset(item.identifier),
-  errorMessage: (item, error) => t('asset_management.delete_error', {
-    address: item.identifier,
-    message: getErrorMessage(error),
-  }),
-  onDeleted: refresh,
-});
-
-const fields = useCustomAssetFields(types);
-
 const {
   collection,
-  filter,
-  isLoading: loading,
-  pagination,
-  refetch,
-  sort,
-} = useServerTable<
-  CustomAsset,
-  CustomAssetRequestPayload,
-  Filters
->({
-  fetch: queryAllCustomAssets,
   fields,
-  sort: {
-    default: [{
-      column: 'name',
-      direction: 'desc',
-    }],
-  },
-  urlState: routeWhen(mainPage),
+  loading,
+  modelExpanded,
+  modelFilter,
+  pagination,
+  refresh,
+  showDeleteConfirmation,
+  sort,
+  types,
+} = useCustomAssetsTable({
+  mainPage: () => mainPage,
 });
 
-function add() {
-  set(editableItem, null);
-  set(openCustomAssetDialog, true);
-}
-
-function edit(editAsset: CustomAsset) {
-  set(editableItem, editAsset);
-  set(openCustomAssetDialog, true);
-}
-
-function editAsset(assetId: Nullable<string>) {
-  if (assetId) {
-    const asset = get(collection).data.find(({ identifier: id }) => id === assetId);
-    if (asset)
-      edit(asset);
-  }
-}
-
-async function refreshTypes() {
-  set(types, await getCustomAssetTypes());
-}
-
-async function refresh() {
-  await Promise.all([refetch(), refreshTypes()]);
-}
+const {
+  add,
+  consumeAddQuery,
+  edit,
+  editAsset,
+  modelEditableItem,
+  modelOpenDialog,
+} = useCustomAssetDialog({
+  assets: () => get(collection).data,
+  identifier: () => identifier,
+});
 
 onMounted(async () => {
   await refresh();
   editAsset(identifier);
-
-  const query = get(route).query;
-  if (query.add) {
-    add();
-    await router.replace({ query: {} });
-  }
-});
-
-watch(() => identifier, (assetId) => {
-  editAsset(assetId);
+  await consumeAddQuery();
 });
 </script>
 
@@ -137,8 +75,8 @@ watch(() => identifier, (assetId) => {
       </RuiButton>
     </template>
     <CustomAssetTable
-      v-model:filters="filter"
-      v-model:expanded="expanded"
+      v-model:filters="modelFilter"
+      v-model:expanded="modelExpanded"
       v-model:pagination="pagination"
       v-model:sort="sort"
       :assets="collection.data"
@@ -149,9 +87,9 @@ watch(() => identifier, (assetId) => {
       @delete-asset="showDeleteConfirmation($event)"
     />
     <CustomAssetFormDialog
-      v-model:open="openCustomAssetDialog"
+      v-model:open="modelOpenDialog"
       :types="types"
-      :editable-item="editableItem"
+      :editable-item="modelEditableItem"
       @refresh="refresh()"
     />
   </TablePageLayout>

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetFormDialog.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetFormDialog.vue
@@ -1,11 +1,8 @@
 <script setup lang="ts">
 import type { CustomAsset } from '@/modules/assets/types';
-import { omit } from 'es-toolkit';
 import { useTemplateRef } from 'vue';
 import CustomAssetForm from '@/modules/assets/admin/custom/CustomAssetForm.vue';
-import { useAssetManagementApi } from '@/modules/assets/api/use-asset-management-api';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useCustomAssetFormDialog } from '@/modules/assets/admin/custom/use-custom-asset-form-dialog';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 
 const open = defineModel<boolean>('open', { required: true });
@@ -25,87 +22,17 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const modelValue = ref<CustomAsset>();
-const loading = ref(false);
-const errorMessages = ref<Record<string, string[]>>({});
 const form = useTemplateRef<InstanceType<typeof CustomAssetForm>>('form');
-const stateUpdated = ref(false);
+const stateUpdated = ref<boolean>(false);
 
-const { setMessage } = useMessageStore();
-const { addCustomAsset, editCustomAsset } = useAssetManagementApi();
-
-const emptyCustomAsset: () => CustomAsset = () => ({
-  customAssetType: '',
-  identifier: '',
-  name: '',
-  notes: '',
-});
-
-async function save() {
-  if (!isDefined(modelValue))
-    return false;
-
-  const formRef = get(form);
-  const valid = formRef?.validate();
-  if (!valid)
-    return false;
-
-  const data = get(modelValue);
-  let success;
-  let identifier = data.identifier;
-
-  const editMode = !!editableItem;
-  set(loading, true);
-  try {
-    if (editMode) {
-      success = await editCustomAsset(data);
-    }
-    else {
-      identifier = await addCustomAsset(omit(data, ['identifier']));
-      success = !!identifier;
-    }
-
-    if (identifier) {
-      formRef?.saveIcon(identifier);
-    }
-  }
-  catch (error: unknown) {
-    success = false;
-    const obj = { message: getErrorMessage(error) };
-    setMessage({
-      description: editMode
-        ? t('asset_management.edit_error', obj)
-        : t('asset_management.add_error', obj),
-    });
-  }
-
-  set(loading, false);
-  if (success) {
-    set(modelValue, undefined);
+const { dialogTitle, loading, modelErrorMessages, modelValue, save } = useCustomAssetFormDialog({
+  editableItem: () => editableItem,
+  form,
+  onSaved: (identifier): void => {
     emit('refresh');
     set(savedAssetId, identifier);
-  }
-  return success;
-}
-
-const dialogTitle = computed<string>(() =>
-  editableItem
-    ? t('asset_management.edit_title')
-    : t('asset_management.add_title'),
-);
-
-watchImmediate([open, () => editableItem], ([open, editableItem]) => {
-  if (!open) {
-    set(modelValue, undefined);
-  }
-  else {
-    if (editableItem) {
-      set(modelValue, editableItem);
-    }
-    else {
-      set(modelValue, emptyCustomAsset());
-    }
-  }
+  },
+  open,
 });
 </script>
 
@@ -123,7 +50,7 @@ watchImmediate([open, () => editableItem], ([open, editableItem]) => {
       v-if="modelValue"
       ref="form"
       v-model="modelValue"
-      v-model:error-messages="errorMessages"
+      v-model:error-messages="modelErrorMessages"
       v-model:state-updated="stateUpdated"
       :types="types"
     />

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetTable.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetTable.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import type { DataTableColumn, DataTableSortData, TablePaginationData } from '@rotki/ui-library';
+import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
 import type { Filters } from '@/modules/assets/admin/custom/use-custom-assets-filter';
 import type { CustomAsset } from '@/modules/assets/types';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
-import { some } from 'es-toolkit/compat';
+import { useCustomAssetTable } from '@/modules/assets/admin/custom/use-custom-asset-table';
 import AssetDetailsBase from '@/modules/assets/AssetDetailsBase.vue';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
@@ -36,50 +36,12 @@ const { t } = useI18n({ useScope: 'global' });
 
 const pillLabels = usePillBarLabels();
 
-const cols = computed<DataTableColumn<CustomAsset>[]>(() => [
-  {
-    cellClass: 'py-0',
-    class: 'w-1/2',
-    key: 'name',
-    label: t('common.asset'),
-    sortable: true,
-  },
-  {
-    cellClass: 'py-0',
-    class: 'w-1/2',
-    key: 'custom_asset_type',
-    label: t('common.type'),
-    sortable: true,
-  },
-  {
-    cellClass: 'py-0',
-    key: 'actions',
-    label: '',
-  },
-]);
+const { cols, expand, getAsset, isExpanded } = useCustomAssetTable(expandedModel);
 
 useRememberTableSorting<CustomAsset>(TableId.CUSTOM_ASSET, sortModel, cols);
 
-const edit = (asset: CustomAsset) => emit('edit', asset);
-const deleteAsset = (asset: CustomAsset) => emit('delete-asset', asset);
-
-function getAsset(item: CustomAsset) {
-  return {
-    customAssetType: item.customAssetType,
-    identifier: item.identifier,
-    isCustomAsset: true,
-    name: item.name,
-    symbol: item.customAssetType,
-  };
-}
-
-function isExpanded(identifier: string) {
-  return some(get(expandedModel), { identifier });
-}
-
-function expand(item: CustomAsset) {
-  set(expandedModel, isExpanded(item.identifier) ? [] : [item]);
-}
+const edit = (asset: CustomAsset): void => emit('edit', asset);
+const deleteAsset = (asset: CustomAsset): void => emit('delete-asset', asset);
 </script>
 
 <template>

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-asset-dialog.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-asset-dialog.spec.ts
@@ -1,0 +1,154 @@
+import type { CustomAsset } from '@/modules/assets/types';
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref, shallowRef } from 'vue';
+import { useCustomAssetDialog } from './use-custom-asset-dialog';
+
+interface RouteHolder {
+  route?: Ref<{ query: Record<string, string> }>;
+}
+
+let assets: Ref<CustomAsset[]>;
+let identifier: Ref<string | null>;
+
+const { held, replace } = vi.hoisted(() => {
+  const held: RouteHolder = {};
+  return {
+    held,
+    replace: vi.fn(async () => Promise.resolve()),
+  };
+});
+
+vi.mock('vue-router', async () => {
+  const { ref: actualRef } = await vi.importActual<typeof import('vue')>('vue');
+  held.route = actualRef({ query: {} });
+  return {
+    useRoute: (): unknown => held.route,
+    useRouter: (): Record<string, unknown> => ({ replace }),
+  };
+});
+
+function asset(overrides: Partial<CustomAsset> = {}): CustomAsset {
+  return {
+    customAssetType: 'real estate',
+    identifier: 'custom-1',
+    name: 'A house',
+    notes: '',
+    ...overrides,
+  };
+}
+
+let scope: ReturnType<typeof effectScope>;
+
+function dialog(): ReturnType<typeof useCustomAssetDialog> {
+  scope = effectScope();
+  return scope.run(() => useCustomAssetDialog({ assets, identifier }))!;
+}
+
+function setQuery(query: Record<string, string>): void {
+  assert(held.route);
+  set(held.route, { query });
+}
+
+describe('modules/assets/admin/custom/useCustomAssetDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    assets = ref<CustomAsset[]>([]);
+    identifier = shallowRef<string | null>(null);
+    setQuery({});
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the add and edit dialog', () => {
+    it('should open on a blank asset to add', () => {
+      const { add, modelEditableItem, modelOpenDialog } = dialog();
+      add();
+
+      expect(get(modelOpenDialog)).toBe(true);
+      expect(get(modelEditableItem)).toBeNull();
+    });
+
+    it('should open on an existing asset to edit', () => {
+      const existing = asset({ identifier: 'custom-9' });
+
+      const { edit, modelEditableItem, modelOpenDialog } = dialog();
+      edit(existing);
+
+      expect(get(modelOpenDialog)).toBe(true);
+      expect(get(modelEditableItem)).toEqual(existing);
+    });
+
+    it('should go back to adding after an edit', () => {
+      const { add, edit, modelEditableItem } = dialog();
+      edit(asset());
+      add();
+
+      expect(get(modelEditableItem)).toBeNull();
+    });
+  });
+
+  describe('opening an asset the route names', () => {
+    it('should edit the one whose identifier matches', () => {
+      const wanted = asset({ identifier: 'custom-2', name: 'A boat' });
+      set(assets, [asset(), wanted]);
+
+      const { editAsset, modelEditableItem, modelOpenDialog } = dialog();
+      editAsset('custom-2');
+
+      expect(get(modelOpenDialog)).toBe(true);
+      expect(get(modelEditableItem)).toEqual(wanted);
+    });
+
+    it('should do nothing for an identifier the page does not hold', () => {
+      set(assets, [asset()]);
+
+      const { editAsset, modelOpenDialog } = dialog();
+      editAsset('custom-absent');
+
+      expect(get(modelOpenDialog)).toBe(false);
+    });
+
+    it('should do nothing without an identifier', () => {
+      set(assets, [asset()]);
+
+      const { editAsset, modelOpenDialog } = dialog();
+      editAsset(null);
+
+      expect(get(modelOpenDialog)).toBe(false);
+    });
+
+    it('should follow the identifier when the route changes it', async () => {
+      const wanted = asset({ identifier: 'custom-3' });
+      set(assets, [asset(), wanted]);
+
+      const { modelEditableItem } = dialog();
+      set(identifier, 'custom-3');
+      await flushPromises();
+
+      expect(get(modelEditableItem)).toEqual(wanted);
+    });
+  });
+
+  describe('an ?add= link', () => {
+    it('should open the dialog and clear the query', async () => {
+      setQuery({ add: 'true' });
+
+      const { consumeAddQuery, modelOpenDialog } = dialog();
+      await consumeAddQuery();
+
+      expect(get(modelOpenDialog)).toBe(true);
+      expect(replace).toHaveBeenCalledWith({ query: {} });
+    });
+
+    it('should do nothing when the query does not ask for it', async () => {
+      const { consumeAddQuery, modelOpenDialog } = dialog();
+      await consumeAddQuery();
+
+      expect(get(modelOpenDialog)).toBe(false);
+      expect(replace).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-asset-dialog.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-asset-dialog.ts
@@ -1,0 +1,92 @@
+import type { Nullable } from '@rotki/common';
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { CustomAsset } from '@/modules/assets/types';
+
+interface UseCustomAssetDialogOptions {
+  /** The assets currently on the page, searched when the route names one to edit. */
+  assets: MaybeRefOrGetter<CustomAsset[]>;
+  /** An asset the route names, which opens straight into its edit dialog. */
+  identifier: MaybeRefOrGetter<Nullable<string>>;
+}
+
+interface UseCustomAssetDialogReturn {
+  /** Opens the dialog on a blank asset. */
+  add: () => void;
+  /**
+   * Consumes an `?add=` query, opening the dialog on a blank asset.
+   *
+   * @remarks
+   * The query is cleared afterwards, so a reload does not reopen the dialog.
+   */
+  consumeAddQuery: () => Promise<void>;
+  /** Opens the dialog on an existing asset. */
+  edit: (asset: CustomAsset) => void;
+  /**
+   * Opens the dialog on the asset with this identifier.
+   *
+   * @remarks
+   * Only assets on the current page can be found, so this does nothing for one the table has not
+   * loaded; an unknown identifier is ignored rather than opening a blank dialog.
+   */
+  editAsset: (assetId: Nullable<string>) => void;
+  /** The asset the dialog is editing; `null` while adding. */
+  modelEditableItem: Ref<CustomAsset | null>;
+  /** Whether the add/edit dialog is open. */
+  modelOpenDialog: Ref<boolean>;
+}
+
+/**
+ * Owns which custom asset the add/edit dialog is showing, and the three ways it gets opened: a
+ * button, a row, and the route.
+ *
+ * @returns the dialog's state and the ways to open it
+ */
+export function useCustomAssetDialog(options: UseCustomAssetDialogOptions): UseCustomAssetDialogReturn {
+  const { assets, identifier } = options;
+
+  const router = useRouter();
+  const route = useRoute();
+
+  const modelEditableItem = shallowRef<CustomAsset | null>(null);
+  const modelOpenDialog = shallowRef<boolean>(false);
+
+  function add(): void {
+    set(modelEditableItem, null);
+    set(modelOpenDialog, true);
+  }
+
+  function edit(asset: CustomAsset): void {
+    set(modelEditableItem, asset);
+    set(modelOpenDialog, true);
+  }
+
+  function editAsset(assetId: Nullable<string>): void {
+    if (!assetId)
+      return;
+
+    const asset = toValue(assets).find(({ identifier: id }) => id === assetId);
+    if (asset)
+      edit(asset);
+  }
+
+  async function consumeAddQuery(): Promise<void> {
+    if (!get(route).query.add)
+      return;
+
+    add();
+    await router.replace({ query: {} });
+  }
+
+  watch(() => toValue(identifier), (assetId) => {
+    editAsset(assetId);
+  });
+
+  return {
+    add,
+    consumeAddQuery,
+    edit,
+    editAsset,
+    modelEditableItem,
+    modelOpenDialog,
+  };
+}

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-asset-form-dialog.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-asset-form-dialog.spec.ts
@@ -1,0 +1,251 @@
+import type { CustomAsset } from '@/modules/assets/types';
+import { flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref, shallowRef } from 'vue';
+import { useCustomAssetFormDialog } from './use-custom-asset-form-dialog';
+
+const { addCustomAsset, editCustomAsset, saveIcon, setMessage, validate } = vi.hoisted(() => ({
+  addCustomAsset: vi.fn(),
+  editCustomAsset: vi.fn(),
+  saveIcon: vi.fn(),
+  setMessage: vi.fn(),
+  validate: vi.fn(() => true),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-management-api', () => ({
+  useAssetManagementApi: (): Record<string, unknown> => ({ addCustomAsset, editCustomAsset }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+const BLANK: CustomAsset = { customAssetType: '', identifier: '', name: '', notes: '' };
+
+function asset(overrides: Partial<CustomAsset> = {}): CustomAsset {
+  return { customAssetType: 'real estate', identifier: 'custom-1', name: 'A house', notes: '', ...overrides };
+}
+
+let open: Ref<boolean>;
+let editableItem: Ref<CustomAsset | null>;
+let form: Ref<{ saveIcon: typeof saveIcon; validate: typeof validate } | null>;
+let onSaved: ReturnType<typeof vi.fn<(identifier: string) => void>>;
+let scope: ReturnType<typeof effectScope>;
+
+function dialog(): ReturnType<typeof useCustomAssetFormDialog> {
+  scope = effectScope();
+  return scope.run(() => useCustomAssetFormDialog({ editableItem, form, onSaved, open }))!;
+}
+
+describe('modules/assets/admin/custom/useCustomAssetFormDialog', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    open = ref<boolean>(true);
+    editableItem = ref<CustomAsset | null>(null);
+    form = shallowRef({ saveIcon, validate });
+    onSaved = vi.fn<(identifier: string) => void>();
+    validate.mockReturnValue(true);
+    addCustomAsset.mockResolvedValue('custom-new');
+    editCustomAsset.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('what the form binds', () => {
+    it('should offer a blank asset when adding', () => {
+      const { modelValue } = dialog();
+
+      expect(get(modelValue)).toEqual(BLANK);
+    });
+
+    it('should offer the asset being edited', () => {
+      set(editableItem, asset());
+
+      const { modelValue } = dialog();
+
+      expect(get(modelValue)).toEqual(asset());
+    });
+
+    it('should hold nothing while the dialog is closed', () => {
+      set(open, false);
+
+      const { modelValue } = dialog();
+
+      expect(get(modelValue)).toBeUndefined();
+    });
+
+    it('should follow the dialog closing', async () => {
+      const { modelValue } = dialog();
+      set(open, false);
+      await flushPromises();
+
+      expect(get(modelValue)).toBeUndefined();
+    });
+
+    it('should follow a change of asset while open', async () => {
+      const { modelValue } = dialog();
+      set(editableItem, asset({ name: 'A boat' }));
+      await flushPromises();
+
+      expect(get(modelValue)).toEqual(asset({ name: 'A boat' }));
+    });
+  });
+
+  describe('the title', () => {
+    it('should say add while creating', () => {
+      const { dialogTitle } = dialog();
+
+      expect(get(dialogTitle)).toBe('asset_management.add_title');
+    });
+
+    it('should say edit while editing', () => {
+      set(editableItem, asset());
+
+      const { dialogTitle } = dialog();
+
+      expect(get(dialogTitle)).toBe('asset_management.edit_title');
+    });
+  });
+
+  describe('before it writes anything', () => {
+    it('should write nothing while the dialog is closed', async () => {
+      set(open, false);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(addCustomAsset).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing while the form is invalid', async () => {
+      validate.mockReturnValue(false);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(addCustomAsset).not.toHaveBeenCalled();
+    });
+
+    it('should write nothing when the form is not mounted', async () => {
+      set(form, null);
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(addCustomAsset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('adding an asset', () => {
+    it('should send it without the identifier the backend assigns', async () => {
+      const { modelValue, save } = dialog();
+      set(modelValue, asset({ identifier: 'ignored' }));
+      await save();
+
+      expect(addCustomAsset).toHaveBeenCalledWith({
+        customAssetType: 'real estate',
+        name: 'A house',
+        notes: '',
+      });
+      expect(editCustomAsset).not.toHaveBeenCalled();
+    });
+
+    it('should hand the caller the identifier the backend assigned', async () => {
+      const { save } = dialog();
+
+      expect(await save()).toBe(true);
+      expect(onSaved).toHaveBeenCalledWith('custom-new');
+      expect(saveIcon).toHaveBeenCalledWith('custom-new');
+    });
+
+    it('should fail when the backend assigns no identifier', async () => {
+      addCustomAsset.mockResolvedValue('');
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(onSaved).not.toHaveBeenCalled();
+      expect(saveIcon).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('editing an asset', () => {
+    beforeEach(() => {
+      set(editableItem, asset());
+    });
+
+    it('should send the asset as it stands', async () => {
+      const { save } = dialog();
+      await save();
+
+      expect(editCustomAsset).toHaveBeenCalledWith(asset());
+      expect(addCustomAsset).not.toHaveBeenCalled();
+    });
+
+    it('should keep the identifier it already had', async () => {
+      const { save } = dialog();
+
+      expect(await save()).toBe(true);
+      expect(onSaved).toHaveBeenCalledWith('custom-1');
+      expect(saveIcon).toHaveBeenCalledWith('custom-1');
+    });
+
+    it('should keep the dialog open when the backend refuses', async () => {
+      editCustomAsset.mockResolvedValue(false);
+
+      const { modelValue, save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(onSaved).not.toHaveBeenCalled();
+      expect(get(modelValue)).toBeDefined();
+    });
+  });
+
+  describe('when the write throws', () => {
+    it('should report an add failure with the adding wording', async () => {
+      addCustomAsset.mockRejectedValue(new Error('the backend is down'));
+
+      const { save } = dialog();
+
+      expect(await save()).toBe(false);
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'asset_management.add_error::the backend is down',
+      });
+    });
+
+    it('should report an edit failure with the editing wording', async () => {
+      set(editableItem, asset());
+      editCustomAsset.mockRejectedValue(new Error('the backend is down'));
+
+      const { save } = dialog();
+      await save();
+
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'asset_management.edit_error::the backend is down',
+      });
+    });
+
+    it('should stop loading so the user can try again', async () => {
+      addCustomAsset.mockRejectedValue(new Error('boom'));
+
+      const { loading, save } = dialog();
+      await save();
+
+      expect(get(loading)).toBe(false);
+    });
+  });
+
+  it('should mark itself loading only while the write runs', async () => {
+    const { loading, save } = dialog();
+
+    const pending = save();
+    expect(get(loading)).toBe(true);
+
+    await pending;
+    expect(get(loading)).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-asset-form-dialog.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-asset-form-dialog.ts
@@ -1,0 +1,150 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { CustomAsset } from '@/modules/assets/types';
+import type { ValidationErrors } from '@/modules/core/api/types/errors';
+import { omit } from 'es-toolkit';
+import { useAssetManagementApi } from '@/modules/assets/api/use-asset-management-api';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+
+interface CustomAssetFormHandle {
+  /** Runs the form's own validation. */
+  validate: () => boolean;
+  /** Uploads the pending icon for the saved asset. */
+  saveIcon: (identifier: string) => void;
+}
+
+interface UseCustomAssetFormDialogOptions {
+  /** The asset being edited, or null when adding. */
+  editableItem: MaybeRefOrGetter<CustomAsset | null | undefined>;
+  /** The form component, which owns validation and the icon upload. */
+  form: MaybeRefOrGetter<CustomAssetFormHandle | null | undefined>;
+  /** Whether the dialog is open; it closes itself once a write lands. */
+  open: Ref<boolean>;
+  /** Called after a successful write, so the caller can refresh its list. */
+  onSaved: (identifier: string) => void;
+}
+
+interface UseCustomAssetFormDialogReturn {
+  /** The dialog's title, which differs between adding and editing. */
+  dialogTitle: ComputedRef<string>;
+  /** Whether a write is in flight. */
+  loading: Readonly<Ref<boolean>>;
+  /** Field errors, which the form binds. */
+  modelErrorMessages: Ref<ValidationErrors>;
+  /**
+   * The asset the form edits.
+   *
+   * @remarks
+   * It mirrors `editableItem` while the dialog is open and is a blank asset when adding, so the
+   * form always has something to bind even before anything is typed.
+   */
+  modelValue: Ref<CustomAsset | undefined>;
+  /**
+   * Validates and writes the asset.
+   *
+   * @returns whether it landed; `false` leaves the dialog open with the reason shown
+   */
+  save: () => Promise<boolean>;
+}
+
+function emptyCustomAsset(): CustomAsset {
+  return {
+    customAssetType: '',
+    identifier: '',
+    name: '',
+    notes: '',
+  };
+}
+
+/**
+ * Drives the custom asset dialog: mirroring the asset being edited, validating, and writing it.
+ *
+ * @returns the dialog's state and its submit
+ */
+export function useCustomAssetFormDialog(
+  options: UseCustomAssetFormDialogOptions,
+): UseCustomAssetFormDialogReturn {
+  const { editableItem, form, onSaved, open } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const modelValue = ref<CustomAsset>();
+  const modelErrorMessages = ref<ValidationErrors>({});
+  const loading = shallowRef<boolean>(false);
+
+  const { setMessage } = useMessageStore();
+  const { addCustomAsset, editCustomAsset } = useAssetManagementApi();
+
+  const dialogTitle = computed<string>(() =>
+    toValue(editableItem)
+      ? t('asset_management.edit_title')
+      : t('asset_management.add_title'),
+  );
+
+  function reportFailure(error: unknown, editMode: boolean): void {
+    const obj = { message: getErrorMessage(error) };
+    setMessage({
+      description: editMode
+        ? t('asset_management.edit_error', obj)
+        : t('asset_management.add_error', obj),
+    });
+  }
+
+  async function save(): Promise<boolean> {
+    if (!isDefined(modelValue))
+      return false;
+
+    const formRef = toValue(form);
+    if (!formRef?.validate())
+      return false;
+
+    const data = get(modelValue);
+    const editMode = !!toValue(editableItem);
+    let identifier = data.identifier;
+    let success: boolean;
+
+    set(loading, true);
+    try {
+      if (editMode) {
+        success = await editCustomAsset(data);
+      }
+      else {
+        identifier = await addCustomAsset(omit(data, ['identifier']));
+        success = !!identifier;
+      }
+
+      if (identifier)
+        formRef.saveIcon(identifier);
+    }
+    catch (error: unknown) {
+      success = false;
+      reportFailure(error, editMode);
+    }
+    set(loading, false);
+
+    if (success) {
+      set(modelValue, undefined);
+      onSaved(identifier);
+    }
+    return success;
+  }
+
+  function mirrorEditableItem([isOpen, item]: [boolean, CustomAsset | null | undefined]): void {
+    if (!isOpen) {
+      set(modelValue, undefined);
+      return;
+    }
+
+    set(modelValue, item ?? emptyCustomAsset());
+  }
+
+  watchImmediate([open, (): CustomAsset | null | undefined => toValue(editableItem)], mirrorEditableItem);
+
+  return {
+    dialogTitle,
+    loading: readonly(loading),
+    modelErrorMessages,
+    modelValue,
+    save,
+  };
+}

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-asset-table.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-asset-table.spec.ts
@@ -1,0 +1,95 @@
+import type { CustomAsset } from '@/modules/assets/types';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { useCustomAssetTable } from './use-custom-asset-table';
+
+function asset(overrides: Partial<CustomAsset> = {}): CustomAsset {
+  return { customAssetType: 'real estate', identifier: 'custom-1', name: 'A house', notes: '', ...overrides };
+}
+
+let expanded: Ref<CustomAsset[]>;
+let scope: ReturnType<typeof effectScope>;
+
+function table(): ReturnType<typeof useCustomAssetTable> {
+  scope = effectScope();
+  return scope.run(() => useCustomAssetTable(expanded))!;
+}
+
+describe('modules/assets/admin/custom/useCustomAssetTable', () => {
+  beforeEach(() => {
+    expanded = ref<CustomAsset[]>([]);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the columns', () => {
+    it('should offer asset, type and actions', () => {
+      const { cols } = table();
+
+      expect(get(cols).map(col => col.key)).toEqual(['name', 'custom_asset_type', 'actions']);
+    });
+
+    it('should let the user sort by asset and type, but not by actions', () => {
+      const { cols } = table();
+
+      expect(get(cols).map(col => !!col.sortable)).toEqual([true, true, false]);
+    });
+  });
+
+  describe('shaping a row for the shared asset display', () => {
+    it('should mark it as a custom asset and show its type as the symbol', () => {
+      const { getAsset } = table();
+
+      expect(getAsset(asset())).toEqual({
+        customAssetType: 'real estate',
+        identifier: 'custom-1',
+        isCustomAsset: true,
+        name: 'A house',
+        symbol: 'real estate',
+      });
+    });
+  });
+
+  describe('expanding a row', () => {
+    it('should report nothing expanded to begin with', () => {
+      const { isExpanded } = table();
+
+      expect(isExpanded('custom-1')).toBe(false);
+    });
+
+    it('should expand the row it is given', () => {
+      const { expand, isExpanded } = table();
+      expand(asset());
+
+      expect(isExpanded('custom-1')).toBe(true);
+    });
+
+    it('should collapse a row that is already expanded', () => {
+      const { expand, isExpanded } = table();
+      expand(asset());
+      expand(asset());
+
+      expect(isExpanded('custom-1')).toBe(false);
+      expect(get(expanded)).toEqual([]);
+    });
+
+    it('should keep only one row open at a time', () => {
+      const { expand, isExpanded } = table();
+      expand(asset({ identifier: 'custom-1' }));
+      expand(asset({ identifier: 'custom-2' }));
+
+      expect(isExpanded('custom-1')).toBe(false);
+      expect(isExpanded('custom-2')).toBe(true);
+      expect(get(expanded)).toHaveLength(1);
+    });
+
+    it('should report only the identifier it was asked about', () => {
+      const { expand, isExpanded } = table();
+      expand(asset({ identifier: 'custom-1' }));
+
+      expect(isExpanded('custom-2')).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-asset-table.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-asset-table.ts
@@ -1,0 +1,86 @@
+import type { DataTableColumn } from '@rotki/ui-library';
+import type { ComputedRef, Ref } from 'vue';
+import type { CustomAsset } from '@/modules/assets/types';
+import { some } from 'es-toolkit/compat';
+
+/** A custom asset shaped for `AssetDetailsBase`, which renders resolved and custom assets alike. */
+interface CustomAssetDetails {
+  customAssetType: string;
+  identifier: string;
+  isCustomAsset: true;
+  name: string;
+  symbol: string;
+}
+
+interface UseCustomAssetTableReturn {
+  /** The table's columns. */
+  cols: ComputedRef<DataTableColumn<CustomAsset>[]>;
+  /**
+   * Expands a row, or collapses it when it is already open.
+   *
+   * @remarks
+   * Only one row is expanded at a time, so opening another closes the first.
+   */
+  expand: (item: CustomAsset) => void;
+  /** Shapes a row for the shared asset display, which has no notion of a custom asset's fields. */
+  getAsset: (item: CustomAsset) => CustomAssetDetails;
+  /** Whether the row with this identifier is expanded. */
+  isExpanded: (identifier: string) => boolean;
+}
+
+/**
+ * The custom assets table's columns and its single-row expansion.
+ *
+ * @param expanded - the expanded rows, which this both reads and replaces
+ * @returns the columns and the expansion helpers the rows bind
+ */
+export function useCustomAssetTable(expanded: Ref<CustomAsset[]>): UseCustomAssetTableReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const cols = computed<DataTableColumn<CustomAsset>[]>(() => [
+    {
+      cellClass: 'py-0',
+      class: 'w-1/2',
+      key: 'name',
+      label: t('common.asset'),
+      sortable: true,
+    },
+    {
+      cellClass: 'py-0',
+      class: 'w-1/2',
+      key: 'custom_asset_type',
+      label: t('common.type'),
+      sortable: true,
+    },
+    {
+      cellClass: 'py-0',
+      key: 'actions',
+      label: '',
+    },
+  ]);
+
+  function getAsset(item: CustomAsset): CustomAssetDetails {
+    return {
+      customAssetType: item.customAssetType,
+      identifier: item.identifier,
+      isCustomAsset: true,
+      name: item.name,
+      symbol: item.customAssetType,
+    };
+  }
+
+  function isExpanded(identifier: string): boolean {
+    return some(get(expanded), { identifier });
+  }
+
+  function expand(item: CustomAsset): void {
+    set(expanded, isExpanded(item.identifier) ? [] : [item]);
+  }
+
+  return {
+    cols,
+    expand,
+    getAsset,
+    isExpanded,
+  };
+}

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-assets-table.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-assets-table.spec.ts
@@ -1,0 +1,156 @@
+import type { CustomAsset } from '@/modules/assets/types';
+import type { Collection } from '@/modules/core/common/collection';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises } from '@vue/test-utils';
+import { setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useCustomAssetsTable } from './use-custom-assets-table';
+
+let collection: Ref<Collection<CustomAsset>>;
+
+const {
+  deleteCustomAsset,
+  getCustomAssetTypes,
+  queryAllCustomAssets,
+  refetch,
+  setMessage,
+} = vi.hoisted(() => ({
+  deleteCustomAsset: vi.fn(async () => Promise.resolve(true)),
+  getCustomAssetTypes: vi.fn(),
+  queryAllCustomAssets: vi.fn(),
+  refetch: vi.fn(async () => Promise.resolve()),
+  setMessage: vi.fn(),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-management-api', () => ({
+  useAssetManagementApi: (): Record<string, unknown> => ({
+    deleteCustomAsset,
+    getCustomAssetTypes,
+    queryAllCustomAssets,
+  }),
+}));
+
+vi.mock('@/modules/assets/admin/custom/use-custom-asset-fields', () => ({
+  useCustomAssetFields: (): Record<string, unknown> => ({}),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', () => ({
+  routeWhen: (main: boolean): unknown => (main ? { mode: 'route' } : undefined),
+  useServerTable: (): Record<string, unknown> => ({
+    collection,
+    filter: ref({}),
+    isLoading: ref<boolean>(false),
+    pagination: ref({ limit: 10, page: 1, total: 0 }),
+    refetch,
+    sort: ref([]),
+  }),
+}));
+
+function asset(overrides: Partial<CustomAsset> = {}): CustomAsset {
+  return {
+    customAssetType: 'real estate',
+    identifier: 'custom-1',
+    name: 'A house',
+    notes: '',
+    ...overrides,
+  };
+}
+
+function page(data: CustomAsset[]): Collection<CustomAsset> {
+  return { data, found: data.length, limit: -1, total: data.length, totalValue: undefined };
+}
+
+let scope: ReturnType<typeof effectScope>;
+
+function table(): ReturnType<typeof useCustomAssetsTable> {
+  scope = effectScope();
+  return scope.run(() => useCustomAssetsTable({ mainPage: true }))!;
+}
+
+describe('modules/assets/admin/custom/useCustomAssetsTable', () => {
+  beforeEach(() => {
+    setActivePinia(createCustomPinia());
+    vi.clearAllMocks();
+    collection = ref<Collection<CustomAsset>>(page([]));
+    getCustomAssetTypes.mockResolvedValue(['real estate', 'art']);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('refreshing', () => {
+    it('should read the page and the types together', async () => {
+      const { refresh } = table();
+      await refresh();
+
+      expect(refetch).toHaveBeenCalledOnce();
+      expect(getCustomAssetTypes).toHaveBeenCalledOnce();
+    });
+
+    it('should offer the types the form can choose from', async () => {
+      const { refresh, types } = table();
+      await refresh();
+
+      expect(get(types)).toEqual(['real estate', 'art']);
+    });
+  });
+
+  describe('deleting an asset', () => {
+    it('should delete nothing until the dialog is confirmed', () => {
+      const { showDeleteConfirmation } = table();
+      showDeleteConfirmation(asset({ identifier: 'custom-5' }));
+
+      expect(get(useConfirmStore().visible)).toBe(true);
+      expect(deleteCustomAsset).not.toHaveBeenCalled();
+    });
+
+    it('should delete exactly the asset the dialog named, then refresh', async () => {
+      const { showDeleteConfirmation } = table();
+      showDeleteConfirmation(asset({ identifier: 'custom-5' }));
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(deleteCustomAsset).toHaveBeenCalledWith('custom-5');
+      expect(deleteCustomAsset).toHaveBeenCalledOnce();
+      expect(refetch).toHaveBeenCalledOnce();
+      expect(getCustomAssetTypes).toHaveBeenCalledOnce();
+    });
+
+    it('should name the asset in the confirmation', () => {
+      const { showDeleteConfirmation } = table();
+      showDeleteConfirmation(asset({ name: 'A house' }));
+
+      expect(get(useConfirmStore().confirmation).message)
+        .toBe('asset_management.confirm_delete.message::A house');
+    });
+
+    it('should report a failed delete against the asset it tried', async () => {
+      deleteCustomAsset.mockRejectedValue(new Error('still referenced'));
+
+      const { showDeleteConfirmation } = table();
+      showDeleteConfirmation(asset({ identifier: 'custom-5' }));
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({
+        description: expect.stringContaining('custom-5'),
+      }));
+    });
+
+    it('should delete nothing when the dialog is dismissed', async () => {
+      const { showDeleteConfirmation } = table();
+      showDeleteConfirmation(asset());
+      await useConfirmStore().dismiss();
+      await flushPromises();
+
+      expect(deleteCustomAsset).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-assets-table.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-assets-table.ts
@@ -1,0 +1,118 @@
+import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
+import type { MaybeRefOrGetter, Ref, WritableComputedRef } from 'vue';
+import type { Filters } from '@/modules/assets/admin/custom/use-custom-assets-filter';
+import type { CustomAsset, CustomAssetRequestPayload } from '@/modules/assets/types';
+import type { Collection } from '@/modules/core/common/collection';
+import { useCustomAssetFields } from '@/modules/assets/admin/custom/use-custom-asset-fields';
+import { useAssetManagementApi } from '@/modules/assets/api/use-asset-management-api';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useCommonTableProps } from '@/modules/core/table/use-common-table-props';
+import { routeWhen, useServerTable } from '@/modules/core/table/use-server-table';
+import { useTableRowDeletion } from '@/modules/core/table/use-table-row-deletion';
+
+interface UseCustomAssetsTableOptions {
+  /** Whether this is the standalone page, which owns the url state. */
+  mainPage: MaybeRefOrGetter<boolean>;
+}
+
+interface UseCustomAssetsTableReturn {
+  /** The page of assets the table renders. */
+  collection: Ref<Collection<CustomAsset>>;
+  /** The declared filter fields the pill bar reads. */
+  fields: ReturnType<typeof useCustomAssetFields>;
+  /** True while a page is being fetched. */
+  loading: Ref<boolean>;
+  /** Rows the user expanded. */
+  modelExpanded: Ref<CustomAsset[]>;
+  /** The active filters; bound with `v-model:filters`. */
+  modelFilter: WritableComputedRef<Filters>;
+  /** Current page and size. */
+  pagination: WritableComputedRef<TablePaginationData>;
+  /** Refetches the current page. */
+  refetch: () => Promise<void>;
+  /** Refetches the page and the custom asset types together. */
+  refresh: () => Promise<void>;
+  /** Asks for confirmation, then deletes the asset and refreshes. */
+  showDeleteConfirmation: (item: CustomAsset) => void;
+  /** The table's sort state. */
+  sort: WritableComputedRef<DataTableSortData<CustomAsset>>;
+  /** The custom asset types, which the form offers as choices. */
+  types: Readonly<Ref<string[]>>;
+}
+
+/**
+ * Drives the custom assets table: the server-paginated page, the types the form offers, and row
+ * deletion.
+ *
+ * @returns the table state, the ways to refresh it, and the delete action its rows offer
+ */
+export function useCustomAssetsTable(options: UseCustomAssetsTableOptions): UseCustomAssetsTableReturn {
+  const { mainPage } = options;
+
+  const { t } = useI18n({ useScope: 'global' });
+
+  const types = ref<string[]>([]);
+
+  const { deleteCustomAsset, getCustomAssetTypes, queryAllCustomAssets } = useAssetManagementApi();
+  const { expanded } = useCommonTableProps<CustomAsset>();
+
+  const fields = useCustomAssetFields(types);
+
+  const {
+    collection,
+    filter,
+    isLoading: loading,
+    pagination,
+    refetch,
+    sort,
+  } = useServerTable<
+    CustomAsset,
+    CustomAssetRequestPayload,
+    Filters
+  >({
+    fetch: queryAllCustomAssets,
+    fields,
+    sort: {
+      default: [{
+        column: 'name',
+        direction: 'desc',
+      }],
+    },
+    urlState: routeWhen(toValue(mainPage)),
+  });
+
+  async function refreshTypes(): Promise<void> {
+    set(types, await getCustomAssetTypes());
+  }
+
+  async function refresh(): Promise<void> {
+    await Promise.all([refetch(), refreshTypes()]);
+  }
+
+  const { showDeleteConfirmation } = useTableRowDeletion<CustomAsset>({
+    confirm: item => ({
+      message: t('asset_management.confirm_delete.message', { asset: item.name }),
+      title: t('asset_management.confirm_delete.title'),
+    }),
+    deleteItem: async item => deleteCustomAsset(item.identifier),
+    errorMessage: (item, error) => t('asset_management.delete_error', {
+      address: item.identifier,
+      message: getErrorMessage(error),
+    }),
+    onDeleted: refresh,
+  });
+
+  return {
+    collection,
+    fields,
+    loading,
+    modelExpanded: expanded,
+    modelFilter: filter,
+    pagination,
+    refetch,
+    refresh,
+    showDeleteConfirmation,
+    sort,
+    types: shallowReadonly(types),
+  };
+}

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetActions.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetActions.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { Filters } from '@/modules/assets/admin/managed/use-assets-filter';
+import type { IgnoredAssetsHandlingType } from '@/modules/assets/types';
 import type { PillParams } from '@/modules/core/table/param-refs';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
-import { IgnoredAssetHandlingType, type IgnoredAssetsHandlingType } from '@/modules/assets/types';
+import { useManagedAssetActions } from '@/modules/assets/admin/managed/use-managed-asset-actions';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import IgnoreButtons from '@/modules/history/IgnoreButtons.vue';
@@ -32,14 +33,11 @@ const { t } = useI18n({ useScope: 'global' });
 
 const pillLabels = usePillBarLabels();
 
-const disabledIgnoreActions = computed<{ ignore: boolean; unIgnore: boolean }>(() => ({
-  ignore: ignoredHandling === IgnoredAssetHandlingType.SHOW_ONLY,
-  unIgnore: ignoredHandling === IgnoredAssetHandlingType.EXCLUDE,
-}));
-
-function clearSelection() {
-  set(selected, []);
-}
+const { clearSelection, disabledIgnoreActions } = useManagedAssetActions({
+  ignoredHandling: () => ignoredHandling,
+  onIgnoredStale: (): void => emit('refresh:ignored'),
+  selected,
+});
 
 function handleIgnore(ignored: boolean): void {
   emit('ignore', ignored);
@@ -48,11 +46,6 @@ function handleIgnore(ignored: boolean): void {
 function handleMarkSpam(): void {
   emit('mark-spam');
 }
-
-watch(() => ignoredHandling, (handling) => {
-  if (handling === IgnoredAssetHandlingType.SHOW_ONLY)
-    emit('refresh:ignored');
-});
 </script>
 
 <template>

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetTable.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetTable.vue
@@ -2,6 +2,7 @@
 import type { SupportedAsset } from '@rotki/common';
 import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
 import type { Filters } from '@/modules/assets/admin/managed/use-assets-filter';
+import type { IgnoredAssetsHandlingType } from '@/modules/assets/types';
 import type { Collection } from '@/modules/core/common/collection';
 import type { PillParams } from '@/modules/core/table/param-refs';
 import type { FieldDef } from '@/modules/core/table/pill/core/types';
@@ -12,7 +13,6 @@ import { useAssetDisplayHelpers } from '@/modules/assets/admin/use-asset-display
 import { useManagedAssetOperations } from '@/modules/assets/admin/use-managed-asset-operations';
 import { useManagedAssetTable } from '@/modules/assets/admin/use-managed-asset-table';
 import AssetDetailsBase from '@/modules/assets/AssetDetailsBase.vue';
-import { EVM_TOKEN, type IgnoredAssetsHandlingType, isSpammableAssetType, SOLANA_CHAIN, SOLANA_TOKEN } from '@/modules/assets/types';
 import { useIgnoredAssetOperations } from '@/modules/assets/use-ignored-asset-operations';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import CopyButton from '@/modules/shell/components/CopyButton.vue';
@@ -62,10 +62,11 @@ const {
   toggleWhitelistAsset,
 } = useManagedAssetOperations(() => emit('refresh'), () => ignoredHandling, selected);
 
-const { cols, data, expand, isExpanded } = useManagedAssetTable(
+const { cols, data, expand, getAssetLocation, isExpanded, spamDisabled } = useManagedAssetTable(
   paginationModel,
   expanded,
   () => collection,
+  selected,
 );
 
 useRememberTableSorting<SupportedAsset>(TableId.SUPPORTED_ASSET, sortModel, cols);
@@ -76,37 +77,6 @@ const { canBeEdited, canBeIgnored, disabledRows, formatType, getAsset } = useAss
 );
 
 const { fetchIgnoredAssets } = useIgnoredAssetOperations();
-
-const spamDisabled = computed<boolean>(() => {
-  const selectedIds = get(selected);
-  if (selectedIds.length === 0)
-    return false;
-
-  const assets = collection.data;
-  return !selectedIds.some((id) => {
-    const asset = assets.find(a => a.identifier === id);
-    return asset && isSpammableAssetType(asset.assetType);
-  });
-});
-
-/**
- * The chain whose explorer can show this asset, when one can.
- *
- * @remarks
- * Hyperliquid Core tokens have none: their ids are not HyperEVM addresses, so no explorer would
- * resolve them. Their icon comes from the resolved asset type instead, so nothing is lost.
- *
- * @returns the chain, or undefined when the asset has no explorer page
- */
-function getAssetLocation(row: SupportedAsset): string | undefined {
-  if (row.assetType === EVM_TOKEN)
-    return row?.evmChain ?? undefined;
-
-  if (row.assetType === SOLANA_TOKEN)
-    return SOLANA_CHAIN;
-
-  return undefined;
-}
 </script>
 
 <template>

--- a/frontend/app/src/modules/assets/admin/managed/use-managed-asset-actions.spec.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-managed-asset-actions.spec.ts
@@ -1,0 +1,93 @@
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref, shallowRef } from 'vue';
+import { IgnoredAssetHandlingType, type IgnoredAssetsHandlingType } from '@/modules/assets/types';
+import { useManagedAssetActions } from './use-managed-asset-actions';
+
+let ignoredHandling: Ref<IgnoredAssetsHandlingType>;
+let selected: Ref<string[]>;
+let onIgnoredStale: ReturnType<typeof vi.fn<() => void>>;
+let scope: ReturnType<typeof effectScope>;
+
+function actions(): ReturnType<typeof useManagedAssetActions> {
+  scope = effectScope();
+  return scope.run(() => useManagedAssetActions({ ignoredHandling, onIgnoredStale, selected }))!;
+}
+
+describe('modules/assets/admin/managed/useManagedAssetActions', () => {
+  beforeEach(() => {
+    ignoredHandling = shallowRef<IgnoredAssetsHandlingType>(IgnoredAssetHandlingType.NONE);
+    selected = ref<string[]>(['eip155:1/erc20:0xABC']);
+    onIgnoredStale = vi.fn<() => void>();
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('which ignore actions are offered', () => {
+    it('should offer both while ignored assets are shown alongside the rest', () => {
+      const { disabledIgnoreActions } = actions();
+
+      expect(get(disabledIgnoreActions)).toEqual({ ignore: false, unIgnore: false });
+    });
+
+    it('should not offer ignoring while only ignored assets are shown', () => {
+      set(ignoredHandling, IgnoredAssetHandlingType.SHOW_ONLY);
+
+      const { disabledIgnoreActions } = actions();
+
+      expect(get(disabledIgnoreActions)).toEqual({ ignore: true, unIgnore: false });
+    });
+
+    it('should not offer un-ignoring while ignored assets are excluded', () => {
+      set(ignoredHandling, IgnoredAssetHandlingType.EXCLUDE);
+
+      const { disabledIgnoreActions } = actions();
+
+      expect(get(disabledIgnoreActions)).toEqual({ ignore: false, unIgnore: true });
+    });
+
+    it('should follow a change of handling', async () => {
+      const { disabledIgnoreActions } = actions();
+      set(ignoredHandling, IgnoredAssetHandlingType.SHOW_ONLY);
+      await flushPromises();
+
+      expect(get(disabledIgnoreActions).ignore).toBe(true);
+    });
+  });
+
+  describe('keeping the ignored list fresh', () => {
+    it('should ask for it when the table switches to showing only ignored assets', async () => {
+      actions();
+      set(ignoredHandling, IgnoredAssetHandlingType.SHOW_ONLY);
+      await flushPromises();
+
+      expect(onIgnoredStale).toHaveBeenCalledOnce();
+    });
+
+    it('should not ask for it on any other handling', async () => {
+      actions();
+      set(ignoredHandling, IgnoredAssetHandlingType.EXCLUDE);
+      await flushPromises();
+
+      expect(onIgnoredStale).not.toHaveBeenCalled();
+    });
+
+    it('should not ask for it before the handling changes', () => {
+      set(ignoredHandling, IgnoredAssetHandlingType.SHOW_ONLY);
+      actions();
+
+      expect(onIgnoredStale).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the selection', () => {
+    it('should clear it', () => {
+      const { clearSelection } = actions();
+      clearSelection();
+
+      expect(get(selected)).toEqual([]);
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/managed/use-managed-asset-actions.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-managed-asset-actions.ts
@@ -1,0 +1,69 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { IgnoredAssetHandlingType, type IgnoredAssetsHandlingType } from '@/modules/assets/types';
+
+/** Which of the two ignore actions the current handling rules out. */
+interface DisabledIgnoreActions {
+  ignore: boolean;
+  unIgnore: boolean;
+}
+
+interface UseManagedAssetActionsOptions {
+  /** How ignored assets are currently being treated. */
+  ignoredHandling: MaybeRefOrGetter<IgnoredAssetsHandlingType>;
+  /**
+   * Called when the ignored list has to be re-read.
+   *
+   * @remarks
+   * Showing only ignored assets makes the list itself the table's contents, so it has to be fresh
+   * before the table renders from it.
+   */
+  onIgnoredStale: () => void;
+  /** The selected asset identifiers, which this clears. */
+  selected: Ref<string[]>;
+}
+
+interface UseManagedAssetActionsReturn {
+  /** Empties the selection. */
+  clearSelection: () => void;
+  /**
+   * Which ignore actions are unavailable.
+   *
+   * @remarks
+   * Ignoring is pointless while only ignored assets are shown, and un-ignoring is pointless while
+   * they are excluded, because in each case the row would leave the table it was acted on from.
+   */
+  disabledIgnoreActions: ComputedRef<DisabledIgnoreActions>;
+}
+
+/**
+ * The bulk actions above the managed assets table: what the current ignore handling allows, and
+ * clearing the selection.
+ *
+ * @returns the disabled state of the ignore buttons and the selection reset
+ */
+export function useManagedAssetActions(
+  options: UseManagedAssetActionsOptions,
+): UseManagedAssetActionsReturn {
+  const { ignoredHandling, onIgnoredStale, selected } = options;
+
+  const disabledIgnoreActions = computed<DisabledIgnoreActions>(() => ({
+    ignore: toValue(ignoredHandling) === IgnoredAssetHandlingType.SHOW_ONLY,
+    unIgnore: toValue(ignoredHandling) === IgnoredAssetHandlingType.EXCLUDE,
+  }));
+
+  function clearSelection(): void {
+    set(selected, []);
+  }
+
+  function refreshIgnoredWhenShownAlone(handling: IgnoredAssetsHandlingType): void {
+    if (handling === IgnoredAssetHandlingType.SHOW_ONLY)
+      onIgnoredStale();
+  }
+
+  watch(() => toValue(ignoredHandling), refreshIgnoredWhenShownAlone);
+
+  return {
+    clearSelection,
+    disabledIgnoreActions,
+  };
+}

--- a/frontend/app/src/modules/assets/admin/missing-mappings/AssetMissingMappings.vue
+++ b/frontend/app/src/modules/assets/admin/missing-mappings/AssetMissingMappings.vue
@@ -1,84 +1,28 @@
 <script setup lang="ts">
-import type { DataTableColumn } from '@rotki/ui-library';
-import type { Filters } from '@/modules/assets/admin/missing-mappings/use-missing-mappings-filter';
-import type { CexMapping } from '@/modules/assets/types';
-import type { MissingMapping } from '@/modules/user-data/schemas';
 import ManageCexMappingFormDialog from '@/modules/assets/admin/cex-mapping/ManageCexMappingFormDialog.vue';
-import { type MissingMappingsRequestPayload, useMissingMappingsDB } from '@/modules/assets/admin/missing-mappings/use-missing-mappings-db';
-import { useMissingMappingsFields } from '@/modules/assets/admin/missing-mappings/use-missing-mappings-fields';
+import { useAssetMissingMappings } from '@/modules/assets/admin/missing-mappings/use-asset-missing-mappings';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
-import { useServerTable } from '@/modules/core/table/use-server-table';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
-const mapping = ref<CexMapping>();
-
-const { t } = useI18n({ useScope: 'global' });
 const pillLabels = usePillBarLabels();
 
-const cols = computed<DataTableColumn<MissingMapping>[]>(() => [{
-  align: 'center',
-  cellClass: 'py-3',
-  key: 'location',
-  label: t('common.location'),
-  sortable: true,
-}, {
-  cellClass: 'py-3',
-  key: 'identifier',
-  label: t('common.asset'),
-  sortable: true,
-}, {
-  cellClass: 'py-3 border-x border-default',
-  class: 'border-x border-default',
-  key: 'details',
-  label: t('common.details'),
-}, {
-  align: 'center',
-  cellClass: 'py-3 w-24',
-  key: 'actions',
-  label: t('common.actions_text'),
-}]);
-
-const { getData, remove } = useMissingMappingsDB();
-
-const fields = useMissingMappingsFields();
-
 const {
-  collection: mappings,
-  filter,
+  cols,
+  fields,
+  mappings,
+  modelFilter,
+  modelMapping,
+  onAddClick,
+  onAddComplete,
   pagination,
   refetch,
   sort,
-} = useServerTable<MissingMapping, MissingMappingsRequestPayload, Filters>({
-  fetch: getData,
-  fields,
-  sort: {
-    default: {
-      column: 'location',
-      direction: 'asc',
-    },
-  },
-});
+} = useAssetMissingMappings();
 
-useRememberTableSorting<MissingMapping>(TableId.ASSET_MISSING_MAPPINGS, sort, cols);
-
-function onAddClick(item: MissingMapping) {
-  set(mapping, {
-    asset: '',
-    location: item.location,
-    locationSymbol: item.identifier,
-  });
-}
-
-async function onAddComplete(item: CexMapping) {
-  await remove({
-    identifier: item.locationSymbol,
-    location: item.location ?? '',
-  });
-  await refetch();
-}
+useRememberTableSorting(TableId.ASSET_MISSING_MAPPINGS, sort, cols);
 
 onMounted(async () => {
   await refetch();
@@ -94,7 +38,7 @@ onMounted(async () => {
     <RuiCard>
       <div class="mb-4 flex">
         <PillFilterBar
-          v-model:matches="filter"
+          v-model:matches="modelFilter"
           class="flex-1 min-w-[12rem] md:min-w-[24rem]"
           :fields="fields"
           :labels="pillLabels"
@@ -139,7 +83,7 @@ onMounted(async () => {
     </RuiCard>
 
     <ManageCexMappingFormDialog
-      v-model="mapping"
+      v-model="modelMapping"
       @refresh="onAddComplete($event)"
     />
   </TablePageLayout>

--- a/frontend/app/src/modules/assets/admin/missing-mappings/use-asset-missing-mappings.spec.ts
+++ b/frontend/app/src/modules/assets/admin/missing-mappings/use-asset-missing-mappings.spec.ts
@@ -1,0 +1,131 @@
+import type { Collection } from '@/modules/core/common/collection';
+import type { MissingMapping } from '@/modules/user-data/schemas';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { useAssetMissingMappings } from './use-asset-missing-mappings';
+
+let mappings: Ref<Collection<MissingMapping>>;
+
+const { getData, refetch, remove } = vi.hoisted(() => ({
+  getData: vi.fn(),
+  refetch: vi.fn(async () => Promise.resolve()),
+  remove: vi.fn(async () => Promise.resolve()),
+}));
+
+vi.mock('@/modules/assets/admin/missing-mappings/use-missing-mappings-db', () => ({
+  useMissingMappingsDB: (): Record<string, unknown> => ({ getData, remove }),
+}));
+
+vi.mock('@/modules/assets/admin/missing-mappings/use-missing-mappings-fields', () => ({
+  useMissingMappingsFields: (): Record<string, unknown> => ({}),
+}));
+
+vi.mock('@/modules/core/table/use-server-table', () => ({
+  useServerTable: (): Record<string, unknown> => ({
+    collection: mappings,
+    filter: ref({}),
+    pagination: ref({ limit: 10, page: 1, total: 0 }),
+    refetch,
+    sort: ref([]),
+  }),
+}));
+
+function missing(overrides: Partial<MissingMapping> = {}): MissingMapping {
+  return { details: '', id: 1, identifier: 'XBT', location: 'kraken', name: 'Kraken', ...overrides };
+}
+
+let scope: ReturnType<typeof effectScope>;
+
+function page(): ReturnType<typeof useAssetMissingMappings> {
+  scope = effectScope();
+  return scope.run(() => useAssetMissingMappings())!;
+}
+
+describe('modules/assets/admin/missing-mappings/useAssetMissingMappings', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    mappings = ref<Collection<MissingMapping>>({
+      data: [],
+      found: 0,
+      limit: -1,
+      total: 0,
+      totalValue: undefined,
+    });
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the columns', () => {
+    it('should offer location, asset, details and actions', () => {
+      const { cols } = page();
+
+      expect(get(cols).map(col => col.key)).toEqual(['location', 'identifier', 'details', 'actions']);
+    });
+
+    it('should let the user sort by location and asset only', () => {
+      const { cols } = page();
+
+      expect(get(cols).map(col => !!col.sortable)).toEqual([true, true, false, false]);
+    });
+  });
+
+  describe('starting to add a mapping', () => {
+    it('should seed the exchange and its symbol from the row', () => {
+      const { modelMapping, onAddClick } = page();
+      onAddClick(missing({ identifier: 'XBT', location: 'kraken' }));
+
+      expect(get(modelMapping)).toEqual({ asset: '', location: 'kraken', locationSymbol: 'XBT' });
+    });
+
+    it('should leave the asset for the user to choose', () => {
+      const { modelMapping, onAddClick } = page();
+      onAddClick(missing());
+
+      expect(get(modelMapping)?.asset).toBe('');
+    });
+
+    it('should hold nothing before a row is picked', () => {
+      const { modelMapping } = page();
+
+      expect(get(modelMapping)).toBeUndefined();
+    });
+  });
+
+  describe('once a mapping has been added', () => {
+    it('should drop the row it was added for and re-read the page', async () => {
+      const { onAddComplete } = page();
+      await onAddComplete({ asset: 'BTC', location: 'kraken', locationSymbol: 'XBT' });
+
+      expect(remove).toHaveBeenCalledWith({ identifier: 'XBT', location: 'kraken' });
+      expect(refetch).toHaveBeenCalledOnce();
+    });
+
+    it('should record an all-exchanges mapping against no location', async () => {
+      const { onAddComplete } = page();
+      await onAddComplete({ asset: 'BTC', location: null, locationSymbol: 'XBT' });
+
+      expect(remove).toHaveBeenCalledWith({ identifier: 'XBT', location: '' });
+    });
+
+    it('should re-read the page only after the row is dropped', async () => {
+      const order: string[] = [];
+      remove.mockImplementation(async () => {
+        order.push('remove');
+        return Promise.resolve();
+      });
+      refetch.mockImplementation(async () => {
+        order.push('refetch');
+        return Promise.resolve();
+      });
+
+      const { onAddComplete } = page();
+      await onAddComplete({ asset: 'BTC', location: 'kraken', locationSymbol: 'XBT' });
+
+      expect(order).toEqual(['remove', 'refetch']);
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/missing-mappings/use-asset-missing-mappings.ts
+++ b/frontend/app/src/modules/assets/admin/missing-mappings/use-asset-missing-mappings.ts
@@ -1,0 +1,130 @@
+import type { DataTableColumn, DataTableSortData, TablePaginationData } from '@rotki/ui-library';
+import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import type { Filters } from '@/modules/assets/admin/missing-mappings/use-missing-mappings-filter';
+import type { CexMapping } from '@/modules/assets/types';
+import type { Collection } from '@/modules/core/common/collection';
+import type { MissingMapping } from '@/modules/user-data/schemas';
+import {
+  type MissingMappingsRequestPayload,
+  useMissingMappingsDB,
+} from '@/modules/assets/admin/missing-mappings/use-missing-mappings-db';
+import { useMissingMappingsFields } from '@/modules/assets/admin/missing-mappings/use-missing-mappings-fields';
+import { useServerTable } from '@/modules/core/table/use-server-table';
+
+interface UseAssetMissingMappingsReturn {
+  /** The table's columns. */
+  cols: ComputedRef<DataTableColumn<MissingMapping>[]>;
+  /** The declared filter fields the pill bar reads. */
+  fields: ReturnType<typeof useMissingMappingsFields>;
+  /** The active filters; bound with `v-model:filters`. */
+  modelFilter: Ref<Filters>;
+  /**
+   * The mapping the dialog is adding, seeded from the row the user picked.
+   *
+   * @remarks
+   * The asset is left empty on purpose: choosing it is the whole point of the dialog.
+   */
+  modelMapping: Ref<CexMapping | undefined>;
+  /** The page of missing mappings the table renders. */
+  mappings: Ref<Collection<MissingMapping>>;
+  /** Opens the dialog on a mapping seeded from this row. */
+  onAddClick: (item: MissingMapping) => void;
+  /**
+   * Drops the row a mapping has just been added for, then re-reads the page.
+   *
+   * @remarks
+   * A mapping saved for all exchanges carries no location, which the local record stores as an
+   * empty string.
+   */
+  onAddComplete: (item: CexMapping) => Promise<void>;
+  /** Current page and size. */
+  pagination: WritableComputedRef<TablePaginationData>;
+  /** Refetches the current page. */
+  refetch: () => Promise<void>;
+  /** The table's sort state. */
+  sort: WritableComputedRef<DataTableSortData<MissingMapping>>;
+}
+
+/**
+ * Drives the missing asset mappings page: the table of exchange symbols rotki could not resolve,
+ * and adding a mapping for one.
+ *
+ * @returns the table state and the two ends of the add flow
+ */
+export function useAssetMissingMappings(): UseAssetMissingMappingsReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const modelMapping = ref<CexMapping>();
+
+  const { getData, remove } = useMissingMappingsDB();
+  const fields = useMissingMappingsFields();
+
+  const cols = computed<DataTableColumn<MissingMapping>[]>(() => [{
+    align: 'center',
+    cellClass: 'py-3',
+    key: 'location',
+    label: t('common.location'),
+    sortable: true,
+  }, {
+    cellClass: 'py-3',
+    key: 'identifier',
+    label: t('common.asset'),
+    sortable: true,
+  }, {
+    cellClass: 'py-3 border-x border-default',
+    class: 'border-x border-default',
+    key: 'details',
+    label: t('common.details'),
+  }, {
+    align: 'center',
+    cellClass: 'py-3 w-24',
+    key: 'actions',
+    label: t('common.actions_text'),
+  }]);
+
+  const {
+    collection: mappings,
+    filter,
+    pagination,
+    refetch,
+    sort,
+  } = useServerTable<MissingMapping, MissingMappingsRequestPayload, Filters>({
+    fetch: getData,
+    fields,
+    sort: {
+      default: {
+        column: 'location',
+        direction: 'asc',
+      },
+    },
+  });
+
+  function onAddClick(item: MissingMapping): void {
+    set(modelMapping, {
+      asset: '',
+      location: item.location,
+      locationSymbol: item.identifier,
+    });
+  }
+
+  async function onAddComplete(item: CexMapping): Promise<void> {
+    await remove({
+      identifier: item.locationSymbol,
+      location: item.location ?? '',
+    });
+    await refetch();
+  }
+
+  return {
+    cols,
+    fields,
+    mappings,
+    modelFilter: filter,
+    modelMapping,
+    onAddClick,
+    onAddComplete,
+    pagination,
+    refetch,
+    sort,
+  };
+}

--- a/frontend/app/src/modules/assets/admin/use-managed-asset-table.spec.ts
+++ b/frontend/app/src/modules/assets/admin/use-managed-asset-table.spec.ts
@@ -1,0 +1,193 @@
+import type { SupportedAsset } from '@rotki/common';
+import type { TablePaginationData } from '@rotki/ui-library';
+import type { Collection } from '@/modules/core/common/collection';
+import { createMock } from '@test/utils/create-mock';
+import { flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { EVM_TOKEN, SOLANA_CHAIN, SOLANA_TOKEN } from '@/modules/assets/types';
+import { useManagedAssetTable } from './use-managed-asset-table';
+
+let itemsPerPage: Ref<number>;
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (): Ref<number> => itemsPerPage,
+}));
+
+function asset(overrides: Partial<SupportedAsset> = {}): SupportedAsset {
+  return createMock<SupportedAsset>({
+    assetType: 'own chain',
+    identifier: 'BTC',
+    ...overrides,
+  });
+}
+
+function page(data: SupportedAsset[], found = data.length): Collection<SupportedAsset> {
+  return { data, found, limit: -1, total: found, totalValue: undefined };
+}
+
+let pagination: Ref<TablePaginationData>;
+let expanded: Ref<SupportedAsset[]>;
+let collection: Ref<Collection<SupportedAsset>>;
+let selected: Ref<string[]>;
+let scope: ReturnType<typeof effectScope>;
+
+function table(): ReturnType<typeof useManagedAssetTable> {
+  scope = effectScope();
+  return scope.run(() => useManagedAssetTable(pagination, expanded, collection, selected))!;
+}
+
+describe('modules/assets/admin/useManagedAssetTable', () => {
+  beforeEach(() => {
+    itemsPerPage = ref<number>(10);
+    pagination = ref<TablePaginationData>({ limit: 10, page: 1, total: 0 });
+    expanded = ref<SupportedAsset[]>([]);
+    collection = ref<Collection<SupportedAsset>>(page([]));
+    selected = ref<string[]>([]);
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('the rows', () => {
+    it('should read them from the collection', () => {
+      set(collection, page([asset({ identifier: 'BTC' })]));
+
+      const { data } = table();
+
+      expect(get(data)).toHaveLength(1);
+    });
+  });
+
+  describe('the columns', () => {
+    it('should offer the asset, its type, address and start alongside the row controls', () => {
+      const { cols } = table();
+
+      expect(get(cols).map(col => col.key)).toContain('symbol');
+      expect(get(cols).map(col => col.key)).toEqual(
+        expect.arrayContaining(['symbol', 'type', 'address', 'started']),
+      );
+    });
+  });
+
+  describe('expanding a row', () => {
+    it('should keep only one row open at a time', () => {
+      const { expand, isExpanded } = table();
+      expand(asset({ identifier: 'BTC' }));
+      expand(asset({ identifier: 'ETH' }));
+
+      expect(isExpanded('BTC')).toBe(false);
+      expect(isExpanded('ETH')).toBe(true);
+    });
+
+    it('should collapse a row that is already expanded', () => {
+      const { expand, isExpanded } = table();
+      expand(asset({ identifier: 'BTC' }));
+      expand(asset({ identifier: 'BTC' }));
+
+      expect(isExpanded('BTC')).toBe(false);
+    });
+  });
+
+  describe('falling back to the last page', () => {
+    it('should step back when the page it is on has emptied', async () => {
+      table();
+      set(collection, page([], 25));
+      await flushPromises();
+
+      expect(get(pagination).page).toBe(3);
+    });
+
+    it('should stay put while the page still holds rows', async () => {
+      table();
+      set(collection, page([asset()], 25));
+      await flushPromises();
+
+      expect(get(pagination).page).toBe(1);
+    });
+
+    it('should stay put when there is nothing at all', async () => {
+      table();
+      set(collection, page([], 0));
+      await flushPromises();
+
+      expect(get(pagination).page).toBe(1);
+    });
+  });
+
+  describe('whether the selection can be marked as spam', () => {
+    it('should stay available while nothing is selected', () => {
+      set(collection, page([asset({ assetType: 'own chain', identifier: 'BTC' })]));
+
+      const { spamDisabled } = table();
+
+      expect(get(spamDisabled)).toBe(false);
+    });
+
+    it('should be available when a selected asset is of a spammable type', () => {
+      set(collection, page([asset({ assetType: EVM_TOKEN, identifier: 'eip155:1/erc20:0xABC' })]));
+      set(selected, ['eip155:1/erc20:0xABC']);
+
+      const { spamDisabled } = table();
+
+      expect(get(spamDisabled)).toBe(false);
+    });
+
+    it('should be unavailable when no selected asset can be spam', () => {
+      set(collection, page([asset({ assetType: 'own chain', identifier: 'BTC' })]));
+      set(selected, ['BTC']);
+
+      const { spamDisabled } = table();
+
+      expect(get(spamDisabled)).toBe(true);
+    });
+
+    it('should be available when only one of several selected assets can be spam', () => {
+      set(collection, page([
+        asset({ assetType: 'own chain', identifier: 'BTC' }),
+        asset({ assetType: EVM_TOKEN, identifier: 'eip155:1/erc20:0xABC' }),
+      ]));
+      set(selected, ['BTC', 'eip155:1/erc20:0xABC']);
+
+      const { spamDisabled } = table();
+
+      expect(get(spamDisabled)).toBe(false);
+    });
+
+    it('should be unavailable when the selection names assets the page does not hold', () => {
+      set(collection, page([asset({ assetType: EVM_TOKEN, identifier: 'eip155:1/erc20:0xABC' })]));
+      set(selected, ['a-row-on-another-page']);
+
+      const { spamDisabled } = table();
+
+      expect(get(spamDisabled)).toBe(true);
+    });
+  });
+
+  describe('which explorer can show an asset', () => {
+    it('should send an evm token to its own chain', () => {
+      const { getAssetLocation } = table();
+
+      expect(getAssetLocation(asset({ assetType: EVM_TOKEN, evmChain: 'ethereum' }))).toBe('ethereum');
+    });
+
+    it('should send a solana token to solana', () => {
+      const { getAssetLocation } = table();
+
+      expect(getAssetLocation(asset({ assetType: SOLANA_TOKEN }))).toBe(SOLANA_CHAIN);
+    });
+
+    it('should offer no explorer for an evm token with no chain', () => {
+      const { getAssetLocation } = table();
+
+      expect(getAssetLocation(asset({ assetType: EVM_TOKEN, evmChain: null }))).toBeUndefined();
+    });
+
+    it('should offer no explorer for any other asset type', () => {
+      const { getAssetLocation } = table();
+
+      expect(getAssetLocation(asset({ assetType: 'own chain' }))).toBeUndefined();
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/use-managed-asset-table.ts
+++ b/frontend/app/src/modules/assets/admin/use-managed-asset-table.ts
@@ -3,19 +3,38 @@ import type { DataTableColumn, TablePaginationData } from '@rotki/ui-library';
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { Collection } from '@/modules/core/common/collection';
 import { some } from 'es-toolkit/compat';
+import { EVM_TOKEN, isSpammableAssetType, SOLANA_CHAIN, SOLANA_TOKEN } from '@/modules/assets/types';
 import { useSetting } from '@/modules/settings/use-setting';
 
 interface UseManagedAssetTableReturn {
   cols: ComputedRef<DataTableColumn<SupportedAsset>[]>;
   data: ComputedRef<SupportedAsset[]>;
   expand: (item: SupportedAsset) => void;
+  /**
+   * The chain whose explorer can show this asset, when one can.
+   *
+   * @remarks
+   * Hyperliquid Core tokens have none: their ids are not HyperEVM addresses, so no explorer would
+   * resolve them. Their icon comes from the resolved asset type instead, so nothing is lost.
+   */
+  getAssetLocation: (row: SupportedAsset) => string | undefined;
   isExpanded: (identifier: string) => boolean;
+  /**
+   * Whether marking the selection as spam is unavailable.
+   *
+   * @remarks
+   * The action stays available while nothing is selected, because the button is what the user
+   * reaches for first. Once there is a selection it is only offered when at least one of the
+   * selected assets is of a type that can be spam.
+   */
+  spamDisabled: ComputedRef<boolean>;
 }
 
 export function useManagedAssetTable(
   paginationModel: Ref<TablePaginationData>,
   expanded: Ref<SupportedAsset[]>,
   collection: MaybeRefOrGetter<Collection<SupportedAsset>>,
+  selected: MaybeRefOrGetter<string[]>,
 ): UseManagedAssetTableReturn {
   const { t } = useI18n({ useScope: 'global' });
   const itemsPerPage = useSetting('itemsPerPage');
@@ -75,10 +94,34 @@ export function useManagedAssetTable(
     }
   });
 
+  const spamDisabled = computed<boolean>(() => {
+    const selectedIds = toValue(selected);
+    if (selectedIds.length === 0)
+      return false;
+
+    const assets = get(data);
+    return !selectedIds.some((id) => {
+      const asset = assets.find(item => item.identifier === id);
+      return asset && isSpammableAssetType(asset.assetType);
+    });
+  });
+
+  function getAssetLocation(row: SupportedAsset): string | undefined {
+    if (row.assetType === EVM_TOKEN)
+      return row.evmChain ?? undefined;
+
+    if (row.assetType === SOLANA_TOKEN)
+      return SOLANA_CHAIN;
+
+    return undefined;
+  }
+
   return {
     cols,
     data,
     expand,
+    getAssetLocation,
     isExpanded,
+    spamDisabled,
   };
 }

--- a/frontend/app/src/modules/assets/admin/use-restore-asset-db.spec.ts
+++ b/frontend/app/src/modules/assets/admin/use-restore-asset-db.spec.ts
@@ -1,0 +1,190 @@
+import { flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, type Ref, ref } from 'vue';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useRestoreAssetDb } from './use-restore-asset-db';
+
+let loading: Ref<boolean>;
+
+const { notify, reload, restoreAssetsDatabase } = vi.hoisted(() => ({
+  notify: vi.fn(),
+  reload: vi.fn(async () => Promise.resolve()),
+  restoreAssetsDatabase: vi.fn(),
+}));
+
+vi.mock('@/modules/assets/use-assets', () => ({
+  useAssets: (): Record<string, unknown> => ({ restoreAssetsDatabase }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): Record<string, unknown> => ({ notify }),
+}));
+
+vi.mock('@/modules/shell/app/use-backend-reload', () => ({
+  useBackendReload: (): Record<string, unknown> => ({ reload }),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', async () => {
+  const actual = await vi.importActual<typeof import('@/modules/task-center/use-task-center')>(
+    '@/modules/task-center/use-task-center',
+  );
+  return {
+    ...actual,
+    useTaskCenter: (): Record<string, unknown> => ({ useIsActive: (): Ref<boolean> => loading }),
+  };
+});
+
+let scope: ReturnType<typeof effectScope>;
+
+function restore(): ReturnType<typeof useRestoreAssetDb> {
+  scope = effectScope();
+  return scope.run(() => useRestoreAssetDb())!;
+}
+
+describe('modules/assets/admin/useRestoreAssetDb', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    loading = ref<boolean>(false);
+    restoreAssetsDatabase.mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    scope?.stop();
+  });
+
+  describe('before it resets anything', () => {
+    it.each(['soft', 'hard'] as const)('should reset nothing until the %s dialog is confirmed', (type) => {
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation(type);
+
+      expect(get(useConfirmStore().visible)).toBe(true);
+      expect(restoreAssetsDatabase).not.toHaveBeenCalled();
+    });
+
+    it('should reset nothing when the dialog is dismissed', async () => {
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation('hard');
+      await useConfirmStore().dismiss();
+      await flushPromises();
+
+      expect(restoreAssetsDatabase).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['soft', 'asset_update.restore.delete_confirmation.soft_reset_message'],
+      ['hard', 'asset_update.restore.delete_confirmation.hard_reset_message'],
+    ] as const)('should warn about what a %s reset costs', (type, expected) => {
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation(type);
+
+      expect(get(useConfirmStore().confirmation).message).toBe(expected);
+    });
+
+    it('should refuse to start a second reset while one is running', async () => {
+      set(loading, true);
+
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation('hard');
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(restoreAssetsDatabase).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a reset that lands', () => {
+    it.each(['soft', 'hard'] as const)('should run the %s reset the dialog named', async (type) => {
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation(type);
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(restoreAssetsDatabase).toHaveBeenCalledWith(type);
+    });
+
+    it('should ask to restart, and reload only once that is confirmed', async () => {
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation('soft');
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(get(useConfirmStore().confirmation).message).toBe('asset_update.restore.success.description');
+      expect(reload).not.toHaveBeenCalled();
+
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(reload).toHaveBeenCalledOnce();
+    });
+
+    it('should report nothing when it succeeds', async () => {
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation('soft');
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(notify).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a reset that fails', () => {
+    it('should report the reason and not offer a restart', async () => {
+      restoreAssetsDatabase.mockResolvedValue({ message: 'the database is locked', success: false });
+
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation('soft');
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'the database is locked' }));
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('should escalate to a second confirmation when assets would be lost', async () => {
+      restoreAssetsDatabase.mockResolvedValue({
+        message: 'There are assets that can not be deleted. Check logs for more details.',
+        success: false,
+      });
+
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation('hard');
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(get(useConfirmStore().confirmation).message)
+        .toBe('asset_update.restore.hard_restore_confirmation.message');
+      expect(notify).toHaveBeenCalledOnce();
+    });
+
+    it('should retry with the same reset type once the escalation is confirmed', async () => {
+      restoreAssetsDatabase.mockResolvedValue({
+        message: 'There are assets that can not be deleted. Check logs for more details.',
+        success: false,
+      });
+
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation('hard');
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      restoreAssetsDatabase.mockClear();
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(restoreAssetsDatabase).toHaveBeenCalledWith('hard');
+    });
+
+    it('should not escalate for an unrelated failure', async () => {
+      restoreAssetsDatabase.mockResolvedValue({ message: 'the database is locked', success: false });
+
+      const { showRestoreConfirmation } = restore();
+      showRestoreConfirmation('hard');
+      await useConfirmStore().confirm();
+      await flushPromises();
+
+      expect(get(useConfirmStore().visible)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/admin/use-restore-asset-db.ts
+++ b/frontend/app/src/modules/assets/admin/use-restore-asset-db.ts
@@ -1,0 +1,111 @@
+import type { Ref } from 'vue';
+import { Severity } from '@rotki/common';
+import { useAssets } from '@/modules/assets/use-assets';
+import { DialogType } from '@/modules/core/common/dialogs';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { useBackendReload } from '@/modules/shell/app/use-backend-reload';
+import { ActivityPart } from '@/modules/task-center/core/types';
+import { ActivityKind, useTaskCenter } from '@/modules/task-center/use-task-center';
+
+type ResetType = 'soft' | 'hard';
+
+/**
+ * The failure that means the reset would delete assets the user added.
+ *
+ * @remarks
+ * Matched on the message because the endpoint reports it as a plain conflict rather than a code.
+ */
+const UNDELETABLE_ASSETS = 'There are assets that can not';
+
+interface UseRestoreAssetDbReturn {
+  /** Whether a reset is running, which is what stops a second one being started. */
+  loading: Ref<boolean>;
+  /** Asks for confirmation, then resets the assets database. */
+  showRestoreConfirmation: (type: ResetType) => void;
+}
+
+/**
+ * Drives the reset-assets-database action: its confirmation, the reset itself, and the reload that
+ * has to follow a successful one.
+ *
+ * @returns whether a reset is running, and the way to start one
+ */
+export function useRestoreAssetDb(): UseRestoreAssetDbReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const { notify } = useNotificationDispatcher();
+  const { restoreAssetsDatabase } = useAssets();
+  const { reload } = useBackendReload();
+  const { show } = useConfirmStore();
+  const { useIsActive } = useTaskCenter();
+
+  const loading = useIsActive(ActivityKind.ASSETS, ActivityPart.RESET);
+
+  async function updateComplete(): Promise<void> {
+    await reload();
+  }
+
+  function showDoneConfirmation(): void {
+    show(
+      {
+        message: t('asset_update.restore.success.description'),
+        primaryAction: t('common.actions.ok'),
+        singleAction: true,
+        title: t('asset_update.restore.success.title'),
+        type: DialogType.SUCCESS,
+      },
+      updateComplete,
+    );
+  }
+
+  function showDoubleConfirmation(type: ResetType): void {
+    show(
+      {
+        message: t('asset_update.restore.hard_restore_confirmation.message'),
+        title: t('asset_update.restore.hard_restore_confirmation.title'),
+      },
+      async () => restoreAssets(type),
+    );
+  }
+
+  async function restoreAssets(resetType: ResetType): Promise<void> {
+    if (get(loading))
+      return;
+
+    const result = await restoreAssetsDatabase(resetType);
+
+    if (result.success) {
+      showDoneConfirmation();
+      return;
+    }
+
+    const { message } = result;
+    if (message.includes(UNDELETABLE_ASSETS))
+      showDoubleConfirmation(resetType);
+
+    notify({
+      display: true,
+      message,
+      severity: Severity.ERROR,
+      title: t('asset_update.restore.title'),
+    });
+  }
+
+  function showRestoreConfirmation(type: ResetType): void {
+    show(
+      {
+        message: type === 'soft'
+          ? t('asset_update.restore.delete_confirmation.soft_reset_message')
+          : t('asset_update.restore.delete_confirmation.hard_reset_message'),
+        title: t('asset_update.restore.delete_confirmation.title'),
+      },
+      async () => restoreAssets(type),
+    );
+  }
+
+  return {
+    loading,
+    showRestoreConfirmation,
+  };
+}


### PR DESCRIPTION
Continues the frontend coverage work for #12964, after #13064. Finishes the `assets/admin` cluster.

Each commit extracts one component's `<script setup>` into a composable beside it, tests the composable directly, and leaves the component as wiring. No behaviour changes except where called out below.

| Component | Extracted to | Tests | Script lines |
|---|---|---|---|
| `CustomAssetContent` | `use-custom-assets-table` + `use-custom-asset-dialog` | 7 + 9 + 3 | 91 ⇒ 47 |
| `CustomAssetFormDialog` | `use-custom-asset-form-dialog` | 20 | 93 ⇒ 27 |
| `CustomAssetTable` | `use-custom-asset-table` | 8 | 67 ⇒ 30 |
| `RestoreAssetDbButton` | `use-restore-asset-db` | 14 | 76 ⇒ 11 |
| `AssetMissingMappings` | `use-asset-missing-mappings` | 8 | 74 ⇒ 25 |
| `ManagedAssetActions` | `use-managed-asset-actions` | 8 | 44 ⇒ 27 |
| `ManagedAssetTable` | its existing `use-managed-asset-table` | 16 | 89 ⇒ 60 |

`src/modules/assets/admin` now runs 49 spec files / 530 tests.

## A pre-existing bug this covers but does not fix

`RestoreAssetDbButton`'s "Dangerous operation" double confirmation is unreachable, so a **hard** reset force-deletes user-added assets without ever asking.

The frontend sends `restoreAssetsDatabase(resetType, resetType === 'hard')`, so a hard reset always sends `ignoreWarnings: true`. The backend's refusal (`hard_reset_assets_list`, guarded by `if len(diff_ids) != 0 and not force`) is the only source of the message the frontend matches on, and a soft reset never emits it. Neither path can produce it.

It regressed in d80077c6da ("feat: add soft reset for assets in frontend", first released in v1.27.0), which collapsed the independent `restoreHard` flag into the mode selector and deleted `confirmHardReset`, but kept `doubleConfirmation` and the message check.

This branch covers the behaviour **as it is**, unreachable branch included. The fix changes behaviour on a destructive path, so it wants its own PR against `bugfixes` rather than riding in a coverage batch.

## Other changes worth a look

- **`CustomAssetContent` is split into two composables, not one.** Table state and the add/edit dialog are independent, and `identifier` is only ever consumed by the dialog. The split moves the loaded page out to a template binding where no composable spec can see it, so `CustomAssetContent.spec.ts` covers that seam; verified by breaking the binding and watching only that spec fail.
- **Three dead guards removed**, one per commit body. The clearest is `item?.name ?? ''` in the custom asset delete confirmation, where `CustomAsset.name` is a required non-nullable string and `useTableRowDeletion` passes a non-null item.
- **`custom/` and `managed/` are deliberately not shared.** The three pairs look like twins and none are: managed carries bulk ignore/spam/whitelist and selection, custom carries a types list and an identifier-driven edit. Naming and shape are mirrored without forcing a common abstraction.

## Verification

All seven `rwt check` gates green on the rebased branch: typos, lint-staged, linked-keys, stylelint, dev-proxy, knip, typecheck.

Negative controls were run rather than assumed: for each new spec the covered line was broken, the named test watched go red, and then restored.
