### PR TITLE
Close stream after last chunk sent

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`13071` Database backups can now be deleted immediately after downloading on Windows, and temporary export files are cleaned up after downloads finish.
 * :feature:`13033` You can now stop rotki querying an account from the accounts table itself, on one of its chains or on all of them, instead of having to remember the address and find it again in the chain settings. The chains that are skipped are marked on the account's row.
 * :feature:`-` Ink is now a supported EVM chain. Balances and transactions can be tracked on it.
 * :feature:`13050` Robinhood Chain is now a supported EVM chain. Balances and transactions can be tracked on it. Transaction history on it needs a Blockscout API key.

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -13,12 +13,13 @@ from contextlib import contextmanager
 from functools import wraps
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, cast, overload
 
 from flask import Response, g, make_response, request, send_file
 from sqlcipher3 import dbapi2 as sqlcipher
 from web3.exceptions import BadFunctionCallOutput
 from werkzeug.datastructures import FileStorage
+from werkzeug.wsgi import ClosingIterator
 
 from rotkehlchen.accounting.export.csv import (
     FILENAME_SKIPPED_EXTERNAL_EVENTS_CSV,
@@ -26,7 +27,10 @@ from rotkehlchen.accounting.export.csv import (
 )
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet, BalanceType
 from rotkehlchen.accounting.structures.processed_event import AccountingEventExportType
-from rotkehlchen.api.rest_helpers.downloads import register_post_download_cleanup
+from rotkehlchen.api.rest_helpers.downloads import (
+    close_before_last_chunk,
+    register_post_download_cleanup,
+)
 from rotkehlchen.api.rest_helpers.wrap import calculate_wrap_score
 from rotkehlchen.api.services.accounting import AccountingService
 from rotkehlchen.api.services.accounts import AccountsService
@@ -248,7 +252,7 @@ from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now
 from rotkehlchen.utils.version_check import get_current_version
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterator, Mapping, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 
     from rotkehlchen.assets.asset import CryptoAsset
     from rotkehlchen.assets.nft_handling import NftHandling
@@ -2934,12 +2938,16 @@ class RestAPI:
             error_msg = f'DB backup file {filepath} is not in the user directory'
             return api_response(wrap_in_fail_result(error_msg), status_code=HTTPStatus.CONFLICT)
 
-        return send_file(
+        response = send_file(
             path_or_file=filepath,
             mimetype='application/octet-stream',
             as_attachment=True,
             download_name=filepath.name,
         )
+        # send_file yields bytes, unlike a generic Response which can also yield strings.
+        stream = ClosingIterator(cast('Iterable[bytes]', response.response))
+        response.response = ClosingIterator(close_before_last_chunk(stream), stream.close)
+        return response
 
     def delete_database_backups(self, files: list[Path]) -> Response:
         for filepath in files:

--- a/rotkehlchen/api/rest.py
+++ b/rotkehlchen/api/rest.py
@@ -13,13 +13,12 @@ from contextlib import contextmanager
 from functools import wraps
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final, Literal, cast, overload
+from typing import TYPE_CHECKING, Any, Final, Literal, overload
 
 from flask import Response, g, make_response, request, send_file
 from sqlcipher3 import dbapi2 as sqlcipher
 from web3.exceptions import BadFunctionCallOutput
 from werkzeug.datastructures import FileStorage
-from werkzeug.wsgi import ClosingIterator
 
 from rotkehlchen.accounting.export.csv import (
     FILENAME_SKIPPED_EXTERNAL_EVENTS_CSV,
@@ -28,7 +27,7 @@ from rotkehlchen.accounting.export.csv import (
 from rotkehlchen.accounting.structures.balance import Balance, BalanceSheet, BalanceType
 from rotkehlchen.accounting.structures.processed_event import AccountingEventExportType
 from rotkehlchen.api.rest_helpers.downloads import (
-    close_before_last_chunk,
+    close_stream_before_last_chunk,
     register_post_download_cleanup,
 )
 from rotkehlchen.api.rest_helpers.wrap import calculate_wrap_score
@@ -252,7 +251,7 @@ from rotkehlchen.utils.misc import ts_ms_to_sec, ts_now
 from rotkehlchen.utils.version_check import get_current_version
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Callable, Iterator, Mapping, Sequence
 
     from rotkehlchen.assets.asset import CryptoAsset
     from rotkehlchen.assets.nft_handling import NftHandling
@@ -2944,10 +2943,7 @@ class RestAPI:
             as_attachment=True,
             download_name=filepath.name,
         )
-        # send_file yields bytes, unlike a generic Response which can also yield strings.
-        stream = ClosingIterator(cast('Iterable[bytes]', response.response))
-        response.response = ClosingIterator(close_before_last_chunk(stream), stream.close)
-        return response
+        return close_stream_before_last_chunk(response)
 
     def delete_database_backups(self, files: list[Path]) -> Response:
         for filepath in files:
@@ -2958,7 +2954,13 @@ class RestAPI:
                     status_code=HTTPStatus.CONFLICT,
                 )
         for filepath in files:
-            filepath.unlink()  # should not raise file not found as marshmallow should check
+            try:
+                filepath.unlink()
+            except OSError as e:
+                return api_response(
+                    wrap_in_fail_result(f'Could not delete DB backup {filepath}: {e!s}'),
+                    status_code=HTTPStatus.CONFLICT,
+                )
         return api_response(OK_RESULT, status_code=HTTPStatus.OK)
 
     def purge_pnl_report_data(self, report_id: int) -> Response:
@@ -3427,13 +3429,13 @@ class RestAPI:
 
         if directory_path is None:
             try:
-                register_post_download_cleanup(exportpath)
-                return send_file(
+                response = send_file(
                     path_or_file=exportpath,
                     mimetype='text/csv',
                     as_attachment=True,
                     download_name=FILENAME_SKIPPED_EXTERNAL_EVENTS_CSV,
                 )
+                return register_post_download_cleanup(response, exportpath)
             except FileNotFoundError:
                 return api_response(
                     wrap_in_fail_result('No file was found'),

--- a/rotkehlchen/api/rest_helpers/downloads.py
+++ b/rotkehlchen/api/rest_helpers/downloads.py
@@ -2,15 +2,37 @@ from __future__ import annotations
 
 import logging
 import tempfile
+from contextlib import closing
 from http import HTTPStatus
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from flask import Response, after_this_request, jsonify, make_response, send_file
 
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from werkzeug.wsgi import ClosingIterator
+
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
+
+
+def close_before_last_chunk(stream: ClosingIterator) -> Iterator[bytes]:
+    """Close a download before yielding the bytes that satisfy the client's Content-Length.
+
+    Keep one chunk pending so full and range downloads release their file before the
+    client can consider the transfer complete and request deletion of that file.
+    """
+    with closing(stream):
+        chunk = next(stream, b'')
+        for next_chunk in stream:
+            yield chunk
+            chunk = next_chunk
+    if chunk:
+        yield chunk
 
 
 def register_post_download_cleanup(temp_file: Path) -> None:

--- a/rotkehlchen/api/rest_helpers/downloads.py
+++ b/rotkehlchen/api/rest_helpers/downloads.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 import logging
 import tempfile
 from contextlib import closing
+from functools import partial
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-from flask import Response, after_this_request, jsonify, make_response, send_file
+from flask import Response, jsonify, make_response, send_file
+from werkzeug.wsgi import ClosingIterator
 
 from rotkehlchen.logging import RotkehlchenLogsAdapter
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
-    from werkzeug.wsgi import ClosingIterator
+    from collections.abc import Iterable, Iterator
 
 logger = logging.getLogger(__name__)
 log = RotkehlchenLogsAdapter(logger)
@@ -35,15 +35,30 @@ def close_before_last_chunk(stream: ClosingIterator) -> Iterator[bytes]:
         yield chunk
 
 
-def register_post_download_cleanup(temp_file: Path) -> None:
-    @after_this_request
-    def do_cleanup(response: Response) -> Response:
-        try:
-            temp_file.unlink()
-            temp_file.parent.rmdir()
-        except (FileNotFoundError, PermissionError, OSError) as e:
-            log.warning(f'Failed to clean up after download of {temp_file}: {e!s}')
-        return response
+def close_stream_before_last_chunk(response: Response) -> Response:
+    """Release a send_file response's handle before delivery of its final chunk.
+
+    The outer close callback also releases the handle when streaming never starts.
+    Normalizing the iterable keeps this safe for responses without a close method.
+    """
+    stream = ClosingIterator(cast('Iterable[bytes]', response.response))
+    response.response = ClosingIterator(close_before_last_chunk(stream), stream.close)
+    return response
+
+
+def _cleanup_download(temp_file: Path) -> None:
+    try:
+        temp_file.unlink()
+        temp_file.parent.rmdir()
+    except OSError as e:
+        log.warning('Failed to clean up after download of %s: %s', temp_file, e)
+
+
+def register_post_download_cleanup(response: Response, temp_file: Path) -> Response:
+    """Delete an export after its stream closes, including on early disconnect."""
+    response.direct_passthrough = False
+    response.call_on_close(partial(_cleanup_download, temp_file))
+    return response
 
 
 def _is_within_temp_dir(path: Path) -> bool:
@@ -70,10 +85,10 @@ def make_download_response(file_path: str, mimetype: str) -> Response:
             ),
         )
 
-    register_post_download_cleanup(path)
-    return send_file(
+    response = send_file(
         path_or_file=file_path,
         mimetype=mimetype,
         as_attachment=True,
         download_name=path.name,
     )
+    return register_post_download_cleanup(response, path)

--- a/rotkehlchen/api/services/history.py
+++ b/rotkehlchen/api/services/history.py
@@ -249,13 +249,13 @@ class HistoryService:
 
         file_path = response['result']['file_path']
         try:
-            register_post_download_cleanup(Path(file_path))
-            return send_file(
+            download_response = send_file(
                 path_or_file=file_path,
                 mimetype='application/zip',
                 as_attachment=True,
                 download_name='report.zip',
             )
+            return register_post_download_cleanup(download_response, Path(file_path))
         except FileNotFoundError:
             return {
                 'result': None,

--- a/rotkehlchen/api/services/user_data.py
+++ b/rotkehlchen/api/services/user_data.py
@@ -390,13 +390,13 @@ class UserDataService:
             }
 
         try:
-            register_post_download_cleanup(Path(zipfile_path))
-            return send_file(
+            download_response = send_file(
                 path_or_file=zipfile_path,
                 mimetype='application/zip',
                 as_attachment=True,
                 download_name='snapshot.zip',
             )
+            return register_post_download_cleanup(download_response, Path(zipfile_path))
         except FileNotFoundError:
             return {
                 'result': None,

--- a/rotkehlchen/tests/api/test_database.py
+++ b/rotkehlchen/tests/api/test_database.py
@@ -3,6 +3,7 @@ import tempfile
 from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import psutil
 import pytest
@@ -154,11 +155,13 @@ def test_backup_download_closes_on_disconnect(
     """Closing an unstarted or partially consumed response must release the backup."""
     rest_api = rotkehlchen_api_server.rest_api
     filepath = rest_api.rotkehlchen.data.db.create_db_backup()
+    filepath.write_bytes(b'x' * (3 * 8192))
     with rotkehlchen_api_server.flask_app.test_request_context():
         response = rest_api.download_database_backup(filepath)
         try:
             if start_download:
                 assert len(next(iter(response.response))) < filepath.stat().st_size
+            assert str(filepath) in {entry.path for entry in psutil.Process().open_files()}
         finally:
             response.close()
         assert str(filepath) not in {entry.path for entry in psutil.Process().open_files()}
@@ -238,4 +241,20 @@ def test_delete_download_backup_errors(
         status_code=HTTPStatus.CONFLICT,
     )
     assert undeletable_file.exists()
+    assert filepath.exists()
+
+
+def test_delete_backup_in_use(rotkehlchen_api_server: APIServer) -> None:
+    rest_api = rotkehlchen_api_server.rest_api
+    filepath = rest_api.rotkehlchen.data.db.create_db_backup()
+    with patch.object(Path, 'unlink', side_effect=PermissionError('File is in use')):
+        response = requests.delete(
+            api_url_for(rotkehlchen_api_server, 'databasebackupsresource'),
+            json={'files': [str(filepath)]},
+        )
+    assert_error_response(
+        response=response,
+        contained_in_msg='Could not delete DB backup',
+        status_code=HTTPStatus.CONFLICT,
+    )
     assert filepath.exists()

--- a/rotkehlchen/tests/api/test_database.py
+++ b/rotkehlchen/tests/api/test_database.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import psutil
 import pytest
 import requests
 
@@ -106,6 +107,61 @@ def test_create_download_delete_backup(
     result = assert_proper_sync_response_with_result(response)
     backups = result['userdb']['backups']
     assert len(backups) == 0
+
+
+@pytest.mark.parametrize('partial_download', [False, True])
+def test_backup_download_releases_original_before_response_cleanup(
+        rotkehlchen_api_server: APIServer,
+        partial_download: bool,
+) -> None:
+    """A completed download must not hold the backup open until response cleanup."""
+    rest_api = rotkehlchen_api_server.rest_api
+    filepath = rest_api.rotkehlchen.data.db.create_db_backup()
+    contents = filepath.read_bytes()
+    with rotkehlchen_api_server.flask_app.test_request_context(
+            headers={'Range': 'bytes=0-99'} if partial_download else {},
+    ):
+        response = rest_api.download_database_backup(filepath)
+        try:
+            assert response.headers['Content-Disposition'] == (
+                f'attachment; filename={filepath.name}'
+            )
+            assert response.mimetype == 'application/octet-stream'
+            if partial_download:
+                assert response.status_code == HTTPStatus.PARTIAL_CONTENT
+                assert response.headers['Content-Range'] == f'bytes 0-99/{len(contents)}'
+                contents = contents[:100]
+            else:
+                assert response.status_code == HTTPStatus.OK
+            assert response.content_length == len(contents)
+            stream = response.iter_encoded()
+            received = bytearray()
+            while len(received) < len(contents):
+                received.extend(next(stream))
+            assert received == contents
+            assert str(filepath) not in {entry.path for entry in psutil.Process().open_files()}
+            assert rest_api.delete_database_backups([filepath]).status_code == HTTPStatus.OK
+            assert not filepath.exists()
+        finally:
+            response.close()
+
+
+@pytest.mark.parametrize('start_download', [False, True])
+def test_backup_download_closes_on_disconnect(
+        rotkehlchen_api_server: APIServer,
+        start_download: bool,
+) -> None:
+    """Closing an unstarted or partially consumed response must release the backup."""
+    rest_api = rotkehlchen_api_server.rest_api
+    filepath = rest_api.rotkehlchen.data.db.create_db_backup()
+    with rotkehlchen_api_server.flask_app.test_request_context():
+        response = rest_api.download_database_backup(filepath)
+        try:
+            if start_download:
+                assert len(next(iter(response.response))) < filepath.stat().st_size
+        finally:
+            response.close()
+        assert str(filepath) not in {entry.path for entry in psutil.Process().open_files()}
 
 
 def test_delete_download_backup_errors(

--- a/rotkehlchen/tests/unit/test_downloads.py
+++ b/rotkehlchen/tests/unit/test_downloads.py
@@ -1,0 +1,50 @@
+import os
+from functools import partial
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import psutil
+import pytest
+from flask import Flask
+
+from rotkehlchen.api.rest_helpers.downloads import make_download_response
+
+
+def unlink_closed_file(path: Path) -> None:
+    assert str(path.resolve()) not in {
+        str(Path(entry.path).resolve()) for entry in psutil.Process().open_files()
+    }
+    os.unlink(path)  # noqa: PTH108  # Bypass the patched Path.unlink.
+
+
+@pytest.mark.parametrize('consume', [False, True])
+@pytest.mark.parametrize('method', ['GET', 'HEAD'])
+def test_export_cleanup_after_stream_close(consume: bool, method: str) -> None:
+    """WSGI cleanup releases the file before unlinking, including aborted and HEAD requests."""
+    with TemporaryDirectory() as directory:
+        export_dir = Path(directory) / 'export'
+        export_dir.mkdir()
+        filepath = export_dir / 'history.csv'
+        contents = b'x' * (3 * 8192)
+        filepath.write_bytes(contents)
+        app = Flask(__name__)
+        app.add_url_rule('/export', endpoint='export', view_func=partial(
+            make_download_response, file_path=str(filepath), mimetype='text/csv',
+        ))
+        with patch.object(Path, 'unlink', autospec=True, side_effect=unlink_closed_file) as unlink:
+            response = app.test_client().open('/export', method=method, buffered=False)
+            try:
+                unlink.assert_not_called()
+                assert str(filepath.resolve()) in {
+                    str(Path(entry.path).resolve()) for entry in psutil.Process().open_files()
+                }
+                if consume:
+                    assert response.get_data() == (contents if method == 'GET' else b'')
+            finally:
+                response.close()
+            unlink.assert_called_once_with(filepath)
+            assert not export_dir.exists()
+            assert str(filepath.resolve()) not in {
+                str(Path(entry.path).resolve()) for entry in psutil.Process().open_files()
+            }


### PR DESCRIPTION
This prevents keeping the file open after the download finishes and allows to call delete on the backup file right after download

Fixes the issue seen in https://github.com/rotki/rotki/actions/runs/34186174085/job/101934828985 after disabling the GIL