### PR TITLE
refactor(ui): address RuiCard parts by name, not position

### DIFF
--- a/frontend/app/src/modules/assets/AssetValueRow.vue
+++ b/frontend/app/src/modules/assets/AssetValueRow.vue
@@ -64,12 +64,9 @@ function showDeleteConfirmation() {
 
 <template>
   <div class="grid sm:grid-cols-3 gap-4">
-    <RuiCard
-      no-padding
-      class="[&>div:first-child]:pb-3"
-    >
+    <RuiCard no-padding>
       <template #custom-header>
-        <div class="px-4 pt-3 flex justify-between items-start">
+        <div class="px-4 pt-3 pb-3 flex justify-between items-start">
           <CardTitle>{{ t('common.price') }}</CardTitle>
           <RuiTooltip :open-delay="200">
             <template #activator>

--- a/frontend/app/src/modules/assets/admin/AssetIconForm.vue
+++ b/frontend/app/src/modules/assets/admin/AssetIconForm.vue
@@ -95,7 +95,8 @@ defineExpose({
     <div class="grid grid-cols-[auto_1fr] gap-6 h-full">
       <RuiCard
         rounded="sm"
-        class="w-32 items-center justify-center [&>div]:!p-6 relative"
+        class="w-32 items-center justify-center relative"
+        :class-names="{ content: '!p-6' }"
       >
         <RuiTooltip
           v-if="preview && refreshable"

--- a/frontend/app/src/modules/calendar/CalendarSelectedEventsPanel.vue
+++ b/frontend/app/src/modules/calendar/CalendarSelectedEventsPanel.vue
@@ -25,7 +25,7 @@ function edit(event: CalendarEvent): void {
 
 <template>
   <RuiCard
-    class="[&>div:last-child]:!pt-2"
+    :class-names="{ content: '!pt-2' }"
     data-testid="calendar-selected-list"
   >
     <template #header>

--- a/frontend/app/src/modules/calendar/CalendarUpcomingEventsPanel.vue
+++ b/frontend/app/src/modules/calendar/CalendarUpcomingEventsPanel.vue
@@ -23,7 +23,7 @@ function edit(event: CalendarEvent): void {
 
 <template>
   <RuiCard
-    class="[&>div:last-child]:!pt-2"
+    :class-names="{ content: '!pt-2' }"
     data-testid="calendar-upcoming-list"
   >
     <template #header>

--- a/frontend/app/src/modules/notes/UserNotesList.vue
+++ b/frontend/app/src/modules/notes/UserNotesList.vue
@@ -80,7 +80,7 @@ onMounted(async () => {
     <RuiCard
       v-for="n in 10"
       :key="n"
-      class="[&>div]:flex [&>div]:flex-col"
+      :class-names="{ content: 'flex flex-col' }"
     >
       <RuiSkeletonLoader class="w-20 mb-3" />
       <RuiSkeletonLoader class="w-24 mb-6" />

--- a/frontend/app/src/pages/staking/[[location]].vue
+++ b/frontend/app/src/pages/staking/[[location]].vue
@@ -30,7 +30,7 @@ const { getRedirectLink, modelLocation, page, staking } = useStakingPage(() => l
 
 <template>
   <div class="container">
-    <RuiCard class="[&>div:first-child]:flex">
+    <RuiCard :class-names="{ content: 'flex' }">
       <DefineIcon #default="{ image }">
         <AppImage
           class="icon-bg"


### PR DESCRIPTION
Follow-up to #13074, where a vue-echarts minor moved the DOM under `<VChart>` and a `[&>div:last-child]:!hidden` selector stopped hiding echarts' tooltip and started hiding the whole chart. e2e was the only gate that caught it; unit tests, typecheck, build, lint and knip were all green on an invisible chart.

`RuiCard` has the same shape of exposure. It renders four **`v-if`-gated** children:

```
<div>                                  ← root (carries your class)
  <div v-if="slots.image"   data-id="card-image">
  <RuiCardHeader v-if="hasHeadContent">
  <div v-if="slots.default" data-id="card-content">
  <div v-if="slots.footer"  data-id="card-footer">
```

so `>div:first-child` does not mean "the header" — it means whichever part happens to be first given the slots that call site passes.

Six call sites now name the part instead:

```diff
-  class="[&>div:last-child]:!pt-2"
+  :class-names="{ content: '!pt-2' }"
```

A seventh, `AssetValueRow`, was not a RuiCard-internals problem at all: `#custom-header` replaces the header wholesale, so the selector was reaching for **its own** div three lines below. `pb-3` moves onto that div and the wrapper class goes away.

`contentClass` is already deprecated in favour of `classNames.content`, so this is the direction the library is pushing anyway.

## Verification

These are cosmetic, and nothing automated asserts padding, so the usual gates prove very little on their own. Three things were checked directly:

**The old selector and the new prop resolve to the same element.** A throwaway spec mounted the real `RuiCard` in both slot combinations these sites use — default-slot-only (one div child, `:first-child`/`:last-child`/`>div` all resolve to `data-id="card-content"`) and header-plus-default (`:last-child` is content, `:first-child` is not) — and confirmed `classNames.content` lands on that same element. **Negative control**: moving the sentinel to `classNames.footer` fails it. Spec removed afterwards.

**Tailwind emits the new utilities.** A DOM test cannot see this: utilities only exist if the scanner finds the literal strings. The built CSS carries `.\!pt-2`, `.\!p-6`, `.flex`, `.flex-col`, and the three old arbitrary-variant rules are gone.

**No specificity regression.** `.[&>div:last-child]:!pt-2 > div:last-child` outranks a bare `.\!pt-2`, so a naive swap could lose to RuiCard's own classes. It does not: the content base is `text-body-1 text-rui-light-text dark:text-rui-dark-text overflow-y-auto` plus a padding variant — **no display utility**, so `flex`/`flex-col` are purely additive — and both padding cases keep their `!` prefix, so they still beat the base `p-4` on `!important`. Dropping those prefixes as "no longer needed" would have silently reverted the calendar padding.

Gates: lint, knip, lint:style, typecheck, build, 11186 unit tests, and the calendar e2e spec (12 passed).

## Left alone

`PrioritizedList.vue:105` keeps its two selectors: they target the **header**, `RuiCardClassNames` is `{ root, content, footer, image }` with no `header` key, and `RuiCardHeader`'s root div has no `data-id` either — its `data-id="prepend"`/`data-id="header"` hooks are nested one level further in. Adding `header` to that interface in ui-library would close the last RuiCard case.

For context, the wider survey: 156 arbitrary-variant selectors across 77 files, 57 on Rui components, 18 on a component that exposes `classNames`. Of those, these 7 were the clean mechanical wins. The rest target things `classNames` does not name (`RuiTooltip [&_*]`, `RuiMenuSelect [&_fieldset]`, `RuiChip [&_[class*=prepend]]`) or want case-by-case judgement. `LoginUsernameField.vue:84`'s `[&_[data-id=activator]]` is already doing the right thing — addressing a stable hook rather than a position.
