### PR TITLE
test: fix two silent defects in the shared test harness

### DIFF
--- a/frontend/app/tests/unit/setup-files/setup.spec.ts
+++ b/frontend/app/tests/unit/setup-files/setup.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { useRoute, useRouter } from 'vue-router';
+
+describe('the global vue-router mock', () => {
+  it.each(['push', 'replace'] as const)('should expose %s and write the query back to the route', async (method) => {
+    const router = useRouter();
+    const route = useRoute();
+
+    await router[method]({ query: { add: 'true' } });
+
+    expect(get(route).query).toStrictEqual({ add: 'true' });
+  });
+});

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -130,6 +130,11 @@ vi.mock('vue-router', () => {
         set(route, { ...get(route), query });
         return true;
       }),
+      // Components that clear a `?add=`-style parameter call replace, so the mock must expose it.
+      replace: vi.fn(({ query }) => {
+        set(route, { ...get(route), query });
+        return true;
+      }),
     })),
     createRouter: vi.fn().mockImplementation(() => ({
       beforeEach: vi.fn(),

--- a/frontend/app/tests/unit/utils/create-pinia.spec.ts
+++ b/frontend/app/tests/unit/utils/create-pinia.spec.ts
@@ -1,0 +1,45 @@
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { createPinia, defineStore, setActivePinia } from 'pinia';
+import { describe, expect, it } from 'vitest';
+
+const useCounterStore = defineStore('harness-counter', () => {
+  const count = ref<number>(0);
+
+  function increment(): void {
+    set(count, get(count) + 1);
+  }
+
+  return { count, increment };
+});
+
+describe('createCustomPinia', () => {
+  it('should apply StoreResetPlugin without the spec mounting anything', () => {
+    setActivePinia(createCustomPinia());
+    const store = useCounterStore();
+    store.increment();
+    expect(store.count).toBe(1);
+
+    store.$reset();
+
+    expect(store.count).toBe(0);
+  });
+
+  it('should still reset after a mount installs the same pinia into another app', () => {
+    const pinia = createCustomPinia();
+    createApp({}).use(pinia);
+    setActivePinia(pinia);
+    const store = useCounterStore();
+    store.increment();
+
+    store.$reset();
+
+    expect(store.count).toBe(0);
+  });
+
+  it('should be the reason for existing: a bare pinia leaves $reset unimplemented', () => {
+    setActivePinia(createPinia());
+    const store = useCounterStore();
+
+    expect(() => store.$reset()).toThrow(/setup syntax/);
+  });
+});

--- a/frontend/app/tests/unit/utils/create-pinia.ts
+++ b/frontend/app/tests/unit/utils/create-pinia.ts
@@ -1,9 +1,26 @@
-import { createPinia } from 'pinia';
+import { createPinia, type Pinia } from 'pinia';
+import { createApp } from 'vue';
 import { StoreResetPlugin } from '@/modules/shell/app/store-plugins';
 
-export function createCustomPinia() {
+/**
+ * A pinia carrying the plugins the application installs, whether or not the spec mounts anything.
+ *
+ * @remarks
+ * `pinia.use()` only queues a plugin: `install(app)` is what moves it into the active list, and that
+ * runs on `app.use(pinia)`. A spec that calls `setActivePinia(createCustomPinia())` and never mounts
+ * therefore ran with no plugins at all, so `$reset` stayed pinia's setup-store version, which throws
+ * in development and does nothing in a production build. Installing into a throwaway app here makes
+ * the helper mean what its name says.
+ *
+ * Mounting with `global: { plugins: [pinia] }` installs again, which re-points pinia at the test's
+ * own app; the plugin list is already drained by then, so nothing is registered twice.
+ *
+ * @returns a pinia with `StoreResetPlugin` applied to every store it creates
+ */
+export function createCustomPinia(): Pinia {
   const pinia = createPinia();
   pinia.use(StoreResetPlugin);
+  createApp({}).use(pinia);
 
   return pinia;
 }


### PR DESCRIPTION
Test-debt paid down alongside the coverage batches of #12964. Touches only `frontend/app/tests/unit/`, so it is independent of any coverage batch.

## 1. `createCustomPinia()` installed no plugins at all

`pinia.use()` only *queues* a plugin. `install(app)` is what moves it into the active list, and that runs on `app.use(pinia)`. A spec that called `setActivePinia(createCustomPinia())` and never mounted anything therefore ran with **no plugins**, so `$reset` stayed pinia's setup-store version — which throws in development and does nothing in a production build.

That was **30 of 68 callers**. The helper now installs into a throwaway app so it means what its name says. Mounting with `global: { plugins: [pinia] }` installs again and re-points pinia at the test's own app, but the plugin list is already drained by then, so nothing registers twice.

## 2. The global `vue-router` mock had no `replace`

Anything consuming a `?add=`-style parameter clears it with `replace`, so a spec mounting such a component threw on an undefined method. Only surfaced when someone happened to write one.

## Why these were invisible

Neither defect ever failed anything. A harness bug does not announce itself — it quietly removes coverage, and the result is indistinguishable from code that works. `createCustomPinia` silently applying no plugins is the sharper case: every affected spec passed.

So **the guard spec is the fix here, not the code change.** Both live under `tests/unit/`, which makes them the first specs ever placed there — every other spec in the repo is co-located in `src/`. A test helper has nowhere else to go, and an unguarded one is exactly how this rots back.

## Verification

Negative controls, re-run on the rebased branch rather than trusted from when the commits were written:

- removing `createApp({}).use(pinia)` turns **only** `should apply StoreResetPlugin without the spec mounting anything` red. The mount-based test correctly stays green, since mounting installs the plugins itself — the two tests discriminate.
- removing the `replace` mock turns **only** `should expose replace and write the query back to the route` red; the `push` case stays green.

`rwt check --full`: 8/8 green, vitest included.

## Not addressed here

A full `pnpm run test:unit` prints **30** `ECONNREFUSED 127.0.0.1:4242` errors and still exits 0 — a real Pinia store reaching the backend from inside a unit test. Confirmed pre-existing (measured with both fixes stashed), so it is not fallout from either. Not filed and not diagnosed; the culprit specs have not been identified.

## Checklist

- [ ] The PR modified the frontend, and updated the [user guide](https://github.com/rotki/docs/blob/main/usage-guides/index.md) to reflect the changes.

Not applicable: test-infrastructure only, no user-facing behaviour.