### PR TITLE
test(e2e): retry the amount-display blur assertion

### DIFF
--- a/frontend/app/tests/e2e/pages/dashboard-page.ts
+++ b/frontend/app/tests/e2e/pages/dashboard-page.ts
@@ -79,15 +79,11 @@ export class DashboardPage {
   }
 
   async amountDisplayIsBlurred(): Promise<void> {
-    const amountDisplay = this.page.locator('[data-testid=amount-display]').first();
-    const filter = await amountDisplay.evaluate(el => getComputedStyle(el).filter);
-    expect(filter).toMatch(/^blur/);
+    await expect(this.page.locator('[data-testid=amount-display]').first()).toHaveCSS('filter', /^blur/);
   }
 
   async amountDisplayIsNotBlurred(): Promise<void> {
-    const amountDisplay = this.page.locator('[data-testid=amount-display]').first();
-    const filter = await amountDisplay.evaluate(el => getComputedStyle(el).filter);
-    expect(filter).not.toMatch(/^blur/);
+    await expect(this.page.locator('[data-testid=amount-display]').first()).not.toHaveCSS('filter', /^blur/);
   }
 
   async percentageDisplayIsBlurred(): Promise<void> {


### PR DESCRIPTION
Fixes a flake in the privacy-mode e2e tests, seen on `Frontend e2e tests / shard-2`:

```
1) [chromium] › tests/e2e/specs/balances/manual-balances.spec.ts:80:3 › balances › test privacy mode is private
   Error: expect(received).toMatch(expected)
   Expected pattern: /^blur/
   Received string:  "none"
     at pages/dashboard-page.ts:84
```

`test privacy mode is semi private` (:70) failed the same way and passed on retry; `test privacy mode is private` (:80) failed on both attempts.

## Cause

The assertion sampled the style once and never retried, while the class it waits for lands after a backend round trip.

1. `rotki-app.ts:214 changePrivacyMode()` clicks the mode option, then immediately closes the menu.
2. That click reaches `usePrivacyMode().changePrivacyMode` → `updateFrontendSetting({ privacyMode })`.
3. `use-frontend-settings-writer.ts` calls `repo.updateFrontend(payload)` only *after* `await api.setSettings(...)` resolves, so the whole settings blob goes to the backend and back before local state moves. Writes are serialised through a module-scoped `pendingWrite` queue, which can delay it further behind another in-flight settings write.
4. The `blur` class on `AmountDisplayBase.vue:74` is bound to `shouldShowAmount`, which reads that repo, so it appears only once the PUT resolves.
5. `dashboard-page.ts` read `getComputedStyle(el).filter` through a raw `evaluate`, which is not a web-first assertion and so is never retried by Playwright.

If the round trip has not landed by the time the menu finishes closing, the class is absent and the filter reads `none`.

## Change

Both amount helpers now use `toHaveCSS`, which polls. This also matches the `percentageDisplay*` helpers directly below them, which already retried via `toHaveClass`.

The 200ms Tailwind `transition` on that span is not a problem: a mid-transition `blur(3.4px)` still matches `/^blur/`.

## Verification

Derived from reading the write path, not from reproducing the race, so CI is the real check here. Lint, typecheck, stylelint, knip and the linked-key checks pass locally.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

Not applicable: test-only change, no user-facing behaviour.