### PR TITLE
chore(frontend): adopt eslint-config 8.2.0 and clear no-leading-body-comment

### DIFF
--- a/frontend/app/electron/main/app-server.ts
+++ b/frontend/app/electron/main/app-server.ts
@@ -33,8 +33,15 @@ export class AppServer {
     }
   }
 
+  /**
+   * Serves the renderer by proxying to the vite dev server.
+   *
+   * @remarks
+   * `httpxy` is imported dynamically because it is a development-only dependency. A static import
+   * would put it in the production main bundle, where it is dead weight and its absence at install
+   * time would be a build failure rather than a path never taken.
+   */
   private async startDevelopmentProxy(port: number, devServerUrl: string, initialRoute?: string): Promise<void> {
-    // Dynamic so httpxy, a dev-only dependency, stays out of the production main bundle.
     const { createProxyServer } = await import('httpxy');
 
     return new Promise((resolve, reject) => {

--- a/frontend/app/electron/main/application.ts
+++ b/frontend/app/electron/main/application.ts
@@ -87,8 +87,15 @@ export class Application {
     await this.initialize();
   }
 
+  /**
+   * Declares the privileged schemes the renderer is served over.
+   *
+   * @remarks
+   * Must run before `app.whenReady()`. Electron reads the privileged scheme list while it sets up
+   * the network stack, so registering later is silently ignored and `app://` then behaves as an
+   * ordinary scheme, without fetch support or a secure origin.
+   */
   private registerAppProtocols() {
-    // Standard scheme must be registered before the app is ready
     protocol.registerSchemesAsPrivileged([
       {
         scheme: 'app',
@@ -221,15 +228,22 @@ export class Application {
     };
   }
 
+  /**
+   * Wires the application-level Electron events.
+   *
+   * @remarks
+   * A deep link into a running instance arrives by two different routes. Windows and Linux start a
+   * second process and hand its argv to `second-instance`, while macOS delivers the url to the
+   * running process through `open-url`. Both are needed, and each is the only route on its
+   * platform.
+   */
   private setupAppEvents() {
     app.on('second-instance', (_event, commandLine, _workingDirectory) => {
-      // Handle protocol URL when app is already running
       this.handleProtocolUrl(commandLine);
       this.window.focus();
     });
 
     app.on('open-url', (event, url) => {
-      // Handle protocol URL on macOS
       event.preventDefault();
       this.handleProtocolUrl([url]);
     });

--- a/frontend/app/electron/main/ipc-handlers/wallet-bridge-ipc-handlers.ts
+++ b/frontend/app/electron/main/ipc-handlers/wallet-bridge-ipc-handlers.ts
@@ -33,8 +33,16 @@ export class WalletBridgeIpcHandlers {
     });
   }
 
+  /**
+   * Opens the wallet bridge page in the user's browser, starting the servers if they are down.
+   *
+   * @remarks
+   * Both servers are checked before anything is started, because the bridge is reopened as often
+   * as it is opened and restarting a live pair would drop a connected wallet. When they are up but
+   * the client has gone, reopening the url is enough to bring it back; the provider selection is
+   * only reset when a connected client is being handed a fresh page.
+   */
   openWalletConnectBridge = async (): Promise<void> => {
-    // Check if servers are already running
     const httpRunning = this.appServer.isListening();
     const wsRunning = this.walletBridgeWebSocketServer.isListening();
     const wsConnected = this.walletBridgeWebSocketServer.isConnected();

--- a/frontend/app/electron/main/ipc-setup.ts
+++ b/frontend/app/electron/main/ipc-setup.ts
@@ -237,14 +237,14 @@ export class IpcManager {
     this.walletImportHandlers.cleanup();
   }
 
+  /** Tells the renderer the wallet bridge has dropped, so it can show the disconnected state. */
   private readonly handleBridgeDisconnected = (): void => {
-    // Notify the main window that the bridge has been disconnected
     this.logger.info('Bridge disconnected, sending notification to main window');
     this.requireCallbacks.sendIpcMessage(IpcCommands.WALLET_BRIDGE_CONNECTION_STATUS, 'disconnected');
   };
 
+  /** Tells the renderer the wallet bridge is back, so it can clear the disconnected state. */
   private readonly handleBridgeReconnected = (): void => {
-    // Notify the main window that the bridge has been reconnected
     this.logger.info('Bridge reconnected, sending notification to main window');
     this.requireCallbacks.sendIpcMessage(IpcCommands.WALLET_BRIDGE_CONNECTION_STATUS, 'reconnected');
   };

--- a/frontend/app/electron/main/log-manager.ts
+++ b/frontend/app/electron/main/log-manager.ts
@@ -78,6 +78,10 @@ export class LogManager {
 
   /**
    * Compress a file using gzip
+   *
+   * @remarks
+   * The input is removed only once the write stream has finished, so a compression that fails
+   * partway leaves the original log in place rather than losing it to a truncated archive.
    */
   private async compressFile(inputPath: string, outputPath: string): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -89,7 +93,6 @@ export class LogManager {
         .pipe(gzipStream)
         .pipe(writeStream)
         .on('finish', () => {
-          // Remove the original file after a successful compression
           try {
             fs.unlinkSync(inputPath);
             resolve();

--- a/frontend/app/electron/main/oauth-utils.ts
+++ b/frontend/app/electron/main/oauth-utils.ts
@@ -35,8 +35,15 @@ function parseFailureCallback(callbackUrl: URL): OAuthResult | undefined {
   };
 }
 
+/**
+ * Reads an OAuth callback url into a result.
+ *
+ * @remarks
+ * The path is what decides the outcome: `/success` and `/failure` are the two the provider sends.
+ * Anything else, including a url that does not parse, is reported as a failure rather than thrown,
+ * so a malformed callback cannot take down the handler that received it.
+ */
 export function parseToken(oAuthUrl: string): OAuthResult {
-  // Parse the OAuth callback URL
   try {
     const callbackUrl = new URL(oAuthUrl);
 

--- a/frontend/app/electron/main/window-manager.ts
+++ b/frontend/app/electron/main/window-manager.ts
@@ -89,8 +89,11 @@ export class WindowManager {
     this.forceQuit = true;
   };
 
+  /**
+   * Shows the window, rebuilding it when none exists. Reachable only on macOS, where closing the
+   * window leaves the app running and a dock click then arrives with nothing to show.
+   */
   readonly activate = async (): Promise<void> => {
-    // On macOS a dock click re-creates the window when none is open.
     if (this.window === null)
       await this.create();
     else
@@ -118,11 +121,17 @@ export class WindowManager {
     await window.loadURL('app://localhost/index.html');
   }
 
+  /**
+   * Loads the task-tracker devtools extension, when it is checked out.
+   *
+   * @remarks
+   * In development `import.meta.dirname` is the `dist/` the main process was built into, three
+   * levels below the root the extension sits in. A missing directory is not an error: the
+   * extension is a convenience, not a dependency.
+   */
   private async loadDevExtensions(window: BrowserWindow): Promise<void> {
-    // In dev `import.meta.dirname` is dist/, from which the extension is three levels up.
     const extensionPath = path.resolve(import.meta.dirname, '..', '..', '..', 'tools', 'chrome-task-tracker');
 
-    // Check if the extension directory exists
     if (!fs.existsSync(extensionPath)) {
       this.logger.debug(`Task tracker extension not found at: ${extensionPath}`);
       return;
@@ -211,13 +220,11 @@ export class WindowManager {
   }
 
   cleanup() {
-    // Remove startup error IPC handlers
     ipcMain.removeAllListeners(IpcCommands.SYNC_GET_STARTUP_ERROR);
     ipcMain.removeAllListeners(IpcCommands.RENDERER_READY);
-    // Reset startup error state
+
     this.startupError = null;
     this.rendererReady = false;
-    // Clean up window listeners
     this.window?.removeAllListeners('show');
     this.window?.removeAllListeners('hide');
     this.window?.removeAllListeners('close');
@@ -249,12 +256,10 @@ export class WindowManager {
    * - RENDERER_READY: Signal from renderer that it's ready to receive async messages
    */
   private setupStartupErrorHandlers(): void {
-    // Sync handler - renderer fetches on init to get any error that occurred before ready
     ipcMain.on(IpcCommands.SYNC_GET_STARTUP_ERROR, (event) => {
       event.returnValue = this.startupError;
     });
 
-    // Ready signal handler - renderer is now listening for async messages
     ipcMain.on(IpcCommands.RENDERER_READY, () => {
       this.onRendererReady();
     });

--- a/frontend/app/electron/main/ws.ts
+++ b/frontend/app/electron/main/ws.ts
@@ -190,7 +190,6 @@ export class WalletBridgeWebSocketServer {
 
   /** Send a notification to the wallet bridge */
   public sendNotification(message: WalletBridgeNotification): void {
-    // Get the active connection
     const connection = this.connectionManager.getActiveConnection();
 
     if (!connection) {
@@ -221,10 +220,8 @@ export class WalletBridgeWebSocketServer {
 
   /** Tear down connection state, leaving the server itself alone */
   private teardown(): void {
-    // Clear idle timer
     this.clearIdleTimer();
 
-    // Close active connection if it exists
     const activeConnection = this.connectionManager.getActiveConnection();
     if (activeConnection) {
       activeConnection.close();

--- a/frontend/app/electron/preload/index.ts
+++ b/frontend/app/electron/preload/index.ts
@@ -24,8 +24,15 @@ contextBridge.exposeInMainWorld('interop', {
   closeApp: async () => ipcRenderer.invoke(IpcCommands.INVOKE_CLOSE_APP),
   openDirectory: async (title: string) => ipcRenderer.invoke(IpcCommands.INVOKE_OPEN_DIRECTORY, title),
   premiumUserLoggedIn: (premiumUser: boolean) => ipcRenderer.send(IpcCommands.PREMIUM_LOGIN, premiumUser),
+  /**
+   * Subscribes the renderer's callbacks to the messages the main process pushes.
+   *
+   * @remarks
+   * A startup error raised before this ran is not delivered here. The renderer fetches that one
+   * synchronously on init instead, which is why the main process keeps it rather than only
+   * emitting it.
+   */
   setListeners(listeners: Listeners): void {
-    // Listen for startup errors pushed after renderer is ready
     ipcRenderer.on(IpcCommands.STARTUP_ERROR, (_event, error: StartupError) => {
       listeners.onError(error.message, error.code);
     });

--- a/frontend/app/playwright.config.ts
+++ b/frontend/app/playwright.config.ts
@@ -129,9 +129,12 @@ ensureDirectories();
 /**
  * Detect system Chromium installation for Arch Linux and other systems.
  * Returns the path to chromium if found, undefined otherwise (uses bundled Chromium).
+ *
+ * @remarks
+ * `which chromium` is tried first, since it finds the binary on most Linux distributions without
+ * assuming where the package put it, and the known paths below are only the fallback.
  */
 function detectSystemChromium(): string | undefined {
-  // Try 'which chromium' first (works on most Linux distros including Arch)
   try {
     const chromiumPath = execSync('which chromium', { encoding: 'utf-8' }).trim();
     if (chromiumPath && fs.existsSync(chromiumPath)) {

--- a/frontend/app/scripts/audit-comments.ts
+++ b/frontend/app/scripts/audit-comments.ts
@@ -133,9 +133,15 @@ function nextCode(lines: string[], from: number): string {
   return '';
 }
 
-/** Classes a `//` line can fall into once the content rules have all missed. */
+/**
+ * Classes a `//` line can fall into once the content rules have all missed.
+ *
+ * @remarks
+ * A line following another `//` yields no class of its own. It is a continuation, so the run it
+ * belongs to is what gets judged, and classing it separately would count one comment several
+ * times.
+ */
 function classifyLineComment(lines: string[], index: number, text: string): string | undefined {
-  // A continuation line is judged by the run it belongs to, not on its own.
   if (lines[index - 1]?.trim().startsWith('//'))
     return undefined;
 

--- a/frontend/app/scripts/check-bundle.ts
+++ b/frontend/app/scripts/check-bundle.ts
@@ -90,9 +90,14 @@ function collectBundle(result: unknown): Bundle {
   return { chunks, html };
 }
 
-/** A package lands in a chunk other than the one the shared rules assign it. */
+/**
+ * A package lands in a chunk other than the one the shared rules assign it.
+ *
+ * @remarks
+ * Violations are keyed by `"<package> -> <actual>"`, so a package split across chunks is reported
+ * once per chunk it wrongly reached rather than once per module inside it.
+ */
 function checkOwnership(chunks: Chunk[]): string[] {
-  // Keyed by "<package> -> <actual>", so a split package reports per chunk, not per module.
   const violations = new Set<string>();
 
   for (const chunk of chunks) {

--- a/frontend/app/scripts/get-protocols.ts
+++ b/frontend/app/scripts/get-protocols.ts
@@ -172,13 +172,17 @@ async function isBackendRunning(): Promise<boolean> {
   }
 }
 
-/** Starts the backend with minimal parameters. */
+/**
+ * Starts the backend with minimal parameters.
+ *
+ * @remarks
+ * Runs against a throwaway data and log directory under the temporary user folder, so the script
+ * never touches a real rotki installation.
+ */
 async function startBackend(): Promise<void> {
-  // Create a folder in /tmp with the username
   const dataDir = path.join(userDir, 'data');
   const logsDir = path.join(userDir, 'logs');
 
-  // Create directories if they don't exist
   if (!fs.existsSync(userDir)) {
     fs.mkdirSync(userDir, { recursive: true });
   }
@@ -306,6 +310,55 @@ function getBlockchains(chains: Chain[]) {
     }));
 }
 
+/**
+ * The single identifier that stands for a group of related protocols.
+ *
+ * @remarks
+ * The unversioned identifier wins when the group contains it, then any variant that is not a
+ * `-v<n>`. Only when the group is versions all the way down does the base name stand in, as a
+ * synthetic entry that has no counterparty of its own.
+ */
+function representativeFor(baseProtocol: string, items: string[]): string {
+  if (items.includes(baseProtocol))
+    return baseProtocol;
+
+  const nonVersionedVariant = items.find(item =>
+    item.startsWith(baseProtocol)
+    && !new RegExp(`^${baseProtocol}-v\\d+$`).test(item),
+  );
+
+  return nonVersionedVariant ?? baseProtocol;
+}
+
+/**
+ * The image and label to publish for one selected protocol.
+ *
+ * @remarks
+ * A synthetic base name matches no counterparty, so its image is borrowed from its first versioned
+ * variant and its label built from the name itself. Every other identifier is looked up directly.
+ */
+function toProtocolEntry(item: string, counterparties: Counterparty[], known: string[]): { image: string; label: string } {
+  if (!known.includes(item)) {
+    const versionedVariant = known.find(protocol => protocol.startsWith(`${item}-v`));
+
+    if (versionedVariant) {
+      const variantData = counterparties.find(counterparty => counterparty.identifier === versionedVariant);
+      assert(variantData);
+      return {
+        image: `${imageUrl}${variantData.image}`,
+        label: toHumanReadable(item, 'sentence'),
+      };
+    }
+  }
+
+  const data = counterparties.find(counterparty => counterparty.identifier === item);
+  assert(data);
+  return {
+    image: `${imageUrl}${data.image}`,
+    label: toHumanReadable(data.label, 'sentence'),
+  };
+}
+
 function getCounterparties(counterparties: Counterparty[]) {
   const identifiers = counterparties.map((item: Counterparty) => item.identifier);
   const filteredCounterparties = identifiers
@@ -323,57 +376,10 @@ function getCounterparties(counterparties: Counterparty[]) {
     return groups;
   }, {});
 
-  const selectedProtocols: string[] = [];
+  const selectedProtocols = Object.entries(protocolGroups)
+    .map(([baseProtocol, items]) => representativeFor(baseProtocol, items));
 
-  // Process each group based on rules
-  Object.entries(protocolGroups).forEach(([baseProtocol, items]) => {
-    // Check if the base protocol exists by itself
-    if (items.includes(baseProtocol)) {
-      selectedProtocols.push(baseProtocol);
-      return;
-    }
-
-    // Check if there's another protocol that starts with the base name but isn't versioned
-    const nonVersionedVariant = items.find(item =>
-      item.startsWith(baseProtocol)
-      && !new RegExp(`^${baseProtocol}-v\\d+$`).test(item),
-    );
-
-    if (nonVersionedVariant) {
-      selectedProtocols.push(nonVersionedVariant);
-      return;
-    }
-
-    // With only versioned variants, the synthetic base stands in, carrying the first's data.
-    selectedProtocols.push(baseProtocol);
-  });
-
-  return selectedProtocols.map((item) => {
-    // For synthetic base protocols that don't exist in counterparties
-    if (!filteredCounterparties.includes(item)) {
-      // Find the first versioned variant to get its image
-      const versionedVariant = filteredCounterparties.find(protocol =>
-        protocol.startsWith(`${item}-v`),
-      );
-
-      if (versionedVariant) {
-        const variantData = counterparties.find(counterparty => counterparty.identifier === versionedVariant);
-        assert(variantData);
-        return {
-          image: `${imageUrl}${variantData.image}`,
-          label: toHumanReadable(item, 'sentence'),
-        };
-      }
-    }
-
-    // Normal case - protocol exists in counterparties
-    const data = counterparties.find(counterparty => counterparty.identifier === item);
-    assert(data);
-    return {
-      image: `${imageUrl}${data.image}`,
-      label: toHumanReadable(data.label, 'sentence'),
-    };
-  });
+  return selectedProtocols.map(item => toProtocolEntry(item, counterparties, filteredCounterparties));
 }
 
 /**

--- a/frontend/app/scripts/serve.ts
+++ b/frontend/app/scripts/serve.ts
@@ -41,9 +41,12 @@ let childProcesses: ChildProcessWithoutNullStreams[] = [];
 
 /**
  * Start or restart App when source files are changed
+ *
+ * @remarks
+ * The dev server's url is assembled here and exported as `VITE_DEV_SERVER_URL`, which is how the
+ * spawned main process learns where to load the renderer from.
  */
 async function setupMainPackageWatcher({ config: { server } }: ViteDevServer, mode: string, remoteDebuggingPort?: number): Promise<BuildOutput> {
-  // Create VITE_DEV_SERVER_URL environment variable to pass it to the main process.
   const protocol = server.https ? 'https:' : 'http:';
   const host = server.host ?? 'localhost';
   const port = server.port; // Vite searches for and occupies the first free port: 3000, 3001, 3002, and so on

--- a/frontend/app/shared/starling/starling-launch.spec.ts
+++ b/frontend/app/shared/starling/starling-launch.spec.ts
@@ -227,12 +227,7 @@ describe('stopStarling', () => {
     expect(child.kill).not.toHaveBeenCalled();
   });
 
-  it('should give the supervisor its exit margin once the stop grace elapses', async () => {
-    /*
-     * The regression this helper exists for: the dev launcher raced `stop` against the grace and
-     * killed as soon as that race resolved, so a starling still reaping core and colibri got
-     * SIGKILLed mid-teardown and orphaned both.
-     */
+  it('should wait the exit margin after the stop grace, rather than killing a supervisor still reaping core and colibri', async () => {
     vi.spyOn(rpc, 'request').mockReturnValue(new Promise<never>(() => {}));
     const starling = launch();
 

--- a/frontend/app/src/modules/accounts/blockchain/address-entries.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/address-entries.spec.ts
@@ -75,8 +75,7 @@ describe('modules/accounts/blockchain/address-entries', () => {
       expect(messagesFor({ address: '', userAddresses: ADDRESS }, true)).toEqual([]);
     });
 
-    it('should ignore the field that is not on screen', () => {
-      // Only one of the two is ever shown, so an empty other field is not something to report.
+    it('should ignore the field that is not on screen, only one of the two ever being shown', () => {
       expect(messagesFor({ address: ADDRESS, userAddresses: '' }, false)).toEqual([]);
       expect(messagesFor({ address: '', userAddresses: ADDRESS }, true)).toEqual([]);
     });

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetForm.vue
@@ -102,11 +102,20 @@ watchImmediate(modelValue, (asset: SupportedAsset) => {
   }
 });
 
-onMounted(() => {
-  // An opened edit dialog seeds the address it already has, which must not read as a fresh one.
+/**
+ * Stops the address the form opens with from triggering a lookup.
+ *
+ * @remarks
+ * Only in edit mode, where the field is seeded from the asset being edited. That write looks the
+ * same to the watcher as one the user made, and acting on it would overwrite the very fields the
+ * dialog was opened to show.
+ */
+function suppressLookupForSeededAddress(): void {
   if (editMode)
     suppressNextLookup();
-});
+}
+
+onMounted(suppressLookupForSeededAddress);
 
 defineExpose({
   saveAsset,

--- a/frontend/app/src/modules/assets/api/use-asset-ignore-api.spec.ts
+++ b/frontend/app/src/modules/assets/api/use-asset-ignore-api.spec.ts
@@ -12,8 +12,7 @@ describe('useAssetIgnoreApi', () => {
   });
 
   describe('getIgnoredAssets', () => {
-    it('should send GET request to colibri and returns asset list', async () => {
-      // Note: getIgnoredAssets targets colibri, so the URL is without /api/1
+    it('should send GET request to colibri, whose url carries no /api/1 prefix, and return the asset list', async () => {
       server.use(
         http.get(`${colibriUrl}/assets/ignored`, () =>
           HttpResponse.json({

--- a/frontend/app/src/modules/assets/prices/use-fetch-prices.spec.ts
+++ b/frontend/app/src/modules/assets/prices/use-fetch-prices.spec.ts
@@ -193,8 +193,7 @@ describe('assetSetDigest', () => {
     expect(assetSetDigest(['DAI'])).not.toBe(assetSetDigest(['DAI', 'ETH']));
   });
 
-  it('should not collide on a shifted separator', () => {
-    // Without folding the separator, ['ab','c'] and ['a','bc'] hash the same byte stream.
+  it('should not collide on a shifted separator, an unfolded one making [ab, c] and [a, bc] the same byte stream', () => {
     expect(assetSetDigest(['ab', 'c'])).not.toBe(assetSetDigest(['a', 'bc']));
   });
 });

--- a/frontend/app/src/modules/auth/use-users-api.spec.ts
+++ b/frontend/app/src/modules/auth/use-users-api.spec.ts
@@ -468,8 +468,7 @@ describe('composables/api/session/users', () => {
       expect(coreCalled).toBe(false);
     });
 
-    it('should return true when logout returns 409 conflict', async () => {
-      // Note: colibri logout uses baseURL override, so no /api/1 prefix
+    it('should return true when colibri logout, whose baseURL override drops the /api/1 prefix, returns 409 conflict', async () => {
       server.use(
         http.post(`${colibriUrl}/user/logout`, () =>
           HttpResponse.json({

--- a/frontend/app/src/modules/balances/balance-grouping.ts
+++ b/frontend/app/src/modules/balances/balance-grouping.ts
@@ -22,7 +22,6 @@ export function getSortedProtocolBalances(protocolBalances: ProtocolBalancesWith
   return Object.entries(protocolBalances)
     .filter(([, balance]) => balance.amount.gt(0))
     .map(([protocol, balance]) => {
-      // Use conditional logic to determine the correct type without casting
       if (protocol === 'address' && balance.chains) {
         const result: ProtocolBalanceWithChains = {
           protocol,

--- a/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.spec.ts
@@ -380,7 +380,6 @@ describe('useBlockchainBalances', () => {
     it('should not query after being cancelled during detection', async () => {
       let stageCancelled = false;
       detectForChain.mockImplementation(async () => {
-        // The cancel lands while detection is in flight, exactly as a user click would.
         stageCancelled = true;
       });
       submitTask.mockImplementation(async (spec: SubmittedSpec) =>

--- a/frontend/app/src/modules/balances/use-blockchain-balances.ts
+++ b/frontend/app/src/modules/balances/use-blockchain-balances.ts
@@ -148,7 +148,6 @@ export function useBlockchainBalances(): UseBlockchainBalancesReturn {
         priority: mode === RefreshMode.USER ? Priority.USER : DEFAULT_PRIORITY,
         rerunnable: true,
         run: async ({ cancelled, runTask }): Promise<Result<void, TaskError>> => {
-          // A dropped refresh settles SKIPPED, never `ok`.
           if (mode === RefreshMode.PERIODIC && isChainRefreshing(chain))
             return err(Skipped({ message: t('actions.balances.blockchain.skipped.busy') }));
 

--- a/frontend/app/src/modules/core/api/request-transformers.ts
+++ b/frontend/app/src/modules/core/api/request-transformers.ts
@@ -26,12 +26,16 @@ export interface TransformOptions {
 
 /**
  * Transforms request body: filters empty properties and converts to snake_case.
+ *
+ * @remarks
+ * Only a plain payload object is transformed. Every other `BodyInit`, a `FormData` or a `Blob`
+ * among them, is passed through untouched, since neither filtering nor key renaming means
+ * anything for it.
  */
 export function transformRequestBody(
   body: BodyInit | Record<string, unknown> | null | undefined,
   options: TransformOptions,
 ): BodyInit | Record<string, unknown> | null | undefined {
-  // Only a plain payload object is transformed; every other BodyInit is sent through untouched.
   if (!isPlainBody(body))
     return body;
 

--- a/frontend/app/src/modules/core/common/file/file.ts
+++ b/frontend/app/src/modules/core/common/file/file.ts
@@ -5,11 +5,15 @@ export function getFilepath(db: UserDbBackup, directory: string): string {
   return `${directory}${file}`;
 }
 
+/**
+ * The last segment of a path, whichever separator it uses.
+ *
+ * @remarks
+ * The paths reaching here are built by the backend, so on Windows they arrive with backslashes.
+ * Normalising to forward slashes first means one search finds the last separator of either kind.
+ */
 export function getFilename(fullPath: string): string {
-  // Replace all backslashes with forward slashes.
   const normalizedPath = fullPath.replace(/\\/g, '/');
-
-  // Return the substring after the last forward slash.
   return normalizedPath.substring(normalizedPath.lastIndexOf('/') + 1);
 }
 

--- a/frontend/app/src/modules/core/common/helpers/e2e.ts
+++ b/frontend/app/src/modules/core/common/helpers/e2e.ts
@@ -38,12 +38,17 @@ export function attemptPolyfillResizeObserver(): void {
       this.observer.disconnect();
     }
 
+    /**
+     * Queues one pending call per callback, flushed together on the next frame.
+     *
+     * @remarks
+     * Replacing this callback's queue entry rather than appending is what enforces the batch: only
+     * the latest entries for a given callback survive to the flush, so a burst of resizes cannot
+     * re-enter the observer and raise the loop-limit error this polyfill exists to avoid.
+     */
     check(entries: ResizeObserverEntry[]): void {
-      // remove previous invocations of "self"
       queue = queue.filter(x => x.cb !== this.callback);
-      // put a new one
       queue.push({ args: entries, cb: this.callback });
-      // trigger update
       queueFlushTimeout ??= requestAnimationFrame(() => {
         queueFlushTimeout = undefined;
         const q = queue;

--- a/frontend/app/src/modules/core/common/use-item-cache.ts
+++ b/frontend/app/src/modules/core/common/use-item-cache.ts
@@ -282,9 +282,12 @@ export function createItemCache<T>(
   /**
    * Ensures the given key is queued for fetching if it's not already cached or pending.
    * Refreshes the cache expiry for entries that haven't expired yet.
+   *
+   * @remarks
+   * Everything read here is a plain record or Set rather than a reactive source, so `resolve`
+   * subscribes to a key only through `track` and not incidentally through this bookkeeping.
    */
   const ensureQueued = (key: string): void => {
-    // Non-reactive reads (plain record / Set) so `resolve` only depends via `track`.
     const cached = values[key];
     const now = Date.now();
     let valid = false;
@@ -313,8 +316,14 @@ export function createItemCache<T>(
     return values[key] ?? null;
   };
 
+  /**
+   * Requeues a key and restarts its expiry.
+   *
+   * @remarks
+   * Deleted before being set so the entry moves to the end of `recent`, keeping it ordered by
+   * ascending expiry. The eviction sweep relies on that order to stop at the first live entry.
+   */
   const refresh = (key: string): void => {
-    // delete-before-set preserves the expiry-ascending order the eviction sweep relies on.
     recent.delete(key);
     recent.set(key, Date.now() + expiry);
     if (unknown.has(key))
@@ -342,8 +351,14 @@ export function createItemCache<T>(
 
   const size = (): number => recent.size;
 
+  /**
+   * Empties the cache and every piece of bookkeeping around it.
+   *
+   * @remarks
+   * `values` is emptied key by key rather than reassigned, so the record keeps its identity and
+   * the callers already holding it keep reading the live one.
+   */
   const reset = (): void => {
-    // Clear the record in place so `values` keeps its identity, then wipe the rest.
     for (const key of Object.keys(values)) delete values[key];
     triggerRef(cache);
     pendingKeys.clear();

--- a/frontend/app/src/modules/core/common/use-ref-debounce.ts
+++ b/frontend/app/src/modules/core/common/use-ref-debounce.ts
@@ -5,12 +5,15 @@ import type { ComputedRef, MaybeRefOrGetter } from 'vue';
  * Useful for maintaining state during brief interruptions (e.g., menu staying open
  * when moving between elements).
  *
+ * @remarks
+ * The source is normalized to a ref once because `refDebounced` accepts nothing else, and the
+ * same ref is then both watched and or-ed with its debounced copy.
+ *
  * @param sourceRef - The source value, ref, or getter to watch
  * @param delay - How long to keep the value true after source becomes false (in ms)
  * @returns A computed ref that stays true during the debounce period
  */
 export function useRefWithDebounce(sourceRef: MaybeRefOrGetter<boolean>, delay: number = 200): ComputedRef<boolean> {
-  // refDebounced only accepts a Ref, so normalize the input once.
   const source = toRef(sourceRef);
   const debouncedRef = refDebounced(source, delay);
   return logicOr(source, debouncedRef);

--- a/frontend/app/src/modules/core/messaging/handler-registry.ts
+++ b/frontend/app/src/modules/core/messaging/handler-registry.ts
@@ -3,6 +3,15 @@ import { createBusinessRegistry } from './registries/business-registry';
 import { createNotificationRegistry } from './registries/notification-registry';
 import { createStatusRegistry } from './registries/status-registry';
 
+/**
+ * Builds the handler for every socket message type.
+ *
+ * @remarks
+ * Call this from a setup context. Every `create*Handler` below it resolves its stores and
+ * composables while it is being built, then closes over them, so the handlers themselves can run
+ * later from a socket callback where no active component instance exists. Building the registry
+ * outside setup fails at that resolution instead, before any message arrives.
+ */
 export function createHandlerRegistry(
   t: ReturnType<typeof useI18n>['t'],
   router: ReturnType<typeof useRouter>,

--- a/frontend/app/src/modules/core/messaging/handlers/calendar-reminder.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/calendar-reminder.ts
@@ -10,7 +10,6 @@ import { createNotificationHandler } from '@/modules/core/messaging/utils';
 import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
 
 export function createCalendarReminderHandler(t: ReturnType<typeof useI18n>['t'], router: ReturnType<typeof useRouter>): NotificationHandler<CalendarEventWithReminder> {
-  // Capture all functions and stores at handler creation time (in setup context)
   const { getChainName } = useSupportedChains();
   const { getAddressName } = useAddressNameResolution();
   const { removeMatching } = useNotificationsStore();

--- a/frontend/app/src/modules/core/messaging/handlers/database-migration.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/database-migration.ts
@@ -3,7 +3,6 @@ import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { createStateHandler } from '@/modules/core/messaging/utils';
 
 export function createDbUpgradeHandler(): StateHandler {
-  // Capture store methods at handler creation time (in setup context)
   const { updateDbUpgradeStatus } = useSessionAuthStore();
 
   return createStateHandler((data) => {
@@ -12,7 +11,6 @@ export function createDbUpgradeHandler(): StateHandler {
 }
 
 export function createDataMigrationHandler(): StateHandler {
-  // Capture store methods at handler creation time (in setup context)
   const { updateDataMigrationStatus } = useSessionAuthStore();
 
   return createStateHandler((data) => {

--- a/frontend/app/src/modules/core/messaging/handlers/database-upload.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/database-upload.ts
@@ -4,7 +4,6 @@ import { createStateHandler } from '@/modules/core/messaging/utils';
 import { useSync } from '@/modules/session/use-session-sync';
 
 export function createDbUploadResultHandler(): StateHandler<DbUploadResult> {
-  // Capture refs at handler creation time (in setup context)
   const { uploadProgress, uploadStatus, uploadStatusAlreadyHandled } = useSync();
 
   return createStateHandler<DbUploadResult>((data) => {
@@ -25,7 +24,6 @@ export function createDbUploadResultHandler(): StateHandler<DbUploadResult> {
 }
 
 export function createDbUploadProgressHandler(): StateHandler<DatabaseUploadProgress> {
-  // Capture ref at handler creation time (in setup context)
   const { uploadProgress } = useSync();
 
   return createStateHandler<DatabaseUploadProgress>((data) => {

--- a/frontend/app/src/modules/core/messaging/handlers/evm-accounts.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/evm-accounts.ts
@@ -3,7 +3,6 @@ import { useAccountMigration } from '@/modules/accounts/use-account-migration';
 import { createStateHandler } from '@/modules/core/messaging/utils';
 
 export function createEvmAccountsHandler(): StateHandler {
-  // Capture composable method at handler creation time (in setup context)
   const { setUpgradedAddresses } = useAccountMigration();
 
   return createStateHandler((data) => {

--- a/frontend/app/src/modules/core/messaging/handlers/missing-api-key.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/missing-api-key.ts
@@ -17,7 +17,6 @@ function isSuppressibleService(service: string): service is SuppressibleMissingK
 }
 
 export function createMissingApiKeyHandler(t: ReturnType<typeof useI18n>['t'], router: ReturnType<typeof useRouter>): NotificationHandler<MissingApiKey> {
-  // Capture interop functions at handler creation time (in setup context)
   const { openUrl } = useInterop();
   const { update } = useSettingsOperations();
   const suppressMissingKeyMsgServices = useSetting('suppressMissingKeyMsgServices');

--- a/frontend/app/src/modules/core/messaging/handlers/monerium-session.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/monerium-session.ts
@@ -4,6 +4,14 @@ import { NotificationCategory, NotificationGroup, Severity } from '@rotki/common
 import { createNotificationHandler } from '@/modules/core/messaging/utils';
 import { useMoneriumOAuth } from '@/modules/integrations/monerium/use-monerium-auth';
 
+/**
+ * Notifies the user that the Monerium session expired and offers to reauthenticate.
+ *
+ * @remarks
+ * The status is set to unauthenticated before the refresh rather than left to it. The backend may
+ * already have dropped the credentials (`invalid_grant`), and the refresh is a round trip, so
+ * without the local write the UI would keep claiming a live session for its duration.
+ */
 export function createMoneriumSessionHandler(
   t: ReturnType<typeof useI18n>['t'],
   router: ReturnType<typeof useRouter>,
@@ -11,7 +19,6 @@ export function createMoneriumSessionHandler(
   const { refreshStatus, setStatus } = useMoneriumOAuth();
 
   return createNotificationHandler<MoneriumSessionKeyExpiredData>(async (data) => {
-    // Backend may have cleared credentials (invalid_grant); update UI state immediately.
     setStatus({ authenticated: false });
     await refreshStatus();
 

--- a/frontend/app/src/modules/core/messaging/handlers/premium-status.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/premium-status.ts
@@ -5,7 +5,6 @@ import { createStateWithNotificationHandler } from '@/modules/core/messaging/uti
 import { usePremium } from '@/modules/premium/use-premium';
 
 export function createPremiumStatusHandler(t: ReturnType<typeof useI18n>['t']): MessageHandler<PremiumStatusUpdateData> {
-  // Capture premium ref at handler creation time (in setup context)
   const premium = usePremium();
 
   return createStateWithNotificationHandler<PremiumStatusUpdateData, boolean>(

--- a/frontend/app/src/modules/core/messaging/handlers/refresh-balances.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/refresh-balances.ts
@@ -3,7 +3,6 @@ import { useBlockchainBalances } from '@/modules/balances/use-blockchain-balance
 import { createStateHandler } from '@/modules/core/messaging/utils';
 
 export function createRefreshBalancesHandler(): StateHandler {
-  // Capture functions at handler creation time (in setup context)
   const { refreshBlockchainBalances } = useBlockchainBalances();
 
   return createStateHandler(async (data) => {

--- a/frontend/app/src/modules/core/messaging/text-utils.spec.ts
+++ b/frontend/app/src/modules/core/messaging/text-utils.spec.ts
@@ -151,8 +151,7 @@ describe('text-utils', () => {
     expect(isValidBchAddress('bitcoin:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a')).toBe(false); // Wrong prefix
   });
 
-  it('should validate Solana addresses', () => {
-    // Valid Solana addresses (base58 encoded, 32-44 characters)
+  it('should accept only base58 Solana addresses of 32 to 44 characters', () => {
     expect(isValidSolanaAddress('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK')).toBe(true);
     expect(isValidSolanaAddress('DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK')).toBe(true);
     expect(isValidSolanaAddress('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')).toBe(true);
@@ -207,8 +206,7 @@ describe('text-utils', () => {
     expect(isValidSs58Address(undefined)).toBe(false);
   });
 
-  it('should validate EVM transaction hashes', () => {
-    // Valid EVM tx hashes (0x followed by 64 hex characters)
+  it('should accept only EVM transaction hashes of 0x plus 64 hex characters', () => {
     expect(isValidEvmTxHash('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')).toBe(true);
     expect(isValidEvmTxHash('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef')).toBe(true);
     expect(isValidEvmTxHash('0xABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890')).toBe(true);
@@ -221,8 +219,7 @@ describe('text-utils', () => {
     expect(isValidEvmTxHash('0x5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060G')).toBe(false); // Invalid hex
   });
 
-  it('should validate Bitcoin transaction hashes', () => {
-    // Valid BTC tx hashes (64 hex characters, no 0x prefix)
+  it('should accept only Bitcoin transaction hashes of 64 hex characters with no 0x prefix', () => {
     expect(isValidBtcTxHash('5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060')).toBe(true);
     expect(isValidBtcTxHash('1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef')).toBe(true);
     expect(isValidBtcTxHash('ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890')).toBe(true);
@@ -234,8 +231,7 @@ describe('text-utils', () => {
     expect(isValidBtcTxHash('5c504ed432cb51138bcf09aa5e8a410dd4a1e204ef84bfed1be16dfba1b22060G')).toBe(false); // Invalid hex
   });
 
-  it('should validate Solana signatures', () => {
-    // Valid Solana signatures (base58, 87-88 characters, decodes to 64 bytes)
+  it('should accept only base58 Solana signatures of 87 to 88 characters decoding to 64 bytes', () => {
     expect(isValidSolanaSignature('5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW')).toBe(true);
     expect(isValidSolanaSignature('3nGJm9dqGhfyJzkLhL7KMQqGGQqyL5aLqWJNF8JvqSDqWqCRAkVVdDhTZmTHJHVQtDk3LLwYvBSVCH9Tg4CKnWqA')).toBe(true);
 
@@ -300,8 +296,7 @@ describe('text-utils', () => {
   });
 
   it('should decode HTML entities', () => {
-    // Numeric rather than `&bull;`: happy-dom decodes only the basic named entities.
-    expect(decodeHtmlEntities('&#8226;')).toBe('\u2022');
+    expect(decodeHtmlEntities('&#8226;')).toBe('\u2022'); // Numeric, since happy-dom decodes only the basic named entities
     expect(decodeHtmlEntities('&lt;div&gt;')).toBe('<div>');
     expect(decodeHtmlEntities('&amp;')).toBe('&');
     expect(decodeHtmlEntities('&quot;')).toBe('"');

--- a/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
+++ b/frontend/app/src/modules/core/notifications/PendingTaskNode.spec.ts
@@ -88,8 +88,7 @@ describe('pendingTaskNode', () => {
     expect(wrapper.text()).toContain('0xbb');
   });
 
-  it('should show a parent its subtree tally in leaves', () => {
-    // One of the two accounts is done: the job is 1 of 2, not 1 of 3 activities.
+  it('should tally a parent over its leaves, not over every activity in the subtree', () => {
     expect(createWrapper().text()).toContain('pending_task.steps::1, 2');
   });
 

--- a/frontend/app/src/modules/core/sigil/use-sigil-queue.ts
+++ b/frontend/app/src/modules/core/sigil/use-sigil-queue.ts
@@ -194,8 +194,14 @@ function handleVisibilityChange(): void {
   }
 }
 
+/**
+ * Starts the periodic flush and drains whatever a previous session left behind.
+ *
+ * @remarks
+ * Any existing timer is cleared first. This is module-level state, so a second call would
+ * otherwise overwrite the handle and leak the interval it was the only reference to.
+ */
 function startQueue(): void {
-  // Guard against double-invocation leaking the previous interval.
   if (flushTimer)
     clearInterval(flushTimer);
 

--- a/frontend/app/src/modules/core/table/pill/core/codec.ts
+++ b/frontend/app/src/modules/core/table/pill/core/codec.ts
@@ -102,6 +102,13 @@ function writeEnumLike(field: FieldDef, target: SerializedState, filter: ActiveF
   writeTarget(field, target, field.multiple ? values : values[0]);
 }
 
+/**
+ * Whether any of the given bounds holds a value.
+ *
+ * @remarks
+ * An empty string counts as absent, not as a value. A bound the user typed into and then cleared
+ * holds one, and it should read the same as a bound never touched.
+ */
 function anyFilled(...values: (string | undefined)[]): boolean {
   return values.some(value => value !== undefined && value.length > 0);
 }
@@ -115,7 +122,6 @@ function anyFilled(...values: (string | undefined)[]): boolean {
  * the serializer already means by it.
  */
 export function hasWritableValue(field: FieldDef, filter: ActiveFilter): boolean {
-  // An empty string is as absent as a missing one: a bound the user cleared holds one.
   const { date = {}, range = {}, values } = filter;
 
   switch (field.valueType) {

--- a/frontend/app/src/modules/core/table/use-table-reducer.ts
+++ b/frontend/app/src/modules/core/table/use-table-reducer.ts
@@ -178,12 +178,14 @@ function reduceParamChanged<TFilter, TItem extends NonNullable<unknown>>(
  * @remarks
  * A navigation is authoritative: it *sets* the intent to `route` or `restore` rather than raising
  * it, which is the one path that can lower a stale `user` intent left behind by an earlier change.
+ *
+ * A `self` event is the echo of a write this reducer already made, so it is dropped rather than
+ * re-applied.
  */
 function reduceRouteApplied<TFilter, TItem extends NonNullable<unknown>>(
   state: TableState<TFilter, TItem>,
   event: Extract<TableEvent<TFilter, TItem>, { type: 'route-applied' }>,
 ): ReduceResult<TFilter, TItem> {
-  // The echo of our own write: skip re-applying state we already hold.
   if (event.source === 'self')
     return { effects: [], state };
 

--- a/frontend/app/src/modules/core/tasks/use-task-handler.spec.ts
+++ b/frontend/app/src/modules/core/tasks/use-task-handler.spec.ts
@@ -252,8 +252,7 @@ describe('useTaskHandler', () => {
       expect(mockCancelAsyncTask).not.toHaveBeenCalled();
     });
 
-    it('should ignore a task the store knows but nothing is awaiting', async () => {
-      // Only `runTask` registers a handler, so a store entry on its own is not cancellable.
+    it('should refuse to cancel a store entry added without runTask, which registers no handler', async () => {
       store.addTask(60, 'Test task');
 
       const deleted = await handler.cancelTaskById(60);

--- a/frontend/app/src/modules/dashboard/graph/net-value-stats.ts
+++ b/frontend/app/src/modules/dashboard/graph/net-value-stats.ts
@@ -13,8 +13,14 @@ export interface NetValueDeltaResult {
   balanceDelta: BigNumber;
 }
 
+/**
+ * The first value in the range that is not zero, or the range's first value if all are.
+ *
+ * @remarks
+ * Leading zeros are skipped because a portfolio reports zero for every point before its first
+ * snapshot. Measuring a delta from one of those would report the whole balance as growth.
+ */
 function firstNonZero(data: BigNumber[], from: number, to: number): BigNumber {
-  // Skip leading zeros — a fresh portfolio reports zero before its first snapshot.
   let start = data[from];
   if (!start)
     return Zero;

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.spec.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.spec.ts
@@ -60,8 +60,7 @@ describe('resolveZoomRange', () => {
     });
   });
 
-  it('should map percentage range against the times window when axis values are absent', () => {
-    // 25%..75% of [1000, 5000] -> [2000, 4000]
+  it('should map percentage range against the times window when axis values are absent, so 25%..75% of [1000, 5000] is [2000, 4000]', () => {
     expect(resolveZoomRange({ end: 75, start: 25 }, times)).toEqual({ end: 4000, start: 2000 });
   });
 

--- a/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.ts
+++ b/frontend/app/src/modules/dashboard/graph/use-net-value-event-handlers.ts
@@ -39,6 +39,8 @@ export function readZoomFields(event: unknown): ZoomFields | undefined {
 
 const ZOOM_MS = 1000;
 
+const DRAG_FLAG_CLEAR_DELAY_MS = 10;
+
 export function resolveZoomRange(fields: ZoomFields | undefined, times: number[]): NetValueZoomRange | undefined {
   if (typeof fields?.startValue === 'number' && typeof fields?.endValue === 'number') {
     return { end: Math.ceil(fields.endValue / ZOOM_MS), start: Math.floor(fields.startValue / ZOOM_MS) };
@@ -104,7 +106,6 @@ export function useNetValueEventHandlers(params: UseNetValueEventHandlersParams)
    * @returns the tooltip's adjusted `x` and `y`, in container coordinates
    */
   function calculateTooltipPosition(): { x: number; y: number } {
-    // Start from the last known mouse coordinates
     const pos = get(mousePos);
     let cursorX = pos.x + 20;
     let cursorY = pos.y + 20;
@@ -232,8 +233,21 @@ export function useNetValueEventHandlers(params: UseNetValueEventHandlersParams)
    * A timer holds the single-click action back long enough for a second click to cancel it, and
    * mousedown/mouseup positions are tracked so a drag is not mistaken for a click.
    */
+  /**
+   * Clears the drag flag once the click that follows this mouseup has been dispatched.
+   *
+   * @remarks
+   * The browser fires `click` after `mouseup`, so clearing the flag synchronously would let the
+   * click that merely ended a drag read it as false and act as an ordinary click. The delay only
+   * has to outlast that dispatch.
+   */
+  function clearDragAfterClickIsDispatched(): void {
+    setTimeout(() => {
+      set(isDragging, false);
+    }, DRAG_FLAG_CLEAR_DELAY_MS);
+  }
+
   function setupContainerClickHandler(container: HTMLElement): void {
-    // Track mouse down/up for drag detection
     containerEventHandlers.mousedown = (e): void => {
       set(dragStartPos, { x: e.offsetX, y: e.offsetY });
       set(isDragging, false);
@@ -253,12 +267,7 @@ export function useNetValueEventHandlers(params: UseNetValueEventHandlersParams)
       }
     };
 
-    containerEventHandlers.mouseup = (): void => {
-      // Reset drag flag after a short delay to ensure click event sees the correct state
-      setTimeout(() => {
-        set(isDragging, false);
-      }, 10);
-    };
+    containerEventHandlers.mouseup = clearDragAfterClickIsDispatched;
 
     containerEventHandlers.click = (): void => {
       if (get(isDragging)) {

--- a/frontend/app/src/modules/dashboard/progress/use-unified-progress.ts
+++ b/frontend/app/src/modules/dashboard/progress/use-unified-progress.ts
@@ -76,14 +76,19 @@ export function useUnifiedProgress(): UseUnifiedProgressReturn {
   const { transactionStatusSummary } = storeToRefs(historyStore);
   const lastQueriedDisplay = useTimeAgo(lastQueriedTimestamp);
 
+  /**
+   * What the indicator says it is doing, or an empty string when it is idle.
+   *
+   * @remarks
+   * A balance or token detection query wins over history events. Both can run at once and the
+   * indicator has one line, so the one the user started is the one it reports.
+   */
   const processingMessage = computed<string>(() => {
-    // Prioritize balance/token detection over history events
     const balanceProgressData = get(balanceProgress);
     if (balanceProgressData?.currentOperation) {
       return balanceProgressData.currentOperation;
     }
 
-    // Only show history events progress if no balance queries are running
     if (get(processing) && !get(isBalanceQuerying)) {
       const progressData = get(historyProgress);
       if (progressData && progressData.totalSteps > 0) {
@@ -97,8 +102,8 @@ export function useUnifiedProgress(): UseUnifiedProgressReturn {
     return '';
   });
 
+  /** How far along that work is, following the same precedence as {@link processingMessage}. */
   const processingPercentage = computed<number>(() => {
-    // Prioritize balance/token detection percentage
     const balanceProgressData = get(balanceProgress);
     if (balanceProgressData) {
       return balanceProgressData.percentage;

--- a/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalanceDeleteDialog.spec.ts
+++ b/frontend/app/src/modules/dashboard/snapshots/components/SnapshotBalanceDeleteDialog.spec.ts
@@ -87,8 +87,7 @@ describe('modules/dashboard/snapshots/components/SnapshotBalanceDeleteDialog', (
     expect(wrapper.find<HTMLInputElement>('.loc').element.value).toBe('ledger');
   });
 
-  it('should disable a location that cannot absorb the removal and block confirm', async () => {
-    // kraken only holds 40 but the balance is 100 — it can't cover the removal.
+  it('should disable a location that cannot absorb the removal and block confirm, kraken holding 40 against a balance of 100', async () => {
     wrapper = createWrapper(createSnapshot(40));
     wrapper.vm.open(0);
     await nextTick();

--- a/frontend/app/src/modules/history/balances/BalanceDivergenceToggle.vue
+++ b/frontend/app/src/modules/history/balances/BalanceDivergenceToggle.vue
@@ -8,8 +8,14 @@ const { isPinned, toggle: togglePanel } = usePinnedPanel(PinnedNames.BALANCE_DIV
 
 const active = isPinned;
 
+/**
+ * Opens or closes the divergence search.
+ *
+ * @remarks
+ * The search has no overlay of its own any more, so this pins the rail panel and reveals it, or
+ * closes it if it is already pinned. No payload is passed because the panel takes none.
+ */
 function toggle(): void {
-  // The divergence search lives only in the pinned rail now: pin it (and focus/reveal) or close it.
   togglePanel({});
 }
 </script>

--- a/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
+++ b/frontend/app/src/modules/history/data-issues/DataIssuesView.vue
@@ -178,10 +178,20 @@ watch(historicalBalanceProcessingCompleted, () => {
   startPromise(reloadAll());
 });
 
-onMounted(async () => {
-  // The dedicated page supersedes the overlay and pinned copies, which would show the same list twice.
+/**
+ * Closes the overlay and pinned copies of this list when it is shown as a page.
+ *
+ * @remarks
+ * The dedicated page supersedes them. Leaving them open would show the user the same issues twice,
+ * in two places that then have to be dismissed separately.
+ */
+function dismissCopiesSupersededByThisPage(): void {
   if (mainPage)
     dismissInlinePanels();
+}
+
+onMounted(async () => {
+  dismissCopiesSupersededByThisPage();
   await reloadAll();
 });
 </script>

--- a/frontend/app/src/modules/history/events-status-handler.ts
+++ b/frontend/app/src/modules/history/events-status-handler.ts
@@ -3,7 +3,6 @@ import { createStateHandler } from '@/modules/core/messaging/utils';
 import { useEventsQueryStatusStore } from '@/modules/history/use-events-query-status-store';
 
 export function createEventsStatusHandler(): StateHandler {
-  // Capture store method at handler creation time (in setup context)
   const { setQueryStatus } = useEventsQueryStatusStore();
 
   return createStateHandler((data) => {

--- a/frontend/app/src/modules/history/events/flows.spec.ts
+++ b/frontend/app/src/modules/history/events/flows.spec.ts
@@ -36,8 +36,7 @@ const flows: Declared[] = Object.entries(modules).flatMap(([file, exported]) =>
 );
 
 describe('history flow declarations', () => {
-  it('should find at least one declared flow', () => {
-    // A glob that silently matches nothing would make every assertion below vacuous.
+  it('should find at least one declared flow, without which every test below passes vacuously', () => {
     expect(flows.length).toBeGreaterThan(0);
   });
 
@@ -49,8 +48,7 @@ describe('history flow declarations', () => {
     expect(value, `missing i18n key: ${declared.flow.titleKey}`).toBeDefined();
   });
 
-  it.each(flows.map(f => [f.name, f] as const))('%s should build an id under its own kind', (_name, declared) => {
-    // The id is what dedups re-entry, so it has to actually belong to the kind it claims.
+  it.each(flows.map(f => [f.name, f] as const))('%s should build an id under its own kind, which is what makes re-entry dedupe against the right flow', (_name, declared) => {
     expect(declared.flow.id().startsWith(declared.flow.kind)).toBe(true);
   });
 
@@ -59,8 +57,7 @@ describe('history flow declarations', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it('should declare every flow beside a producer, not in a shared registry', () => {
-    // The co-location contract: a declaration lives in the module whose work it names.
+  it('should declare every flow in the module whose work it names, not in a shared registry', () => {
     for (const declared of flows)
       expect(declared.file).toMatch(/\/modules\/.+\.flow\.ts$/);
   });

--- a/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.ts
@@ -46,12 +46,19 @@ export const useHistoryTransactionDecoding = createSharedComposable(() => {
   const { decodableTxChainsInfo, getChainName, isBtcChains, isEvmLikeChains } = useSupportedChains();
   const { fetchUndecodedTransactionsBreakdown } = useUndecodedTransactionsStatus();
 
+  /**
+   * Submits the decoding activity for one chain.
+   *
+   * @remarks
+   * The activity id is derived from the chain and the cache flag, so there is exactly one activity
+   * per chain. That is what makes liveness, cancellation and rerun per-chain: decoding another
+   * chain does not dedupe against this one, and cancelling this one leaves the others running.
+   */
   const decodeTransactionsTask = async (
     chain: string,
     ignoreCache = false,
     placement: DecodePlacement = {},
   ): Promise<void> => {
-    // One activity per chain, so liveness, cancellation and rerun are all per-chain.
     const outcome = await submitTask({
       deps: placement.deps,
       id: decodeActivityId(chain, ignoreCache),

--- a/frontend/app/src/modules/history/events/use-history-events-deletion.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-deletion.ts
@@ -322,12 +322,18 @@ export function useHistoryEventsDeletion(
     });
   }
 
+  /**
+   * Deletes a selection that cuts through a swap.
+   *
+   * @remarks
+   * A swap is only meaningful whole, so selecting any of its legs deletes the group entire. The id
+   * list therefore spans every `groupIds` member, not the `selectedIds` the user actually picked.
+   */
   async function handlePartialSwapDeletion(
     partialSwapGroups: Array<{ groupIds: number[]; selectedIds: number[] }>,
     remainingEventIds: number[],
     transactions: Map<string, TransactionGroup>,
   ): Promise<void> {
-    // Collect all event IDs that need to be deleted (including full swap groups)
     const allEventIds = [
       ...partialSwapGroups.flatMap(group => group.groupIds),
       ...remainingEventIds,

--- a/frontend/app/src/modules/history/events/use-history-events-selection-actions.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-selection-actions.ts
@@ -73,8 +73,14 @@ export function useHistoryEventsSelectionActions(
     return { ignoredCount, notIgnoredCount };
   });
 
+  /**
+   * Leaves selection mode once an accounting rule has been created.
+   *
+   * @remarks
+   * The rule reclassifies the selected events, so the selection the user made against the old
+   * classification no longer describes anything they would want to act on again.
+   */
   function handleAccountingRuleRefresh(): void {
-    // Exit selection mode after successfully creating a rule
     selectionMode.actions.exit();
   }
 

--- a/frontend/app/src/modules/history/events/use-pinned-match-panel.ts
+++ b/frontend/app/src/modules/history/events/use-pinned-match-panel.ts
@@ -226,15 +226,23 @@ export function usePinnedMatchPanel<T extends PinnedMatchSubject>(
     }
   });
 
-  // Watch for prop changes to handle navigation when the panel is already open
-  watch(highlightedGroupIdentifier, (newHighlight, oldHighlight) => {
-    // Only trigger if the highlight actually changed (not on initial mount)
+  /**
+   * Follows a highlight that changed while the panel was already open.
+   *
+   * @remarks
+   * The mount path above has already navigated to whatever highlight the panel opened with, so
+   * this exists for the prop changing underneath a panel that stays put. Comparing against the
+   * previous value is what keeps it from repeating that first navigation.
+   */
+  function navigateToChangedHighlight(newHighlight?: string, oldHighlight?: string): void {
     if (!newHighlight || newHighlight === oldHighlight)
       return;
 
     set(activeGroupIdentifier, newHighlight);
     navigateToHighlighted(newHighlight);
-  });
+  }
+
+  watch(highlightedGroupIdentifier, navigateToChangedHighlight);
 
   return {
     activeGroupIdentifier: readonly(activeGroupIdentifier),

--- a/frontend/app/src/modules/history/events/use-selection-mode.ts
+++ b/frontend/app/src/modules/history/events/use-selection-mode.ts
@@ -62,6 +62,19 @@ export function useHistoryEventsSelectionMode(): UseHistoryEventsSelectionModeRe
     };
   });
 
+  /**
+   * Leaves the select-all-matching mode, because a manual pick has replaced it.
+   *
+   * @remarks
+   * The mode stands for every row the current filter matches, most of which are never loaded, so
+   * it is a claim about the query rather than a set of ids. The moment the user toggles a row the
+   * selection becomes an explicit set, and the two cannot both hold.
+   */
+  const leaveSelectAllMatching = (): void => {
+    if (get(selectAllMatching))
+      set(selectAllMatching, false);
+  };
+
   const actions: SelectionActions = {
     clear: () => {
       set(selectedIds, new Set());
@@ -77,7 +90,6 @@ export function useHistoryEventsSelectionMode(): UseHistoryEventsSelectionModeRe
         actions.clear();
     },
     toggleAll: () => {
-      // If selectAllMatching is enabled, disable it and clear
       if (get(selectAllMatching)) {
         actions.clear();
         return;
@@ -89,9 +101,7 @@ export function useHistoryEventsSelectionMode(): UseHistoryEventsSelectionModeRe
         set(selectedIds, new Set(get(availableIds)));
     },
     toggleEvent: (eventId: number) => {
-      // Disable selectAllMatching when manually toggling events
-      if (get(selectAllMatching))
-        set(selectAllMatching, false);
+      leaveSelectAllMatching();
 
       const ids = new Set(get(selectedIds));
       if (ids.has(eventId))
@@ -102,9 +112,7 @@ export function useHistoryEventsSelectionMode(): UseHistoryEventsSelectionModeRe
       set(selectedIds, ids);
     },
     toggleSwap: (eventIds: number[]) => {
-      // Disable selectAllMatching when manually toggling events
-      if (get(selectAllMatching))
-        set(selectAllMatching, false);
+      leaveSelectAllMatching();
 
       const ids = new Set(get(selectedIds));
       const allSelected = eventIds.every(id => ids.has(id));

--- a/frontend/app/src/modules/history/events/use-virtual-rows.ts
+++ b/frontend/app/src/modules/history/events/use-virtual-rows.ts
@@ -138,15 +138,27 @@ interface UseVirtualRowsReturn {
   getCardHeight: (index: number) => number;
 }
 
+/**
+ * Flattens the grouped events into the single list the virtualizer renders.
+ *
+ * @remarks
+ * A `HistoryEventRow` that is an array is a subgroup, holding either the legs of a swap or the two
+ * sides of a matched asset movement. It carries no discriminant, so the two are told apart by
+ * inspecting the events, and each is rendered collapsed behind a single row until expanded.
+ *
+ * The three pieces of state here are all overrides of a default rather than the full picture. A
+ * group missing from `groupVisibleCounts` shows `INITIAL_EVENTS_LIMIT` rows, and a subgroup absent
+ * from the expanded sets is collapsed, so nothing has to be seeded when a group first arrives. The
+ * expanded sets are keyed by `subgroupKey`, not by identifier, because a subgroup has no id of its
+ * own.
+ */
 export function useVirtualRows(
   groups: ComputedRef<HistoryEventEntry[]>,
   eventsByGroup: ComputedRef<Record<string, HistoryEventRow[]>>,
   isSubgroupIncomplete: (events: HistoryEventEntry[]) => boolean,
 ): UseVirtualRowsReturn {
-  // Track how many items are visible per group (beyond initial limit)
   const groupVisibleCounts = shallowRef<Map<string, number>>(new Map());
   const expandedSwaps = shallowRef<Set<string>>(new Set());
-  // Track which matched movement rows are expanded (key: see `subgroupKey`)
   const expandedMovements = shallowRef<Set<string>>(new Set());
 
   const flattenedRows = computed<VirtualRow[]>(() => {
@@ -186,11 +198,9 @@ export function useVirtualRows(
       const visibleEvents = allEvents.slice(0, limit);
 
       visibleEvents.forEach((event, i) => {
-        // Handle array (subgroup - could be swap or matched movement)
         if (Array.isArray(event)) {
           const forcedOpenWithoutCollapseControls = isSubgroupIncomplete(event);
 
-          // Check if this is a matched asset movement (not a swap)
           if (isMatchedMovementGroup(event)) {
             const movementKey = subgroupKey(groupId, event);
             const isMovementExpanded = forcedOpenWithoutCollapseControls || expandedMovementsSet.has(movementKey);

--- a/frontend/app/src/modules/history/management/forms/asset-movement-event-form.spec.ts
+++ b/frontend/app/src/modules/history/management/forms/asset-movement-event-form.spec.ts
@@ -60,8 +60,7 @@ describe('assetMovementSchema', () => {
     expect(issuePaths(emptyAssetMovementForm(''))).toEqual(['asset', 'location']);
   });
 
-  it('should accept an enabled fee that is entirely blank', () => {
-    // Which is how the form has always let a movement have no fee while the checkbox is on.
+  it('should accept an enabled fee that is entirely blank, so the checkbox can be on with no fee', () => {
     expect(issuePaths({ ...validState(), hasFee: true })).toEqual([]);
   });
 

--- a/frontend/app/src/modules/history/management/forms/use-evm-tx-lookup.ts
+++ b/frontend/app/src/modules/history/management/forms/use-evm-tx-lookup.ts
@@ -179,8 +179,15 @@ export function useEvmTxAutoFill(options: EvmTxAutoFillOptions): UseEvmTxAutoFil
     set(loading, false);
   }
 
+  /**
+   * Clears the lookup back to its idle state.
+   *
+   * @remarks
+   * Bumping the request id is what makes this safe to call mid-flight: a lookup already in the air
+   * compares its own id on return, finds it stale, and drops its result instead of writing it over
+   * the cleared fields.
+   */
   function reset(): void {
-    // Bump the id so any in-flight result is treated as stale and discarded.
     currentRequestId++;
     set(loading, false);
     set(canRetry, false);

--- a/frontend/app/src/modules/history/transaction-status-handler.ts
+++ b/frontend/app/src/modules/history/transaction-status-handler.ts
@@ -3,7 +3,6 @@ import { createStateHandler } from '@/modules/core/messaging/utils';
 import { useTxQueryStatusStore } from '@/modules/history/use-tx-query-status-store';
 
 export function createTransactionStatusHandler(): StateHandler {
-  // Capture store method at handler creation time (in setup context)
   const { setUnifiedTxQueryStatus } = useTxQueryStatusStore();
 
   return createStateHandler((data) => {

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-auth-state.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-auth-state.ts
@@ -106,8 +106,14 @@ export function useGnosisPayAuthSteps(
   validatingAddress: MaybeRefOrGetter<boolean>,
   signInSuccess: MaybeRefOrGetter<boolean>,
 ): UseGnosisPayAuthStepsReturn {
+  /**
+   * The step the wizard is on, derived from what has been satisfied so far.
+   *
+   * @remarks
+   * Account verification has no step of its own: it happens in the background, so the wizard sits
+   * on `NOT_READY` until it completes rather than showing the user a stage they cannot act on.
+   */
   const currentStep = computed<number>(() => {
-    // Skip showing the account verification step - it happens in background
     if (!toValue(hasRegisteredAccounts))
       return AuthStep.NOT_READY;
     if (!toValue(isWalletConnected))

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.ts
@@ -65,8 +65,14 @@ export const useGnosisPaySafeMigration = createSharedComposable((): UseGnosisPay
     return Boolean(getApiKey(GNOSIS_PAY_SERVICE));
   };
 
+  /**
+   * Looks for a safe migration the user has not tracked yet.
+   *
+   * @remarks
+   * The request is premium-gated, so it is not made at all unless Gnosis Pay is configured. A user
+   * without it would otherwise be told about a premium requirement for a service they do not use.
+   */
   const checkMigration = async (): Promise<void> => {
-    // Skip the (premium-gated) request entirely when Gnosis Pay is not configured.
     if (!await isGnosisPayConfigured()) {
       set(untrackedSafe, undefined);
       return;

--- a/frontend/app/src/modules/premium/setup-premium.ts
+++ b/frontend/app/src/modules/premium/setup-premium.ts
@@ -32,10 +32,15 @@ EChartsCore.use([
   ToolboxComponent,
 ]);
 
+/**
+ * Publishes the shared runtime the premium bundle expects to find on `window`.
+ *
+ * @remarks
+ * Safe to call more than once. `window.Vue` being set is the marker that the setup has already
+ * run, and re-publishing would hand the premium components a second Vue instance rather than the
+ * one the app is mounted with.
+ */
 export async function setupPremium(): Promise<void> {
-  /**
-   * If setup has run already no need to do it again
-   */
   if (!window.Vue) {
     window.Vue = Vue;
     window.VueUse = VueUse;

--- a/frontend/app/src/modules/session/single-tab/use-single-tab.ts
+++ b/frontend/app/src/modules/session/single-tab/use-single-tab.ts
@@ -111,15 +111,28 @@ function createSingleTab(): UseSingleTabReturn {
     window.location.reload();
   }
 
+  /**
+   * Tells the other tabs this one is giving up the session.
+   *
+   * @remarks
+   * Only the active tab announces a release. A paused tab closing owns nothing to hand over, and
+   * announcing it would wake the others into claiming a session the active tab still holds.
+   */
   function broadcastRelease(): void {
-    // Only the active tab hands off; a paused tab closing must not wake the others.
     if (!supported || !get(active))
       return;
     ensureChannel()?.postMessage({ tabId, type: 'release' } satisfies TabMessage);
   }
 
+  /**
+   * Gives up the session and stops taking part in the tab handshake.
+   *
+   * @remarks
+   * The handoff is broadcast before the channel closes, since a closed channel delivers nothing.
+   * Marking this tab active afterwards is for its own sake: a paused tab that reloads lands on
+   * login, the session it was waiting for being gone.
+   */
   function release(): void {
-    // Hand off before dropping the channel; a paused tab reloads onto login, the session being gone.
     broadcastRelease();
     cancelScheduledReclaim();
     set(active, true);

--- a/frontend/app/src/modules/settings/HideSmallBalances.vue
+++ b/frontend/app/src/modules/settings/HideSmallBalances.vue
@@ -79,14 +79,23 @@ watchImmediate([balanceValueThreshold, open], ([thresholds]) => {
   form.state.hideBelow = threshold ?? DEFAULT_THRESHOLD;
 });
 
-watch(() => form.state.hide, (hide) => {
-  // Switching hiding off puts the field back to a value that cannot be blocking the save.
+/**
+ * Keeps the threshold field valid as hiding is switched on and off.
+ *
+ * @remarks
+ * Switching hiding off restores the default threshold rather than leaving whatever was typed. The
+ * field is still validated while hidden, so an incomplete value left behind would block the save
+ * for a setting the user has just turned off.
+ */
+function resetThresholdForHiding(hide: boolean): void {
   form.reset({
     applyToAllBalances: form.state.applyToAllBalances,
     hide,
     hideBelow: hide ? form.state.hideBelow : DEFAULT_THRESHOLD,
   });
-});
+}
+
+watch(() => form.state.hide, resetThresholdForHiding);
 </script>
 
 <template>

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleForm.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleForm.spec.ts
@@ -311,8 +311,7 @@ describe('settings/accounting/rule/AccountingRuleForm.vue', () => {
       expect(wrapper.emitted('update:stateUpdated')).toBeUndefined();
     });
 
-    it('should still read an edited field as an unsaved change', async () => {
-      // The contrast that makes the assertion above mean something.
+    it('should still read an edited field as an unsaved change, the contrast that keeps the test above honest', async () => {
       wrapper = createWrapper({ modelValue: createRule() });
 
       toggle('taxable').vm.$emit('update:modelValue', { value: true });

--- a/frontend/app/src/modules/settings/controls/setting-field-schemas.spec.ts
+++ b/frontend/app/src/modules/settings/controls/setting-field-schemas.spec.ts
@@ -28,8 +28,7 @@ describe('textSettingSchema', () => {
     expect(messagesOf(schema, 'abc')).toStrictEqual([]);
   });
 
-  it('should not report a length error for an optional blank value', () => {
-    // Reporting both would show "too long" on an empty field the user never has to fill in.
+  it('should not report a length error for an optional blank value, which would read as "too long" on an empty field', () => {
     expect(messagesOf(textSettingSchema({ maxLength: 3, messages }), '')).toStrictEqual([]);
   });
 });

--- a/frontend/app/src/modules/settings/data-security/PasswordConfirmationSetting.vue
+++ b/frontend/app/src/modules/settings/data-security/PasswordConfirmationSetting.vue
@@ -55,8 +55,14 @@ const hasChanged = computed<boolean>(() => {
   return currentDays !== storedDays || get(enabled) !== get(enablePasswordConfirmation);
 });
 
+/**
+ * Applies the toggle, asking first when it is being turned off.
+ *
+ * @remarks
+ * Turning the confirmation off weakens the account, so unlike turning it on it goes through a
+ * warning rather than being applied directly.
+ */
 function handleToggleChange(value: boolean): void {
-  // Turning the confirmation off weakens the account, so it is confirmed rather than just applied.
   if (!value)
     set(showDisableWarning, true);
   else

--- a/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.spec.ts
+++ b/frontend/app/src/modules/settings/general/amount/NumericSeparatorsSettings.spec.ts
@@ -51,19 +51,27 @@ describe('numericSeparatorsSettings', () => {
     return writeManyMock.mock.calls.at(-1)?.[0];
   }
 
+  /**
+   * Stands in for the settings repository: a successful write becomes the new source of truth.
+   *
+   * @remarks
+   * The component reads back what it wrote, so a mock that only recorded the call would leave the
+   * sources on their old values and the test would pass against a component that never persisted.
+   */
+  async function writeThroughToSources(patch: Record<string, string>): Promise<{ success: boolean }> {
+    if (patch.thousandSeparator !== undefined)
+      set(thousandSource, patch.thousandSeparator);
+    if (patch.decimalSeparator !== undefined)
+      set(decimalSource, patch.decimalSeparator);
+    return { success: true };
+  }
+
   beforeEach(() => {
     vi.useFakeTimers();
     thousandSource = ref<string>(',');
     decimalSource = ref<string>('.');
     writeManyMock.mockReset();
-    writeManyMock.mockImplementation(async (patch: Record<string, string>) => {
-      // Mirror the repo: a successful write becomes the new source of truth.
-      if (patch.thousandSeparator !== undefined)
-        set(thousandSource, patch.thousandSeparator);
-      if (patch.decimalSeparator !== undefined)
-        set(decimalSource, patch.decimalSeparator);
-      return { success: true };
-    });
+    writeManyMock.mockImplementation(writeThroughToSources);
     useSettingMock.mockImplementation((key: string) => (key === 'thousandSeparator' ? thousandSource : decimalSource));
   });
 

--- a/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.ts
+++ b/frontend/app/src/modules/settings/suggestions/use-settings-suggestions.ts
@@ -38,13 +38,16 @@ function getCurrentValue(
 /**
  * Turns one suggestion into the row the dialog shows, or nothing when this user has no reason to see
  * it. The three shapes differ in what "already satisfied" means for them.
+ *
+ * @remarks
+ * A suggestion offering choices always stands, even when one of them is what the user already has,
+ * because only its own builder knows which of them count. The other two shapes are filtered here.
  */
 function shapePending(
   suggestion: SettingsSuggestion,
   currentValue: unknown,
   fromVersion: string,
 ): PendingSuggestion | undefined {
-  // A choice stands even when an option is what the user already has; its builder gates it instead.
   if (suggestion.choices)
     return { ...suggestion, currentValue, fromVersion };
 

--- a/frontend/app/src/modules/shell/app/use-backend-management.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-management.spec.ts
@@ -245,8 +245,7 @@ describe('useBackendManagement', () => {
       expect(mockConnect).toHaveBeenCalled();
     });
 
-    it('should stay a no-op where no control endpoint is served', async () => {
-      // The plain web build: probing says no, so the old behaviour stands.
+    it('should stay a no-op on the plain web build, where probing finds no control endpoint', async () => {
       packaged = false;
       mockControlProbe.mockResolvedValue(false);
 

--- a/frontend/app/src/modules/shell/app/use-backend-messages.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-messages.ts
@@ -25,6 +25,18 @@ interface UseBackendMessagesInternalReturn {
   unregisterOAuthCallbackHandler: (handler: OAuthCallback) => void;
 }
 
+/**
+ * Wipes the requested debug state and reloads if anything was actually cleared.
+ *
+ * @remarks
+ * The reload is what makes the wipe visible. Storage-backed refs keep their value in memory once
+ * read, so clearing the underlying storage leaves the running app showing the old state.
+ */
+function reloadAfterWipingDebugState(group: DebugStateGroup): void {
+  if (resetDebugState(group).length > 0)
+    window.location.reload();
+}
+
 function useBackendMessagesInternal(): UseBackendMessagesInternalReturn {
   const startupErrorMessage = shallowRef<string>('');
   const isMacOsVersionUnsupported = shallowRef<boolean>(false);
@@ -131,11 +143,7 @@ function useBackendMessagesInternal(): UseBackendMessagesInternalReturn {
         haltBackendActivity();
         api.stopRequests();
       },
-      onResetDebugState: (group: DebugStateGroup) => {
-        // Storage-backed refs hold their value in memory, so a wipe only shows after a reload.
-        if (resetDebugState(group).length > 0)
-          window.location.reload();
-      },
+      onResetDebugState: reloadAfterWipingDebugState,
       onRestart: () => {
         set(startupErrorMessage, '');
         // Re-enable connections for the restart attempt

--- a/frontend/app/src/modules/shell/components/GlobalSearch.vue
+++ b/frontend/app/src/modules/shell/components/GlobalSearch.vue
@@ -63,12 +63,23 @@ watch(open, (isOpen) => {
   });
 });
 
+/**
+ * Whether this keystroke is the search shortcut on the platform the app is running on.
+ *
+ * @remarks
+ * macOS puts the shortcut on Command and every other platform on Control, and the check is one way
+ * round rather than accepting either, so the wrong modifier does not open the palette.
+ */
+function isSearchShortcut(event: KeyboardEvent): boolean {
+  const modifier = get(isMac) ? event.metaKey : event.ctrlKey;
+  return modifier && event.key === key;
+}
+
 onBeforeMount(async () => {
   set(isMac, await interop.isMac());
 
   window.addEventListener('keydown', (event) => {
-    // Mac uses Command, others use Control
-    if (((get(isMac) && event.metaKey) || (!get(isMac) && event.ctrlKey)) && event.key === key)
+    if (isSearchShortcut(event))
       set(open, true);
   });
 });

--- a/frontend/app/src/modules/shell/pinned/use-pinned-persistence.spec.ts
+++ b/frontend/app/src/modules/shell/pinned/use-pinned-persistence.spec.ts
@@ -96,8 +96,7 @@ describe('usePinnedPersistence', () => {
     expect(get(store.activePinnedId)).toBe(PinnedNames.MATCH_ASSET_MOVEMENTS);
   });
 
-  it('should ignore a corrupt or legacy-shaped stored value instead of throwing', () => {
-    // `names` is not an array (corruption or an old schema).
+  it('should ignore a stored value whose `names` is not an array, instead of throwing', () => {
     localStorage.setItem(TABS_KEY, JSON.stringify({ activeId: 'x', names: 'oops' }));
     const store = useAreaVisibilityStore();
     const { pinnedPanels } = storeToRefs(store);

--- a/frontend/app/src/modules/shell/sync-progress/components/SyncProgressPanel.vue
+++ b/frontend/app/src/modules/shell/sync-progress/components/SyncProgressPanel.vue
@@ -51,12 +51,21 @@ onKeyStroke('Escape', () => {
     collapse();
 });
 
-watch(phase, (newPhase, oldPhase) => {
-  // Reset dismissed state when a new sync starts
+/**
+ * Brings the panel back for a sync the user has not dismissed yet.
+ *
+ * @remarks
+ * Only the complete-to-syncing edge counts as a new sync. Dismissing applies to the sync that was
+ * running at the time, so it must not carry over to the next one, and must not be undone by any
+ * other phase change within the same sync.
+ */
+function undismissOnNewSync(newPhase: SyncPhase, oldPhase: SyncPhase | undefined): void {
   if (oldPhase === SyncPhase.COMPLETE && newPhase === SyncPhase.SYNCING) {
     set(dismissed, false);
   }
-});
+}
+
+watch(phase, undismissOnNewSync);
 </script>
 
 <template>

--- a/frontend/app/src/modules/shell/sync-progress/use-chain-progress.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-chain-progress.ts
@@ -104,6 +104,21 @@ function isDone(status: AddressStatus): boolean {
     || status === AddressStatus.FAILED;
 }
 
+/**
+ * Orders chains for the panel: those with work in flight first, then alphabetically.
+ *
+ * @remarks
+ * Only whether a chain has any address in progress separates the two ranks, not how many, so a
+ * chain does not jump around the list as its own addresses finish one by one.
+ */
+function byActiveThenName(a: ChainProgress, b: ChainProgress): number {
+  if (a.inProgress > 0 && b.inProgress === 0)
+    return -1;
+  if (b.inProgress > 0 && a.inProgress === 0)
+    return 1;
+  return a.chain.localeCompare(b.chain);
+}
+
 function calculateChainProgress(addresses: AddressProgress[]): number {
   if (addresses.length === 0)
     return 0;
@@ -172,13 +187,6 @@ export function useChainProgress(
         progress: calculateChainProgress(addresses),
         total: addresses.length,
       };
-    }).sort((a, b) => {
-      // Sort by: in-progress first, then by chain name
-      if (a.inProgress > 0 && b.inProgress === 0)
-        return -1;
-      if (b.inProgress > 0 && a.inProgress === 0)
-        return 1;
-      return a.chain.localeCompare(b.chain);
-    });
+    }).sort(byActiveThenName);
   });
 }

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-progress.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-progress.ts
@@ -76,6 +76,18 @@ function mapLocationStatus(data: HistoryEventsQueryData): LocationProgress {
  * Events (exchange history) have medium weight (30%) as they involve external API calls.
  * Decoding has the lowest weight (20%) as it's a local operation that's typically fast.
  */
+/** Locations in the order the panel lists them: what is running, then what is still to come. */
+const STATUS_PRIORITY: Record<LocationProgress['status'], number> = {
+  [LocationStatus.QUERYING]: 0,
+  [LocationStatus.PENDING]: 1,
+  [LocationStatus.CANCELLED]: 2,
+  [LocationStatus.COMPLETE]: 3,
+};
+
+function byStatusPriority(a: LocationProgress, b: LocationProgress): number {
+  return STATUS_PRIORITY[a.status] - STATUS_PRIORITY[b.status];
+}
+
 const PROGRESS_WEIGHTS = {
   decoding: 0.2,
   events: 0.3,
@@ -142,16 +154,7 @@ export function useSyncProgress(): UseSyncProgressReturn {
     const statusMap = get(eventsQueryStatus);
     return Object.values(statusMap)
       .map(data => mapLocationStatus(data))
-      .sort((a, b) => {
-        // Sort by: querying first, then pending, then cancelled, then complete
-        const priority: Record<LocationProgress['status'], number> = {
-          [LocationStatus.QUERYING]: 0,
-          [LocationStatus.PENDING]: 1,
-          [LocationStatus.CANCELLED]: 2,
-          [LocationStatus.COMPLETE]: 3,
-        };
-        return priority[a.status] - priority[b.status];
-      });
+      .sort(byStatusPriority);
   });
 
   /**

--- a/frontend/app/src/modules/staking/liquity/liquity-aggregation.spec.ts
+++ b/frontend/app/src/modules/staking/liquity/liquity-aggregation.spec.ts
@@ -167,8 +167,7 @@ describe('modules/staking/liquity/collectProxies', () => {
   };
   const pools: LiquityPoolDetails = {};
 
-  it('should be null when no address was selected', () => {
-    // With no account filter there is no owner to attribute a proxy to.
+  it('should be null when no address was selected, leaving no owner to attribute a proxy to', () => {
     expect(collectProxies(staking, pools, [])).toBeNull();
   });
 

--- a/frontend/app/src/modules/staking/liquity/liquity-aggregation.ts
+++ b/frontend/app/src/modules/staking/liquity/liquity-aggregation.ts
@@ -53,6 +53,10 @@ function selectEntries<T extends BalanceEntry>(
  * Each field keeps its asset identifier: `balanceSum` returns only an amount and a value, and every
  * entry names the same asset for a given field.
  *
+ * @remarks
+ * The first entry is copied rather than accumulated into, and every field is then reassigned as a
+ * new object rather than mutated, so summing never writes through to the entries the store holds.
+ *
  * @returns the summed entry, or `null` when nothing was selected
  */
 export function aggregateEntries<T extends BalanceEntry>(
@@ -60,7 +64,6 @@ export function aggregateEntries<T extends BalanceEntry>(
   selectedAddresses: string[],
 ): T | null {
   return selectEntries(source, selectedAddresses).reduce<T | null>((total, entry) => {
-    // This copy is what keeps the store's objects intact; later fields are reassigned, not mutated.
     if (total === null)
       return { ...entry };
 

--- a/frontend/app/src/modules/staking/liquity/use-liquity-page.ts
+++ b/frontend/app/src/modules/staking/liquity/use-liquity-page.ts
@@ -24,8 +24,14 @@ export function useLiquityPage(): UseLiquityPageReturn {
   const currencySymbol = useSetting('currencySymbol');
   const premium = usePremium();
 
+  /**
+   * Loads everything the Liquity page shows, optionally forcing a refresh.
+   *
+   * @remarks
+   * The price query status is cleared first. It is keyed by asset rather than by run, so whatever
+   * the previous fetch left behind would be read as progress belonging to this one.
+   */
   async function fetch(refresh = false): Promise<void> {
-    // The previous run's per-asset progress would otherwise be read as this run's.
     resetProtocolStatsPriceQueryStatus('liquity');
 
     await Promise.all([

--- a/frontend/app/src/modules/task-center/core/rerun/policy.spec.ts
+++ b/frontend/app/src/modules/task-center/core/rerun/policy.spec.ts
@@ -3,8 +3,7 @@ import { ActivityKind } from '../types';
 import { EditKind, invalidatedKinds } from './policy';
 
 describe('invalidatedKinds', () => {
-  it('should map every event mutation to the computed downstream work', () => {
-    // PNL_REPORT is deliberately deferred (runs native but kept out of smart re-run for now).
+  it('should map every event mutation to historical balances alone, PNL_REPORT being deliberately held out of smart re-run', () => {
     for (const kind of Object.values(EditKind)) {
       expect(invalidatedKinds(kind)).toEqual([
         ActivityKind.HISTORICAL_BALANCES,

--- a/frontend/app/src/modules/wallet/bridge/use-bridge-message-handlers.ts
+++ b/frontend/app/src/modules/wallet/bridge/use-bridge-message-handlers.ts
@@ -61,10 +61,15 @@ export function useBridgeMessageHandlers(sendMessage?: (message: any) => void): 
     setupWalletEventForwarding(newProvider);
   });
 
+  /**
+   * Answers the bridge with the providers currently available, detecting them if needed.
+   *
+   * @remarks
+   * Only the descriptive fields are sent. A provider object holds a live reference back to its own
+   * connection, so passing one whole would put a cycle through the bridge's JSON encoding.
+   */
   async function rpcGetAvailableProviders(message: WalletBridgeRequest): Promise<WalletBridgeResponse> {
-    // Single async method that detects if needed and returns providers
     const providers = await getAvailableProviders();
-    // Serialize providers for bridge - remove circular references from provider objects
     const serializedProviders = providers.map(provider => ({
       info: provider.info,
       isConnected: provider.isConnected,
@@ -106,8 +111,14 @@ export function useBridgeMessageHandlers(sendMessage?: (message: any) => void): 
     return createSuccessResponse(message.id, success);
   }
 
+  /**
+   * Answers the bridge's readiness check.
+   *
+   * @remarks
+   * Rotki's own method rather than an RPC one, and deliberately so: it must answer before any
+   * provider is selected, which is exactly what the caller is waiting to find out.
+   */
   function rpcPing(message: WalletBridgeRequest): WalletBridgeResponse {
-    // Custom ping method for bridge readiness check - doesn't require RPC provider
     addLog('Received bridge ping - responding with pong', 'info');
     return createSuccessResponse(message.id, ROTKI_RPC_RESPONSES.PONG);
   }

--- a/frontend/app/src/modules/wallet/providers/use-unified-providers.ts
+++ b/frontend/app/src/modules/wallet/providers/use-unified-providers.ts
@@ -149,9 +149,14 @@ function createUnifiedProvidersComposable(): UnifiedProvidersComposable {
     return breakdown;
   }
 
-  /** Detection with retries, since an extension can announce itself after the page has loaded. */
+  /**
+   * Detection with retries, since an extension can announce itself after the page has loaded.
+   *
+   * @remarks
+   * Defaults are applied by spreading a single object rather than per field, which keeps the
+   * complexity rule from counting each defaulted field as a branch of this function.
+   */
   async function detectProviders(options: UnifiedDetectionOptions = {}): Promise<EnhancedProviderDetail[]> {
-    // Spread rather than per-field defaults: the rule counts each defaulted field as a branch.
     const settings = { ...DETECTION_DEFAULTS, ...options };
 
     set(isDetecting, true);

--- a/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
+++ b/frontend/app/src/modules/wallet/send/TradeAssetSelector.vue
@@ -115,7 +115,6 @@ function isSelected(option: TradeAssetOption): boolean {
  * the whole list, which is already ordered native-first.
  */
 watchImmediate([() => address, chain, orderedAssets], ([, currentChain]) => {
-  // The display order, so the default is the row the dialog would show first.
   const owned = get(orderedAssets);
 
   if (!currentChain) {

--- a/frontend/app/src/modules/wallet/use-wallet-store.ts
+++ b/frontend/app/src/modules/wallet/use-wallet-store.ts
@@ -39,7 +39,6 @@ type WalletConnectInstance = ReturnType<typeof import('./use-wallet-connect').us
 type InjectedWalletInstance = ReturnType<typeof import('./bridge/use-injected-wallet').useInjectedWallet>;
 
 export const useWalletStore = defineStore(STORE_ID, () => {
-  // Core wallet state - centralized instead of delegated
   const preparing = ref<boolean>(false);
   const waitingForWalletConfirmation = ref<boolean>(false);
   const walletMode = ref<WalletMode>(WALLET_MODES.LOCAL_BRIDGE);

--- a/frontend/app/src/pages/asset-manager/more/solana-token-migration/index.vue
+++ b/frontend/app/src/pages/asset-manager/more/solana-token-migration/index.vue
@@ -76,13 +76,21 @@ function handleMergeSuggestion({ sourceAsset, targetAsset }: { sourceAsset: stri
       }),
       title: t('asset_management.solana_token_migration.merge_suggestion.title'),
     },
-    () => {
-      // User confirmed - open merge dialog with prefilled values
-      set(mergeSourceIdentifier, sourceAsset);
-      set(mergeTargetIdentifier, targetAsset);
-      set(mergeTool, true);
-    },
+    () => openMergePrefilledWith(sourceAsset, targetAsset),
   );
+}
+
+/**
+ * Opens the merge tool with both assets already chosen.
+ *
+ * @remarks
+ * Runs only once the user has accepted the suggestion, so the merge dialog opens on the pair the
+ * suggestion named rather than empty.
+ */
+function openMergePrefilledWith(sourceAsset: string, targetAsset: string): void {
+  set(mergeSourceIdentifier, sourceAsset);
+  set(mergeTargetIdentifier, targetAsset);
+  set(mergeTool, true);
 }
 
 function handleMergeCompleted({ sourceIdentifier }: { sourceIdentifier: string; targetIdentifier: string }): void {

--- a/frontend/app/src/pages/reports/use-report-detail.spec.ts
+++ b/frontend/app/src/pages/reports/use-report-detail.spec.ts
@@ -127,8 +127,7 @@ describe('pages/reports/useReportDetail', () => {
     expect(getActionableItems).toHaveBeenCalledTimes(1);
   });
 
-  it('should skip the actionable items for an older report', async () => {
-    // The store still names LATEST_REPORT_ID as the last generated one, so this route is not it.
+  it('should skip the actionable items for a report that is not the last generated one', async () => {
     routeState.params = { id: String(OLDER_REPORT_ID) };
     storeState.reports = createReports([createReport({ identifier: OLDER_REPORT_ID })]);
 

--- a/frontend/app/src/pages/reports/use-reports-page-actions.ts
+++ b/frontend/app/src/pages/reports/use-reports-page-actions.ts
@@ -49,8 +49,14 @@ export function useReportsPageActions(options: UseReportsPageActionsOptions): Us
 
   const importDataLoading = shallowRef<boolean>(false);
 
+  /**
+   * Generates a report for the period and navigates to it.
+   *
+   * @remarks
+   * The report-issues pin is cleared first, when it is the active one. It describes the report
+   * being replaced, so leaving it up would show issues against a report that no longer exists.
+   */
   async function generate(period: ProfitLossReportPeriod): Promise<void> {
-    // Clear the report-issues pin (if it is the active one) before regenerating.
     unpinReportCard();
 
     const formatDate = (timestamp: number): string =>

--- a/frontend/app/src/pages/reports/use-reports-page.ts
+++ b/frontend/app/src/pages/reports/use-reports-page.ts
@@ -43,8 +43,14 @@ export function useReportsPage(options: UseReportsPageOptions): UseReportsPageRe
   const router = useRouter();
   const route = useRoute();
 
+  /**
+   * Opens a freshly generated report, unless the user has moved on.
+   *
+   * @remarks
+   * Generation is asynchronous and can finish long after it was started, so the current route is
+   * checked first. Navigating regardless would pull the user out of wherever they went next.
+   */
   function navigateToReport(reportId: number): void {
-    // Guard against a late generation landing after the user has already navigated away.
     if (get(route).name !== '/reports/')
       return;
 

--- a/frontend/app/src/pages/statistics/snapshots/snapshot-query.spec.ts
+++ b/frontend/app/src/pages/statistics/snapshots/snapshot-query.spec.ts
@@ -25,8 +25,7 @@ describe('pages/statistics/snapshots/parseSnapshotFilters', () => {
     });
   });
 
-  it('should reject a bound that is not a number rather than passing NaN on', () => {
-    // NaN would compare false against every timestamp and read as an empty account.
+  it('should reject a bound that is not a number rather than passing on a NaN, which compares false against every timestamp and reads as an empty account', () => {
     expect(parseSnapshotFilters({ from: 'yesterday' })).toEqual({
       fromTimestamp: undefined,
       toTimestamp: undefined,

--- a/frontend/app/tests/e2e/coverage.ts
+++ b/frontend/app/tests/e2e/coverage.ts
@@ -24,9 +24,11 @@ const EXCLUDED_PATHS = [
 
 /**
  * Check if a filename looks like a bundled/hashed file (e.g., utils-D1WHamuv.js)
+ *
+ * @remarks
+ * Matches `Name-[hash].js` or `.css`, where the hash is eight alphanumeric characters.
  */
 function isBundledFile(pathname: string): boolean {
-  // `Name-[hash].js` or `.css`, where the hash is eight alphanumeric characters.
   return /^\/[^/]+-\w{8}\.(js|css)$/.test(pathname);
 }
 

--- a/frontend/app/tests/e2e/pages/address-book-page.ts
+++ b/frontend/app/tests/e2e/pages/address-book-page.ts
@@ -46,8 +46,14 @@ export class AddressBookPage {
     return this.table().locator('tbody tr[data-id="row"]');
   }
 
+  /**
+   * The row for an address or a name.
+   *
+   * @remarks
+   * The table renders an address truncated, so only its leading hex is on the page and matching
+   * the full string would find nothing. A name is rendered whole and is matched as given.
+   */
   rowFor(addressOrName: string) {
-    // For 0x... addresses match by the leading hex, otherwise match the full text.
     const needle = addressOrName.startsWith('0x') ? addressOrName.slice(0, 12) : addressOrName;
     return this.rows().filter({ hasText: needle });
   }

--- a/frontend/app/tests/e2e/pages/airdrops-page.ts
+++ b/frontend/app/tests/e2e/pages/airdrops-page.ts
@@ -63,9 +63,12 @@ export class AirdropsPage {
    * dataset. The airdrops endpoint returns an async task; the task list and
    * task-result endpoints are mocked to complete it with {@link AIRDROPS_RESULT}.
    * Must be called before navigating to the page.
+   *
+   * The query endpoint hands out a fresh task id on every call, because the page queries it twice,
+   * once on mount and again on refresh, and a reused id would let the second read the first's
+   * result.
    */
   async setupMocks(): Promise<void> {
-    // Query endpoint -> hand out a fresh task id on every call (mount + refresh).
     await this.page.route('**/api/1/blockchains/eth/airdrops**', async (route) => {
       const id = this.nextTaskId++;
       this.airdropTaskIds.add(id);

--- a/frontend/app/tests/e2e/pages/api-keys-page.ts
+++ b/frontend/app/tests/e2e/pages/api-keys-page.ts
@@ -9,8 +9,15 @@ export class ApiKeysPage {
     await RotkiApp.navigateTo(this.page, 'api-keys', submenu);
   }
 
+  /**
+   * Adds an exchange through the form, against mocked endpoints.
+   *
+   * @remarks
+   * Every route is registered before the form is touched. Playwright applies a route only to
+   * requests made after it is installed, so a mock added later lets the real request through and
+   * the assertion on the captured payload then reads an empty object.
+   */
   async addExchange(apiKey: string, apiSecret: string, exchange: string, name: string): Promise<void> {
-    // Set up route mocks BEFORE triggering any requests
     let capturedRequest: { api_key?: string; api_secret?: string; name?: string; location?: string } = {};
 
     await this.page.route('**/api/1/exchanges', async (route) => {

--- a/frontend/app/tests/e2e/pages/assets-manager-page.ts
+++ b/frontend/app/tests/e2e/pages/assets-manager-page.ts
@@ -192,8 +192,14 @@ export class AssetsManagerPage {
     await this.confirmDelete();
   }
 
+  /**
+   * Opens the add-asset dialog, closing whatever dialog is already open.
+   *
+   * @remarks
+   * Only one bottom dialog exists at a time, so a leftover one from an earlier step would be the
+   * dialog this method then went on to fill in.
+   */
   async showAddAssetModal(): Promise<void> {
-    // Ensure any existing dialog is closed first
     const dialog = this.page.locator('[data-testid=bottom-dialog]');
     if (await dialog.isVisible()) {
       await this.page.keyboard.press('Escape');

--- a/frontend/app/tests/e2e/pages/blockchain-accounts-page.ts
+++ b/frontend/app/tests/e2e/pages/blockchain-accounts-page.ts
@@ -14,8 +14,14 @@ export class BlockchainAccountsPage {
     await waitForNoRunningTasks(this.page);
   }
 
+  /**
+   * Opens the add-account dialog.
+   *
+   * @remarks
+   * Notifications are cleared first and waited out. They stack over this corner of the page, so a
+   * leftover one intercepts the click on the add button and the dialog never opens.
+   */
   async openAddDialog(): Promise<void> {
-    // Dismiss any notifications if present
     const dismissButton = this.page.locator('[data-testid=notification_dismiss-all]');
     if (await dismissButton.isVisible()) {
       await dismissButton.click();
@@ -82,12 +88,19 @@ export class BlockchainAccountsPage {
     await confirmDialog(this.page, 'Account delete');
   }
 
+  /**
+   * Deletes the account at the given row position and waits for the table to shrink.
+   *
+   * @remarks
+   * The drop in count is the settle signal: the delete is only complete once one account has gone,
+   * and neither the dialog closing nor the progress bar detaching proves that. Address displays are
+   * counted rather than `tr` elements, since there is exactly one per account and no row markup
+   * that could stand for something else.
+   */
   async deleteAccount(position: number): Promise<void> {
-    // Use labeled-address-display for reliable counting of actual account entries
     const accountAddresses = this.page.locator('[data-testid=account-table] [data-testid=labeled-address-display]');
     const initialCount = await accountAddresses.count();
 
-    // Use the row selector to find the delete button
     const rows = this.page.locator('[data-testid=account-table] tbody tr[data-id="row"]');
     await rows.nth(position).locator('button[data-testid=row-delete]').click();
     await this.confirmDelete();
@@ -96,7 +109,6 @@ export class BlockchainAccountsPage {
     await blockchainSection.waitFor({ state: 'attached', timeout: TIMEOUT_LONG });
     await blockchainSection.locator('tbody td div[role=progressbar]').waitFor({ state: 'detached', timeout: TIMEOUT_VERY_LONG });
 
-    // Wait for the account count to decrease (confirms delete completed)
     await expect(accountAddresses).toHaveCount(initialCount - 1, { timeout: TIMEOUT_LONG / 2 });
   }
 

--- a/frontend/app/tests/e2e/pages/dashboard-page.ts
+++ b/frontend/app/tests/e2e/pages/dashboard-page.ts
@@ -112,8 +112,14 @@ export class DashboardPage {
     await this.page.locator('[data-testid=snapshot-action]').click();
   }
 
+  /**
+   * Opens the snapshot import dialog.
+   *
+   * @remarks
+   * Call {@link DashboardPage.openSnapshotMenu} first. The Import button lives inside that menu,
+   * so this finds nothing while it is closed.
+   */
   async openImportSnapshotDialog(): Promise<SnapshotImportDialog> {
-    // The snapshot menu must already be open; the Import button lives inside it.
     await this.page.getByRole('button', { name: 'Import', exact: true }).click();
     const dialog = new SnapshotImportDialog(this.page);
     await dialog.waitForVisible();

--- a/frontend/app/tests/e2e/pages/history-event-rows.ts
+++ b/frontend/app/tests/e2e/pages/history-event-rows.ts
@@ -122,6 +122,16 @@ export class HistoryEventRows {
     await row.locator('[data-testid=swap-expand]').click();
   }
 
+  /**
+   * Deletes an already-resolved row and confirms the dialog.
+   *
+   * @remarks
+   * Resolve the row by id, never by index. The list is timestamp descending and re-renders under
+   * the test, so an `nth(0)` read before the click and an `nth(0)` delete after it can name two
+   * different rows and the assertion still passes. `data-subgroup-id` sits on both the collapsed
+   * row and the collapse header, so a locator built on it survives expanding and only a real
+   * deletion clears it.
+   */
   async delete(row: Locator): Promise<void> {
     await row.hover();
     await row.locator('[data-testid=row-delete]').click();

--- a/frontend/app/tests/e2e/pages/manual-balances-page.ts
+++ b/frontend/app/tests/e2e/pages/manual-balances-page.ts
@@ -43,8 +43,14 @@ export class ManualBalancesPage {
     await expect(this.page.locator('[data-testid=price-refresh]')).not.toBeDisabled();
   }
 
+  /**
+   * Asserts how many balance entries the table shows.
+   *
+   * @remarks
+   * The expected row count is one higher than the number of entries, because the table appends a
+   * total row that is not an entry.
+   */
   async visibleEntries(visible: number): Promise<void> {
-    // The total row is added to the visible entries
     await expect(this.page.locator('[data-testid=manual-balances] tbody tr')).toHaveCount(visible + 1);
   }
 

--- a/frontend/app/tests/e2e/pages/pill-filter-bar.ts
+++ b/frontend/app/tests/e2e/pages/pill-filter-bar.ts
@@ -207,13 +207,14 @@ export class PillFilterBar {
    * remote search is in flight, so passing the field key adds a deterministic fallback: clicking
    * the pill toggles its own menu shut. Selections in these editors commit on click, so nothing
    * is lost either way.
+   *
+   * There is no shared root to wait on, so whichever editor is open stands in through its own
+   * first control. An editor left open covers part of the bar and swallows the next click. The
+   * date editor takes two presses, and `setDateBound` has spent the first on the picker's
+   * calendar, so the press here is the one `DateValueEditor` sees, and the one that commits a
+   * bound typed as a bare date.
    */
   async closeEditor(fieldKey?: string): Promise<void> {
-    /* There is no shared root to wait on, so whichever editor is open stands in through its own
-       first control. An editor left open covers part of the bar and swallows the next click.
-       The date editor takes two presses, and `setDateBound` has spent the first on the picker's
-       calendar, so the press here is the one `DateValueEditor` sees, and the one that commits a
-       bound typed as a bare date. */
     const editor = this.page
       .locator([
         '[data-testid=value-select-search]',

--- a/frontend/app/tests/e2e/pages/purge-data-page.ts
+++ b/frontend/app/tests/e2e/pages/purge-data-page.ts
@@ -8,8 +8,14 @@ type CexCategoryLabel = 'All' | 'Trades' | 'Deposits / Withdrawals' | 'Other eve
 export class PurgeDataPage {
   constructor(private readonly page: Page) {}
 
+  /**
+   * Reaches the purge-data settings through the user menu.
+   *
+   * @remarks
+   * Clicked through rather than navigated to. Going straight to the route lands on a blank shell,
+   * because the layout never bootstraps.
+   */
   async visit(): Promise<void> {
-    // Navigating straight to the route lands on a blank shell: the layout never bootstraps.
     await this.page.locator('[data-testid=user-menu-button]').click();
     await this.page.locator('[data-testid=user-dropdown]').waitFor({ state: 'visible' });
     await this.page.locator('[data-testid=settings-button]').click();

--- a/frontend/app/tests/e2e/pages/rotki-app.ts
+++ b/frontend/app/tests/e2e/pages/rotki-app.ts
@@ -17,8 +17,15 @@ export class RotkiApp {
     private readonly request: APIRequestContext,
   ) {}
 
+  /**
+   * Seeds the external-service keys the run needs.
+   *
+   * @remarks
+   * Under `MOCK_RPC_MODE` no key is set at all. A real etherscan key would let the app reach the
+   * live API for anything the mock does not answer, which is exactly the non-determinism the mock
+   * exists to remove.
+   */
   private async loadEnv(): Promise<void> {
-    // Skip etherscan key when using mock RPC to force all calls through the mock
     if (process.env.MOCK_RPC_MODE) {
       return;
     }

--- a/frontend/app/tests/e2e/pages/rpc-settings-page.ts
+++ b/frontend/app/tests/e2e/pages/rpc-settings-page.ts
@@ -90,8 +90,14 @@ export class RpcSettingsPage {
     await this.page.locator('[data-testid=bottom-dialog]').waitFor({ state: 'detached' });
   }
 
+  /**
+   * Asserts that a node with this name is listed, carrying this endpoint.
+   *
+   * @remarks
+   * The row is found by filtering the node list on the name rather than by position, so the
+   * assertion still names the right node when the list is reordered or another node is added.
+   */
   async confirmRPCAddition(name: string, endpoint: string): Promise<void> {
-    // Use filter to find the specific node row
     const nodeRow = this.page.locator('[data-testid=ethereum-node]').filter({ hasText: name });
     await expect(nodeRow).toBeVisible();
     await expect(nodeRow).toContainText(endpoint);

--- a/frontend/app/tests/e2e/pages/snapshot-editor-page.ts
+++ b/frontend/app/tests/e2e/pages/snapshot-editor-page.ts
@@ -76,8 +76,14 @@ export class SnapshotEditorPage {
     await dialog.waitFor({ state: 'hidden' });
   }
 
+  /**
+   * Edits the balance row for an asset, setting a new amount.
+   *
+   * @remarks
+   * The row must also hold an edit control, not just the asset text. The "USD Value" header
+   * carries asset symbols of its own, so filtering on text alone matches the header first.
+   */
   async editBalanceRow(asset: string, newAmount: string): Promise<void> {
-    // The "USD Value" header carries asset symbols too, so a bare hasText can match it.
     const row = this.balancesTable
       .locator('tr', { hasText: asset })
       .filter({ has: this.page.locator('[data-testid=row-edit]') })

--- a/frontend/app/tests/e2e/pages/snapshot-list-page.ts
+++ b/frontend/app/tests/e2e/pages/snapshot-list-page.ts
@@ -18,8 +18,8 @@ export class SnapshotListPage {
     return this.table.locator('tr', { has: this.page.locator(`[data-testid=snapshot-list-row][data-key="${timestamp}"]`) });
   }
 
+  /** Opens the snapshot list, a submenu leaf under the Statistics group. */
   async visit(): Promise<void> {
-    // Snapshots is a submenu leaf under the Statistics group.
     await RotkiApp.navigateTo(this.page, 'statistics', 'statistics-snapshots');
     await this.table.waitFor({ state: 'visible' });
   }

--- a/frontend/app/tests/e2e/rpc-mock/server.ts
+++ b/frontend/app/tests/e2e/rpc-mock/server.ts
@@ -191,8 +191,15 @@ function buildResponseBody(id: number | string, fields: Record<string, unknown>)
   return JSON.stringify({ jsonrpc: '2.0', id, ...fields });
 }
 
+/**
+ * Answers one JSON-RPC call from the cassette.
+ *
+ * @remarks
+ * Balance scanner calls are resolved semantically, by address and token, before the hash lookup is
+ * tried. A hash covers the exact call as recorded, so it makes replay depend on the app asking for
+ * the same addresses in the same order; resolving from the balance maps does not.
+ */
 function handleReplayRequest(req: JsonRpcRequest, hash: string): string {
-  // Try semantic balance scanner resolution first (order-independent)
   if (balanceMaps) {
     const resolved = tryResolveBalanceCall(req.method, req.params, balanceMaps);
     if (resolved !== null) {
@@ -284,9 +291,11 @@ const server = createServer((req: IncomingMessage, res: ServerResponse) => {
 /**
  * Handles the server's control endpoints (health/cassette/save/stats).
  * Returns `true` when the request was one of them and a response was sent.
+ *
+ * @remarks
+ * `/health` is what Playwright polls to decide the mock is up before it starts a shard.
  */
 async function handleControlEndpoint(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
-  // Health check endpoint for Playwright
   if (req.url === '/health') {
     sendJson(res, 200, { status: 'ok', mode: MODE, cassette: cassetteName, entries: Object.keys(cassette).length });
     return true;

--- a/frontend/app/tests/e2e/specs/app/account-creation.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/account-creation.spec.ts
@@ -47,8 +47,7 @@ test.describe('accounts', () => {
         await app.logout();
       });
 
-      test('login', async () => {
-        // After logout we're already on the login page with animations disabled
+      test('login again without navigating, since the logout above lands on the login page', async () => {
         await app.login(username);
         await app.checkGetPremiumButton();
         await app.logout();

--- a/frontend/app/tests/e2e/specs/app/address-book.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/address-book.spec.ts
@@ -1,6 +1,8 @@
 import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { AddressBookPage } from '../../pages/address-book-page';
 
+const DEFAULT_PAGE_SIZE = 10;
+
 const ADDR_PRIVATE = '0x1111111111111111111111111111111111111111';
 
 test.describe.serial('address book', () => {
@@ -53,16 +55,15 @@ test.describe.serial('address book', () => {
     await page.cancelDialog();
   });
 
-  test('paginates when more than 10 entries exist', async () => {
-    // Default page size is 10, so 11 entries guarantees a second page.
-    for (let i = 0; i < 11; i++) {
+  test('paginates once the entries outgrow a page', async () => {
+    for (let i = 0; i < DEFAULT_PAGE_SIZE + 1; i++) {
       // Encode i in the address prefix so each entry has a unique value.
       const addr = `0x${i.toString(16).padStart(2, '0')}${'b'.repeat(38)}`;
       const name = `entry-${i.toString().padStart(2, '0')}`;
       await page.addEntry({ address: addr, name });
     }
 
-    await page.expectVisibleRowCount(10);
+    await page.expectVisibleRowCount(DEFAULT_PAGE_SIZE);
     await page.expectNextPageEnabled(true);
 
     await page.goToNextPage();

--- a/frontend/app/tests/e2e/specs/app/exchange-purge.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/exchange-purge.spec.ts
@@ -11,10 +11,15 @@ import { PurgeDataPage } from '../../pages/purge-data-page';
 
 const LOCATION = 'kraken';
 
+/**
+ * Seeds one row of every purgeable category for the exchange under test.
+ *
+ * @remarks
+ * The base timestamp is a minute in the past, so the purge endpoint's `to_timestamp = now()`
+ * filter takes the rows in. Each helper stamps its `unique_id` from that timestamp, which is what
+ * lets a reseed after a purge produce fresh rows rather than collide with the purged ones.
+ */
 async function seedAllCategories(request: Parameters<typeof apiSeedSwap>[0]): Promise<void> {
-  /* The ids in each helper's `unique_id` are stamped from the timestamp, so every reseed makes
-     fresh rows even after a purge. In the past, so the endpoint's `to_timestamp = now()` filter
-     includes them. */
   const base = Date.now() - 60_000;
   await apiSeedSwap(request, { location: LOCATION, sequenceIndex: 0, timestampMs: base });
   await apiSeedAssetMovement(request, { location: LOCATION, sequenceIndex: 0, timestampMs: base + 1 });
@@ -35,10 +40,21 @@ test.describe.serial('exchange purge by category', () => {
     await cleanupContext(ctx);
   });
 
-  test.beforeEach(async ({ request }) => {
-    // Purging here starts every test from a known set and proves nothing was left behind.
+  /**
+   * Returns the exchange to the full seeded set, whatever the previous test purged.
+   *
+   * @remarks
+   * The purge runs before the reseed rather than after each test, so a test that failed partway
+   * cannot leave rows behind that the next one would then count. Every test therefore starts from
+   * the same known set, and the counts it asserts are the seeding's, not the previous test's.
+   */
+  async function resetToSeededState(request: Parameters<typeof apiSeedSwap>[0]): Promise<void> {
     await apiPurgeExchangeData(request, LOCATION, 'all');
     await seedAllCategories(request);
+  }
+
+  test.beforeEach(async ({ request }) => {
+    await resetToSeededState(request);
   });
 
   // A swap expands into spend and receive, so a trade counts two; the others stay 1:1.

--- a/frontend/app/tests/e2e/specs/app/tag-manager.spec.ts
+++ b/frontend/app/tests/e2e/specs/app/tag-manager.spec.ts
@@ -1,6 +1,8 @@
 import { cleanupContext, createLoggedInContext, type SharedTestContext, test } from '../../fixtures/test-fixtures';
 import { TagManagerPage } from '../../pages/tag-manager';
 
+const DEFAULT_PAGE_SIZE = 10;
+
 test.describe.serial('tag manager', () => {
   let ctx: SharedTestContext;
   let page: TagManagerPage;
@@ -36,12 +38,11 @@ test.describe.serial('tag manager', () => {
     await page.expectAtLeastVisibleRows(3);
   });
 
-  test('paginates when more than 10 tags exist', async () => {
-    // Four tags exist by now, so nine more pass the default page size of 10.
-    for (let i = 0; i < 9; i++)
+  test('paginates once the tags from this suite outgrow a page', async () => {
+    for (let i = 0; i < DEFAULT_PAGE_SIZE; i++)
       await page.createTag(`tag-${i.toString().padStart(2, '0')}`, `tag ${i}`);
 
-    await page.expectVisibleRowCount(10);
+    await page.expectVisibleRowCount(DEFAULT_PAGE_SIZE);
     await page.expectNextPageEnabled(true);
 
     await page.goToNextPage();

--- a/frontend/app/tests/e2e/specs/history/history-events.spec.ts
+++ b/frontend/app/tests/e2e/specs/history/history-events.spec.ts
@@ -129,8 +129,7 @@ test.describe.serial('history events', () => {
     await expect.poll(async () => receiveAmount.textContent(), { timeout: TIMEOUT_MEDIUM }).not.toBe(before);
   });
 
-  test('delete fee sub-event from online swap', async () => {
-    // The swap created earlier has three sub-events: spend, receive and fee.
+  test('delete the fee sub-event of the online swap, leaving its spend and receive', async () => {
     const rowsBeforeExpand = await page.getExpandedEventRows();
     await page.rows.expand(swapRow);
 
@@ -184,8 +183,7 @@ test.describe.serial('history events', () => {
     await expect(row.locator('[data-testid=event-amount]').first()).toContainText(updatedAmount);
   });
 
-  test('delete history event', async () => {
-    // Named, since a total over the table cannot say which row went away.
+  test('delete the named history event, since a row total cannot say which row went', async () => {
     await page.rows.delete(onlineRow);
 
     await expect(onlineRow).toHaveCount(0, { timeout: TIMEOUT_MEDIUM });
@@ -304,19 +302,13 @@ test.describe.serial('history events', () => {
     await page.rows.expectNotes(row, updatedAmount);
   });
 
-  test('delete solana event', async () => {
-    // Named: reading the top row and then deleting the top row would also pass on a re-sort.
+  test('delete the named solana event, which a read-then-delete of the top row would fake', async () => {
     await page.rows.delete(solanaRow);
 
     await expect(solanaRow).toHaveCount(0, { timeout: TIMEOUT_MEDIUM });
   });
 
-  test('delete swap event', async () => {
-    /* Addressed by id, never by index: the list is timestamp DESC and re-renders under the test,
-       so `nth(0)` deleted a different swap than the one read. `data-subgroup-id` is on both the
-       collapsed row and the collapse header, so expanding still matches and only a deletion
-       clears it. The solana swap, because the online one is left expanded by an earlier test and
-       an expanded group's header carries no row actions. */
+  test('delete the solana swap, the online one being left expanded by an earlier test with no row actions on its header', async () => {
     await page.rows.delete(solanaSwapRow);
 
     await expect(solanaSwapRow).toHaveCount(0, { timeout: TIMEOUT_MEDIUM });
@@ -336,7 +328,6 @@ test.describe.serial('evm history events', () => {
   test.beforeAll(async ({ browser, request }) => {
     ctx = await createLoggedInContext(browser, request, {
       seed: (username) => {
-        // The user DB is only writable here, while the account exists but is logged out.
         seedHistoricPrices(TEST_PRICE_ENTRIES, TEST_EVENT_TIMESTAMP);
 
         seedEvmTransaction(username, evmEventFixture.txRef);
@@ -427,8 +418,7 @@ test.describe.serial('evm history events', () => {
     multiSwapRow = await page.rows.waitForNewRow(before, SWAP_ROW);
   });
 
-  test('delete extra sub-event from multi-asset swap', async () => {
-    // Six sub-events, and the newest timestamp puts them first, which the index below relies on.
+  test('delete a sub-event of the multi-asset swap, whose six sort first on the newest timestamp', async () => {
     const rowsBeforeExpand = await page.getExpandedEventRows();
     await page.rows.expand(multiSwapRow);
 
@@ -483,9 +473,7 @@ test.describe.serial('evm history events', () => {
     await page.rows.expectNotes(row, updatedAmount);
   });
 
-  test('the row action on a lone evm event excludes it from accounting', async () => {
-    /* The only event of a decoded EVM transaction would come back with the transaction, so the
-       row action becomes an ignore: the row stays and its group gains the ignored badge. */
+  test('the row action on the only event of a decoded evm transaction ignores it rather than deleting, since a delete would come back with the transaction', async () => {
     const ignored = ctx.sharedPage.locator('[data-testid=ignored-in-accounting]');
     await expect(ignored).toHaveCount(0);
 
@@ -495,8 +483,7 @@ test.describe.serial('evm history events', () => {
     await expect(evmRow).toHaveCount(1);
   });
 
-  test('delete evm swap event', async () => {
-    // The multi-asset swap is still expanded, and its collapse header carries no row actions.
+  test('delete the evm swap while the multi-asset swap stays expanded, its header offering no actions', async () => {
     await page.rows.delete(evmSwapRow);
 
     await expect(evmSwapRow).toHaveCount(0, { timeout: TIMEOUT_MEDIUM });

--- a/frontend/app/tests/e2e/specs/settings/account.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/account.spec.ts
@@ -21,8 +21,7 @@ test.describe.serial('settings::data & security', () => {
     await pageUserSecurity.confirmSuccess();
   });
 
-  test('verify that new password works', async () => {
-    // Logout and login with the new password
+  test('verify the new password works, by logging out and back in with it', async () => {
     await ctx.app.relogin(ctx.username, newPassword);
   });
 });

--- a/frontend/app/tests/e2e/specs/settings/chains.spec.ts
+++ b/frontend/app/tests/e2e/specs/settings/chains.spec.ts
@@ -42,8 +42,7 @@ test.describe.serial('settings::chains', () => {
     await chainsPage.verifyTabExists('default');
   });
 
-  test('can add and remove a chain-specific indexer order', async () => {
-    // First ensure the chain is not configured by removing it if it exists
+  test('can add and remove a chain-specific indexer order, freeing a slot first when all chains are configured', async () => {
     const isDisabled = await chainsPage.isAddChainButtonDisabled();
     if (isDisabled) {
       // All chains are configured, remove one first

--- a/frontend/dev-proxy/src/index.ts
+++ b/frontend/dev-proxy/src/index.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import http, { type IncomingMessage, type ServerResponse } from 'node:http';
 import net from 'node:net';
 import process from 'node:process';
-import { Readable } from 'node:stream';
+import { type Duplex, Readable } from 'node:stream';
 import consola, { LogLevels } from 'consola';
 import { createProxyServer } from 'httpxy';
 import { parseBody, readBody } from './body';
@@ -235,8 +235,15 @@ const server = http.createServer((req, res) => {
     .catch(error => consola.error(error));
 });
 
-server.on('upgrade', (req, socket, head) => {
-  // Node types the upgrade socket as Duplex; an HTTP/1.1 upgrade is always the net.Socket httpxy wants.
+/**
+ * Hands a websocket upgrade to the proxy.
+ *
+ * @remarks
+ * Node types the upgrade socket as a `Duplex`, while httpxy wants a `net.Socket`. An HTTP/1.1
+ * upgrade always is one, so the check is a narrowing rather than a case that happens, and the
+ * socket is destroyed rather than cast if it ever is not.
+ */
+function proxyUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): void {
   if (!(socket instanceof net.Socket)) {
     socket.destroy();
     return;
@@ -245,7 +252,9 @@ server.on('upgrade', (req, socket, head) => {
     consola.error(error);
     socket.destroy();
   });
-});
+}
+
+server.on('upgrade', proxyUpgrade);
 
 server.listen(port, () => {
   consola.log(`Proxy server is running at http://127.0.0.1:${port}`);

--- a/frontend/dev-proxy/src/mock-engine.spec.ts
+++ b/frontend/dev-proxy/src/mock-engine.spec.ts
@@ -41,8 +41,7 @@ describe('mock engine', () => {
       expect(engine.transformResponse(request('POST', UPDATES), { result: 'backend' })).toBeUndefined();
     });
 
-    it('should not let a mock answer for a path it merely starts with', () => {
-      // Regression: `mockKey.includes(requestPath)` let a mock for /api/1/assets/updates answer /api/1/assets.
+    it('should not let a mock for /api/1/assets/updates answer /api/1/assets, a path it merely starts with', () => {
       const engine = createMockEngine({ [UPDATES]: { GET: { result: 'wrong' } } });
 
       expect(engine.transformResponse(request('GET', '/api/1/assets'), { result: 'backend' })).toBeUndefined();
@@ -74,8 +73,7 @@ describe('mock engine', () => {
       expect(engine.transformResponse(request('GET', UPDATES), {})).toStrictEqual({ result: 2 });
     });
 
-    it('should advance the same cursor whatever query string the url carries', () => {
-      // Regression: the cursor was keyed on the full url in one branch and on the path in another.
+    it('should advance the same cursor whatever query string the url carries, keying it on the path in every branch', () => {
       const engine = createMockEngine(mocks);
 
       expect(engine.transformResponse(request('GET', UPDATES), {})).toStrictEqual({ result: 1 });
@@ -179,8 +177,7 @@ describe('mock engine', () => {
         .toStrictEqual({ message: '', result: { completed: [taskId], pending: [] } });
     });
 
-    it('should merge into the path the app actually polls, without a trailing slash', () => {
-      // Regression: matching only `/api/1/tasks/` meant the merge never fired for the app's `/tasks`.
+    it('should merge into the app\'s /api/1/tasks, not only the trailing-slash form it never polls', () => {
       const engine = createMockEngine(mocks);
       const taskId = taskIdOf(engine.transformResponse(request('POST', UPDATES, { async_query: true }), {}));
 

--- a/frontend/dev-proxy/src/mock-engine.ts
+++ b/frontend/dev-proxy/src/mock-engine.ts
@@ -120,9 +120,14 @@ export function createMockEngine(
     };
   }
 
-  /** Answers a poll for one mocked task; a real backend task falls through. */
+  /**
+   * Answers a poll for one mocked task; a real backend task falls through.
+   *
+   * @remarks
+   * The path segment after `/tasks/` is not always an id. Siblings such as `/tasks/trigger` and
+   * `/tasks/scheduler` share the prefix, and parsing to `NaN` is what routes them onward.
+   */
   function taskOutcome(req: MockRequest): unknown {
-    // Non-numeric siblings (/tasks/trigger, /tasks/scheduler) fall through.
     const taskId = Number.parseInt(req.path.replace(`${TASKS_PATH}/`, ''), 10);
     if (Number.isNaN(taskId))
       return undefined;

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -132,11 +132,11 @@ catalogs:
       specifier: 1.62.1
       version: 1.62.1
     '@rotki/eslint-config':
-      specifier: 8.1.0
-      version: 8.1.0
+      specifier: 8.2.0
+      version: 8.2.0
     '@rotki/eslint-plugin':
-      specifier: 1.6.1
-      version: 1.6.1
+      specifier: 1.7.0
+      version: 1.7.0
     '@rotki/ui-library':
       specifier: 2.24.0
       version: 2.24.0
@@ -392,10 +392,10 @@ importers:
         version: 4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0)
       '@rotki/eslint-config':
         specifier: 'catalog:'
-        version: 8.1.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.6.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.42)(eslint-plugin-tsdoc@0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)
+        version: 8.2.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.42)(eslint-plugin-tsdoc@0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)
       '@rotki/eslint-plugin':
         specifier: 'catalog:'
-        version: 1.6.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+        version: 1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       cac:
         specifier: 'catalog:'
         version: 7.0.0
@@ -2272,13 +2272,13 @@ packages:
       rollup:
         optional: true
 
-  '@rotki/eslint-config@8.1.0':
-    resolution: {integrity: sha512-BBbK9l7gr3v5At/VxaG4ZDTIkOX7Q6caaNDdhnn+h7nACoE7kagt/o+myj6GAEAFGb/sqzAZTBUOFyXOLI8ajQ==}
+  '@rotki/eslint-config@8.2.0':
+    resolution: {integrity: sha512-4fcQZx1w5b3NsXGOCnnFV6vfcPp5oIUH1G5OG5vc1bmpAoISnHZDzyB7J+Ld1WixfJxIYkaNiF8+4nMxMqaO0w==}
     engines: {node: '>=24 <25', pnpm: '>=11 <12'}
     peerDependencies:
       '@intlify/eslint-plugin-vue-i18n': ^4.2.0
       '@prettier/plugin-xml': ^3.4.1
-      '@rotki/eslint-plugin': '>=1.6.0'
+      '@rotki/eslint-plugin': '>=1.7.0'
       eslint: ^9.20.0 || ^10.0.0
       eslint-plugin-slop: '>=0.1.3'
       eslint-plugin-sonarjs: '>=4.0.0'
@@ -2300,8 +2300,8 @@ packages:
       eslint-plugin-tsdoc:
         optional: true
 
-  '@rotki/eslint-plugin@1.6.1':
-    resolution: {integrity: sha512-h+eChcWbR+9meg5JnCRBo1iN2Bc88er5rgJG7Ruy+f2Fbsd0EFO9Rnwku+eQKLObYAPD8M8Al6x1agRuy+sfwA==}
+  '@rotki/eslint-plugin@1.7.0':
+    resolution: {integrity: sha512-h+ts+/fBpZx8iPUUVHozQgqI1UA+KyhgAmHvwZu7NSLHfMsFytTIAJyJVd4bIfo920Yj4ewZTZ5ENQOrjgAPHQ==}
     engines: {node: '>=24 <25', pnpm: '>=10 <12'}
     peerDependencies:
       eslint: ^9.20.0 || ^10.0.0
@@ -2410,9 +2410,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@24.12.2':
-    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
-
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
@@ -2508,10 +2505,6 @@ packages:
 
   '@typescript-eslint/types@8.56.1':
     resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/types@8.67.0':
-    resolution: {integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/types@8.68.0':
@@ -4122,9 +4115,6 @@ packages:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
 
-  get-tsconfig@4.14.0:
-    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
-
   get-tsconfig@4.14.3:
     resolution: {integrity: sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==}
 
@@ -5471,11 +5461,6 @@ packages:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier@3.9.5:
-    resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   prettier@3.9.6:
     resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
@@ -5690,11 +5675,6 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -6019,10 +5999,6 @@ packages:
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -6131,9 +6107,6 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
-
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -6770,7 +6743,7 @@ snapshots:
   '@antfu/install-pkg@2.0.1':
     dependencies:
       package-manager-detector: 1.8.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -7217,7 +7190,7 @@ snapshots:
   '@es-joy/jsdoccomment@0.95.1':
     dependencies:
       '@types/estree': 1.0.9
-      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/types': 8.68.0
       comment-parser: 1.4.8
       esquery: 1.7.0
       jsdoc-type-pratt-parser: 9.1.2
@@ -7587,7 +7560,7 @@ snapshots:
       json5: 2.2.3
       jsonc-eslint-parser: 3.3.0
       parse5: 7.3.0
-      semver: 7.8.4
+      semver: 7.8.5
       synckit: 0.11.13
       vue-eslint-parser: 10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
       yaml-eslint-parser: 2.1.0
@@ -8082,7 +8055,7 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.7
 
-  '@rotki/eslint-config@8.1.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.6.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.42)(eslint-plugin-tsdoc@0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)':
+  '@rotki/eslint-config@8.2.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.42)(eslint-plugin-tsdoc@0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)':
     dependencies:
       '@antfu/install-pkg': 2.0.1
       '@clack/prompts': 1.7.0
@@ -8123,7 +8096,7 @@ snapshots:
       yaml-eslint-parser: 2.1.0
     optionalDependencies:
       '@intlify/eslint-plugin-vue-i18n': 4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0)
-      '@rotki/eslint-plugin': 1.6.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@rotki/eslint-plugin': 1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       eslint-plugin-tsdoc: 0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@eslint/json'
@@ -8135,7 +8108,7 @@ snapshots:
       - typescript
       - vitest
 
-  '@rotki/eslint-plugin@1.6.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@rotki/eslint-plugin@1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/parser': 8.68.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.68.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
@@ -8192,7 +8165,7 @@ snapshots:
   '@stylistic/eslint-plugin@5.10.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))
-      '@typescript-eslint/types': 8.67.0
+      '@typescript-eslint/types': 8.68.0
       eslint: 10.9.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
@@ -8262,10 +8235,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@24.12.2':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
@@ -8277,7 +8246,7 @@ snapshots:
 
   '@types/qrcode@1.5.6':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.13.3
 
   '@types/responselike@1.0.3':
     dependencies:
@@ -8303,7 +8272,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.12.2
+      '@types/node': 24.13.3
 
   '@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
@@ -8382,8 +8351,6 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.56.1': {}
-
-  '@typescript-eslint/types@8.67.0': {}
 
   '@typescript-eslint/types@8.68.0': {}
 
@@ -8467,7 +8434,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)':
     dependencies:
@@ -8477,7 +8444,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       typescript: 6.0.3
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8508,6 +8475,14 @@ snapshots:
       msw: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
 
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
+
   '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.0
@@ -8535,7 +8510,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
 
   '@vitest/utils@4.1.11':
     dependencies:
@@ -9978,7 +9953,7 @@ snapshots:
       eslint-parser-plain: 0.1.1
       ohash: 2.0.11
       oxfmt: 0.35.0
-      prettier: 3.9.5
+      prettier: 3.9.6
       synckit: 0.11.13
 
   eslint-plugin-html@8.2.0:
@@ -10032,7 +10007,7 @@ snapshots:
       enhanced-resolve: 5.24.0
       eslint: 10.9.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-es-x: 7.8.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))
-      get-tsconfig: 4.14.0
+      get-tsconfig: 4.14.3
       globals: 15.15.0
       globrex: 0.1.2
       ignore: 5.3.2
@@ -10487,10 +10462,6 @@ snapshots:
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.4
-
-  get-tsconfig@4.14.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@4.14.3:
     dependencies:
@@ -12031,8 +12002,6 @@ snapshots:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier@3.9.5: {}
-
   prettier@3.9.6: {}
 
   proc-log@6.1.0: {}
@@ -12240,8 +12209,6 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
-
-  semver@7.8.4: {}
 
   semver@7.8.5: {}
 
@@ -12614,8 +12581,6 @@ snapshots:
 
   tinycolor2@1.6.0: {}
 
-  tinyexec@1.2.4: {}
-
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
@@ -12702,8 +12667,6 @@ snapshots:
   unbash@4.0.10: {}
 
   uncrypto@0.1.3: {}
-
-  undici-types@7.16.0: {}
 
   undici-types@7.18.2: {}
 
@@ -13088,6 +13051,36 @@ snapshots:
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      '@vitest/ui': 4.1.11(vitest@4.1.11)
+      happy-dom: 20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -59,8 +59,8 @@ catalog:
   '@intlify/unplugin-vue-i18n': 11.2.5
   '@pinia/testing': 2.0.1
   '@playwright/test': 1.62.1
-  '@rotki/eslint-config': 8.1.0
-  '@rotki/eslint-plugin': 1.6.1
+  '@rotki/eslint-config': 8.2.0
+  '@rotki/eslint-plugin': 1.7.0
   '@rotki/ui-library': 2.24.0
   '@tsconfig/node24': 24.0.5
   '@types/node': 24.13.3

--- a/frontend/scripts/dev-instance/instance.ts
+++ b/frontend/scripts/dev-instance/instance.ts
@@ -48,8 +48,14 @@ function envKeysDiverge(
   return diverging;
 }
 
+/**
+ * The environment variables that pin this instance to its own ports and data directory.
+ *
+ * @remarks
+ * One origin covers the whole backend chain, because starling fronts core and serves colibri under
+ * `/colibri`. Only the dev-proxy case needs a second origin, and it is the exception.
+ */
 function computeDesiredManagedEnv(name: string, slot: number, ports: PortSet, useProxy: boolean): Record<string, string> {
-  // starling fronts core and colibri (under `/colibri`), so one origin covers the whole chain.
   const starlingOrigin = `http://127.0.0.1:${ports.starlingProxy}`;
   return {
     INSTANCE_NAME: name,

--- a/frontend/scripts/dev/services.ts
+++ b/frontend/scripts/dev/services.ts
@@ -208,20 +208,29 @@ async function assertDevProxyPortFree(port: number): Promise<void> {
   );
 }
 
+/**
+ * Starts the premium dev-proxy between starling and core.
+ *
+ * @remarks
+ * The chain is frontend to starling's proxy to dev-proxy to core, and only `/api/1/*` is routed
+ * through it. starling stays the single renderer origin, so `VITE_BACKEND_URL` is untouched.
+ */
 function spawnProxyForBackend(instance: InstanceRuntime | null, corePort: number): void {
-  /* The premium dev-proxy sits between starling and core: frontend -> starling proxy ->
-     dev-proxy -> core. starling stays the single renderer origin, so `VITE_BACKEND_URL` is
-     untouched, and only `/api/1/*` is routed through the proxy. */
   startDevProxy({
     PORT: String(devProxyPort(instance)),
     BACKEND: `http://127.0.0.1:${corePort}`,
   });
 }
 
+/**
+ * Starts the premium dev-proxy for the starling that Electron spawns itself.
+ *
+ * @remarks
+ * That starling routes `/api/1/*` through this proxy once it is told the port below. The renderer
+ * is handed starling's origin over IPC and has to keep it, so nothing here touches
+ * `VITE_BACKEND_URL`.
+ */
 function spawnProxyForElectron(instance: InstanceRuntime | null): void {
-  /* Electron spawns its own starling, which routes `/api/1/*` through this proxy once told the
-     port below. The renderer is handed starling's origin over IPC and must keep it, so nothing
-     here touches VITE_BACKEND_URL. */
   const backendPort = instance?.ports.restApi ?? DEFAULT_PORTS.restApi;
   startDevProxy({
     PORT: String(devProxyPort(instance)),

--- a/frontend/scripts/dev/starling.ts
+++ b/frontend/scripts/dev/starling.ts
@@ -9,6 +9,21 @@ import { registerShutdownHook } from './process-pool';
 
 const logger = createDevLogger('dev:starling');
 
+/**
+ * Reports a starling event, raising only a crash to an error.
+ *
+ * @remarks
+ * Startup problems surface through the `start` request instead, which does not resolve until the
+ * whole tree is up. What reaches here arrives afterwards, so a crash is the only event that says
+ * something has gone wrong.
+ */
+function logStarlingEvent(method: string): void {
+  if (method === 'event.crashed')
+    logger.error('a backend service crashed, see the starling output above');
+  else
+    logger.info(`starling event: ${method}`);
+}
+
 const API_HOST = '127.0.0.1';
 
 /** How long `stop` may take: starling only answers once the tree is down. */
@@ -58,11 +73,13 @@ export interface StarlingDevPorts {
  *
  * The `start` request is the readiness gate — it resolves only once the whole
  * tree is up, so there is nothing here to poll.
+ *
+ * Under `strictPorts` a slot has reserved every port already, so each is bound exactly and the
+ * start fails if something else holds it, rather than drifting onto a neighbouring instance's.
  */
 export async function startStarlingSupervisor(
   options: StarlingDevOptions,
 ): Promise<{ env: StarlingDevEnv; ports: StarlingDevPorts }> {
-  // A slot reserves every port, so instance mode binds exactly and fails if something holds it.
   const taken = new Set<number>();
   const resolve = async (port: number): Promise<number> => {
     if (options.strictPorts) {
@@ -110,13 +127,7 @@ export async function startStarlingSupervisor(
     `Starting starling supervisor (proxy on ${proxyPort}, core ${corePort}, colibri ${colibriPort}${upstreamNote})`,
   );
 
-  const rpc = new StarlingRpc({ warn: message => logger.warn(message) }, (method) => {
-    // The `start` reply is the readiness gate, so only a crash, which arrives later, matters.
-    if (method === 'event.crashed')
-      logger.error('a backend service crashed, see the starling output above');
-    else
-      logger.info(`starling event: ${method}`);
-  });
+  const rpc = new StarlingRpc({ warn: message => logger.warn(message) }, logStarlingEvent);
 
   const { child, exited } = spawnStarling({
     invocation,

--- a/frontend/scripts/start-dev.ts
+++ b/frontend/scripts/start-dev.ts
@@ -72,8 +72,14 @@ async function dispatchManagementSubcommand(options: DevCliOptions): Promise<boo
   return false;
 }
 
+/**
+ * Loads the development environment, the override file taking precedence over the base.
+ *
+ * @remarks
+ * The order is the mechanism: dotenv never replaces a variable that is already set, so whichever
+ * file is read first wins. Loading the base first would make the override file inert.
+ */
 function loadDevEnv(): void {
-  // dotenv never overrides a set var, so the override file is loaded before the `app/.env` base.
   if (fs.existsSync(ENV_FILE_RELATIVE)) {
     config({ path: ENV_FILE_RELATIVE });
   }


### PR DESCRIPTION
Bumps `@rotki/eslint-config` to 8.2.0, which brings `@rotki/eslint-plugin` 1.7.0 and with it [`no-leading-body-comment`](https://github.com/rotki/eslint-plugin/pull/51), then clears everything the new rule reports.

The rule is the third of the comment rules. `no-comment-run` stops an explanation sprawling into narration and `tsdoc-on-declaration` asks for it on the declaration; this one stops it sitting a line below the declaration instead, where no reader, editor tooltip or call site looks for it.

## The bump on its own

160 errors across 119 files, and `no-leading-body-comment` is the only rule that fires. The bump introduces no other regressions.

| messageId | n | the fix it asks for |
|---|---|---|
| `body` | 92 | TSDoc on the named declaration |
| `testBody` | 42 | fold into the `it()` title |
| `callback` | 26 | lift the body into a named function |

Lint is red until all 160 are cleared, so the fixes are in the same PR, one commit per module.

## What the pass turned up

**One sentence, eleven copies, nine files.** Every `create*Handler` in the messaging registry opened with a variation of *"Capture X at handler creation time (in setup context)"*. That is one fact about `createHandlerRegistry` — the single thing that has to run in a setup context — and it now lives there once.

**Comments that were already documented on the thing they described**, and so just went:

| comment in | already stated on |
|---|---|
| `history-events.spec.ts` seed callback | the `seed?:` option in `test-fixtures.ts` |
| `use-blockchain-balances.ts` run callback | `chainJob`'s own TSDoc, in the same file |
| `window-manager.ts` handler labels | `setupStartupErrorHandlers`' TSDoc, directly above |

**A repeated rule became a name.** `toggleEvent` and `toggleSwap` both opened with the same line about dropping `selectAllMatching`; that is now `leaveSelectAllMatching()`, read at both call sites instead of restated at each.

**A page-object contract moved to the page object.** The "address rows by id, never by index" trap was explained inside one history-events test. It governs every caller of `rows.delete`, so it is now on `rows.delete`.

**Two test defects, found by reading rather than by running.** `tag-manager.spec.ts` claimed "four tags exist by now" where earlier tests create three; it now seeds a full page's worth, which makes it independent of that count either way. `address-book.spec.ts` grew a `DEFAULT_PAGE_SIZE` constant so the loop bound and the assertion are visibly the same number.

## A bug in the rule, found here

`callerName` read a member expression through to its object, so Playwright's `test.beforeEach` resolved to `test` and was reported as a **test body** — advising the author to fold the comment into a title a hook does not have. `test.describe` was misclassified the same way.

Fixed in the plugin: a property is read as the kind when it names one, leaving `it.each` and `test.skip` resolving to the object and staying tests. The fix ships in `@rotki/eslint-plugin` 1.7.1 and matters for Playwright hooks written from here on. **This PR does not depend on it** — the one file it affected reads better with its hook body extracted into a documented `resetToSeededState`, which is what it now does.

## Known limitation: `schemas.ts` cannot take documentation

`HistoryEventRow`'s array arm is a subgroup — swap legs, or the two sides of a matched asset movement — and the type says nothing about it. Documenting it there took `history/events/schemas.ts` from 394 lines to 403, over the 400-line `max-lines` cap.

The guidance is to split rather than shorten the doc, but the only clean seam (the `OnlineHistoryEventsQueryType` block) has ~20 importers, which would turn a comment cleanup into a module reorganisation. The fact is on `useVirtualRows` instead, which renders those rows. The split is worth its own PR.

`electron/main/window-manager.ts` hit the same cap; there the line came back by deleting a leftover restatement, which the comment guidance ranks as a deletion anyway.

## Checks

`lint` · `typecheck` · `lint:style` · `check:linked-keys` · `knip` · `build` all clean. `test:unit`: 1039 files, 11,186 passed, 1 todo.

`knip` is worth calling out — it is a CI step no pnpm script invokes, and it is the gate that catches an export left orphaned by an extraction. Several extractions here.
