### PR TITLE
test(e2e): replace one-shot DOM reads with retrying assertions

### DIFF
--- a/frontend/app/tests/e2e/pages/address-book-page.ts
+++ b/frontend/app/tests/e2e/pages/address-book-page.ts
@@ -56,10 +56,14 @@ export class AddressBookPage {
     return this.rows().filter({ hasText: name });
   }
 
+  /**
+   * @remarks
+   * Waits on the table rather than on the tab's own selected state: the caller is usually about to
+   * assert that state, and a helper that waited for it would make that assertion tautological.
+   */
   async selectScope(scope: Scope): Promise<void> {
     await this.page.locator(`[data-testid=address-book-scope-tab][data-key="${scope}"]`).click();
-    // Wait for any in-flight fetch to settle by checking row attachment.
-    await this.page.waitForTimeout(200);
+    await this.table().waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
   }
 
   async expectScopeActive(scope: Scope): Promise<void> {

--- a/frontend/app/tests/e2e/pages/address-book-page.ts
+++ b/frontend/app/tests/e2e/pages/address-book-page.ts
@@ -156,7 +156,12 @@ export class AddressBookPage {
 
   /** Waits for the table to settle on a row count, which a filter changes asynchronously. */
   async expectVisibleRowCount(expected: number): Promise<void> {
-    await expect.poll(async () => this.visibleRowCount(), { timeout: TIMEOUT_MEDIUM }).toBe(expected);
+    await expect(this.rows()).toHaveCount(expected, { timeout: TIMEOUT_MEDIUM });
+  }
+
+  /** For a page whose size is bounded from below but not pinned, such as the last page. */
+  async expectAtLeastVisibleRows(expected: number): Promise<void> {
+    await expect.poll(async () => this.rows().count(), { timeout: TIMEOUT_MEDIUM }).toBeGreaterThanOrEqual(expected);
   }
 
   async expectRow(address: string, name?: string): Promise<void> {
@@ -172,10 +177,6 @@ export class AddressBookPage {
 
   async expectNoRow(address: string): Promise<void> {
     await expect(this.rowFor(address)).toHaveCount(0);
-  }
-
-  async visibleRowCount(): Promise<number> {
-    return this.rows().count();
   }
 
   async goToNextPage(): Promise<void> {

--- a/frontend/app/tests/e2e/pages/calendar-page.ts
+++ b/frontend/app/tests/e2e/pages/calendar-page.ts
@@ -46,7 +46,6 @@ export class CalendarPage {
 
   async clickToday(): Promise<void> {
     await this.page.getByTestId('calendar-today').click();
-    await this.page.waitForTimeout(150);
   }
 
   async expectTodayDisabled(): Promise<void> {
@@ -236,17 +235,10 @@ export class CalendarPage {
 
   async goToNextMonth(): Promise<void> {
     await this.page.getByTestId('calendar-next-month').click();
-    await this.page.waitForTimeout(150);
   }
 
   async goToPrevMonth(): Promise<void> {
     await this.page.getByTestId('calendar-prev-month').click();
-    await this.page.waitForTimeout(150);
-  }
-
-  async currentMonthLabel(): Promise<string> {
-    const value = await this.page.getByTestId('calendar-month-label').locator('input').inputValue();
-    return value;
   }
 
   async expectMonthLabel(label: string): Promise<void> {

--- a/frontend/app/tests/e2e/pages/dashboard-page.ts
+++ b/frontend/app/tests/e2e/pages/dashboard-page.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 import { type BigNumber, Zero } from '@rotki/common';
 import { parseBigNumber, updateLocationBalance } from '../helpers/utils';
 import { RotkiApp } from './rotki-app';
@@ -12,11 +12,24 @@ export class DashboardPage {
     await RotkiApp.navigateTo(this.page, 'dashboard');
   }
 
+  /**
+   * Reads a settled amount out of an `AmountDisplay`.
+   *
+   * @remarks
+   * While the value is loading the component renders a skeleton and no text at all, so a bare
+   * `textContent` can return an empty string that `parseBigNumber` then reads as zero: a balance
+   * comparison against it fails for a reason that has nothing to do with the balances. Waiting for
+   * the element to hold text is the gate; the read after it is safe.
+   */
+  private async readAmount(amount: Locator): Promise<BigNumber> {
+    await expect(amount).not.toBeEmpty();
+    return parseBigNumber(await amount.textContent() ?? '0');
+  }
+
   async getOverallBalance(): Promise<BigNumber> {
-    const amountText = await this.page
-      .locator('[data-testid=overall-balances-net-worth] [data-testid=display-amount]')
-      .textContent();
-    return parseBigNumber(amountText ?? '0');
+    return this.readAmount(
+      this.page.locator('[data-testid=overall-balances-net-worth] [data-testid=display-amount]'),
+    );
   }
 
   async getBlockchainBalances(): Promise<Map<string, BigNumber>> {
@@ -32,8 +45,9 @@ export class DashboardPage {
       if (!location)
         continue;
 
-      const amountText = await element.locator('[data-testid=display-amount]').textContent();
-      updateLocationBalance(amountText ?? '0', balances, location);
+      const amount = element.locator('[data-testid=display-amount]');
+      await expect(amount).not.toBeEmpty();
+      updateLocationBalance(await amount.textContent() ?? '0', balances, location);
     }
 
     return balances;
@@ -54,8 +68,7 @@ export class DashboardPage {
       return Zero;
     }
 
-    const amountText = await displayAmount.textContent();
-    return parseBigNumber(amountText ?? '0');
+    return this.readAmount(displayAmount);
   }
 
   async getLocationBalances(): Promise<Map<string, BigNumber>> {
@@ -71,8 +84,9 @@ export class DashboardPage {
       if (!location)
         continue;
 
-      const amountText = await element.locator('[data-testid=display-amount]').textContent();
-      updateLocationBalance(amountText ?? '0', balances, location);
+      const amount = element.locator('[data-testid=display-amount]');
+      await expect(amount).not.toBeEmpty();
+      updateLocationBalance(await amount.textContent() ?? '0', balances, location);
     }
 
     return balances;

--- a/frontend/app/tests/e2e/pages/interface-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/interface-settings-page.ts
@@ -4,6 +4,8 @@ import { confirmInlineSuccess, openSettingsTab } from '../helpers/utils';
 
 const SECTION_IDS = ['interface_only', 'graph', 'alias', 'newly_detected_tokens', 'theme'] as const;
 
+type ExplorerField = 'address' | 'tx' | 'block' | 'token';
+
 export class InterfaceSettingsPage {
   constructor(private readonly page: Page) {}
 
@@ -21,7 +23,7 @@ export class InterfaceSettingsPage {
    * The explorer field. Its save button is a sibling of the field rather than a child, so it is
    * reached relative to the field instead of carrying a test id of its own.
    */
-  private explorer(field: 'address' | 'tx' | 'block' | 'token') {
+  private explorer(field: ExplorerField) {
     const input = this.page.locator(`[data-testid=explorer-${field}-input]`);
     return {
       input,
@@ -31,7 +33,7 @@ export class InterfaceSettingsPage {
     };
   }
 
-  async setExplorerUrl(field: 'address' | 'tx' | 'block' | 'token', url: string): Promise<void> {
+  async setExplorerUrl(field: ExplorerField, url: string): Promise<void> {
     const { textbox } = this.explorer(field);
     await textbox.scrollIntoViewIfNeeded();
     await textbox.clear();
@@ -39,20 +41,33 @@ export class InterfaceSettingsPage {
     await textbox.blur();
   }
 
-  async saveExplorerUrl(field: 'address' | 'tx' | 'block' | 'token'): Promise<void> {
+  async saveExplorerUrl(field: ExplorerField): Promise<void> {
     await this.explorer(field).save.click();
   }
 
-  async explorerMessages(field: 'address' | 'tx' | 'block' | 'token'): Promise<string> {
-    return this.explorer(field).messages.innerText();
+  /**
+   * Validation runs off the field's own reactivity, a tick or more after `blur` returns, so every
+   * assertion here has to poll rather than sample the DOM once.
+   */
+  async expectExplorerMessage(field: ExplorerField, text: string): Promise<void> {
+    await expect(this.explorer(field).messages).toContainText(text);
   }
 
-  async explorerSaveDisabled(field: 'address' | 'tx' | 'block' | 'token'): Promise<boolean> {
-    return this.explorer(field).save.isDisabled();
+  /** For a rule whose wording is not what the test is pinning: some complaint, not a specific one. */
+  async expectExplorerRejected(field: ExplorerField): Promise<void> {
+    await expect(this.explorer(field).messages).not.toBeEmpty();
   }
 
-  async explorerValue(field: 'address' | 'tx' | 'block' | 'token'): Promise<string> {
-    return this.explorer(field).textbox.inputValue();
+  async expectSaveDisabled(field: ExplorerField): Promise<void> {
+    await expect(this.explorer(field).save).toBeDisabled();
+  }
+
+  async expectSaveEnabled(field: ExplorerField): Promise<void> {
+    await expect(this.explorer(field).save).toBeEnabled();
+  }
+
+  async expectExplorerValue(field: ExplorerField, url: string): Promise<void> {
+    await expect(this.explorer(field).textbox).toHaveValue(url);
   }
 
   async toggleAnimations(): Promise<void> {

--- a/frontend/app/tests/e2e/pages/pill-filter-bar.ts
+++ b/frontend/app/tests/e2e/pages/pill-filter-bar.ts
@@ -33,13 +33,22 @@ export class PillFilterBar {
     return this.page.locator(`[data-testid=filter-pill][data-field="${fieldKey}"]`);
   }
 
-  async pillCount(): Promise<number> {
-    return this.page.locator('[data-testid=filter-pill]').count();
+  async expectPillCount(expected: number): Promise<void> {
+    await expect(this.page.locator('[data-testid=filter-pill]')).toHaveCount(expected, { timeout: TIMEOUT_MEDIUM });
   }
 
-  /** The value segment's text, i.e. what the pill claims is filtered. */
-  async pillValue(fieldKey: string): Promise<string> {
-    return (await this.pill(fieldKey).locator('[data-testid=filter-pill-value]').innerText()).trim();
+  /** The value segment, i.e. what the pill claims is filtered. */
+  private pillValue(fieldKey: string): Locator {
+    return this.pill(fieldKey).locator('[data-testid=filter-pill-value]');
+  }
+
+  async expectPillValue(fieldKey: string, text: string): Promise<void> {
+    await expect(this.pillValue(fieldKey)).toContainText(text, { timeout: TIMEOUT_MEDIUM });
+  }
+
+  /** The overflow counter is absent below the threshold, so its absence is what a test pins. */
+  async expectPillValueMissing(fieldKey: string, text: string): Promise<void> {
+    await expect(this.pillValue(fieldKey)).not.toContainText(text, { timeout: TIMEOUT_MEDIUM });
   }
 
   async expectPillVisible(fieldKey: string): Promise<void> {
@@ -121,9 +130,15 @@ export class PillFilterBar {
     await input.press('Enter');
   }
 
-  /** Whether the open free-text editor considers what is typed a valid value. */
-  async textValueIsValid(): Promise<boolean> {
-    return this.page.locator('[data-testid=text-valid]').isVisible();
+  /**
+   * The open free-text editor rejects what is typed.
+   *
+   * @remarks
+   * Validity is recomputed as the value changes, so the marker appears and disappears a tick behind
+   * the typing that drives it.
+   */
+  async expectTextValueInvalid(): Promise<void> {
+    await expect(this.page.locator('[data-testid=text-valid]')).toBeHidden({ timeout: TIMEOUT_MEDIUM });
   }
 
   async setRangeBound(bound: 'min' | 'max', value: string): Promise<void> {
@@ -174,15 +189,14 @@ export class PillFilterBar {
     await this.pill(fieldKey).click();
   }
 
-  /** The operator segment of a pill, absent when the field is on its default operator. */
-  async pillText(fieldKey: string): Promise<string> {
-    return (await this.pill(fieldKey).innerText()).trim();
+  /** The whole pill, including the operator segment that is absent on the default operator. */
+  async expectPillText(fieldKey: string, text: string): Promise<void> {
+    await expect(this.pill(fieldKey)).toContainText(text, { timeout: TIMEOUT_MEDIUM });
   }
 
-  /** Whether the open free-text editor is rejecting what is typed (invalid or already added). */
-  async textFieldError(): Promise<string> {
-    const editor = this.page.locator('[data-testid=text-input]');
-    return (await editor.innerText()).trim();
+  /** What the open free-text editor says about the value: invalid, or already added. */
+  async expectTextFieldError(text: string | RegExp): Promise<void> {
+    await expect(this.page.locator('[data-testid=text-input]')).toContainText(text, { timeout: TIMEOUT_MEDIUM });
   }
 
   /**
@@ -272,12 +286,12 @@ export class PillFilterBar {
     await expect(this.filterSuggestion(fieldKey, op)).toBeVisible({ timeout: TIMEOUT_MEDIUM });
   }
 
-  async hasFilterSuggestion(fieldKey: string, op: string): Promise<boolean> {
-    return this.filterSuggestion(fieldKey, op).isVisible();
+  async expectNoFilterSuggestion(fieldKey: string, op: string): Promise<void> {
+    await expect(this.filterSuggestion(fieldKey, op)).toBeHidden({ timeout: TIMEOUT_MEDIUM });
   }
 
-  async filterSuggestionText(fieldKey: string, op: string): Promise<string> {
-    return (await this.filterSuggestion(fieldKey, op).innerText()).replace(/\s+/g, ' ').trim();
+  async expectFilterSuggestionText(fieldKey: string, op: string, text: string): Promise<void> {
+    await expect(this.filterSuggestion(fieldKey, op)).toContainText(text, { timeout: TIMEOUT_MEDIUM });
   }
 
   async pickFilterSuggestion(fieldKey: string, op: string): Promise<void> {
@@ -349,8 +363,8 @@ export class PillFilterBar {
   }
 
   /** The header's "1-10 of 24" summary, which is the only place the unpaged total is shown. */
-  async pageRange(): Promise<string> {
-    return (await this.page.locator('[data-testid=events-page-range]').innerText()).replace(/\s+/g, ' ').trim();
+  async expectPageRange(text: string): Promise<void> {
+    await expect(this.page.locator('[data-testid=events-page-range]')).toContainText(text, { timeout: TIMEOUT_MEDIUM });
   }
 
   async nextPage(): Promise<void> {

--- a/frontend/app/tests/e2e/pages/pill-filter-keyboard.ts
+++ b/frontend/app/tests/e2e/pages/pill-filter-keyboard.ts
@@ -12,8 +12,14 @@ import { focusedAttribute, focusedFieldAttribute } from '../helpers/focused-elem
 export class PillFilterKeyboard {
   constructor(private readonly page: Page) {}
 
-  /** `data-testid` of whatever currently holds focus, for asserting tab order. */
-  async focusedTestId(): Promise<string | null> {
+  /**
+   * `data-testid` of whatever currently holds focus.
+   *
+   * @remarks
+   * Private, and so are its three siblings: each reads the document once, which is never what an
+   * assertion wants, so the `expect*` methods below are the only way to reach them.
+   */
+  private async focusedTestId(): Promise<string | null> {
     return focusedAttribute(this.page, 'data-testid');
   }
 
@@ -21,7 +27,7 @@ export class PillFilterKeyboard {
    * The focused element's `data-index`. Rows carry their position here rather than in the test id,
    * so asserting the id alone would only prove "some row of this kind" has focus.
    */
-  async focusedIndex(): Promise<string | null> {
+  private async focusedIndex(): Promise<string | null> {
     return focusedAttribute(this.page, 'data-index');
   }
 
@@ -31,13 +37,35 @@ export class PillFilterKeyboard {
    * The editors put their test ids on a field wrapper rather than on the `<input>` inside it, so
    * `focusedTestId` reads null for them even when the right field has the caret.
    */
-  async focusedFieldTestId(): Promise<string | null> {
+  private async focusedFieldTestId(): Promise<string | null> {
     return focusedFieldAttribute(this.page, 'data-testid');
   }
 
   /** The `data-key` of the focused field's test-id element, for families that carry their value there. */
-  async focusedFieldKey(): Promise<string | null> {
+  private async focusedFieldKey(): Promise<string | null> {
     return focusedFieldAttribute(this.page, 'data-key');
+  }
+
+  /**
+   * Waits for an element carrying `testId` to hold focus.
+   *
+   * @remarks
+   * The counterpart of `expectFocusedField` for elements that carry the test id themselves. Focus
+   * lands a tick or more after the key that moved it, so it has to be polled for.
+   */
+  async expectFocused(testId: string): Promise<void> {
+    await expect.poll(async () => this.focusedTestId(), { timeout: TIMEOUT_MEDIUM }).toBe(testId);
+  }
+
+  /**
+   * Waits for the focused element to be the one at `index` within its family.
+   *
+   * @remarks
+   * Asserted after `expectFocused`, never instead of it: the index alone would be satisfied by any
+   * element that happens to sit at that position.
+   */
+  async expectFocusedIndex(index: string): Promise<void> {
+    await expect.poll(async () => this.focusedIndex(), { timeout: TIMEOUT_MEDIUM }).toBe(index);
   }
 
   /**

--- a/frontend/app/tests/e2e/pages/pill-views-menu.ts
+++ b/frontend/app/tests/e2e/pages/pill-views-menu.ts
@@ -58,13 +58,13 @@ export class PillViewsMenu {
   }
 
   /** The muted line under a view's name, saying what it filters. */
-  async summary(name: string): Promise<string> {
-    return (await this.row(name).innerText()).trim();
+  async expectSummary(name: string, text: string): Promise<void> {
+    await expect(this.row(name)).toContainText(text);
   }
 
-  /** Whether the menu offers to save at all: with nothing filtered there is nothing to name. */
-  async canSave(): Promise<boolean> {
-    return this.page.locator('[data-testid=pill-views-save]').isEnabled();
+  /** With nothing filtered there is nothing to name, so the menu offers no save. */
+  async expectCannotSave(): Promise<void> {
+    await expect(this.page.locator('[data-testid=pill-views-save]')).toBeDisabled();
   }
 
   /** Dismisses the menu with Escape, which is the keyboard route out of it. */

--- a/frontend/app/tests/e2e/pages/price-manager-page.ts
+++ b/frontend/app/tests/e2e/pages/price-manager-page.ts
@@ -3,7 +3,29 @@ import { TIMEOUT_MEDIUM, TIMEOUT_SHORT } from '../helpers/constants';
 import { PillFilterBar } from './pill-filter-bar';
 import { RotkiApp } from './rotki-app';
 
-async function selectAsset(testId: string, asset: string, page: Page): Promise<void> {
+/**
+ * How to recognise the wanted option once the typeahead has answered.
+ *
+ * A symbol carries a stable option id, so `id` names the exact entry. A custom asset's id is a
+ * UUID the spec never sees, so `name` matches on the text instead.
+ */
+export type AssetMatch = 'id' | 'name';
+
+/**
+ * Picks an asset out of a RuiAutoComplete typeahead.
+ *
+ * @remarks
+ * AssetSelect debounces its search (~800ms), so the option has to be waited for rather than read
+ * off whatever the menu is showing at click time. The caller says which kind of asset it is asking
+ * for: choosing between the two by racing a timeout would let a slow search downgrade a symbol
+ * lookup into "click whatever rendered", and the test would go on asserting about the wrong asset.
+ *
+ * @param testId - the select's `data-testid`
+ * @param asset - a symbol for `id`, the asset's name for `name`
+ * @param page - the page holding the select
+ * @param match - which of the two the caller is passing
+ */
+async function selectAsset(testId: string, asset: string, page: Page, match: AssetMatch = 'id'): Promise<void> {
   const select = page.getByTestId(testId);
   // A previously selected chip would block the new typeahead query.
   const clearButton = select.locator('[data-id=clear]');
@@ -14,19 +36,10 @@ async function selectAsset(testId: string, asset: string, page: Page): Promise<v
   await page.keyboard.type(asset);
   const menu = page.locator('[role="listbox"], [role="menu"]').last();
   await menu.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
-  /* The id is stable for fiats but unpredictable for a custom asset's UUID, so the first
-     option is the fallback. AssetSelect's search is debounced (~800ms), so the by-id option
-     has to be waited for first, or the fallback clicks whatever stale entry is rendered. */
-  const byId = menu.locator(`#asset-${asset.toLowerCase()}`).first();
-  const firstOption = menu.locator('button[type="button"]').first();
-  let option = byId;
-  try {
-    await byId.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
-  }
-  catch {
-    option = firstOption;
-    await firstOption.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
-  }
+  const option = match === 'id'
+    ? menu.locator(`#asset-${asset.toLowerCase()}`).first()
+    : menu.locator('button[type="button"]').filter({ hasText: asset }).first();
+  await option.waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
   await option.click();
   await menu.waitFor({ state: 'hidden', timeout: TIMEOUT_SHORT });
 }
@@ -68,9 +81,16 @@ export class LatestPricePage {
     return this.rows().filter({ hasText: value });
   }
 
-  async addPrice(fromAsset: string, toAsset: string, value: string): Promise<void> {
+  /**
+   * Adds a latest price.
+   *
+   * @remarks
+   * `fromMatch` is `name` when `fromAsset` is a custom asset, whose id is a UUID the spec never
+   * sees. The `to` asset is always a symbol.
+   */
+  async addPrice(fromAsset: string, toAsset: string, value: string, fromMatch: AssetMatch = 'id'): Promise<void> {
     await this.page.getByTestId('latest-price-add').click();
-    await selectAsset('latest-price-from-asset', fromAsset, this.page);
+    await selectAsset('latest-price-from-asset', fromAsset, this.page, fromMatch);
     await selectAsset('latest-price-to-asset', toAsset, this.page);
     await this.page.getByTestId('latest-price-value').locator('input').fill(value);
     await confirmDialog(this.page);

--- a/frontend/app/tests/e2e/pages/purge-data-page.ts
+++ b/frontend/app/tests/e2e/pages/purge-data-page.ts
@@ -19,10 +19,14 @@ export class PurgeDataPage {
   }
 
   /**
-   * Picks an option from a `RuiAutoComplete`-backed control identified by its
-   * test id. Selection-by-id (`#item-<key>`) is preferred for stability;
-   * if the option for the typed text isn't rendered yet (debounced search,
-   * lazy lists, etc.) we fall back to typing then clicking the first match.
+   * Picks an option out of a `RuiAutoComplete`-backed control.
+   *
+   * @remarks
+   * A short list renders every option up front; a long or debounced one renders the wanted option
+   * only once the query narrows it, so a miss means "type to filter" rather than "give up". Both
+   * routes end on the same exact-text option: clicking the first rendered one instead would pick a
+   * different option whenever the search was merely slow, and the purge would run on the wrong
+   * source.
    */
   private async selectOption(testId: string, text: string): Promise<void> {
     const select = this.page.getByTestId(testId);
@@ -33,14 +37,12 @@ export class PurgeDataPage {
     const byText = menu.getByText(text, { exact: true }).first();
     try {
       await byText.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
-      await byText.click();
     }
     catch {
       await this.page.keyboard.type(text);
-      const firstOption = menu.locator('button[type="button"]').first();
-      await firstOption.waitFor({ state: 'visible', timeout: TIMEOUT_SHORT });
-      await firstOption.click();
+      await byText.waitFor({ state: 'visible', timeout: TIMEOUT_MEDIUM });
     }
+    await byText.click();
     await menu.waitFor({ state: 'hidden', timeout: TIMEOUT_SHORT });
   }
 

--- a/frontend/app/tests/e2e/pages/snapshot-list-page.ts
+++ b/frontend/app/tests/e2e/pages/snapshot-list-page.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 import { RotkiApp } from './rotki-app';
 import { SnapshotEditorPage } from './snapshot-editor-page';
 
@@ -24,8 +24,17 @@ export class SnapshotListPage {
     await this.table.waitFor({ state: 'visible' });
   }
 
-  async hasSnapshot(timestamp: number): Promise<boolean> {
-    return this.row(timestamp).isVisible();
+  async expectSnapshot(timestamp: number): Promise<void> {
+    await expect(this.row(timestamp)).toBeVisible();
+  }
+
+  /**
+   * @remarks
+   * A delete refreshes the net-value series the list reads from, so the row goes some time after
+   * the request returns.
+   */
+  async expectNoSnapshot(timestamp: number): Promise<void> {
+    await expect(this.row(timestamp)).toHaveCount(0);
   }
 
   async openEditor(timestamp: number): Promise<SnapshotEditorPage> {

--- a/frontend/app/tests/e2e/pages/tag-manager.ts
+++ b/frontend/app/tests/e2e/pages/tag-manager.ts
@@ -109,8 +109,20 @@ export class TagManagerPage {
     await this.search('');
   }
 
-  async visibleRowCount(): Promise<number> {
-    return this.rows().count();
+  /**
+   * Waits for the table to settle on a row count.
+   *
+   * @remarks
+   * Searching and creating both redraw the table asynchronously, so the count has to be polled for
+   * rather than read once off whatever is rendered when the assertion runs.
+   */
+  async expectVisibleRowCount(expected: number): Promise<void> {
+    await expect(this.rows()).toHaveCount(expected);
+  }
+
+  /** For a page whose size is bounded from below but not pinned, such as the last page. */
+  async expectAtLeastVisibleRows(expected: number): Promise<void> {
+    await expect.poll(async () => this.rows().count()).toBeGreaterThanOrEqual(expected);
   }
 
   async goToNextPage(): Promise<void> {

--- a/frontend/app/tests/e2e/specs/app/address-book.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/address-book.spec.ts
@@ -1,4 +1,3 @@
-import { expect } from '@playwright/test';
 import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { AddressBookPage } from '../../pages/address-book-page';
 
@@ -63,11 +62,11 @@ test.describe.serial('address book', () => {
       await page.addEntry({ address: addr, name });
     }
 
-    expect(await page.visibleRowCount()).toBe(10);
+    await page.expectVisibleRowCount(10);
     await page.expectNextPageEnabled(true);
 
     await page.goToNextPage();
-    expect(await page.visibleRowCount()).toBeGreaterThan(0);
+    await page.expectAtLeastVisibleRows(1);
     await page.expectNextPageEnabled(false);
   });
 

--- a/frontend/app/tests/e2e/specs/app/assets.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/assets.spec.ts
@@ -166,7 +166,7 @@ test.describe('assets', () => {
       await customPage.expectRow(assetName);
 
       await pricePage.visit();
-      await pricePage.addPrice(assetName, 'USD', '4242');
+      await pricePage.addPrice(assetName, 'USD', '4242', 'name');
       await pricePage.expectRowWithValue('4,242');
     });
 

--- a/frontend/app/tests/e2e/specs/app/snapshot-edit.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/snapshot-edit.spec.ts
@@ -137,7 +137,7 @@ test.describe.serial('snapshot edit', () => {
   test('opens the editor from the snapshot list', async () => {
     const list = new SnapshotListPage(ctx.sharedPage);
     await list.visit();
-    expect(await list.hasSnapshot(SNAPSHOT_TIMESTAMP)).toBe(true);
+    await list.expectSnapshot(SNAPSHOT_TIMESTAMP);
 
     const editor = await list.openEditor(SNAPSHOT_TIMESTAMP);
     await editor.waitForLoaded();
@@ -148,8 +148,7 @@ test.describe.serial('snapshot edit', () => {
     await list.visit();
     await list.deleteSnapshot(SNAPSHOT_TIMESTAMP);
 
-    // The list reads the net-value series, refreshed after a delete, so no reload is needed.
-    expect(await list.hasSnapshot(SNAPSHOT_TIMESTAMP)).toBe(false);
+    await list.expectNoSnapshot(SNAPSHOT_TIMESTAMP);
   });
 });
 

--- a/frontend/app/tests/e2e/specs/app/tag-manager.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/tag-manager.spec.ts
@@ -1,4 +1,3 @@
-import { expect } from '@playwright/test';
 import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { TagManagerPage } from '../../pages/tag-manager';
 
@@ -30,11 +29,11 @@ test.describe.serial('tag manager', () => {
     await page.createTag('gamma', 'third tag');
 
     await page.search('beta');
-    expect(await page.visibleRowCount()).toBe(1);
+    await page.expectVisibleRowCount(1);
     await page.expectTagVisible('beta');
 
     await page.clearSearch();
-    expect(await page.visibleRowCount()).toBeGreaterThanOrEqual(3);
+    await page.expectAtLeastVisibleRows(3);
   });
 
   test('paginates when more than 10 tags exist', async () => {
@@ -42,11 +41,11 @@ test.describe.serial('tag manager', () => {
     for (let i = 0; i < 9; i++)
       await page.createTag(`tag-${i.toString().padStart(2, '0')}`, `tag ${i}`);
 
-    expect(await page.visibleRowCount()).toBe(10);
+    await page.expectVisibleRowCount(10);
     await page.expectNextPageEnabled(true);
 
     await page.goToNextPage();
-    expect(await page.visibleRowCount()).toBeGreaterThan(0);
+    await page.expectAtLeastVisibleRows(1);
     await page.expectNextPageEnabled(false);
   });
 

--- a/frontend/app/tests/e2e/specs/history/pill-filter.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/pill-filter.spec.ts
@@ -113,7 +113,7 @@ test.describe.serial('history events pill filter', () => {
     await bar.waitForVisible();
 
     await expectRows(TOTAL_SEEDED_EVENTS);
-    expect(await bar.pillCount()).toBe(0);
+    await bar.expectPillCount(0);
   });
 
   test('adding a protocol filter from the add menu narrows the table', async () => {
@@ -123,7 +123,7 @@ test.describe.serial('history events pill filter', () => {
 
     await bar.expectPillVisible('counterparties');
     // The pill shows the protocol's display name, not its wire id.
-    expect(await bar.pillValue('counterparties')).toContain('Uniswap');
+    await bar.expectPillValue('counterparties', 'Uniswap');
 
     await expectRows(2);
     await expect.poll(() => url(), { timeout: 10000 }).toContain('counterparties=uniswap-v2');
@@ -173,7 +173,7 @@ test.describe.serial('history events pill filter', () => {
 
     // Not an address: the editor must not offer it as valid, and nothing reaches the URL.
     await bar.typeTextValue('not-an-address');
-    expect(await bar.textValueIsValid()).toBe(false);
+    await bar.expectTextValueInvalid();
     expect(url()).not.toContain('addresses=');
 
     await bar.typeTextValue(ADDRESS_ALPHA);
@@ -319,7 +319,7 @@ test.describe.serial('history events pill filter', () => {
     // Everything except the five EVM events, i.e. the one plain history event.
     await expectRows(TOTAL_SEEDED_EVENTS - pillFilterEvents.length);
     // A non-default operator is spelled out on the pill; the default `is` stays hidden.
-    expect(await bar.pillText('entryTypes')).toContain('is not');
+    await bar.expectPillText('entryTypes', 'is not');
 
     await bar.clearAll();
     await expectRows(TOTAL_SEEDED_EVENTS);
@@ -331,7 +331,7 @@ test.describe.serial('history events pill filter', () => {
     await bar.waitForVisible();
 
     await bar.expectPillVisible('counterparties');
-    expect(await bar.pillValue('counterparties')).toContain('Curve');
+    await bar.expectPillValue('counterparties', 'Curve');
     await expectRows(2);
 
     await bar.clearAll();
@@ -379,7 +379,7 @@ test.describe.serial('history events pill filter', () => {
 
     // The second attempt is refused out loud rather than silently swallowed.
     await bar.typeTextValue(ADDRESS_ALPHA);
-    expect((await bar.textFieldError()).toLowerCase()).toContain('already added');
+    await bar.expectTextFieldError(/already added/i);
     await bar.closeEditor();
 
     await expectRows(2);
@@ -464,7 +464,7 @@ test.describe.serial('history events pill filter', () => {
     await bar.waitForVisible();
 
     await bar.expectPillVisible('state');
-    expect(await bar.pillValue('state')).toContain('Customized');
+    await bar.expectPillValue('state', 'Customized');
 
     // Clearing has to take the param with it, or the request filters by a state nothing shows.
     await bar.clearAll();
@@ -477,7 +477,7 @@ test.describe.serial('history events pill filter', () => {
   test('a saved view stores and restores both a matcher and a param pill', async () => {
     await views.open();
     // Nothing is filtered yet, so there is nothing to name.
-    expect(await views.canSave()).toBe(false);
+    await views.expectCannotSave();
     await views.close();
 
     await bar.addField('location');
@@ -491,7 +491,7 @@ test.describe.serial('history events pill filter', () => {
     await views.open();
     await views.save('Alpha on mainnet');
     // The row says what it filters, so a view is recognisable by more than the name given to it.
-    expect(await views.summary('Alpha on mainnet')).toContain('Ethereum');
+    await views.expectSummary('Alpha on mainnet', 'Ethereum');
     await views.close();
 
     await bar.clearAll();
@@ -571,7 +571,7 @@ test.describe.serial('history events pill filter', () => {
     await bar.keyboard.pressFocused('Enter');
 
     await bar.expectPillVisible('location');
-    expect(await bar.pillValue('location')).toContain('Kraken');
+    await bar.expectPillValue('location', 'Kraken');
     await expectRows(1);
     await expect.poll(() => url(), { timeout: 10000 }).toContain('location=kraken');
 
@@ -590,7 +590,7 @@ test.describe.serial('history events pill filter', () => {
     // Ambiguous on purpose: `100` cannot say which bound is meant, so both are offered.
     await bar.expectFilterSuggestion('amount', 'gt');
     await bar.expectFilterSuggestion('amount', 'lt');
-    expect(await bar.filterSuggestionText('amount', 'gt')).toContain('greater than 100');
+    await bar.expectFilterSuggestionText('amount', 'gt', 'greater than 100');
 
     await bar.pickFilterSuggestion('amount', 'gt');
 
@@ -638,7 +638,7 @@ test.describe.serial('history events pill filter', () => {
     await bar.narrow('100');
 
     await bar.expectFilterSuggestion('amount', 'gt');
-    expect(await bar.hasFilterSuggestion('period', 'after')).toBe(false);
+    await bar.expectNoFilterSuggestion('period', 'after');
 
     // Escape both clears the input and closes the popover, so the next test starts from a bare bar.
     await bar.pressInNarrow('Escape');
@@ -720,7 +720,7 @@ test.describe.serial('history events pill filter', () => {
     // "less than" keeps only the upper bound, so the lower one must leave the URL with it.
     await expect.poll(() => url(), { timeout: 10000 }).not.toContain('minAmount=');
     expect(url()).toContain('maxAmount=100');
-    expect(await bar.pillText('amount')).toContain('less than');
+    await bar.expectPillText('amount', 'less than');
 
     await bar.dismissEditor();
     await bar.clearAll();
@@ -813,13 +813,13 @@ test.describe.serial('history events pill filter', () => {
       await bar.selectValue(value, search);
     await bar.closeEditor('counterparties');
 
-    expect(await bar.pillValue('counterparties')).not.toContain('+');
+    await bar.expectPillValueMissing('counterparties', '+');
 
     await bar.openPillEditor('counterparties');
     await bar.selectValue('aave-v3', 'aave');
     await bar.closeEditor('counterparties');
 
-    expect(await bar.pillValue('counterparties')).toContain('+1');
+    await bar.expectPillValue('counterparties', '+1');
 
     await bar.clearAll();
     await expectRows(TOTAL_SEEDED_EVENTS);
@@ -876,12 +876,12 @@ test.describe.serial('history events pill filter paging', () => {
 
     await expectRows(PAGE_SIZE);
     // The header is the only place the unpaged total appears.
-    expect(await bar.pageRange()).toContain(String(PAGED_TOTAL));
+    await bar.expectPageRange(String(PAGED_TOTAL));
   });
 
   test('applying a filter from a later page returns to the first', async () => {
     await bar.nextPage();
-    await expect.poll(async () => bar.pageRange(), { timeout: 10000 }).toContain('11-20');
+    await bar.expectPageRange('11-20');
 
     await bar.addField('location');
     await bar.selectValue('kraken');
@@ -889,19 +889,18 @@ test.describe.serial('history events pill filter paging', () => {
 
     // Without a page reset the filtered rows would sit on a page that no longer exists.
     await expectRows(PAGED_KRAKEN);
-    expect(await bar.pageRange()).toContain(`1-${PAGED_KRAKEN}`);
+    await bar.expectPageRange(`1-${PAGED_KRAKEN}`);
   });
 
   test('a filter survives sorting by date', async () => {
     /** Newest first by default, so the last kraken event leads. */
-    const firstNote = async (): Promise<string | null> =>
-      ctx.sharedPage.locator(ROW).first().locator('[data-testid=event-notes]').textContent();
-    expect(await firstNote()).toContain(`paged ${PAGED_KRAKEN - 1}`);
+    const firstNote = ctx.sharedPage.locator(ROW).first().locator('[data-testid=event-notes]');
+    await expect(firstNote).toContainText(`paged ${PAGED_KRAKEN - 1}`);
 
     await bar.toggleDateSort();
 
     // The sort has to actually reverse the rows, or this test would pass on a dead button.
-    await expect.poll(firstNote, { timeout: 10000 }).toContain('paged 0');
+    await expect(firstNote).toContainText('paged 0', { timeout: 10000 });
     // And the filter has to still be applied on the other side of it.
     await bar.expectPillVisible('location');
     await expectRows(PAGED_KRAKEN);
@@ -958,7 +957,7 @@ test.describe.serial('history events pill filter across chains', () => {
       await expect(ctx.sharedPage.locator(ROW).first().locator('[data-testid=event-notes]'))
         .toContainText(expected);
       // Both pills read "USDC", so the label alone cannot tell which is applied.
-      expect(await bar.pillValue('asset')).toContain('USDC');
+      await bar.expectPillValue('asset', 'USDC');
     }
   });
 });

--- a/frontend/app/tests/e2e/specs/history/pill-filter.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/pill-filter.spec.ts
@@ -532,17 +532,17 @@ test.describe.serial('history events pill filter', () => {
 
     await views.open();
     // Opening lands focus on the list, which is where the arrow keys and Escape are handled.
-    expect(await bar.keyboard.focusedTestId()).toBe('pill-views-list');
+    await bar.keyboard.expectFocused('pill-views-list');
 
     // The name field is one Tab away while the list holds no view of its own.
     await bar.keyboard.pressFocused('Tab');
-    expect(await bar.keyboard.focusedTestId()).toBe('pill-views-name');
+    await bar.keyboard.expectFocused('pill-views-name');
     await bar.keyboard.typeFocused('kb optimism');
     await bar.keyboard.pressFocused('Enter');
 
     // Saving hands focus back to the list, which now holds the view.
     await views.expectVisible('kb optimism');
-    expect(await bar.keyboard.focusedTestId()).toBe('pill-views-list');
+    await bar.keyboard.expectFocused('pill-views-list');
     await views.close();
 
     /* A second view, so moving the highlight is a move rather than a wrap onto itself. Saved
@@ -556,9 +556,9 @@ test.describe.serial('history events pill filter', () => {
     await views.open();
     // Tab out of the list reaches the stored view itself, so a row is reachable without a mouse.
     await bar.keyboard.pressFocused('Tab');
-    expect(await bar.keyboard.focusedTestId()).toBe('pill-views-apply');
+    await bar.keyboard.expectFocused('pill-views-apply');
     // The index matters: Tab must land on the FIRST row, not merely on some row.
-    expect(await bar.keyboard.focusedIndex()).toBe('0');
+    await bar.keyboard.expectFocusedIndex('0');
     await views.save('kb kraken');
     await views.close();
 
@@ -654,7 +654,7 @@ test.describe.serial('history events pill filter', () => {
     await bar.dismissEditor();
 
     await bar.expectNoPill('counterparties');
-    expect(await bar.keyboard.focusedFieldTestId()).toBe('pill-narrow-input');
+    await bar.keyboard.expectFocusedField('pill-narrow-input');
     await expectRows(TOTAL_SEEDED_EVENTS);
   });
 
@@ -662,7 +662,7 @@ test.describe.serial('history events pill filter', () => {
   test('a field can be picked from the add menu with the keyboard', async () => {
     await bar.openAddMenu();
     // The menu focuses its search on mount, so typing narrows without clicking into it.
-    expect(await bar.keyboard.focusedFieldTestId()).toBe('pill-menu-search');
+    await bar.keyboard.expectFocusedField('pill-menu-search');
     await bar.keyboard.typeFocused('proto');
     await bar.keyboard.pressFocused('Enter');
 
@@ -738,10 +738,10 @@ test.describe.serial('history events pill filter', () => {
     // Pills precede the input, so shift-tab walks back into the last one's remove control first.
     await bar.focusNarrowInput();
     await bar.keyboard.pressFocused('Shift+Tab');
-    expect(await bar.keyboard.focusedTestId()).toBe('filter-pill-remove');
+    await bar.keyboard.expectFocused('filter-pill-remove');
 
     await bar.keyboard.pressFocused('Shift+Tab');
-    expect(await bar.keyboard.focusedTestId()).toBe('filter-pill-open');
+    await bar.keyboard.expectFocused('filter-pill-open');
 
     // Enter on the focused pill has to open the same editor a click does.
     await bar.keyboard.pressFocused('Enter');

--- a/frontend/app/tests/e2e/specs/settings/interface.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/interface.spec.ts
@@ -1,4 +1,3 @@
-import { expect } from '@playwright/test';
 import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { InterfaceSettingsPage } from '../../pages/interface-settings-page';
 
@@ -28,25 +27,25 @@ test.describe.serial('settings::interface', () => {
 
   test('rejects an explorer url that is not https', async () => {
     await page.setExplorerUrl('address', 'http://example.com/address/');
-    expect(await page.explorerMessages('address')).toContain('Only https urls are allowed');
-    expect(await page.explorerSaveDisabled('address')).toBe(true);
+    await page.expectExplorerMessage('address', 'Only https urls are allowed');
+    await page.expectSaveDisabled('address');
   });
 
   // 'https://' fails only the url rule, so it covers that check rather than repeating the one above.
   test('rejects an explorer url that is only a scheme', async () => {
     await page.setExplorerUrl('address', 'https://');
-    expect(await page.explorerMessages('address')).not.toBe('');
-    expect(await page.explorerSaveDisabled('address')).toBe(true);
+    await page.expectExplorerRejected('address');
+    await page.expectSaveDisabled('address');
   });
 
   test('saves a valid explorer url and keeps it after re-login', async () => {
     await page.setExplorerUrl('address', explorerUrl);
-    expect(await page.explorerSaveDisabled('address')).toBe(false);
+    await page.expectSaveEnabled('address');
     await page.saveExplorerUrl('address');
 
     // Navigating re-reads the in-memory repo, so only a fresh login proves what was persisted.
     await ctx.app.relogin(ctx.username);
     await page.visit();
-    expect(await page.explorerValue('address')).toBe(explorerUrl);
+    await page.expectExplorerValue('address', explorerUrl);
   });
 });


### PR DESCRIPTION
Follow-up to #13072, which fixed one instance of a pattern that turned out to be widespread: an assertion that samples the DOM once, through a call Playwright does not retry, while the thing it describes lands asynchronously.

## What was wrong

**Typeahead helpers picked the wrong option on a slow search.** `price-manager-page.ts` and `purge-data-page.ts` each waited 5s for their intended option and, on a miss, clicked whatever the menu had rendered first. The price manager genuinely needs two strategies, since a custom asset's id is a UUID the spec never sees, but choosing between them by racing a timeout meant a merely-slow search silently downgraded a symbol lookup into "click whatever". The test then went on asserting about a different asset, and stayed green.

**Twenty-seven assertions sampled the DOM once.** `innerText`, `isVisible`, `isEnabled`, `textContent` and `count` do not retry, so each raced the redraw it described: a filter pill's text, a suggestion row, a page range, a table after a search, a snapshot after a delete, an explorer field's validation after `blur`.

The cause was structural: page objects returned raw values, which leaves a spec no choice but `expect(await ...)`.

**Nine focus assertions bypassed helpers written for exactly this.** `PillFilterKeyboard` already documented why focus must be polled for and provided `expectFocusedField` on `expect.poll`, but nine call sites reached past it to the raw getters. Two of them run immediately after a menu opens, which is where focus moves latest.

**Four fixed sleeps.** Three sat in front of assertions that already poll. The fourth, in `selectScope`, carried a comment claiming it checked row attachment; it checked nothing.

## What changed

Page objects now expose the assertion rather than the value, and the getters behind them are private or gone. `toContainText`, `toBeDisabled`, `toHaveValue`, `toHaveCount` and `toBeVisible` replace the manual comparisons, and their whitespace normalising replaces several hand-rolled `.replace(/\s+/g, ' ').trim()` calls.

The dashboard readers stay readers, because their callers compare balances numerically. They gain a wait for the amount to hold text: `AmountDisplayBase` renders a skeleton with no text while loading, which `parseBigNumber` read as zero.

## Verification

Full suite, four local shards: **238 passed, 1 skipped, 8.8 minutes.**

Negative control, since a passing suite only shows the assertions still pass, not that they can still fail. Sabotaging the pill locator so it resolves nothing turned the assertions red with `element(s) not found`, at both the sites the serial describe reached before aborting, and again at `a pill collapses values past the icon cap` under a sabotage narrow enough to leave the earlier tests passing.

That control also corrected a change I had made on a wrong assumption. I had added `toBeVisible` guards in front of the two negated matchers, believing a negated matcher would pass for an absent element where the `innerText` it replaced would throw. It does not: text matchers require the locator to resolve, and the negation applies to the text. The guards were unnecessary and are not in this branch.

Local e2e here is contention-prone, so the green run is weak evidence on its own; CI across repeated runs is the real check. Nothing here demonstrates the races were firing in CI either. The only observed failure is the shard-2 one that prompted #13072.

Not included: converting the ~570 raw `locator('[data-testid=...]')` calls to `getByTestId`. That is mechanical churn across nearly every e2e file and belongs in its own PR.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

Not applicable: test-only change, no user-facing behaviour.