### PR TITLE
fix(frontend): scan .ts files for tailwind classes

### DIFF
--- a/frontend/app/tailwind.config.ts
+++ b/frontend/app/tailwind.config.ts
@@ -147,6 +147,7 @@ export default {
     './src/layouts/**/*.vue',
     './src/modules/**/*.vue',
     './src/pages/**/*.vue',
+    './src/**/*.ts',
   ],
   theme: {
     container: {
@@ -198,7 +199,6 @@ export default {
     'min-h-[560px]',
     '!pt-0',
     'h-[30rem]',
-    '!bg-rui-error/15',
     '[&>span]:!text-xs',
     '!transition-none',
   ],


### PR DESCRIPTION
The tailwind `content` globs only matched `*.vue`, so any class literal that lives in a `.ts` file was never scanned and its utility was never generated. The template still asks for the class, the stylesheet does not have it, and the element silently falls back to whatever else is in its class list.

`test(notifications): cover the notification card` (ab2f24fc54) tripped this by extracting `Notification.vue`'s script into `use-notification-card.ts`. That moved `colorBgClass` and `expandButtonClass` out of a scanned file, and five utilities stopped being emitted:

- `!to-rui-warning/10`, `!to-rui-error/10`, `!to-rui-info/10`, `!to-rui-secondary/10`
- `!bg-rui-secondary/10`

The collapsed message's fade is two stacked gradients: the wrapper fades to white, the button on top re-tints it to the card colour. With the tint stop gone, the fade ended at white, painting a white band across the bottom of every tinted notification card. Reminder cards lost their background tint outright, since `!bg-rui-secondary/10` is the one background class no `.vue` file duplicates.

The same trap had already been papered over once: `!bg-rui-error/15`, used by `history/events/action-types.ts`, sat in the safelist. Scanning `.ts` generates it, so that entry goes with this change.

## Verification

Built the CSS before and after. Before, all five classes are absent from `dist/*.css`. After:

```
to-rui-warning\/10{--tw-gradient-to:rgba(var(--rui-warning-main), .1) var(--tw-gradient-to-position)!important}
to-rui-error\/10{...}  to-rui-info\/10{...}  to-rui-secondary\/10{...}
bg-rui-secondary\/10{background-color:rgba(var(--rui-secondary-main), .1)!important}
```

`bg-rui-error/15` still appears with its safelist entry removed, which is what proves the new glob is doing the work.

Checked in the running app with four notifications, one per severity, each long enough to collapse behind the expand arrow. Every fade now ends at its own card background:

```
warning  card rgba(237,108,2,.1)   fade -> rgba(237,108,2,.1)
error    card rgba(211,47,47,.1)   fade -> rgba(211,47,47,.1)
reminder card rgba(102,112,133,.1) fade -> rgba(102,112,133,.1)
info     card rgba(2,136,209,.1)   fade -> rgba(2,136,209,.1)
```

Negative control, reverting only the glob line and letting the dev server rebuild:

```
warning  card rgba(237,108,2,.1)   fade -> rgb(255,255,255)
reminder card rgb(255,255,255)
```

Emitted css grows 884 bytes before compression (613,674 -> 614,558).
