### PR TITLE
feat(settings): add a provider key across every chain

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* :feature:`12640` An Infura, Alchemy or QuickNode key can now be put on every chain the provider serves in one go. Add an RPC node as usual, and when the endpoint is one of theirs rotki offers to add the same key to the other chains: it works out each chain's address for it, connects them one by one and keeps those that answer, telling you per chain what happened. Chains the provider does not serve, and those already using the key, are named and left alone, and the nodes added this way can be removed again in one action. Where a provider needs the network switched on for the key, as Infura and QuickNode do, you are told before anything is added.
+* :bug:`-` Adding an RPC node, or reconnecting one, now tells you when the node could not be connected. The failure was dropped silently, so a node that never answered looked like it had been added and simply went unused.
 * :bug:`13071` Database backups can now be deleted immediately after downloading on Windows, and temporary export files are cleaned up after downloads finish.
 * :feature:`13033` You can now stop rotki querying an account from the accounts table itself, on one of its chains or on all of them, instead of having to remember the address and find it again in the chain settings. The chains that are skipped are marked on the account's row.
 * :feature:`-` Ink is now a supported EVM chain. Balances and transactions can be tracked on it.

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -3046,6 +3046,9 @@
       "message": "Are you sure you want to delete the RPC node '{node}' ({endpoint}) for {chain}?",
       "title": "Delete {chain} RPC Node"
     },
+    "connect_error": {
+      "title": "Could not connect every {chain} RPC node"
+    },
     "connected": {
       "cooling_down": "Rate limited",
       "failure": "Failed",

--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5718,9 +5718,61 @@
     "endpoint": "Endpoint",
     "owned": "Owned",
     "owned_hint": "Enable if this node is a private node owned by the user",
+    "owned_hint_provider": "Every chain this key is added to gets it as an owned node with a weight of 0, so they are tried first and your existing nodes keep their weights relative to each other.",
     "weight": "Weight",
     "weight_hint": "Node weight {weight}/100 (when adjusting a public node's weight other nodes will be adjusted accordingly)",
     "weight_per_hundred": "/100"
+  },
+  "rpc_provider_setup": {
+    "actions": {
+      "close": "Close",
+      "retry": "Retry failed"
+    },
+    "apply": {
+      "archive": "Archive",
+      "count": {
+        "added": "{count} added",
+        "failed": "{count} failed",
+        "untried": "{count} not tried"
+      },
+      "details": "Per chain",
+      "expand_failed": "Expand to see why | Expand to see why {count} chain failed | Expand to see why {count} chains failed",
+      "progress": "Connecting…",
+      "progress_chain": "Connecting to {chain}…",
+      "progress_count": "{done} of {total}",
+      "reason": {
+        "rejected": "Key rejected",
+        "unknown": "Not added",
+        "unreachable": "No answer",
+        "wrong_network": "Wrong network"
+      },
+      "summary_archive": "{archive} of them serve archive data.",
+      "unknown_error": "The node could not be verified, so it was not kept."
+    },
+    "enablement": {
+      "multichain_endpoint": "{provider} serves other networks from one endpoint only once Multichain is enabled on it, which their newer plans offer. A network that is not served will be reported below and left out.",
+      "per_network": "{provider} enables networks per key, and they are on by default. A network that is switched off for this key will be reported below and left out."
+    },
+    "offer": {
+      "enable": "Also add this key to the other chains {provider} serves | Also add this key to the {count} other chain {provider} serves | Also add this key to the {count} other chains {provider} serves",
+      "hint": "This looks like an {provider} endpoint."
+    },
+    "remove": {
+      "chip": "{provider} · {count}",
+      "confirm": "Remove",
+      "label": "Provider keys in use:",
+      "message": "Remove the {provider} node on {chains}? Your other nodes are left alone, and this may be a node rotki ships by default rather than one you added. | Remove the {count} {provider} nodes on {chains}? Your other nodes are left alone, and some may be nodes rotki ships by default rather than ones you added.",
+      "partial": "Removed {removed} {provider} nodes, {failed} could not be removed.",
+      "title": "Remove {provider} nodes"
+    },
+    "select": {
+      "already_added": "Already added",
+      "none": "Every other chain {provider} serves already has one of its nodes.",
+      "picker": "Choose chains · {count} of {total}",
+      "replaces_key": "Updates {node}",
+      "unreadable": "The existing nodes of {chains} could not be read, so they are left out.",
+      "unsupported": "{provider} does not serve {chains}."
+    }
   },
   "settings": {
     "go_to_section": "Go to section",

--- a/frontend/app/src/modules/settings/api/use-evm-nodes-api.spec.ts
+++ b/frontend/app/src/modules/settings/api/use-evm-nodes-api.spec.ts
@@ -272,7 +272,7 @@ describe('composables/api/settings/evm-nodes-api', () => {
         http.post(`${backendUrl}/api/1/blockchains/ETH/nodes`, async ({ request }) => {
           requestBody = await request.json();
           return HttpResponse.json({
-            result: true,
+            result: { errors: [] },
             message: '',
           });
         }),
@@ -281,7 +281,7 @@ describe('composables/api/settings/evm-nodes-api', () => {
       const { reConnectNode } = useEvmNodesApi();
       const result = await reConnectNode(5);
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ errors: [] });
       expect(requestBody).toEqual({
         identifier: 5,
       });
@@ -294,7 +294,7 @@ describe('composables/api/settings/evm-nodes-api', () => {
         http.post(`${backendUrl}/api/1/blockchains/ETH/nodes`, async ({ request }) => {
           requestBody = await request.json();
           return HttpResponse.json({
-            result: true,
+            result: { errors: [] },
             message: '',
           });
         }),
@@ -303,8 +303,22 @@ describe('composables/api/settings/evm-nodes-api', () => {
       const { reConnectNode } = useEvmNodesApi();
       const result = await reConnectNode();
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ errors: [] });
       expect(requestBody).toEqual({});
+    });
+
+    it('should return the nodes the backend could not connect', async () => {
+      server.use(
+        http.post(`${backendUrl}/api/1/blockchains/ETH/nodes`, () =>
+          HttpResponse.json({
+            result: { errors: [{ name: 'my node', error: 'Failed to connect' }] },
+            message: '',
+          })),
+      );
+
+      const { reConnectNode } = useEvmNodesApi();
+
+      expect(await reConnectNode(5)).toEqual({ errors: [{ name: 'my node', error: 'Failed to connect' }] });
     });
   });
 

--- a/frontend/app/src/modules/settings/api/use-evm-nodes-api.ts
+++ b/frontend/app/src/modules/settings/api/use-evm-nodes-api.ts
@@ -6,6 +6,7 @@ import {
   BlockchainRpcNodeAddPayload,
   BlockchainRpcNodeEditPayload,
   BlockchainRpcNodeList,
+  RpcNodeConnectResult,
 } from '@/modules/settings/types/rpc';
 
 interface UseEvmNodesApiReturn {
@@ -13,7 +14,7 @@ interface UseEvmNodesApiReturn {
   addEvmNode: (node: Omit<BlockchainRpcNode, 'identifier'>) => Promise<boolean>;
   editEvmNode: (node: BlockchainRpcNode) => Promise<boolean>;
   deleteEvmNode: (identifier: number) => Promise<boolean>;
-  reConnectNode: (identifier?: number) => Promise<boolean>;
+  reConnectNode: (identifier?: number) => Promise<RpcNodeConnectResult>;
 }
 
 export function useEvmNodesApi(chain: MaybeRefOrGetter<string> = Blockchain.ETH): UseEvmNodesApiReturn {
@@ -32,7 +33,10 @@ export function useEvmNodesApi(chain: MaybeRefOrGetter<string> = Blockchain.ETH)
     body: { identifier },
   });
 
-  const reConnectNode = async (identifier?: number): Promise<boolean> => api.post<boolean>(get(url), { identifier });
+  const reConnectNode = async (identifier?: number): Promise<RpcNodeConnectResult> => {
+    const response = await api.post<RpcNodeConnectResult>(get(url), { identifier });
+    return RpcNodeConnectResult.parse(response);
+  };
 
   return {
     addEvmNode,

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.spec.ts
@@ -110,6 +110,30 @@ describe('settings/general/rpc/BlockchainRpcNodeForm.vue', () => {
     expect(wrapper.props('modelValue').node.name).toBe('renamed node');
   });
 
+  it('should hold ownership, activity and weight while the node is part of a fan-out', async () => {
+    wrapper = createWrapper(stateFor({ active: false, owned: false, weight: 30 }));
+
+    await wrapper.setProps({ restricted: true });
+    await nextTick();
+
+    const node = wrapper.props('modelValue').node;
+    expect(node).toMatchObject({ active: true, owned: true, weight: 0 });
+    expect(wrapper.find('[data-testid=node-owned] input').attributes('disabled')).toBeDefined();
+    expect(wrapper.find('[data-testid=node-active] input').attributes('disabled')).toBeDefined();
+  });
+
+  it('should give the held fields back when the fan-out is turned off', async () => {
+    wrapper = createWrapper(stateFor({ active: false, owned: false, weight: 30 }));
+
+    await wrapper.setProps({ restricted: true });
+    await nextTick();
+    await wrapper.setProps({ restricted: false });
+    await nextTick();
+
+    expect(wrapper.props('modelValue').node).toMatchObject({ active: false, owned: false, weight: 30 });
+    expect(wrapper.find('[data-testid=node-owned] input').attributes('disabled')).toBeUndefined();
+  });
+
   it('should report the state as updated once a field is edited', async () => {
     wrapper = createWrapper();
     await vi.advanceTimersByTimeAsync(600);

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeForm.vue
@@ -20,6 +20,11 @@ const errors = defineModel<ValidationErrors>('errorMessages', { required: true }
 const stateUpdated = defineModel<boolean>('stateUpdated', { default: false, required: false });
 const modelValue = defineModel<BlockchainRpcNodeManageState>({ required: true });
 
+/** Whether the node is one of a provider fan-out, which owns how it is weighted and flagged. */
+const { restricted = false } = defineProps<{
+  restricted?: boolean;
+}>();
+
 const { t } = useI18n({ useScope: 'global' });
 
 const schema = computed<ZodType>(() => blockchainRpcNodeSchema({
@@ -48,6 +53,32 @@ const numericWeight = computed<number>({
     form.state.weight = value.toString();
   },
 });
+
+/** What the fields held before the fan-out took them over, so unticking it costs nothing. */
+const released = shallowRef<Pick<BlockchainRpcNodeFormState, 'active' | 'owned' | 'weight'>>();
+
+/**
+ * Holds ownership, activity and weight while the node is part of a provider fan-out.
+ *
+ * @remarks
+ * Every chain in a fan-out is added on the same terms, so the chain on screen cannot be an
+ * exception. Weight follows ownership on its own: the slider is already disabled for an owned node.
+ */
+function lockProviderFields(locked: boolean): void {
+  if (locked) {
+    set(released, { active: form.state.active, owned: form.state.owned, weight: form.state.weight });
+    Object.assign(form.state, { active: true, owned: true, weight: '0' });
+    return;
+  }
+
+  const previous = get(released);
+  if (previous) {
+    Object.assign(form.state, previous);
+    set(released, undefined);
+  }
+}
+
+watch(() => restricted, lockProviderFields);
 
 // The dialog reads the node it saves straight off the model, so every edit is written back to it.
 watch(() => form.state, (state) => {
@@ -131,16 +162,18 @@ defineExpose({
       v-model="form.state.owned"
       color="primary"
       class="mt-4"
+      data-testid="node-owned"
       :label="t('rpc_node_form.owned')"
-      :disabled="isEtherscan"
-      :hint="t('rpc_node_form.owned_hint')"
+      :disabled="isEtherscan || restricted"
+      :hint="restricted ? t('rpc_node_form.owned_hint_provider') : t('rpc_node_form.owned_hint')"
     />
     <RuiSwitch
       v-model="form.state.active"
       color="primary"
       class="mt-4"
+      data-testid="node-active"
       :label="t('rpc_node_form.active')"
-      :disabled="isEtherscan"
+      :disabled="isEtherscan || restricted"
       :hint="t('rpc_node_form.active_hint')"
     />
   </div>

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeFormDialog.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeFormDialog.spec.ts
@@ -1,0 +1,235 @@
+import type { BlockchainRpcNodeManageState } from '@/modules/settings/types/rpc';
+import { Blockchain } from '@rotki/common';
+import { createCustomPinia } from '@test/utils/create-pinia';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import BlockchainRpcNodeFormDialog from '@/modules/settings/general/rpc/BlockchainRpcNodeFormDialog.vue';
+import { RPC_SETUP_STATUS, type RpcSetupRow } from '@/modules/settings/general/rpc/providers/use-rpc-provider-setup';
+
+const { addEvmNode, readNodes, retry, rows, run } = vi.hoisted(() => {
+  const rows: { value: RpcSetupRow[] } = { value: [] };
+  return { addEvmNode: vi.fn(), readNodes: vi.fn(), retry: vi.fn(), rows, run: vi.fn() };
+});
+
+vi.mock('@/modules/settings/api/use-evm-nodes-api', () => ({
+  useEvmNodesApi: (): Record<string, unknown> => ({
+    addEvmNode,
+    deleteEvmNode: vi.fn(),
+    editEvmNode: vi.fn(),
+    fetchEvmNodes: vi.fn().mockResolvedValue([]),
+    reConnectNode: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/settings/general/rpc/providers/use-rpc-nodes-by-chain', () => ({
+  useRpcNodesByChain: (): Record<string, unknown> => ({ readNodes }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', async () => {
+  const { computed, toValue } = await import('vue');
+  return {
+    useSupportedChains: (): Record<string, unknown> => ({
+      getChainName: (chain: string): string => chain,
+      useChainName: (chain: unknown) => computed(() => String(toValue(chain) ?? '')),
+    }),
+  };
+});
+
+vi.mock('@/modules/settings/general/rpc/providers/use-rpc-provider-setup', async (importOriginal) => {
+  const original = await importOriginal<Record<string, unknown>>();
+  const { computed, ref } = await import('vue');
+  const rowsRef = ref<RpcSetupRow[]>([]);
+
+  // A hoisted holder is a plain object, so back its `value` with a ref the component can see.
+  Object.defineProperty(rows, 'value', {
+    get: () => rowsRef.value,
+    set: (value: RpcSetupRow[]) => {
+      rowsRef.value = value;
+    },
+  });
+
+  return {
+    ...original,
+    useRpcProviderSetup: (): Record<string, unknown> => ({
+      loadExisting: vi.fn(),
+      reset: vi.fn(),
+      retry,
+      rows: rowsRef,
+      run,
+      running: ref(false),
+      stop: vi.fn(),
+      summary: computed(() => ({
+        added: 0,
+        archive: 0,
+        failed: rowsRef.value.filter(row => row.status === RPC_SETUP_STATUS.FAILED).length,
+        total: rowsRef.value.length,
+      })),
+    }),
+  };
+});
+
+const BigDialogStub = {
+  emits: ['confirm', 'cancel'],
+  props: ['display', 'action'],
+  template: `<div v-if="display">
+    <slot />
+    <button data-testid="stub-confirm" @click="$emit('confirm')" />
+  </div>`,
+};
+
+const FormStub = {
+  methods: { validate: (): boolean => true },
+  template: '<div data-testid="stub-form" />',
+};
+
+const CHAINS = [Blockchain.ETH, Blockchain.OPTIMISM, Blockchain.BASE];
+
+function addState(endpoint: string): BlockchainRpcNodeManageState {
+  return {
+    mode: 'add',
+    node: {
+      active: true,
+      blockchain: Blockchain.ETH,
+      endpoint,
+      identifier: 0,
+      name: 'Infura',
+      owned: true,
+      weight: 0,
+    },
+  };
+}
+
+function node(endpoint: string): Record<string, unknown> {
+  return { active: true, blockchain: Blockchain.OPTIMISM, endpoint, identifier: 1, name: 'Infura', owned: true, weight: 0 };
+}
+
+function mountDialog(endpoint: string): VueWrapper {
+  return mount(BlockchainRpcNodeFormDialog, {
+    global: {
+      plugins: [createCustomPinia()],
+      stubs: { BigDialog: BigDialogStub, BlockchainRpcNodeForm: FormStub, ChainIcon: true },
+    },
+    props: { chains: CHAINS, modelValue: addState(endpoint) },
+  });
+}
+
+async function optIn(wrapper: VueWrapper): Promise<void> {
+  await wrapper.find('[data-testid=provider-fan-out-enable] input').setValue(true);
+  await flushPromises();
+}
+
+describe('modules/settings/general/rpc/BlockchainRpcNodeFormDialog.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addEvmNode.mockResolvedValue(true);
+    readNodes.mockResolvedValue({ nodes: {}, unreadable: [] });
+    rows.value = [];
+  });
+
+  it('should offer the other chains only for a recognised provider', () => {
+    expect(mountDialog('https://eth.example/rpc').find('[data-testid=provider-fan-out-offer]').exists()).toBe(false);
+    expect(mountDialog('https://mainnet.infura.io/v3/abcdef').find('[data-testid=provider-fan-out-offer]').exists()).toBe(true);
+  });
+
+  it('should add only the chain on screen when the offer is left alone', async () => {
+    const wrapper = mountDialog('https://mainnet.infura.io/v3/abcdef');
+
+    await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+    await flushPromises();
+
+    expect(addEvmNode).toHaveBeenCalledOnce();
+    expect(run).not.toHaveBeenCalled();
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([undefined]);
+  });
+
+  it('should walk the other chains once the user opts in', async () => {
+    const wrapper = mountDialog('https://mainnet.infura.io/v3/abcdef');
+    await optIn(wrapper);
+
+    await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+    await flushPromises();
+
+    expect(addEvmNode).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledWith([
+      expect.objectContaining({ chain: Blockchain.OPTIMISM }),
+      expect.objectContaining({ chain: Blockchain.BASE }),
+    ]);
+    expect(wrapper.find('[data-testid=provider-summary]').exists()).toBe(true);
+  });
+
+  it('should not walk the other chains when the node itself could not be added', async () => {
+    addEvmNode.mockRejectedValue(new Error('already exists'));
+    const wrapper = mountDialog('https://mainnet.infura.io/v3/abcdef');
+    await optIn(wrapper);
+
+    await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+    await flushPromises();
+
+    expect(run).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-testid=stub-form]').exists()).toBe(true);
+  });
+
+  it('should keep the dialog open on the results, and close it on cancel', async () => {
+    const wrapper = mountDialog('https://mainnet.infura.io/v3/abcdef');
+    await optIn(wrapper);
+
+    await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid=stub-form]').exists()).toBe(false);
+    expect(wrapper.emitted('complete')).toHaveLength(2);
+  });
+
+  it('should not offer the other chains while editing a node', () => {
+    const wrapper = mount(BlockchainRpcNodeFormDialog, {
+      global: {
+        plugins: [createCustomPinia()],
+        stubs: { BigDialog: BigDialogStub, BlockchainRpcNodeForm: FormStub, ChainIcon: true },
+      },
+      props: {
+        chains: CHAINS,
+        modelValue: { ...addState('https://mainnet.infura.io/v3/abcdef'), mode: 'edit' },
+      },
+    });
+
+    expect(wrapper.find('[data-testid=provider-fan-out-offer]').exists()).toBe(false);
+  });
+
+  it('should just close when every other chain already holds the key', async () => {
+    readNodes.mockResolvedValue({
+      nodes: {
+        [Blockchain.BASE]: [node('https://base-mainnet.infura.io/v3/abcdef')],
+        [Blockchain.OPTIMISM]: [node('https://optimism-mainnet.infura.io/v3/abcdef')],
+      },
+      unreadable: [],
+    });
+    const wrapper = mountDialog('https://mainnet.infura.io/v3/abcdef');
+    await optIn(wrapper);
+
+    await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+    await flushPromises();
+
+    expect(addEvmNode).toHaveBeenCalledOnce();
+    expect(run).not.toHaveBeenCalled();
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([undefined]);
+  });
+
+  it('should walk only the chains that failed when the run is retried', async () => {
+    const wrapper = mountDialog('https://mainnet.infura.io/v3/abcdef');
+    await optIn(wrapper);
+
+    await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+    await flushPromises();
+
+    rows.value = [
+      { chain: Blockchain.OPTIMISM, endpoint: 'o', name: 'Infura', status: RPC_SETUP_STATUS.ADDED },
+      { chain: Blockchain.BASE, endpoint: 'b', error: 'nope', name: 'Infura', status: RPC_SETUP_STATUS.FAILED },
+    ];
+    await nextTick();
+    await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+    await flushPromises();
+
+    expect(retry).toHaveBeenCalledWith([expect.objectContaining({ chain: Blockchain.BASE })]);
+    expect(addEvmNode).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeFormDialog.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeFormDialog.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { RpcProviderCandidate } from '@/modules/settings/general/rpc/providers/rpc-provider-plan';
 import type { BlockchainRpcNode, BlockchainRpcNodeManageState } from '@/modules/settings/types/rpc';
 import { assert, Blockchain } from '@rotki/common';
 import { omit } from 'es-toolkit';
@@ -9,17 +10,22 @@ import { useMessageStore } from '@/modules/core/common/use-message-store';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useEvmNodesApi } from '@/modules/settings/api/use-evm-nodes-api';
 import BlockchainRpcNodeForm from '@/modules/settings/general/rpc/BlockchainRpcNodeForm.vue';
-import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
+import RpcProviderFanOutOffer from '@/modules/settings/general/rpc/providers/RpcProviderFanOutOffer.vue';
+import RpcProviderRunResults from '@/modules/settings/general/rpc/providers/RpcProviderRunResults.vue';
+import { useRpcNodeFanOut } from '@/modules/settings/general/rpc/providers/use-rpc-node-fan-out';
+import { RPC_SETUP_STATUS, useRpcProviderSetup } from '@/modules/settings/general/rpc/providers/use-rpc-provider-setup';
+import BigDialog, { type BigDialogLayout } from '@/modules/shell/components/dialogs/BigDialog.vue';
 
 const model = defineModel<BlockchainRpcNodeManageState | undefined>({ required: true });
+
+/** The chains that hold a node list, which is what a provider key can be fanned out over. */
+const { chains } = defineProps<{
+  chains: string[];
+}>();
 
 const emit = defineEmits<{
   complete: [];
 }>();
-
-function resetForm() {
-  set(model, undefined);
-}
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -27,6 +33,8 @@ const errorMessages = ref<ValidationErrors>({});
 const submitting = ref<boolean>(false);
 const form = useTemplateRef<InstanceType<typeof BlockchainRpcNodeForm>>('form');
 const stateUpdated = ref(false);
+/** Whether the dialog is still the form, or already reporting what the other chains did. */
+const phase = ref<'form' | 'results'>('form');
 
 const { useChainName } = useSupportedChains();
 
@@ -53,7 +61,71 @@ const dialogTitle = computed(() => {
 const api = useEvmNodesApi(chain);
 const { setMessage } = useMessageStore();
 
-async function save() {
+const {
+  candidates,
+  chosen,
+  credential,
+  enablementNote,
+  modelEnabled: fanOutEnabled,
+  preparing,
+  provider,
+  reset: resetFanOut,
+  selected: selectedChains,
+  toggle: toggleChain,
+  unreadableNames,
+  unsupportedNames,
+} = useRpcNodeFanOut(
+  () => get(model)?.node.endpoint ?? '',
+  () => get(model)?.node.name ?? '',
+  chain,
+  () => chains,
+);
+const { reset: resetRun, retry, rows, running, run, stop, summary } = useRpcProviderSetup();
+
+/** The offer only makes sense while adding: an edit is one node on one chain by definition. */
+const offered = computed<boolean>(() => get(model)?.mode === 'add' && get(provider) !== undefined);
+
+/** The results are a short list, so they take the height they need instead of the form's. */
+const layout = computed<BigDialogLayout | undefined>(() =>
+  get(phase) === 'results' ? { autoHeight: true, maxWidth: '640px' } : undefined);
+
+const action = computed(() => {
+  if (get(phase) === 'form')
+    return { primary: t('common.actions.save') };
+
+  return {
+    hidden: get(running) || get(summary).failed === 0,
+    primary: t('rpc_provider_setup.actions.retry'),
+    secondary: t('rpc_provider_setup.actions.close'),
+  };
+});
+
+function resetForm(): void {
+  stop();
+  resetRun();
+  resetFanOut();
+  set(phase, 'form');
+  set(model, undefined);
+}
+
+/**
+ * Walks the other chains, keeping the dialog open on what each one did.
+ *
+ * @remarks
+ * The node the form added is not among them: it is already in the list the manager reloads.
+ */
+async function fanOutToOtherChains(candidates: RpcProviderCandidate[], walk: () => Promise<void>): Promise<void> {
+  if (candidates.length === 0) {
+    resetForm();
+    return;
+  }
+
+  set(phase, 'results');
+  await walk();
+  emit('complete');
+}
+
+async function save(): Promise<void> {
   if (!get(form)?.validate())
     return;
 
@@ -62,13 +134,14 @@ async function save() {
 
   const editing = state.mode === 'edit';
   const node = state.node;
+  let saved = false;
 
   set(submitting, true);
   try {
     if (editing)
       await api.editEvmNode(node);
     else await api.addEvmNode(omit(node, ['identifier']));
-    resetForm();
+    saved = true;
     emit('complete');
   }
   catch (error: unknown) {
@@ -106,6 +179,30 @@ async function save() {
   finally {
     set(submitting, false);
   }
+
+  if (!saved)
+    return;
+
+  if (get(fanOutEnabled)) {
+    const candidates = get(chosen);
+    await fanOutToOtherChains(candidates, async () => run(candidates));
+  }
+  else {
+    resetForm();
+  }
+}
+
+async function confirm(): Promise<void> {
+  if (get(phase) === 'form') {
+    await save();
+    return;
+  }
+
+  const failed = get(rows)
+    .filter(row => row.status === RPC_SETUP_STATUS.FAILED)
+    .map(row => row.chain);
+  const failedCandidates = get(candidates).filter(candidate => failed.includes(candidate.chain));
+  await fanOutToOtherChains(failedCandidates, async () => retry(failedCandidates));
 }
 </script>
 
@@ -113,18 +210,42 @@ async function save() {
   <BigDialog
     :display="!!modelValue"
     :title="dialogTitle"
-    :action="{ primary: t('common.actions.save') }"
-    :prompt-on-close="stateUpdated"
+    :action="action"
+    :prompt-on-close="phase === 'form' && stateUpdated"
+    :layout="layout"
     :loading="submitting"
-    @confirm="save()"
+    @confirm="confirm()"
     @cancel="resetForm()"
   >
-    <BlockchainRpcNodeForm
-      v-if="model"
-      ref="form"
-      v-model="model"
-      v-model:error-messages="errorMessages"
-      v-model:state-updated="stateUpdated"
+    <RpcProviderRunResults
+      v-if="phase === 'results'"
+      :rows="rows"
+      :running="running"
+      :summary="summary"
+      :enablement="enablementNote"
+      :credential="credential"
     />
+    <template v-else>
+      <RpcProviderFanOutOffer
+        v-if="offered && provider"
+        v-model="fanOutEnabled"
+        :provider="provider.name"
+        :candidates="candidates"
+        :selected="selectedChains"
+        :preparing="preparing"
+        :unsupported="unsupportedNames"
+        :unreadable="unreadableNames"
+        :enablement="enablementNote"
+        @toggle="toggleChain($event.chain, $event.checked)"
+      />
+      <BlockchainRpcNodeForm
+        v-if="model"
+        ref="form"
+        v-model="model"
+        v-model:error-messages="errorMessages"
+        v-model:state-updated="stateUpdated"
+        :restricted="fanOutEnabled"
+      />
+    </template>
   </BigDialog>
 </template>

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.spec.ts
@@ -66,7 +66,7 @@ async function createWrapper(nodes: BlockchainRpcNode[]): Promise<VueWrapper> {
       plugins: [createCustomPinia()],
       stubs: { BlockchainRpcNodeFormDialog: true, RpcNodeStatusCell: true, RpcReconnectButton: true },
     },
-    props: { chain: Blockchain.ETH },
+    props: { chain: Blockchain.ETH, chains: [Blockchain.ETH, Blockchain.OPTIMISM] },
   });
   await flushPromises();
   return wrapper;

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
@@ -7,8 +7,14 @@ import { useBlockchainRpcNodeManager } from '@/modules/settings/general/rpc/use-
 import RowActions from '@/modules/shell/components/RowActions.vue';
 import SimpleTable from '@/modules/shell/components/SimpleTable.vue';
 
-const { chain } = defineProps<{
+const { chain, chains } = defineProps<{
   chain: Blockchain;
+  /** Every chain that holds a node list, which the add dialog offers a provider key across. */
+  chains: string[];
+}>();
+
+const emit = defineEmits<{
+  complete: [];
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
@@ -32,8 +38,15 @@ onMounted(async () => {
   await loadNodes();
 });
 
+/** A save may have been a provider fan-out, which changes more than this chain's list. */
+async function onDialogComplete(): Promise<void> {
+  await loadNodes();
+  emit('complete');
+}
+
 defineExpose({
   addNewRpcNode,
+  loadNodes,
 });
 </script>
 
@@ -163,6 +176,7 @@ defineExpose({
   </SimpleTable>
   <BlockchainRpcNodeFormDialog
     v-model="modelState"
-    @complete="loadNodes()"
+    :chains="chains"
+    @complete="onDialogComplete()"
   />
 </template>

--- a/frontend/app/src/modules/settings/general/rpc/RpcSettings.vue
+++ b/frontend/app/src/modules/settings/general/rpc/RpcSettings.vue
@@ -2,6 +2,7 @@
 import type BlockchainRpcNodeManager from '@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue';
 import type SimpleRpcNodeManager from '@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue';
 import { startPromise } from '@shared/utils';
+import RpcProviderKeys from '@/modules/settings/general/rpc/providers/RpcProviderKeys.vue';
 import RpcSettingOption from '@/modules/settings/general/rpc/RpcSettingOption.vue';
 import { isChainTab, tabKey, useRpcSettingsTabs } from '@/modules/settings/general/rpc/use-rpc-settings-tabs';
 import SettingCategoryHeader from '@/modules/settings/SettingCategoryHeader.vue';
@@ -21,6 +22,7 @@ const {
   allRailOptions,
   firstOtherKey,
   canAddNode,
+  nodeChains,
   selectTab,
 } = useRpcSettingsTabs();
 
@@ -32,6 +34,20 @@ function addNodeClick(): void {
   if (refElement?.[0]) {
     refElement[0].addNewRpcNode();
   }
+}
+
+const providerKeysRef = useTemplateRef<InstanceType<typeof RpcProviderKeys>>('providerKeysRef');
+
+/** Removing a provider's nodes may have emptied the chain on screen, so its list is re-read. */
+function reloadActiveManager(): void {
+  const refElement = get(evmRpcNodeManagerRef)?.[0];
+  if (refElement && 'loadNodes' in refElement)
+    startPromise(refElement.loadNodes());
+}
+
+/** A fan-out adds nodes to chains the chips count, so they are re-read once the dialog is done. */
+function reloadProviderKeys(): void {
+  startPromise(get(providerKeysRef)?.reload() ?? Promise.resolve());
 }
 
 function scrollActiveIntoView(): void {
@@ -60,21 +76,29 @@ watch(rpcSettingTabs, () => scrollActiveIntoView());
           {{ t('general_settings.rpc_node_setting.subtitle') }}
         </template>
       </SettingCategoryHeader>
-      <RuiButton
-        v-if="canAddNode"
-        color="primary"
-        data-testid="add-node"
-        @click="addNodeClick()"
-      >
-        <template #prepend>
-          <RuiIcon
-            name="lu-plus"
-            size="16"
-          />
-        </template>
-        {{ t('evm_rpc_node_manager.add_button') }}
-      </RuiButton>
+      <div class="flex flex-wrap gap-2">
+        <RuiButton
+          v-if="canAddNode"
+          color="primary"
+          data-testid="add-node"
+          @click="addNodeClick()"
+        >
+          <template #prepend>
+            <RuiIcon
+              name="lu-plus"
+              size="16"
+            />
+          </template>
+          {{ t('evm_rpc_node_manager.add_button') }}
+        </RuiButton>
+      </div>
     </div>
+    <RpcProviderKeys
+      ref="providerKeysRef"
+      class="pt-4"
+      :chains="nodeChains"
+      @removed="reloadActiveManager()"
+    />
     <div class="pt-6 md:flex md:items-stretch md:gap-6 md:flex-1 md:min-h-0">
       <template v-if="isMdAndUp">
         <div
@@ -168,6 +192,8 @@ watch(rpcSettingTabs, () => scrollActiveIntoView());
               v-if="isChainTab(tab) && !tab.setting"
               ref="evmRpcNodeManagerRef"
               :chain="tab.chain"
+              :chains="nodeChains"
+              @complete="reloadProviderKeys()"
             />
             <SimpleRpcNodeManagerAsync
               v-else-if="tab.setting"

--- a/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderCandidateRow.vue
+++ b/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderCandidateRow.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import type { RpcProviderCandidate } from '@/modules/settings/general/rpc/providers/rpc-provider-plan';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import ChainIcon from '@/modules/shell/components/ChainIcon.vue';
+
+const { candidate, selected } = defineProps<{
+  candidate: RpcProviderCandidate;
+  selected: boolean;
+}>();
+
+const emit = defineEmits<{
+  toggle: [checked: boolean];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+const { getChainName } = useSupportedChains();
+</script>
+
+<template>
+  <div
+    class="flex items-center gap-2 py-0.5"
+    data-testid="provider-candidate"
+  >
+    <!-- The chain rides inside the checkbox's own label, so it is both the accessible name and part
+         of the hit target. -->
+    <RuiCheckbox
+      :model-value="selected"
+      :disabled="!!candidate.existing"
+      color="primary"
+      hide-details
+      size="sm"
+      @update:model-value="emit('toggle', $event)"
+    >
+      <span class="flex items-center gap-2 min-w-0">
+        <ChainIcon
+          :chain="candidate.chain"
+          size="20px"
+        />
+        <span class="text-sm truncate">{{ getChainName(candidate.chain) }}</span>
+      </span>
+    </RuiCheckbox>
+    <span
+      v-if="candidate.existing"
+      class="ml-auto text-xs text-rui-text-secondary"
+    >
+      {{ t('rpc_provider_setup.select.already_added') }}
+    </span>
+    <span
+      v-else-if="candidate.outdated"
+      class="ml-auto text-xs text-rui-primary"
+    >
+      {{ t('rpc_provider_setup.select.replaces_key', { node: candidate.outdated.name }) }}
+    </span>
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderFanOutOffer.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderFanOutOffer.spec.ts
@@ -1,0 +1,84 @@
+import type { RpcProviderCandidate } from '@/modules/settings/general/rpc/providers/rpc-provider-plan';
+import { Blockchain } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import RpcProviderFanOutOffer from '@/modules/settings/general/rpc/providers/RpcProviderFanOutOffer.vue';
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({
+    getChainName: (chain: string): string => chain,
+  }),
+}));
+
+function candidate(chain: string, existing = false): RpcProviderCandidate {
+  return {
+    chain,
+    endpoint: `https://${chain}.infura.io/v3/abcdef`,
+    ...(existing
+      ? { existing: { active: true, blockchain: chain, endpoint: 'e', identifier: 1, name: 'Infura', owned: true, weight: 0 } }
+      : {}),
+    name: 'Infura',
+  };
+}
+
+function mountOffer(props: Record<string, unknown> = {}): VueWrapper {
+  return mount(RpcProviderFanOutOffer, {
+    global: { stubs: { ChainIcon: true } },
+    props: {
+      candidates: [candidate(Blockchain.OPTIMISM), candidate(Blockchain.BASE)],
+      modelValue: false,
+      provider: 'Infura',
+      selected: [Blockchain.OPTIMISM, Blockchain.BASE],
+      ...props,
+    },
+  });
+}
+
+describe('settings/general/rpc/providers/RpcProviderFanOutOffer.vue', () => {
+  it('should offer the other chains without opting the user in', () => {
+    const wrapper = mountOffer();
+
+    expect(wrapper.find('[data-testid=provider-fan-out-offer]').text()).toContain('offer.hint');
+    expect(wrapper.find('[data-testid=provider-fan-out-enable] input').element).toHaveProperty('checked', false);
+    expect(wrapper.find('[data-testid=provider-chain-picker]').exists()).toBe(false);
+  });
+
+  it('should show the picker once the user opts in', () => {
+    const wrapper = mountOffer({ modelValue: true });
+
+    expect(wrapper.find('[data-testid=provider-selection-summary]').text()).toContain('select.picker::2, 2');
+    expect(wrapper.findAll('[data-testid=provider-candidate]')).toHaveLength(2);
+  });
+
+  it('should count the selection once a chain is unticked', () => {
+    const wrapper = mountOffer({ modelValue: true, selected: [Blockchain.OPTIMISM] });
+
+    expect(wrapper.find('[data-testid=provider-selection-summary]').text()).toContain('select.picker::1, 2');
+  });
+
+  it('should report a chain it is unticking', async () => {
+    const wrapper = mountOffer({ modelValue: true });
+
+    await wrapper.findAll('[data-testid=provider-candidate] input[type=checkbox]')[0].setValue(false);
+
+    expect(wrapper.emitted('toggle')?.[0]).toEqual([{ chain: Blockchain.OPTIMISM, checked: false }]);
+  });
+
+  it('should say so when every other chain already holds the key', () => {
+    const wrapper = mountOffer({
+      candidates: [candidate(Blockchain.OPTIMISM, true)],
+      modelValue: true,
+      selected: [],
+    });
+
+    expect(wrapper.find('[data-testid=provider-nothing-to-add]').text()).toContain('select.none');
+    expect(wrapper.find('[data-testid=provider-chain-picker]').exists()).toBe(false);
+  });
+
+  it('should keep the picker back while the chains are being read', () => {
+    const wrapper = mountOffer({ modelValue: true, preparing: true });
+
+    expect(wrapper.find('[data-testid=provider-chain-picker]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=provider-nothing-to-add]').exists()).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderFanOutOffer.vue
+++ b/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderFanOutOffer.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import type { RpcProviderCandidate } from '@/modules/settings/general/rpc/providers/rpc-provider-plan';
+import RpcProviderCandidateRow from '@/modules/settings/general/rpc/providers/RpcProviderCandidateRow.vue';
+
+const modelEnabled = defineModel<boolean>({ required: true });
+
+const {
+  candidates,
+  enablement = '',
+  provider,
+  selected,
+  unreadable = '',
+  unsupported = '',
+} = defineProps<{
+  /** Every other chain the provider serves, those already holding the key included. */
+  candidates: RpcProviderCandidate[];
+  enablement?: string;
+  preparing?: boolean;
+  /** The provider's own name, which is what the offer is worth naming. */
+  provider: string;
+  selected: readonly string[];
+  unreadable?: string;
+  unsupported?: string;
+}>();
+
+const emit = defineEmits<{
+  toggle: [change: { chain: string; checked: boolean }];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+
+const addable = computed<number>(() => candidates.filter(candidate => !candidate.existing).length);
+const count = computed<number>(() => selected.length);
+</script>
+
+<template>
+  <RuiAlert
+    type="info"
+    class="mb-4"
+    data-testid="provider-fan-out-offer"
+  >
+    <div class="flex flex-col gap-1">
+      <span>{{ t('rpc_provider_setup.offer.hint', { provider }) }}</span>
+      <RuiCheckbox
+        v-model="modelEnabled"
+        color="primary"
+        hide-details
+        size="sm"
+        data-testid="provider-fan-out-enable"
+      >
+        <span class="text-sm">{{ t('rpc_provider_setup.offer.enable', { count: addable, provider }, addable) }}</span>
+      </RuiCheckbox>
+
+      <div
+        v-if="modelEnabled"
+        class="pl-8 flex flex-col gap-2"
+      >
+        <RuiProgress
+          v-if="preparing"
+          circular
+          variant="indeterminate"
+          size="16"
+          color="primary"
+        />
+        <div
+          v-else-if="addable === 0"
+          class="text-sm"
+          data-testid="provider-nothing-to-add"
+        >
+          {{ t('rpc_provider_setup.select.none', { provider }) }}
+        </div>
+        <template v-else>
+          <RuiAccordions>
+            <RuiAccordion
+              eager
+              header-grow
+              :class-names="{ header: 'p-0', content: 'pt-2' }"
+              data-testid="provider-chain-picker"
+            >
+              <template #header>
+                <span
+                  class="text-sm"
+                  data-testid="provider-selection-summary"
+                >
+                  {{ t('rpc_provider_setup.select.picker', { count, total: addable }) }}
+                </span>
+              </template>
+              <div class="flex flex-col">
+                <RpcProviderCandidateRow
+                  v-for="candidate in candidates"
+                  :key="candidate.chain"
+                  :candidate="candidate"
+                  :selected="selected.includes(candidate.chain)"
+                  @toggle="emit('toggle', { chain: candidate.chain, checked: $event })"
+                />
+              </div>
+            </RuiAccordion>
+          </RuiAccordions>
+          <!-- Outside the accordion: its height is a measured pixel value with the overflow hidden,
+               so a line added to it after the measurement is clipped in half. -->
+          <p
+            v-if="unsupported"
+            class="text-xs text-rui-text-secondary"
+            data-testid="provider-unsupported"
+          >
+            {{ t('rpc_provider_setup.select.unsupported', { chains: unsupported, provider }) }}
+          </p>
+          <p
+            v-if="unreadable"
+            class="text-xs text-rui-text-secondary"
+            data-testid="provider-unreadable"
+          >
+            {{ t('rpc_provider_setup.select.unreadable', { chains: unreadable }) }}
+          </p>
+          <p
+            v-if="enablement"
+            class="text-xs text-rui-text-secondary"
+            data-testid="provider-enablement"
+          >
+            {{ enablement }}
+          </p>
+        </template>
+      </div>
+    </div>
+  </RuiAlert>
+</template>

--- a/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderKeys.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderKeys.spec.ts
@@ -1,0 +1,141 @@
+import type { RpcProviderUsage } from '@/modules/settings/general/rpc/providers/rpc-provider-usage';
+import { Blockchain } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import RpcProviderKeys from '@/modules/settings/general/rpc/providers/RpcProviderKeys.vue';
+
+const { confirm, refresh, removeAll, setMessage, usages } = vi.hoisted(() => {
+  const usages: { value: RpcProviderUsage[] } = { value: [] };
+  return { confirm: vi.fn(), refresh: vi.fn(), removeAll: vi.fn(), setMessage: vi.fn(), usages };
+});
+
+vi.mock('@/modules/settings/general/rpc/providers/use-rpc-provider-removal', async () => {
+  const { computed, ref } = await import('vue');
+  return {
+    useRpcProviderRemoval: (): Record<string, unknown> => ({
+      refresh,
+      removeAll,
+      removing: ref(false),
+      usages: computed(() => usages.value),
+    }),
+  };
+});
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({ show: confirm }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, unknown> => ({ setMessage }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({
+    getChainName: (chain: string): string => chain,
+  }),
+}));
+
+function usage(id: 'infura' | 'alchemy', key: string, chains: string[]): RpcProviderUsage {
+  return {
+    id,
+    key,
+    name: id === 'infura' ? 'Infura' : 'Alchemy',
+    nodes: chains.map((chain, index) => ({ chain, identifier: index + 1, name: 'node' })),
+  };
+}
+
+const CHAINS = [Blockchain.ETH, Blockchain.OPTIMISM];
+
+function mountKeys(): VueWrapper {
+  return mount(RpcProviderKeys, { props: { chains: CHAINS } });
+}
+
+/** Runs what the confirmation would have run, without asserting on the dialog itself. */
+async function acceptConfirmation(): Promise<void> {
+  await confirm.mock.calls[0][1]();
+  await flushPromises();
+}
+
+describe('settings/general/rpc/providers/RpcProviderKeys.vue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usages.value = [];
+    removeAll.mockResolvedValue({ failed: 0, removed: 2 });
+  });
+
+  it('should read the chains it is given', () => {
+    mountKeys();
+
+    expect(refresh).toHaveBeenCalledWith(CHAINS);
+  });
+
+  it('should render nothing while no provider key is in use', () => {
+    expect(mountKeys().find('[data-testid=provider-keys]').exists()).toBe(false);
+  });
+
+  it('should name the provider and count its nodes', () => {
+    usages.value = [usage('infura', 'dead…beef', [Blockchain.ETH, Blockchain.OPTIMISM])];
+
+    const chip = mountKeys().find('[data-testid=provider-key-infura-dead…beef]');
+
+    expect(chip.text()).toContain('remove.chip::2, Infura');
+  });
+
+  it('should tell two keys of one provider apart by naming them', () => {
+    usages.value = [
+      usage('infura', 'aaaa…aaaa', [Blockchain.ETH]),
+      usage('infura', 'bbbb…bbbb', [Blockchain.OPTIMISM]),
+    ];
+
+    const chips = mountKeys().findAll('[data-testid^=provider-key-infura]');
+
+    expect(chips[0].text()).toContain('Infura aaaa…aaaa');
+    expect(chips[1].text()).toContain('Infura bbbb…bbbb');
+  });
+
+  it('should leave the key off a provider with only one', () => {
+    usages.value = [
+      usage('infura', 'aaaa…aaaa', [Blockchain.ETH]),
+      usage('alchemy', 'bbbb…bbbb', [Blockchain.OPTIMISM]),
+    ];
+
+    const chips = mountKeys().findAll('[data-testid^=provider-key-]');
+
+    expect(chips[0].text()).not.toContain('aaaa…aaaa');
+  });
+
+  it('should name every chain that loses a node before removing any', async () => {
+    usages.value = [usage('infura', 'dead…beef', [Blockchain.ETH, Blockchain.OPTIMISM])];
+    const wrapper = mountKeys();
+
+    await wrapper.find('[data-testid=provider-key-infura-dead…beef] button').trigger('click');
+
+    expect(removeAll).not.toHaveBeenCalled();
+    expect(confirm.mock.calls[0][0].message).toContain(`${Blockchain.ETH}, ${Blockchain.OPTIMISM}`);
+  });
+
+  it('should remove the key, re-read the chains and report it upwards', async () => {
+    usages.value = [usage('infura', 'dead…beef', [Blockchain.ETH])];
+    const wrapper = mountKeys();
+
+    await wrapper.find('[data-testid=provider-key-infura-dead…beef] button').trigger('click');
+    await acceptConfirmation();
+
+    expect(removeAll).toHaveBeenCalledWith(expect.objectContaining({ id: 'infura' }));
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(wrapper.emitted('removed')).toHaveLength(1);
+    expect(setMessage).not.toHaveBeenCalled();
+  });
+
+  it('should say so when only some of the nodes could be removed', async () => {
+    removeAll.mockResolvedValue({ failed: 1, removed: 1 });
+    usages.value = [usage('infura', 'dead…beef', [Blockchain.ETH, Blockchain.OPTIMISM])];
+    const wrapper = mountKeys();
+
+    await wrapper.find('[data-testid=provider-key-infura-dead…beef] button').trigger('click');
+    await acceptConfirmation();
+
+    expect(setMessage).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    expect(wrapper.emitted('removed')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderKeys.vue
+++ b/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderKeys.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import type { RpcProviderUsage } from '@/modules/settings/general/rpc/providers/rpc-provider-usage';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useRpcProviderRemoval } from '@/modules/settings/general/rpc/providers/use-rpc-provider-removal';
+
+/** The chains that hold a node list, which is where a provider's nodes can be. */
+const { chains } = defineProps<{
+  chains: string[];
+}>();
+
+const emit = defineEmits<{
+  removed: [];
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+const { show } = useConfirmStore();
+const { setMessage } = useMessageStore();
+const { getChainName } = useSupportedChains();
+const { refresh, removeAll, removing, usages } = useRpcProviderRemoval();
+
+async function reload(): Promise<void> {
+  await refresh(chains);
+}
+
+/**
+ * Names a provider, and its key when that is the only thing telling two entries apart.
+ *
+ * @remarks
+ * Showing the key on every chip would be noise; showing it on none would make two keys of one
+ * provider indistinguishable, which is exactly the case where removing the wrong one costs the most.
+ */
+function labelFor(usage: RpcProviderUsage): string {
+  const shared = get(usages).filter(other => other.id === usage.id).length > 1;
+  return shared && usage.key ? `${usage.name} ${usage.key}` : usage.name;
+}
+
+async function remove(usage: RpcProviderUsage): Promise<void> {
+  const { failed, removed } = await removeAll(usage);
+  await reload();
+  emit('removed');
+
+  if (failed > 0) {
+    setMessage({
+      description: t('rpc_provider_setup.remove.partial', { failed, provider: usage.name, removed }),
+      success: false,
+      title: t('rpc_provider_setup.remove.title', { provider: labelFor(usage) }),
+    });
+  }
+}
+
+/**
+ * Names every chain that loses a node.
+ *
+ * @remarks
+ * Nothing records whether a node was added by the user or shipped by rotki — the Solana defaults
+ * include a provider endpoint — so the confirmation lists what will go rather than implying these
+ * are all the user's own.
+ */
+function confirmRemoval(usage: RpcProviderUsage): void {
+  show({
+    message: t('rpc_provider_setup.remove.message', {
+      chains: usage.nodes.map(node => getChainName(node.chain)).join(', '),
+      count: usage.nodes.length,
+      provider: labelFor(usage),
+    }, usage.nodes.length),
+    primaryAction: t('rpc_provider_setup.remove.confirm'),
+    title: t('rpc_provider_setup.remove.title', { provider: labelFor(usage) }),
+  }, async () => remove(usage));
+}
+
+watchImmediate(() => chains, reload);
+
+defineExpose({ reload });
+</script>
+
+<template>
+  <div
+    v-if="usages.length > 0"
+    class="flex flex-wrap items-center gap-2"
+    data-testid="provider-keys"
+  >
+    <span class="text-xs text-rui-text-secondary">{{ t('rpc_provider_setup.remove.label') }}</span>
+    <RuiChip
+      v-for="usage in usages"
+      :key="`${usage.id}-${usage.key}`"
+      size="sm"
+      closeable
+      :disabled="removing"
+      :data-testid="usage.key ? `provider-key-${usage.id}-${usage.key}` : `provider-key-${usage.id}`"
+      @click:close="confirmRemoval(usage)"
+    >
+      {{ t('rpc_provider_setup.remove.chip', { count: usage.nodes.length, provider: labelFor(usage) }) }}
+    </RuiChip>
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderResultRow.vue
+++ b/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderResultRow.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { RPC_CONNECT_ERROR, summariseRpcConnectError } from '@/modules/settings/general/rpc/providers/rpc-connect-error';
+import { RPC_SETUP_STATUS, type RpcSetupRow } from '@/modules/settings/general/rpc/providers/use-rpc-provider-setup';
+import ChainIcon from '@/modules/shell/components/ChainIcon.vue';
+
+const { row, message = '' } = defineProps<{
+  /** The backend's own words, already masked, shown under a chain that was left out. */
+  message?: string;
+  row: RpcSetupRow;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+const { getChainName } = useSupportedChains();
+
+const kept = computed<boolean>(() =>
+  row.status === RPC_SETUP_STATUS.ADDED || row.status === RPC_SETUP_STATUS.UPDATED);
+
+/** Three words for why a chain was left out, with the backend's own message kept for the details. */
+const reason = computed<string>(() => {
+  if (row.status !== RPC_SETUP_STATUS.FAILED)
+    return '';
+
+  const kind = summariseRpcConnectError(row.error ?? '');
+  if (kind === RPC_CONNECT_ERROR.REJECTED)
+    return t('rpc_provider_setup.apply.reason.rejected');
+  if (kind === RPC_CONNECT_ERROR.WRONG_NETWORK)
+    return t('rpc_provider_setup.apply.reason.wrong_network');
+
+  return kind === RPC_CONNECT_ERROR.UNREACHABLE
+    ? t('rpc_provider_setup.apply.reason.unreachable')
+    : t('rpc_provider_setup.apply.reason.unknown');
+});
+</script>
+
+<template>
+  <div
+    class="flex items-center gap-2 py-2"
+    data-testid="provider-result"
+  >
+    <ChainIcon
+      :chain="row.chain"
+      size="20px"
+    />
+    <div class="flex flex-col min-w-0">
+      <span
+        class="text-sm"
+        :class="{ 'text-rui-text-secondary': row.status === RPC_SETUP_STATUS.PENDING }"
+      >
+        {{ getChainName(row.chain) }}
+      </span>
+      <span
+        v-if="message"
+        class="text-xs text-rui-text-secondary break-all"
+      >
+        {{ message }}
+      </span>
+    </div>
+
+    <div class="ml-auto flex items-center gap-2 text-xs shrink-0">
+      <template v-if="kept">
+        <span
+          v-if="row.archive"
+          class="text-rui-text-secondary"
+        >
+          {{ t('rpc_provider_setup.apply.archive') }}
+        </span>
+        <RuiIcon
+          name="lu-check"
+          size="16"
+          class="text-rui-success"
+        />
+      </template>
+      <template v-else-if="row.status === RPC_SETUP_STATUS.FAILED">
+        <span class="text-rui-text-secondary">{{ reason }}</span>
+        <RuiIcon
+          name="lu-x"
+          size="16"
+          class="text-rui-error"
+        />
+      </template>
+      <RuiProgress
+        v-else-if="row.status === RPC_SETUP_STATUS.RUNNING"
+        circular
+        variant="indeterminate"
+        size="16"
+        color="primary"
+      />
+      <RuiIcon
+        v-else
+        name="lu-minus"
+        size="16"
+        class="text-rui-text-disabled"
+      />
+    </div>
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderRunResults.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderRunResults.spec.ts
@@ -1,0 +1,103 @@
+import { Blockchain } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import RpcProviderRunResults from '@/modules/settings/general/rpc/providers/RpcProviderRunResults.vue';
+import { RPC_SETUP_STATUS, type RpcSetupRow, type RpcSetupSummary } from '@/modules/settings/general/rpc/providers/use-rpc-provider-setup';
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({
+    getChainName: (chain: string): string => chain,
+  }),
+}));
+
+function row(overrides: Partial<RpcSetupRow> = {}): RpcSetupRow {
+  return {
+    chain: Blockchain.OPTIMISM,
+    endpoint: 'https://optimism-mainnet.infura.io/v3/abcdef',
+    name: 'Infura',
+    status: RPC_SETUP_STATUS.ADDED,
+    ...overrides,
+  };
+}
+
+function summaryOf(rows: RpcSetupRow[]): RpcSetupSummary {
+  return {
+    added: rows.filter(item => item.status === RPC_SETUP_STATUS.ADDED).length,
+    archive: rows.filter(item => item.archive).length,
+    failed: rows.filter(item => item.status === RPC_SETUP_STATUS.FAILED).length,
+    total: rows.length,
+  };
+}
+
+function mountResults(rows: RpcSetupRow[], running = false, credential = ''): VueWrapper {
+  return mount(RpcProviderRunResults, {
+    global: { stubs: { ChainIcon: true } },
+    props: { credential, rows, running, summary: summaryOf(rows) },
+  });
+}
+
+describe('settings/general/rpc/providers/RpcProviderRunResults.vue', () => {
+  it('should count what failed next to what was added', () => {
+    const wrapper = mountResults([
+      row({ chain: Blockchain.ETH }),
+      row({ error: 'nope', status: RPC_SETUP_STATUS.FAILED }),
+    ]);
+
+    expect(wrapper.find('[data-testid=provider-added-count]').text()).toContain('apply.count.added');
+    expect(wrapper.find('[data-testid=provider-failed-count]').text()).toContain('apply.count.failed');
+  });
+
+  it('should tell the user to expand while a failure is collapsed', async () => {
+    const wrapper = mountResults([row({ error: 'nope', status: RPC_SETUP_STATUS.FAILED })]);
+
+    expect(wrapper.find('[data-testid=provider-details-hint]').text()).toContain('apply.expand_failed');
+
+    await wrapper.find('[data-testid=provider-details] [data-accordion-trigger]').trigger('click');
+    await nextTick();
+
+    expect(wrapper.find('[data-testid=provider-details-hint]').exists()).toBe(false);
+  });
+
+  it('should leave the expand hint off a run that added every chain', () => {
+    const wrapper = mountResults([row()]);
+
+    expect(wrapper.find('[data-testid=provider-details-hint]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid=provider-failed-count]').exists()).toBe(false);
+  });
+
+  it('should name the chain it is connecting to while the run works', () => {
+    const wrapper = mountResults([
+      row({ chain: Blockchain.ETH }),
+      row({ status: RPC_SETUP_STATUS.RUNNING }),
+    ], true);
+
+    const progress = wrapper.find('[data-testid=provider-progress]');
+    expect(progress.text()).toContain('apply.progress_chain');
+    expect(progress.find('chain-icon-stub').attributes('chain')).toBe(Blockchain.OPTIMISM);
+    expect(wrapper.find('[data-testid=provider-progress-count]').text()).toContain('apply.progress_count');
+  });
+
+  it('should fall back to the counts in the gap between two chains', () => {
+    const wrapper = mountResults([row({ status: RPC_SETUP_STATUS.PENDING })], true);
+
+    const progress = wrapper.find('[data-testid=provider-progress]');
+    expect(progress.text()).toContain('apply.progress');
+    expect(progress.text()).not.toContain('apply.progress_chain');
+    expect(progress.find('chain-icon-stub').exists()).toBe(false);
+  });
+
+  it('should keep the key out of a message that quotes the endpoint', () => {
+    const error = 'Failed to connect at https://optimism-mainnet.infura.io/v3/abcdef and https://optimism-mainnet.infura.io/v3/abcdef';
+    const wrapper = mountResults([row({ error, status: RPC_SETUP_STATUS.FAILED })], false, 'abcdef');
+
+    const message = wrapper.find('[data-testid=provider-result]').text();
+    expect(message).toContain('Failed to connect at');
+    expect(message).not.toContain('abcdef');
+  });
+
+  it('should announce the run, which is the only place its state is told', () => {
+    const wrapper = mountResults([row()]);
+
+    expect(wrapper.find('[data-testid=provider-summary]').attributes('aria-live')).toBe('polite');
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderRunResults.vue
+++ b/frontend/app/src/modules/settings/general/rpc/providers/RpcProviderRunResults.vue
@@ -1,0 +1,198 @@
+<script setup lang="ts">
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { tidyRpcConnectMessage } from '@/modules/settings/general/rpc/providers/rpc-connect-error';
+import { maskRpcEndpoint } from '@/modules/settings/general/rpc/providers/rpc-providers';
+import RpcProviderResultRow from '@/modules/settings/general/rpc/providers/RpcProviderResultRow.vue';
+import {
+  RPC_SETUP_STATUS,
+  type RpcSetupRow,
+  type RpcSetupSummary,
+} from '@/modules/settings/general/rpc/providers/use-rpc-provider-setup';
+import ChainIcon from '@/modules/shell/components/ChainIcon.vue';
+
+const {
+  credential = '',
+  enablement = '',
+  rows,
+  running,
+  summary,
+} = defineProps<{
+  /** The provider key, so a backend message quoting the endpoint does not put it on screen. */
+  credential?: string;
+  enablement?: string;
+  rows: RpcSetupRow[];
+  running: boolean;
+  summary: RpcSetupSummary;
+}>();
+
+const { t } = useI18n({ useScope: 'global' });
+const { getChainName } = useSupportedChains();
+
+const failedRows = computed<RpcSetupRow[]>(() => rows.filter(row => row.status === RPC_SETUP_STATUS.FAILED));
+
+/** Chains the run has finished with, which is what the line counts while it works. */
+const settled = computed<number>(() => rows
+  .filter(row => row.status !== RPC_SETUP_STATUS.PENDING && row.status !== RPC_SETUP_STATUS.RUNNING)
+  .length);
+
+const progress = computed<number>(() => rows.length === 0 ? 0 : (get(settled) / rows.length) * 100);
+
+/**
+ * The chains a stopped run never reached, so the two counts always add up to the total.
+ *
+ * @remarks
+ * Zero on a run that walked every chain, which is what keeps the third count off the line.
+ */
+const untried = computed<number>(() => summary.total - summary.added - summary.failed);
+
+/** Whether the finished run left a chain behind, the only case the counts alone under-tell. */
+const hasFailures = computed<boolean>(() => !running && summary.failed > 0);
+
+/** The chain the run is connecting to, which is the one thing the counts alone do not say. */
+const runningChain = computed<string>(() =>
+  rows.find(row => row.status === RPC_SETUP_STATUS.RUNNING)?.chain ?? '');
+
+/**
+ * The line the run shows while it works, with the count carried separately beside it.
+ *
+ * @remarks
+ * Drops the chain in the gap between two chains, where no row is running and naming the one just
+ * left would be a lie.
+ */
+const progressLabel = computed<string>(() => {
+  const chain = get(runningChain);
+  return chain
+    ? t('rpc_provider_setup.apply.progress_chain', { chain: getChainName(chain) })
+    : t('rpc_provider_setup.apply.progress');
+});
+
+/** The reason a chain was left out, in the backend's own words and with the credential hidden. */
+function failureMessage(row: RpcSetupRow): string {
+  if (row.status !== RPC_SETUP_STATUS.FAILED)
+    return '';
+
+  if (!row.error)
+    return t('rpc_provider_setup.apply.unknown_error');
+
+  return tidyRpcConnectMessage(credential ? maskRpcEndpoint(row.error, credential) : row.error);
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-4">
+    <div
+      class="text-sm"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="provider-summary"
+    >
+      <div
+        v-if="running"
+        class="flex items-center gap-2"
+        data-testid="provider-progress"
+      >
+        <!-- Kept even between two chains, so the label does not shift when the icon goes. -->
+        <div class="w-[18px] shrink-0">
+          <ChainIcon
+            v-if="runningChain"
+            :chain="runningChain"
+            size="18px"
+          />
+        </div>
+        <span class="truncate min-w-0">{{ progressLabel }}</span>
+        <span
+          class="ml-auto shrink-0 text-rui-text-secondary tabular-nums"
+          data-testid="provider-progress-count"
+        >
+          {{ t('rpc_provider_setup.apply.progress_count', { done: settled, total: rows.length }) }}
+        </span>
+      </div>
+      <div
+        v-else
+        class="flex items-center flex-wrap gap-x-3 gap-y-1"
+      >
+        <span
+          class="flex items-center gap-1"
+          :class="summary.added > 0 ? 'text-rui-success' : 'text-rui-text-secondary'"
+          data-testid="provider-added-count"
+        >
+          <RuiIcon
+            name="lu-check"
+            size="16"
+          />
+          {{ t('rpc_provider_setup.apply.count.added', { count: summary.added }) }}
+        </span>
+        <span
+          v-if="summary.failed > 0"
+          class="flex items-center gap-1 text-rui-error font-medium"
+          data-testid="provider-failed-count"
+        >
+          <RuiIcon
+            name="lu-x"
+            size="16"
+          />
+          {{ t('rpc_provider_setup.apply.count.failed', { count: summary.failed }) }}
+        </span>
+        <span
+          v-if="untried > 0"
+          class="text-rui-text-secondary"
+          data-testid="provider-untried-count"
+        >
+          {{ t('rpc_provider_setup.apply.count.untried', { count: untried }) }}
+        </span>
+        <span
+          v-if="summary.archive > 0"
+          class="text-rui-text-secondary"
+        >
+          {{ t('rpc_provider_setup.apply.summary_archive', { ...summary }) }}
+        </span>
+      </div>
+    </div>
+    <RuiProgress
+      v-if="running"
+      :value="progress"
+      color="primary"
+      size="4"
+    />
+    <RuiAccordions>
+      <RuiAccordion
+        eager
+        header-grow
+        :class-names="{ header: 'p-0', content: 'pt-2' }"
+        data-testid="provider-details"
+      >
+        <template #header="{ open: expanded }">
+          <span
+            v-if="hasFailures && !expanded"
+            class="text-xs text-rui-error font-medium"
+            data-testid="provider-details-hint"
+          >
+            {{ t('rpc_provider_setup.apply.expand_failed', { count: summary.failed }, summary.failed) }}
+          </span>
+          <span
+            v-else
+            class="text-xs text-rui-text-secondary"
+          >
+            {{ t('rpc_provider_setup.apply.details') }}
+          </span>
+        </template>
+        <div class="flex flex-col">
+          <p
+            v-if="!running && failedRows.length > 0 && enablement"
+            class="text-xs text-rui-text-secondary pb-2"
+          >
+            {{ enablement }}
+          </p>
+          <div class="flex flex-col divide-y divide-rui-grey-100 dark:divide-rui-grey-800">
+            <RpcProviderResultRow
+              v-for="row in rows"
+              :key="row.chain"
+              :row="row"
+              :message="failureMessage(row)"
+            />
+          </div>
+        </div>
+      </RuiAccordion>
+    </RuiAccordions>
+  </div>
+</template>

--- a/frontend/app/src/modules/settings/general/rpc/providers/rpc-connect-error.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/rpc-connect-error.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RPC_CONNECT_ERROR,
+  summariseRpcConnectError,
+  tidyRpcConnectMessage,
+} from '@/modules/settings/general/rpc/providers/rpc-connect-error';
+
+describe('settings/general/rpc/providers/rpc-connect-error', () => {
+  it('should read a plain connection failure as unreachable', () => {
+    const message = 'Failed to connect to ethereum node NodeName(name=\'Infura\') at endpoint https://mainnet.infura.io/v3/key';
+
+    expect(summariseRpcConnectError(message)).toBe(RPC_CONNECT_ERROR.UNREACHABLE);
+  });
+
+  it('should prefer the rejected key when the message is both', () => {
+    const message = 'Failed to connect to Solana RPC at https://solana-mainnet.infura.io/v3/key due to 401 Client Error';
+
+    expect(summariseRpcConnectError(message)).toBe(RPC_CONNECT_ERROR.REJECTED);
+  });
+
+  it.each([
+    ['401', 'request failed with 401'],
+    ['403', 'got a 403 back'],
+    ['unauthorized', 'Unauthorized'],
+    ['invalid key', 'invalid api key supplied'],
+  ])('should read %s as a rejected key', (_case, message) => {
+    expect(summariseRpcConnectError(message)).toBe(RPC_CONNECT_ERROR.REJECTED);
+  });
+
+  it('should read a chain mismatch as the wrong network', () => {
+    const message = 'Connected to node at endpoint https://x but it is not on the right network';
+
+    expect(summariseRpcConnectError(message)).toBe(RPC_CONNECT_ERROR.WRONG_NETWORK);
+  });
+
+  it('should not guess at a message it does not recognise', () => {
+    expect(summariseRpcConnectError('something else entirely')).toBe(RPC_CONNECT_ERROR.UNKNOWN);
+    expect(summariseRpcConnectError('')).toBe(RPC_CONNECT_ERROR.UNKNOWN);
+  });
+
+  describe('tidyRpcConnectMessage', () => {
+    it('should drop the node repr, the chain and the second copy of the endpoint', () => {
+      const message = 'Failed to connect to ethereum node NodeName(name=\'Infura\', endpoint=\'https://mainnet.infura.io/v3/dead…beef\', owned=True, blockchain=<SupportedBlockchain.ETHEREUM: \'ETH\'>) at endpoint https://mainnet.infura.io/v3/dead…beef';
+
+      expect(tidyRpcConnectMessage(message)).toBe('Failed to connect at endpoint https://mainnet.infura.io/v3/dead…beef');
+    });
+
+    it('should keep the cause and drop only the repeated endpoint', () => {
+      const message = 'Failed to connect to Solana RPC at https://solana-mainnet.infura.io/v3/dead…beef due to 401 Client Error: Unauthorized for url: https://solana-mainnet.infura.io/v3/dead…beef';
+
+      expect(tidyRpcConnectMessage(message)).toBe('Failed to connect to Solana RPC at https://solana-mainnet.infura.io/v3/dead…beef due to 401 Client Error: Unauthorized');
+    });
+
+    it('should keep two endpoints that differ', () => {
+      const message = 'Connected to https://one.example at endpoint https://two.example';
+
+      expect(tidyRpcConnectMessage(message)).toBe(message);
+    });
+
+    it('should pass a message of another shape through untouched', () => {
+      expect(tidyRpcConnectMessage('something else entirely')).toBe('something else entirely');
+      expect(tidyRpcConnectMessage('')).toBe('');
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/rpc-connect-error.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/rpc-connect-error.ts
@@ -1,0 +1,69 @@
+export const RPC_CONNECT_ERROR = {
+  REJECTED: 'rejected',
+  UNKNOWN: 'unknown',
+  UNREACHABLE: 'unreachable',
+  WRONG_NETWORK: 'wrong-network',
+} as const;
+
+export type RpcConnectError = typeof RPC_CONNECT_ERROR[keyof typeof RPC_CONNECT_ERROR];
+
+/**
+ * Ordered because a message can match more than one pattern.
+ *
+ * @remarks
+ * "Failed to connect … due to 401" is both a connection failure and a rejected key, and the key is
+ * the half the user can act on, so the credential patterns are tested first.
+ */
+const patterns: [RpcConnectError, RegExp][] = [
+  [RPC_CONNECT_ERROR.REJECTED, /\b401\b|\b403\b|unauthori[sz]ed|forbidden|invalid (?:api )?key/i],
+  [RPC_CONNECT_ERROR.WRONG_NETWORK, /right network|network id|chain id|unexpected node version/i],
+  [RPC_CONNECT_ERROR.UNREACHABLE, /failed to connect|connection|timed? ?out|unreachable|resolve/i],
+];
+
+/**
+ * Classifies a backend connect failure into something a list row can say in three words.
+ *
+ * @param message - the backend's own message, which the caller still shows in full on demand
+ * @returns the kind of failure, or `unknown` when nothing matches
+ */
+export function summariseRpcConnectError(message: string): RpcConnectError {
+  return patterns.find(([, pattern]) => pattern.test(message))?.[0] ?? RPC_CONNECT_ERROR.UNKNOWN;
+}
+
+/** The `NodeName(name=…, owned=True, blockchain=<…>)` repr, which holds no parentheses of its own. */
+const NODE_REPR = /\s*NodeName\([^()]*\)/g;
+
+/** The chain the message names, which the row it sits under already carries. */
+const CHAIN_IN_LEAD = /^(Failed to connect) to \S+ node\b/i;
+
+/** An endpoint, with the phrase that introduces it when there is one. */
+const ENDPOINT = /(?:\s+(?:at endpoint|for url:))?\s+(https?:\/\/\S+)/gi;
+
+/**
+ * Rewrites a backend connect failure into something worth reading in a list row.
+ *
+ * @remarks
+ * The backend answers with a Python repr of the node and then quotes the endpoint a second time, so
+ * one failure costs three wrapped lines that are mostly internals. Each rewrite is conditional on
+ * its own pattern and none of them invent text, so a message that does not have this shape is
+ * passed through untouched. Drop this once the backend's own message is fixed.
+ *
+ * @param message - the backend's own message, with the credential already masked
+ * @returns the message without the repr, the chain it names twice, and the repeated endpoint
+ */
+export function tidyRpcConnectMessage(message: string): string {
+  const seen = new Set<string>();
+
+  return message
+    .replace(NODE_REPR, '')
+    .replace(CHAIN_IN_LEAD, '$1')
+    .replace(ENDPOINT, (match, url: string) => {
+      if (seen.has(url))
+        return '';
+
+      seen.add(url);
+      return match;
+    })
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}

--- a/frontend/app/src/modules/settings/general/rpc/providers/rpc-provider-plan.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/rpc-provider-plan.spec.ts
@@ -1,0 +1,134 @@
+import type { RpcProviderMatch } from '@/modules/settings/general/rpc/providers/rpc-providers';
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { Blockchain } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import {
+  buildRpcProviderPlan,
+  toRpcNodePayload,
+} from '@/modules/settings/general/rpc/providers/rpc-provider-plan';
+
+function node(partial: Partial<BlockchainRpcNode>): BlockchainRpcNode {
+  return {
+    active: true,
+    blockchain: Blockchain.ETH,
+    endpoint: 'https://rpc.example.com',
+    identifier: 1,
+    name: 'a node',
+    owned: false,
+    weight: 20,
+    ...partial,
+  };
+}
+
+const infura: RpcProviderMatch = {
+  chain: Blockchain.ETH,
+  credentials: { key: 'abcdef' },
+  providerId: 'infura',
+};
+
+describe('settings/general/rpc/providers/rpc-provider-plan', () => {
+  describe('buildRpcProviderPlan', () => {
+    it('should build one candidate per served chain, in the order given', () => {
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.OPTIMISM, Blockchain.ETH], {});
+
+      expect(candidates.map(candidate => candidate.chain)).toEqual([Blockchain.OPTIMISM, Blockchain.ETH]);
+      expect(candidates[1].endpoint).toBe('https://mainnet.infura.io/v3/abcdef');
+      expect(candidates[1].name).toBe('Infura');
+    });
+
+    it('should report the chains the provider does not serve instead of dropping them', () => {
+      const { candidates, unsupported } = buildRpcProviderPlan(
+        infura,
+        [Blockchain.ETH, Blockchain.GNOSIS, Blockchain.SONIC],
+        {},
+      );
+
+      expect(candidates).toHaveLength(1);
+      expect(unsupported).toEqual([Blockchain.GNOSIS, Blockchain.SONIC]);
+    });
+
+    it('should flag a chain that already holds exactly this endpoint', () => {
+      const existing = node({ endpoint: 'https://mainnet.infura.io/v3/abcdef', name: 'Infura' });
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.ETH], { [Blockchain.ETH]: [existing] });
+
+      expect(candidates[0].existing).toBe(existing);
+      expect(candidates[0].outdated).toBeUndefined();
+    });
+
+    it('should offer to update a node holding the same provider with an older key', () => {
+      const older = node({ endpoint: 'https://mainnet.infura.io/v3/an-older-key', name: 'Infura' });
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.ETH], { [Blockchain.ETH]: [older] });
+
+      expect(candidates[0].existing).toBeUndefined();
+      expect(candidates[0].outdated).toBe(older);
+    });
+
+    it('should ignore nodes from other providers when looking for an existing one', () => {
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.ETH], {
+        [Blockchain.ETH]: [
+          node({ endpoint: 'https://eth-mainnet.g.alchemy.com/v2/key' }),
+          node({ endpoint: '', name: 'etherscan' }),
+        ],
+      });
+
+      expect(candidates[0].existing).toBeUndefined();
+      expect(candidates[0].outdated).toBeUndefined();
+    });
+
+    it('should not collide with an existing node of the same name', () => {
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.ETH], {
+        [Blockchain.ETH]: [
+          node({ endpoint: 'https://other.example.com', name: 'Infura' }),
+          node({ endpoint: 'https://another.example.com', name: 'Infura (2)' }),
+        ],
+      });
+
+      expect(candidates[0].name).toBe('Infura (3)');
+    });
+
+    it('should name the nodes what the caller asked for', () => {
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.ETH], {}, 'Work key');
+
+      expect(candidates[0].name).toBe('Work key');
+    });
+
+    it('should keep a custom name unique against the names a chain already holds', () => {
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.ETH], {
+        [Blockchain.ETH]: [node({ endpoint: 'https://other.example.com', name: 'Work key' })],
+      }, 'Work key');
+
+      expect(candidates[0].name).toBe('Work key (2)');
+    });
+
+    it.each([
+      ['an empty name', ''],
+      ['only whitespace', '   '],
+    ])('should fall back to the provider name given %s', (_case, preferred) => {
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.ETH], {}, preferred);
+
+      expect(candidates[0].name).toBe('Infura');
+    });
+
+    it('should treat a chain with no known nodes as empty', () => {
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.BSC], {});
+
+      expect(candidates[0].existing).toBeUndefined();
+      expect(candidates[0].name).toBe('Infura');
+    });
+  });
+
+  describe('toRpcNodePayload', () => {
+    it('should add the node as owned with a zero weight, so existing weights are untouched', () => {
+      const { candidates } = buildRpcProviderPlan(infura, [Blockchain.ETH], {});
+
+      expect(toRpcNodePayload(candidates[0])).toEqual({
+        active: true,
+        blockchain: Blockchain.ETH,
+        endpoint: 'https://mainnet.infura.io/v3/abcdef',
+        name: 'Infura',
+        owned: true,
+        weight: 0,
+      });
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/rpc-provider-plan.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/rpc-provider-plan.ts
@@ -1,0 +1,114 @@
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import {
+  buildRpcEndpoint,
+  getRpcProvider,
+  isRpcProviderEndpoint,
+  type RpcProviderMatch,
+} from '@/modules/settings/general/rpc/providers/rpc-providers';
+
+export interface RpcProviderCandidate {
+  chain: string;
+  endpoint: string;
+  /** The node this chain already holds on exactly this endpoint, which leaves nothing to do. */
+  existing?: BlockchainRpcNode;
+  name: string;
+  /**
+   * The node this chain holds on the same provider with different credentials.
+   *
+   * @remarks
+   * This is a key the user is replacing, so the endpoint is updated in place rather than added
+   * beside the old one, which would leave the chain holding a node that no longer authenticates.
+   */
+  outdated?: BlockchainRpcNode;
+}
+
+export interface RpcProviderPlan {
+  /** One entry per chain the provider and rotki both support, in rotki's own chain order. */
+  candidates: RpcProviderCandidate[];
+  /** The chains rotki supports that this provider does not serve. */
+  unsupported: string[];
+}
+
+/**
+ * Names the node after its provider, since names are scoped to a chain's own list.
+ *
+ * @remarks
+ * Nothing in the schema stops two nodes sharing a name, so this only keeps the list readable.
+ */
+function uniqueName(providerName: string, taken: string[]): string {
+  if (!taken.includes(providerName))
+    return providerName;
+
+  let suffix = 2;
+  while (taken.includes(`${providerName} (${suffix})`))
+    suffix += 1;
+
+  return `${providerName} (${suffix})`;
+}
+
+/**
+ * Works out what one provider key can cover, given the chains rotki has and the nodes each one
+ * already holds.
+ *
+ * @param match - the provider and credentials read off the pasted endpoint
+ * @param chains - the chains rotki can manage nodes for, in the order the ui shows them
+ * @param nodesByChain - the nodes each of those chains already has
+ * @param preferredName - what to call the nodes, defaulting to the provider's own name; blank falls
+ * back to that default, since the backend rejects an empty name
+ * @returns the per-chain candidates, and the chains this provider cannot serve
+ */
+export function buildRpcProviderPlan(
+  match: RpcProviderMatch,
+  chains: string[],
+  nodesByChain: Record<string, BlockchainRpcNode[]>,
+  preferredName = '',
+): RpcProviderPlan {
+  const provider = getRpcProvider(match.providerId);
+  const served = new Set(provider.chains);
+  const wanted = preferredName.trim() || provider.name;
+  const candidates: RpcProviderCandidate[] = [];
+  const unsupported: string[] = [];
+
+  for (const chain of chains) {
+    const endpoint = served.has(chain) ? buildRpcEndpoint(match, chain) : undefined;
+    if (!endpoint) {
+      unsupported.push(chain);
+      continue;
+    }
+
+    const nodes = nodesByChain[chain] ?? [];
+    const onProvider = nodes.filter(node => isRpcProviderEndpoint(node.endpoint, match.providerId));
+    candidates.push({
+      chain,
+      endpoint,
+      existing: onProvider.find(node => node.endpoint === endpoint),
+      name: uniqueName(wanted, nodes.map(node => node.name)),
+      outdated: onProvider.find(node => node.endpoint !== endpoint),
+    });
+  }
+
+  return { candidates, unsupported };
+}
+
+/**
+ * The node a candidate is added as.
+ *
+ * @remarks
+ * Owned with a weight of zero on purpose: owned nodes are tried before the weighted ones whatever
+ * their weight, so nothing has to be taken from the user's own nodes to make this one count.
+ *
+ * A zero still leaves the chain's weights *proportionally* untouched rather than literally so: the
+ * backend rescales every other node of the chain into `1 - weight` on insert, which is a no-op only
+ * when they already sum to 100. rotki's shipped defaults do not (ethereum's sum to 115), so the
+ * first insert renormalises them, and removing the node again does not put the old numbers back.
+ */
+export function toRpcNodePayload(candidate: RpcProviderCandidate): Omit<BlockchainRpcNode, 'identifier'> {
+  return {
+    active: true,
+    blockchain: candidate.chain,
+    endpoint: candidate.endpoint,
+    name: candidate.name,
+    owned: true,
+    weight: 0,
+  };
+}

--- a/frontend/app/src/modules/settings/general/rpc/providers/rpc-provider-usage.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/rpc-provider-usage.spec.ts
@@ -1,0 +1,102 @@
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { Blockchain } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { groupNodesByProvider } from '@/modules/settings/general/rpc/providers/rpc-provider-usage';
+
+function node(identifier: number, endpoint: string, name = 'a node'): BlockchainRpcNode {
+  return {
+    active: true,
+    blockchain: Blockchain.ETH,
+    endpoint,
+    identifier,
+    name,
+    owned: true,
+    weight: 0,
+  };
+}
+
+describe('settings/general/rpc/providers/rpc-provider-usage', () => {
+  it('should gather one provider\'s nodes from every chain', () => {
+    const usages = groupNodesByProvider({
+      [Blockchain.ETH]: [node(1, 'https://mainnet.infura.io/v3/key', 'Infura')],
+      [Blockchain.OPTIMISM]: [node(2, 'https://optimism-mainnet.infura.io/v3/key', 'Infura')],
+    });
+
+    expect(usages).toHaveLength(1);
+    expect(usages[0]).toMatchObject({ id: 'infura', name: 'Infura' });
+    expect(usages[0].nodes).toEqual([
+      { chain: Blockchain.ETH, identifier: 1, name: 'Infura' },
+      { chain: Blockchain.OPTIMISM, identifier: 2, name: 'Infura' },
+    ]);
+  });
+
+  it('should keep providers apart and leave everything else alone', () => {
+    const usages = groupNodesByProvider({
+      [Blockchain.ETH]: [
+        node(1, 'https://mainnet.infura.io/v3/key'),
+        node(2, 'https://eth-mainnet.g.alchemy.com/v2/key'),
+        node(3, 'https://eth-rpc.publicnode.com'),
+        node(4, '', 'etherscan'),
+      ],
+    });
+
+    expect(usages.map(usage => usage.id)).toEqual(['infura', 'alchemy']);
+    expect(usages.every(usage => usage.nodes.length === 1)).toBe(true);
+  });
+
+  it('should keep two keys of one provider apart, so removing one leaves the other', () => {
+    const usages = groupNodesByProvider({
+      [Blockchain.ETH]: [
+        node(1, 'https://mainnet.infura.io/v3/0123456789abcdef', 'Personal'),
+        node(2, 'https://mainnet.infura.io/v3/fedcba9876543210', 'Work'),
+      ],
+      [Blockchain.OPTIMISM]: [node(3, 'https://optimism-mainnet.infura.io/v3/fedcba9876543210', 'Work')],
+    });
+
+    expect(usages).toHaveLength(2);
+    expect(usages.map(usage => usage.nodes.map(entry => entry.identifier))).toEqual([[1], [2, 3]]);
+    expect(new Set(usages.map(usage => usage.key)).size).toBe(2);
+  });
+
+  it('should mask the key it groups by, so the raw credential never leaves the module', () => {
+    const usages = groupNodesByProvider({
+      [Blockchain.ETH]: [node(1, 'https://mainnet.infura.io/v3/0123456789abcdef')],
+    });
+
+    expect(usages[0].key).toBe('0123…cdef');
+    expect(JSON.stringify(usages)).not.toContain('0123456789abcdef');
+  });
+
+  it('should keep the same quicknode token on two endpoint names apart', () => {
+    const usages = groupNodesByProvider({
+      [Blockchain.OPTIMISM]: [
+        node(1, 'https://vineyard.optimism.quiknode.pro/token/'),
+        node(2, 'https://orchard.optimism.quiknode.pro/token/'),
+      ],
+    });
+
+    expect(usages).toHaveLength(2);
+  });
+
+  it('should bucket a provider url it cannot parse rather than dropping it', () => {
+    const usages = groupNodesByProvider({
+      [Blockchain.ETH]: [node(1, 'https://mainnet.infura.io/v3/key/extra/segments', 'hand written')],
+    });
+
+    expect(usages).toHaveLength(1);
+    expect(usages[0]).toMatchObject({ id: 'infura', key: '' });
+  });
+
+  it('should group a node added by hand, since nothing records where a node came from', () => {
+    const usages = groupNodesByProvider({
+      [Blockchain.ETH]: [node(9, 'https://mainnet.infura.io/v3/some-other-key', 'my own node')],
+    });
+
+    expect(usages[0].nodes).toEqual([{ chain: Blockchain.ETH, identifier: 9, name: 'my own node' }]);
+  });
+
+  it('should return nothing when no provider holds a node', () => {
+    expect(groupNodesByProvider({ [Blockchain.ETH]: [node(1, 'https://eth-rpc.publicnode.com')] })).toEqual([]);
+    expect(groupNodesByProvider({})).toEqual([]);
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/rpc-provider-usage.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/rpc-provider-usage.ts
@@ -1,0 +1,79 @@
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import {
+  detectRpcProvider,
+  getRpcProvider,
+  isRpcProviderEndpoint,
+  maskRpcKey,
+  RPC_PROVIDER_IDS,
+  type RpcProviderId,
+} from '@/modules/settings/general/rpc/providers/rpc-providers';
+
+interface RpcProviderNode {
+  chain: string;
+  identifier: number;
+  name: string;
+}
+
+export interface RpcProviderUsage {
+  id: RpcProviderId;
+  /**
+   * The credential these nodes authenticate with, masked.
+   *
+   * @remarks
+   * Empty when the endpoint sits on the provider's host but does not parse, which is the bucket a
+   * hand-written variant of one of their urls falls into. Masked rather than raw so the whole key
+   * never reaches component state.
+   */
+  key: string;
+  name: string;
+  /** Every node this credential holds, across every chain. */
+  nodes: RpcProviderNode[];
+}
+
+/** Nodes are grouped by what they authenticate with, which for QuickNode is the endpoint plus token. */
+function credentialOf(endpoint: string): { group: string; id: RpcProviderId; key: string } | undefined {
+  const match = detectRpcProvider(endpoint);
+  if (match) {
+    const { endpointName = '', key } = match.credentials;
+    return { group: `${match.providerId}:${endpointName}:${key}`, id: match.providerId, key: maskRpcKey(key) };
+  }
+
+  const id = RPC_PROVIDER_IDS.find(candidate => isRpcProviderEndpoint(endpoint, candidate));
+  return id ? { group: `${id}:unparsed`, id, key: '' } : undefined;
+}
+
+/**
+ * Groups the nodes a set of chains hold by the provider credential serving them.
+ *
+ * @remarks
+ * One entry per key, not per provider: two keys of the same provider are two separate things to the
+ * user, and merging them would let one removal take out both. Matched on the endpoint rather than on
+ * a stored provider id, since nothing records where a node came from — a node added by hand years
+ * ago counts the same as one this dialog wrote.
+ *
+ * @param nodesByChain - the nodes each chain holds
+ * @returns one entry per credential that holds at least one node, in provider order
+ */
+export function groupNodesByProvider(nodesByChain: Record<string, BlockchainRpcNode[]>): RpcProviderUsage[] {
+  const usages = new Map<string, RpcProviderUsage>();
+
+  for (const [chain, chainNodes] of Object.entries(nodesByChain)) {
+    for (const node of chainNodes) {
+      const credential = credentialOf(node.endpoint);
+      if (!credential)
+        continue;
+
+      const usage = usages.get(credential.group) ?? {
+        id: credential.id,
+        key: credential.key,
+        name: getRpcProvider(credential.id).name,
+        nodes: [],
+      };
+      usage.nodes.push({ chain, identifier: node.identifier, name: node.name });
+      usages.set(credential.group, usage);
+    }
+  }
+
+  return [...usages.values()].sort((a, b) =>
+    RPC_PROVIDER_IDS.indexOf(a.id) - RPC_PROVIDER_IDS.indexOf(b.id) || a.key.localeCompare(b.key));
+}

--- a/frontend/app/src/modules/settings/general/rpc/providers/rpc-providers.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/rpc-providers.spec.ts
@@ -1,0 +1,193 @@
+import { Blockchain } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import {
+  buildRpcEndpoint,
+  detectRpcProvider,
+  getRpcProvider,
+  isRpcProviderEndpoint,
+  maskRpcEndpoint,
+  maskRpcKey,
+  type RpcProviderMatch,
+} from '@/modules/settings/general/rpc/providers/rpc-providers';
+
+describe('settings/general/rpc/providers/rpc-providers', () => {
+  describe('detectRpcProvider', () => {
+    it('should detect infura with the chain the network slug names', () => {
+      expect(detectRpcProvider('https://mainnet.infura.io/v3/abcdef')).toEqual({
+        chain: Blockchain.ETH,
+        credentials: { key: 'abcdef' },
+        providerId: 'infura',
+      });
+
+      expect(detectRpcProvider('https://optimism-mainnet.infura.io/v3/abcdef')).toMatchObject({
+        chain: Blockchain.OPTIMISM,
+        providerId: 'infura',
+      });
+    });
+
+    it('should detect alchemy', () => {
+      expect(detectRpcProvider('https://eth-mainnet.g.alchemy.com/v2/key-123')).toEqual({
+        chain: Blockchain.ETH,
+        credentials: { key: 'key-123' },
+        providerId: 'alchemy',
+      });
+    });
+
+    it('should detect quicknode with its endpoint name and network subdomain', () => {
+      expect(detectRpcProvider('https://hidden-vineyard.optimism.quiknode.pro/token123/')).toEqual({
+        chain: Blockchain.OPTIMISM,
+        credentials: { endpointName: 'hidden-vineyard', key: 'token123' },
+        providerId: 'quicknode',
+      });
+    });
+
+    it('should read a quicknode url without a network segment as ethereum', () => {
+      expect(detectRpcProvider('https://hidden-vineyard.quiknode.pro/token123/')).toEqual({
+        chain: Blockchain.ETH,
+        credentials: { endpointName: 'hidden-vineyard', key: 'token123' },
+        providerId: 'quicknode',
+      });
+    });
+
+    it('should match a provider network rotki does not support, without a chain', () => {
+      const match = detectRpcProvider('https://linea-mainnet.g.alchemy.com/v2/key-123');
+      expect(match).toMatchObject({ providerId: 'alchemy' });
+      expect(match?.chain).toBeUndefined();
+    });
+
+    it.each([
+      ['an unknown host', 'https://rpc.ankr.com/eth'],
+      ['an empty endpoint, as the etherscan node has', ''],
+      ['a bare hostname with no key', 'https://mainnet.infura.io'],
+      ['an infura url with the wrong path prefix', 'https://mainnet.infura.io/v2/abcdef'],
+      ['an infura url with an extra path segment', 'https://mainnet.infura.io/v3/abcdef/extra'],
+      ['a nested infura subdomain', 'https://a.b.infura.io/v3/abcdef'],
+      ['the provider apex with no subdomain', 'https://infura.io/v3/abcdef'],
+      ['a websocket endpoint', 'wss://mainnet.infura.io/ws/v3/abcdef'],
+      ['a quicknode url with too many labels', 'https://a.b.c.quiknode.pro/token/'],
+      ['garbage', 'not a url'],
+    ])('should not detect a provider from %s', (_case, endpoint) => {
+      expect(detectRpcProvider(endpoint)).toBeUndefined();
+    });
+
+    it('should tolerate surrounding whitespace', () => {
+      expect(detectRpcProvider('  https://mainnet.infura.io/v3/abcdef  ')).toMatchObject({
+        providerId: 'infura',
+      });
+    });
+  });
+
+  describe('buildRpcEndpoint', () => {
+    const infura: RpcProviderMatch = {
+      chain: Blockchain.ETH,
+      credentials: { key: 'abcdef' },
+      providerId: 'infura',
+    };
+
+    it('should build every chain the provider serves from one key', () => {
+      expect(buildRpcEndpoint(infura, Blockchain.ETH)).toBe('https://mainnet.infura.io/v3/abcdef');
+      expect(buildRpcEndpoint(infura, Blockchain.BSC)).toBe('https://bsc-mainnet.infura.io/v3/abcdef');
+    });
+
+    it('should return undefined for a chain the provider does not serve', () => {
+      expect(buildRpcEndpoint(infura, Blockchain.GNOSIS)).toBeUndefined();
+    });
+
+    it('should use the provider\'s own name for a chain, not rotki\'s', () => {
+      expect(buildRpcEndpoint(infura, Blockchain.HYPERLIQUID)).toBe('https://hyperevm-mainnet.infura.io/v3/abcdef');
+      expect(buildRpcEndpoint({ ...infura, providerId: 'alchemy' }, Blockchain.OPTIMISM))
+        .toBe('https://opt-mainnet.g.alchemy.com/v2/abcdef');
+    });
+
+    it('should round-trip a detected endpoint back to itself', () => {
+      const endpoint = 'https://hidden-vineyard.optimism.quiknode.pro/token123/';
+      const match = detectRpcProvider(endpoint);
+      expect(match).toBeDefined();
+      expect(buildRpcEndpoint(match!, Blockchain.OPTIMISM)).toBe(endpoint);
+    });
+
+    it.each([
+      [Blockchain.OPTIMISM, 'optimism'],
+      [Blockchain.POLYGON_POS, 'matic'],
+      [Blockchain.GNOSIS, 'xdai'],
+      [Blockchain.BSC, 'bsc'],
+      [Blockchain.ARBITRUM_ONE, 'arbitrum-mainnet'],
+      [Blockchain.SONIC, 'sonic-mainnet'],
+    ])('should address quicknode %s at its own network name', (chain, network) => {
+      const match = detectRpcProvider('https://vineyard.optimism.quiknode.pro/token/');
+      expect(buildRpcEndpoint(match!, chain)).toBe(`https://vineyard.${network}.quiknode.pro/token/`);
+    });
+
+    it('should not offer a quicknode chain whose url needs a path segment', () => {
+      const match = detectRpcProvider('https://vineyard.optimism.quiknode.pro/token/');
+      expect(buildRpcEndpoint(match!, Blockchain.HYPERLIQUID)).toBeUndefined();
+    });
+
+    it('should build quicknode ethereum without a network segment', () => {
+      const match = detectRpcProvider('https://hidden-vineyard.optimism.quiknode.pro/token123/');
+      expect(buildRpcEndpoint(match!, Blockchain.ETH)).toBe('https://hidden-vineyard.quiknode.pro/token123/');
+    });
+  });
+
+  describe('getRpcProvider', () => {
+    it('should expose the chains a provider serves', () => {
+      const provider = getRpcProvider('alchemy');
+      expect(provider.name).toBe('Alchemy');
+      expect(provider.enablement).toBe('none');
+      expect(provider.chains).toContain(Blockchain.GNOSIS);
+    });
+
+    it('should keep the three providers\' enablement rules apart', () => {
+      expect(getRpcProvider('infura').enablement).toBe('per-network');
+      expect(getRpcProvider('quicknode').enablement).toBe('multichain-endpoint');
+      expect(getRpcProvider('alchemy').enablement).toBe('none');
+    });
+
+    it('should serve every chain it lists', () => {
+      for (const id of ['infura', 'alchemy', 'quicknode'] as const) {
+        const match: RpcProviderMatch = {
+          credentials: { endpointName: 'name', key: 'key' },
+          providerId: id,
+        };
+        for (const chain of getRpcProvider(id).chains)
+          expect(buildRpcEndpoint(match, chain)).toBeDefined();
+      }
+    });
+  });
+
+  describe('isRpcProviderEndpoint', () => {
+    it('should recognise any url on the provider host', () => {
+      expect(isRpcProviderEndpoint('https://polygon-mainnet.infura.io/v3/other', 'infura')).toBe(true);
+      expect(isRpcProviderEndpoint('https://polygon-mainnet.infura.io/v3/other', 'alchemy')).toBe(false);
+      expect(isRpcProviderEndpoint('', 'infura')).toBe(false);
+    });
+  });
+
+  describe('maskRpcEndpoint', () => {
+    it('should hide the key inside an endpoint', () => {
+      expect(maskRpcEndpoint('https://mainnet.infura.io/v3/0123456789abcdef', '0123456789abcdef'))
+        .toBe('https://mainnet.infura.io/v3/0123…cdef');
+    });
+
+    it('should hide every occurrence, since a backend error quotes the endpoint twice', () => {
+      const key = '0123456789abcdef';
+      const error = `Failed to connect to node at https://mainnet.infura.io/v3/${key} at endpoint https://mainnet.infura.io/v3/${key}`;
+
+      expect(maskRpcEndpoint(error, key)).not.toContain(key);
+    });
+
+    it('should leave a keyless endpoint alone', () => {
+      expect(maskRpcEndpoint('https://eth-rpc.publicnode.com', '')).toBe('https://eth-rpc.publicnode.com');
+    });
+  });
+
+  describe('maskRpcKey', () => {
+    it('should keep the ends of a long key and hide the rest', () => {
+      expect(maskRpcKey('0123456789abcdef')).toBe('0123…cdef');
+    });
+
+    it('should hide a short key entirely', () => {
+      expect(maskRpcKey('0123456789')).toBe('…');
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/rpc-providers.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/rpc-providers.ts
@@ -1,0 +1,280 @@
+import { Blockchain } from '@rotki/common';
+
+export const RPC_PROVIDER_IDS = ['infura', 'alchemy', 'quicknode'] as const;
+
+export type RpcProviderId = typeof RPC_PROVIDER_IDS[number];
+
+interface RpcProviderCredentials {
+  /** The api key or token the endpoint authenticates with. */
+  key: string;
+  /** The per-endpoint subdomain QuickNode puts in front of the network, absent for the others. */
+  endpointName?: string;
+}
+
+export interface RpcProviderMatch {
+  credentials: RpcProviderCredentials;
+  /** The rotki chain the endpoint points at, absent when the network is not one rotki supports. */
+  chain?: string;
+  providerId: RpcProviderId;
+}
+
+/**
+ * What the user may have to do on the provider's own side before the other networks answer.
+ *
+ * @remarks
+ * The three differ, which is what the issue asked to establish: Infura keys carry a per-network
+ * switch that is on by default, so a refusal there means that one network was turned off for the
+ * key; a QuickNode endpoint serves other networks only once Multichain is enabled on it; an
+ * Alchemy app is issued one key for every network and needs nothing.
+ */
+type RpcProviderEnablement = 'multichain-endpoint' | 'none' | 'per-network';
+
+export interface RpcProvider {
+  /** rotki chain ids this provider serves, in the order the tables declare them. */
+  chains: string[];
+  enablement: RpcProviderEnablement;
+  id: RpcProviderId;
+  name: string;
+}
+
+interface RpcProviderDefinition extends Omit<RpcProvider, 'chains'> {
+  /** Builds the endpoint this provider serves `network` on. */
+  build: (network: string, credentials: RpcProviderCredentials) => string;
+  /**
+   * rotki chain id to the provider's own network slug.
+   *
+   * @remarks
+   * Slugs are not derivable from rotki's chain ids and each provider names its networks its own
+   * way, so every entry is copied from that provider's own documentation and carries the date it
+   * was read. A chain the provider is not confirmed to serve is left out rather than guessed: an
+   * absent entry is simply not offered, while a wrong one tells the user their key failed when it
+   * was the url that was wrong.
+   */
+  networks: Record<string, string>;
+  /** Reads the network slug and the credentials out of one of this provider's urls. */
+  parse: (url: URL) => { credentials: RpcProviderCredentials; network: string } | undefined;
+  /** Whether a url is served by this provider at all, whatever its network. */
+  owns: (url: URL) => boolean;
+}
+
+/**
+ * The subdomain in front of `suffix`, or undefined when the host is not under it.
+ *
+ * @remarks
+ * Returns the whole prefix, dots included, so a caller that expects a single label has to check.
+ * `sub('a.b.infura.io', 'infura.io')` is `'a.b'`, and `sub('infura.io', 'infura.io')` is undefined.
+ */
+function sub(hostname: string, suffix: string): string | undefined {
+  const host = hostname.toLowerCase();
+  const dotted = `.${suffix}`;
+  if (!host.endsWith(dotted))
+    return undefined;
+
+  const prefix = host.slice(0, -dotted.length);
+  return prefix.length > 0 ? prefix : undefined;
+}
+
+/** The non-empty segments of a path, so a trailing slash never becomes an empty token. */
+function segments(pathname: string): string[] {
+  return pathname.split('/').filter(segment => segment.length > 0);
+}
+
+/** The key from a `/<prefix>/<key>` path, rejecting anything longer or differently shaped. */
+function keyAfter(pathname: string, prefix: string): string | undefined {
+  const parts = segments(pathname);
+  return parts.length === 2 && parts[0] === prefix ? parts[1] : undefined;
+}
+
+/**
+ * QuickNode addresses ethereum mainnet without a network segment, so the empty slug is a real
+ * network rather than a missing one.
+ */
+const QUICKNODE_ETHEREUM = '';
+
+const definitions: Record<RpcProviderId, RpcProviderDefinition> = {
+  alchemy: {
+    build: (network, { key }) => `https://${network}.g.alchemy.com/v2/${key}`,
+    enablement: 'none',
+    id: 'alchemy',
+    name: 'Alchemy',
+    /** From the `Network` enum the Alchemy SDK builds its own urls from, read 2026-09-08. */
+    networks: {
+      [Blockchain.ARBITRUM_ONE]: 'arb-mainnet',
+      [Blockchain.BASE]: 'base-mainnet',
+      [Blockchain.BSC]: 'bnb-mainnet',
+      [Blockchain.ETH]: 'eth-mainnet',
+      [Blockchain.GNOSIS]: 'gnosis-mainnet',
+      [Blockchain.HYPERLIQUID]: 'hyperliquid-mainnet',
+      [Blockchain.INK]: 'ink-mainnet',
+      [Blockchain.OPTIMISM]: 'opt-mainnet',
+      [Blockchain.POLYGON_POS]: 'polygon-mainnet',
+      [Blockchain.SCROLL]: 'scroll-mainnet',
+      [Blockchain.SOLANA]: 'solana-mainnet',
+      [Blockchain.SONIC]: 'sonic-mainnet',
+    },
+    owns: url => sub(url.hostname, 'g.alchemy.com') !== undefined,
+    parse(url) {
+      const network = sub(url.hostname, 'g.alchemy.com');
+      const key = keyAfter(url.pathname, 'v2');
+      if (network === undefined || network.includes('.') || key === undefined)
+        return undefined;
+
+      return { credentials: { key }, network };
+    },
+  },
+  infura: {
+    build: (network, { key }) => `https://${network}.infura.io/v3/${key}`,
+    enablement: 'per-network',
+    id: 'infura',
+    name: 'Infura',
+    /**
+     * From the endpoint table at docs.infura.io, read 2026-09-08.
+     *
+     * @remarks
+     * Gnosis, Sonic and Ink are absent from that table, so they are not offered. Hyperliquid is
+     * served under Infura's own name for it, HyperEVM, which is the same chain id rotki uses.
+     */
+    networks: {
+      [Blockchain.ARBITRUM_ONE]: 'arbitrum-mainnet',
+      [Blockchain.BASE]: 'base-mainnet',
+      [Blockchain.BSC]: 'bsc-mainnet',
+      [Blockchain.ETH]: 'mainnet',
+      [Blockchain.HYPERLIQUID]: 'hyperevm-mainnet',
+      [Blockchain.MONAD]: 'monad-mainnet',
+      [Blockchain.OPTIMISM]: 'optimism-mainnet',
+      [Blockchain.POLYGON_POS]: 'polygon-mainnet',
+      [Blockchain.SCROLL]: 'scroll-mainnet',
+      [Blockchain.SOLANA]: 'solana-mainnet',
+    },
+    owns: url => sub(url.hostname, 'infura.io') !== undefined,
+    parse(url) {
+      const network = sub(url.hostname, 'infura.io');
+      const key = keyAfter(url.pathname, 'v3');
+      if (network === undefined || network.includes('.') || key === undefined)
+        return undefined;
+
+      return { credentials: { key }, network };
+    },
+  },
+  quicknode: {
+    build: (network, { endpointName, key }) => network === QUICKNODE_ETHEREUM
+      ? `https://${endpointName}.quiknode.pro/${key}/`
+      : `https://${endpointName}.${network}.quiknode.pro/${key}/`,
+    enablement: 'multichain-endpoint',
+    id: 'quicknode',
+    name: 'QuickNode',
+    /**
+     * From the `docs-demo.<network>.quiknode.pro` host in each chain's own `eth_chainId` page,
+     * read 2026-09-08, with the chain id in the sample response checked against rotki's.
+     *
+     * @remarks
+     * Ink is left out because those pages only document `ink-sepolia`, and Hyperliquid because
+     * QuickNode serves it at `hype-mainnet` with an `/evm` path segment that this url shape cannot
+     * express. Both would build an endpoint that cannot answer.
+     */
+    networks: {
+      [Blockchain.ARBITRUM_ONE]: 'arbitrum-mainnet',
+      [Blockchain.BASE]: 'base-mainnet',
+      [Blockchain.BSC]: 'bsc',
+      [Blockchain.ETH]: QUICKNODE_ETHEREUM,
+      [Blockchain.GNOSIS]: 'xdai',
+      [Blockchain.MONAD]: 'monad-mainnet',
+      [Blockchain.OPTIMISM]: 'optimism',
+      [Blockchain.POLYGON_POS]: 'matic',
+      [Blockchain.SCROLL]: 'scroll-mainnet',
+      [Blockchain.SOLANA]: 'solana-mainnet',
+      [Blockchain.SONIC]: 'sonic-mainnet',
+    },
+    owns: url => sub(url.hostname, 'quiknode.pro') !== undefined,
+    parse(url) {
+      const prefix = sub(url.hostname, 'quiknode.pro');
+      const parts = segments(url.pathname);
+      if (prefix === undefined || parts.length !== 1)
+        return undefined;
+
+      const labels = prefix.split('.');
+      if (labels.length > 2)
+        return undefined;
+
+      const [endpointName, network = QUICKNODE_ETHEREUM] = labels;
+      return { credentials: { endpointName, key: parts[0] }, network };
+    },
+  },
+};
+
+function toUrl(endpoint: string): URL | undefined {
+  try {
+    const url = new URL(endpoint.trim());
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url : undefined;
+  }
+  catch {
+    return undefined;
+  }
+}
+
+function chainOfNetwork(definition: RpcProviderDefinition, network: string): string | undefined {
+  return Object.entries(definition.networks).find(([, slug]) => slug === network)?.[0];
+}
+
+/** The provider, without the parsing internals the ui has no business touching. */
+export function getRpcProvider(id: RpcProviderId): RpcProvider {
+  const { networks, ...provider } = definitions[id];
+  return { ...provider, chains: Object.keys(networks) };
+}
+
+/**
+ * Recognises one of the known providers from a pasted endpoint.
+ *
+ * @remarks
+ * Returns undefined on anything it is not sure about, since the caller turns a match into a set of
+ * urls it will write to the user's node list. A url whose host is the provider's but whose network
+ * rotki does not support still matches, with no `chain`: the key is usable, that one chain is not.
+ */
+export function detectRpcProvider(endpoint: string): RpcProviderMatch | undefined {
+  const url = toUrl(endpoint);
+  if (!url)
+    return undefined;
+
+  for (const definition of Object.values(definitions)) {
+    const parsed = definition.parse(url);
+    if (!parsed)
+      continue;
+
+    return {
+      chain: chainOfNetwork(definition, parsed.network),
+      credentials: parsed.credentials,
+      providerId: definition.id,
+    };
+  }
+
+  return undefined;
+}
+
+/** The endpoint a match's credentials address `chain` on, or undefined when it does not serve it. */
+export function buildRpcEndpoint(match: RpcProviderMatch, chain: string): string | undefined {
+  const definition = definitions[match.providerId];
+  const network = definition.networks[chain];
+  return network === undefined ? undefined : definition.build(network, match.credentials);
+}
+
+/** Whether an endpoint is served by a provider, used to spot nodes a chain already has. */
+export function isRpcProviderEndpoint(endpoint: string, id: RpcProviderId): boolean {
+  const url = toUrl(endpoint);
+  return !!url && definitions[id].owns(url);
+}
+
+/** The credential with its middle hidden, so a shared screen never shows a whole key. */
+export function maskRpcKey(key: string): string {
+  return key.length <= 10 ? '…' : `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+/**
+ * Text with every occurrence of the credential masked.
+ *
+ * @remarks
+ * Used on the endpoints a list repeats, and on the backend's own failure messages, which quote the
+ * endpoint more than once and would otherwise put the whole key on screen.
+ */
+export function maskRpcEndpoint(text: string, key: string): string {
+  return key.length > 0 ? text.replaceAll(key, maskRpcKey(key)) : text;
+}

--- a/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-node-fan-out.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-node-fan-out.spec.ts
@@ -1,0 +1,127 @@
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { Blockchain } from '@rotki/common';
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRpcNodeFanOut } from '@/modules/settings/general/rpc/providers/use-rpc-node-fan-out';
+
+const { readNodes } = vi.hoisted(() => ({ readNodes: vi.fn() }));
+
+vi.mock('@/modules/settings/general/rpc/providers/use-rpc-nodes-by-chain', () => ({
+  useRpcNodesByChain: (): Record<string, unknown> => ({ readNodes }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({
+    getChainName: (chain: string): string => chain,
+  }),
+}));
+
+const INFURA = 'https://mainnet.infura.io/v3/abcdef';
+const CHAINS = [Blockchain.ETH, Blockchain.OPTIMISM, Blockchain.BASE, Blockchain.GNOSIS];
+
+function infuraNode(endpoint: string): BlockchainRpcNode {
+  return {
+    active: true,
+    blockchain: Blockchain.OPTIMISM,
+    endpoint,
+    identifier: 1,
+    name: 'Infura',
+    owned: true,
+    weight: 0,
+  };
+}
+
+async function enabledFanOut(
+  endpoint = INFURA,
+  name = '',
+): Promise<ReturnType<typeof useRpcNodeFanOut>> {
+  const fanOut = useRpcNodeFanOut(() => endpoint, () => name, () => Blockchain.ETH, () => CHAINS);
+  set(fanOut.modelEnabled, true);
+  await flushPromises();
+  return fanOut;
+}
+
+describe('settings/general/rpc/providers/use-rpc-node-fan-out', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readNodes.mockResolvedValue({ nodes: {}, unreadable: [] });
+  });
+
+  it('should read the other chains as soon as a provider is recognised', async () => {
+    const fanOut = useRpcNodeFanOut(() => INFURA, () => '', () => Blockchain.ETH, () => CHAINS);
+    await flushPromises();
+
+    expect(readNodes).toHaveBeenCalledOnce();
+    expect(get(fanOut.candidates)).toHaveLength(2);
+    expect(get(fanOut.modelEnabled)).toBe(false);
+  });
+
+  it('should read nothing for an endpoint it does not recognise', async () => {
+    useRpcNodeFanOut(() => 'https://eth.example/rpc', () => '', () => Blockchain.ETH, () => CHAINS);
+    await flushPromises();
+
+    expect(readNodes).not.toHaveBeenCalled();
+  });
+
+  it('should leave out the chain the form is already adding', async () => {
+    const fanOut = await enabledFanOut();
+
+    expect(readNodes).toHaveBeenCalledWith([Blockchain.OPTIMISM, Blockchain.BASE, Blockchain.GNOSIS]);
+    expect(get(fanOut.candidates).map(candidate => candidate.chain)).not.toContain(Blockchain.ETH);
+  });
+
+  it('should name the chains the provider does not serve', async () => {
+    const fanOut = await enabledFanOut();
+
+    expect(get(fanOut.unsupportedNames)).toContain(Blockchain.GNOSIS);
+    expect(get(fanOut.candidates).map(candidate => candidate.chain)).toEqual([Blockchain.OPTIMISM, Blockchain.BASE]);
+  });
+
+  it('should tick every chain that has nothing on this key yet', async () => {
+    readNodes.mockResolvedValue({
+      nodes: { [Blockchain.OPTIMISM]: [infuraNode('https://optimism-mainnet.infura.io/v3/abcdef')] },
+      unreadable: [],
+    });
+
+    const fanOut = await enabledFanOut();
+
+    expect(get(fanOut.selected)).toEqual([Blockchain.BASE]);
+    expect(get(fanOut.chosen)).toHaveLength(1);
+  });
+
+  it('should drop a chain the user unticks', async () => {
+    const fanOut = await enabledFanOut();
+    fanOut.toggle(Blockchain.BASE, false);
+
+    expect(get(fanOut.selected)).toEqual([Blockchain.OPTIMISM]);
+    expect(get(fanOut.chosen).map(candidate => candidate.chain)).toEqual([Blockchain.OPTIMISM]);
+  });
+
+  it('should name the chains whose nodes could not be read', async () => {
+    readNodes.mockResolvedValue({ nodes: {}, unreadable: [Blockchain.BASE] });
+
+    const fanOut = await enabledFanOut();
+
+    expect(get(fanOut.unreadableNames)).toContain(Blockchain.BASE);
+    expect(get(fanOut.candidates).map(candidate => candidate.chain)).toEqual([Blockchain.OPTIMISM]);
+  });
+
+  it('should carry the key, so a message quoting the endpoint can be masked', async () => {
+    const fanOut = await enabledFanOut();
+
+    expect(get(fanOut.credential)).toBe('abcdef');
+  });
+
+  it('should say what the provider needs switched on for the key', async () => {
+    const fanOut = await enabledFanOut();
+
+    expect(get(fanOut.enablementNote)).toContain('enablement.per_network');
+  });
+
+  it('should recognise nothing in an endpoint of another shape', () => {
+    const fanOut = useRpcNodeFanOut(() => 'https://eth.example/rpc', () => '', () => Blockchain.ETH, () => CHAINS);
+
+    expect(get(fanOut.provider)).toBeUndefined();
+    expect(get(fanOut.enablementNote)).toBe('');
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-node-fan-out.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-node-fan-out.ts
@@ -1,0 +1,180 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import {
+  buildRpcProviderPlan,
+  type RpcProviderCandidate,
+} from '@/modules/settings/general/rpc/providers/rpc-provider-plan';
+import {
+  detectRpcProvider,
+  getRpcProvider,
+  type RpcProvider,
+  type RpcProviderMatch,
+} from '@/modules/settings/general/rpc/providers/rpc-providers';
+import { useRpcNodesByChain } from '@/modules/settings/general/rpc/providers/use-rpc-nodes-by-chain';
+
+interface UseRpcNodeFanOutReturn {
+  /** One entry per other chain the provider serves, including those that already hold the key. */
+  candidates: ComputedRef<RpcProviderCandidate[]>;
+  /** The key read off the endpoint, so a backend message quoting it can be masked. */
+  credential: ComputedRef<string>;
+  /** The chains the user has left ticked, which is what a run walks. */
+  chosen: ComputedRef<RpcProviderCandidate[]>;
+  /** What the user has to do on the provider's side, empty for a provider that needs nothing. */
+  enablementNote: ComputedRef<string>;
+  /** Whether the user has asked for the other chains. Writable, since a checkbox binds it. */
+  modelEnabled: Ref<boolean>;
+  /** Whether the chains' existing nodes are still being read. */
+  preparing: Readonly<Ref<boolean>>;
+  provider: ComputedRef<RpcProvider | undefined>;
+  reset: () => void;
+  /** The chains ticked, which the picker binds against. */
+  selected: Readonly<Ref<readonly string[]>>;
+  toggle: (chain: string, checked: boolean) => void;
+  /** The chains whose node list could not be read, so nothing is planned for them. */
+  unreadableNames: ComputedRef<string>;
+  /** The chains rotki supports that this provider does not serve. */
+  unsupportedNames: ComputedRef<string>;
+}
+
+/**
+ * Works out what one provider key can cover beyond the chain being added.
+ *
+ * @remarks
+ * The chain the form is on is deliberately not a candidate: that node is added by the form, with
+ * the weight and flags the user set on it, and this covers only the chains they are not looking at.
+ *
+ * @param endpoint - the endpoint typed into the node form, which is what names the provider
+ * @param nodeName - the name typed into the node form, used for the other chains too
+ * @param currentChain - the chain the form is adding to, which the form itself covers
+ * @param chains - every chain that holds a node list
+ * @returns the plan, the selection, and the flag a checkbox binds to
+ */
+export function useRpcNodeFanOut(
+  endpoint: MaybeRefOrGetter<string>,
+  nodeName: MaybeRefOrGetter<string>,
+  currentChain: MaybeRefOrGetter<string>,
+  chains: MaybeRefOrGetter<string[]>,
+): UseRpcNodeFanOutReturn {
+  const { t } = useI18n({ useScope: 'global' });
+  const { getChainName } = useSupportedChains();
+  const { readNodes } = useRpcNodesByChain();
+
+  const modelEnabled = shallowRef<boolean>(false);
+  const preparing = shallowRef<boolean>(false);
+  const selected = ref<string[]>([]);
+  const existingNodes = ref<Record<string, BlockchainRpcNode[]>>({});
+  const readableChains = ref<string[]>([]);
+  const unreadable = ref<string[]>([]);
+
+  const match = computed<RpcProviderMatch | undefined>(() => detectRpcProvider(toValue(endpoint)));
+
+  const provider = computed<RpcProvider | undefined>(() => {
+    const providerId = get(match)?.providerId;
+    return providerId ? getRpcProvider(providerId) : undefined;
+  });
+
+  const otherChains = computed<string[]>(() => toValue(chains).filter(chain => chain !== toValue(currentChain)));
+
+  /**
+   * Recomputed rather than stored, so renaming the node re-derives every candidate's name, and the
+   * per-chain uniquing that goes with it, without reading the chains again.
+   */
+  const plan = computed(() => {
+    const detected = get(match);
+    return detected
+      ? buildRpcProviderPlan(detected, get(readableChains), get(existingNodes), toValue(nodeName))
+      : undefined;
+  });
+
+  const candidates = computed<RpcProviderCandidate[]>(() => get(plan)?.candidates ?? []);
+  const selectable = computed<RpcProviderCandidate[]>(() => get(candidates).filter(candidate => !candidate.existing));
+
+  const chosen = computed<RpcProviderCandidate[]>(() => {
+    const picked = get(selected);
+    return get(selectable).filter(candidate => picked.includes(candidate.chain));
+  });
+
+  const unsupportedNames = computed<string>(() => (get(plan)?.unsupported ?? []).map(getChainName).join(', '));
+  const unreadableNames = computed<string>(() => get(unreadable).map(getChainName).join(', '));
+
+  const enablementNote = computed<string>(() => {
+    const current = get(provider);
+    if (!current)
+      return '';
+
+    if (current.enablement === 'per-network')
+      return t('rpc_provider_setup.enablement.per_network', { provider: current.name });
+
+    return current.enablement === 'multichain-endpoint'
+      ? t('rpc_provider_setup.enablement.multichain_endpoint', { provider: current.name })
+      : '';
+  });
+
+  function toggle(chain: string, checked: boolean): void {
+    const picked = get(selected).filter(item => item !== chain);
+    set(selected, checked ? [...picked, chain] : picked);
+  }
+
+  function reset(): void {
+    set(modelEnabled, false);
+    set(selected, []);
+    set(existingNodes, {});
+    set(readableChains, []);
+    set(unreadable, []);
+  }
+
+  /**
+   * Reads what the other chains already hold, so the plan can tell which are covered.
+   *
+   * @remarks
+   * Run as soon as a provider is recognised rather than when the offer is taken up: the count
+   * belongs in the offer itself, and a read started on the tick puts a spinner between the user and
+   * the thing they just asked for.
+   */
+  async function prepare(): Promise<void> {
+    set(preparing, true);
+    try {
+      const existing = await readNodes(get(otherChains));
+      set(existingNodes, existing.nodes);
+      set(readableChains, get(otherChains).filter(chain => !existing.unreadable.includes(chain)));
+      set(unreadable, existing.unreadable);
+      set(selected, get(candidates).filter(candidate => !candidate.existing).map(candidate => candidate.chain));
+    }
+    finally {
+      set(preparing, false);
+    }
+  }
+
+  /**
+   * Reads the other chains once per provider, not once per keystroke.
+   *
+   * @remarks
+   * Only the provider decides which chains are candidates and which already hold one of its nodes;
+   * the key only decides the endpoint each candidate is given, which is built from the plan.
+   */
+  watch(() => get(match)?.providerId, async (providerId) => {
+    set(modelEnabled, false);
+    if (!providerId) {
+      reset();
+      return;
+    }
+
+    await prepare();
+  }, { immediate: true });
+
+  return {
+    candidates,
+    chosen,
+    credential: computed<string>(() => get(match)?.credentials.key ?? ''),
+    enablementNote,
+    modelEnabled,
+    preparing: readonly(preparing),
+    provider,
+    reset,
+    selected: readonly(selected),
+    toggle,
+    unreadableNames,
+    unsupportedNames,
+  };
+}

--- a/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-nodes-by-chain.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-nodes-by-chain.ts
@@ -1,0 +1,40 @@
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { useEvmNodesApi } from '@/modules/settings/api/use-evm-nodes-api';
+
+export interface RpcNodesByChain {
+  nodes: Record<string, BlockchainRpcNode[]>;
+  /** The chains whose node list could not be read, which are not safe to plan against. */
+  unreadable: string[];
+}
+
+interface UseRpcNodesByChainReturn {
+  readNodes: (chains: string[]) => Promise<RpcNodesByChain>;
+}
+
+/**
+ * Reads several chains' node lists at once.
+ *
+ * @remarks
+ * A chain that cannot be read is named rather than reported as empty: the two look the same to a
+ * caller planning against them, and "this chain has no nodes" is the answer that silently does the
+ * wrong thing.
+ */
+export function useRpcNodesByChain(): UseRpcNodesByChainReturn {
+  async function readNodes(chains: string[]): Promise<RpcNodesByChain> {
+    const results = await Promise.allSettled(chains.map(async chain => ({
+      chain,
+      nodes: await useEvmNodesApi(chain).fetchEvmNodes(),
+    })));
+
+    const read: RpcNodesByChain = { nodes: {}, unreadable: [] };
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled')
+        read.nodes[result.value.chain] = result.value.nodes;
+      else
+        read.unreadable.push(chains[index]);
+    });
+    return read;
+  }
+
+  return { readNodes };
+}

--- a/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-provider-removal.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-provider-removal.spec.ts
@@ -1,0 +1,99 @@
+import type { RpcProviderUsage } from '@/modules/settings/general/rpc/providers/rpc-provider-usage';
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { Blockchain } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRpcProviderRemoval } from '@/modules/settings/general/rpc/providers/use-rpc-provider-removal';
+
+const { chainsGivenToApi, deleteEvmNode, fetchEvmNodes } = vi.hoisted(() => ({
+  chainsGivenToApi: vi.fn(),
+  deleteEvmNode: vi.fn(),
+  fetchEvmNodes: vi.fn(),
+}));
+
+vi.mock('@/modules/settings/api/use-evm-nodes-api', () => ({
+  useEvmNodesApi: (chain: string): Record<string, unknown> => {
+    chainsGivenToApi(chain);
+    return { deleteEvmNode, fetchEvmNodes };
+  },
+}));
+
+function node(identifier: number, endpoint: string): BlockchainRpcNode {
+  return {
+    active: true,
+    blockchain: Blockchain.ETH,
+    endpoint,
+    identifier,
+    name: 'Infura',
+    owned: true,
+    weight: 0,
+  };
+}
+
+describe('settings/general/rpc/providers/use-rpc-provider-removal', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    deleteEvmNode.mockResolvedValue(true);
+  });
+
+  describe('refresh', () => {
+    it('should list the providers holding nodes across the chains', async () => {
+      fetchEvmNodes
+        .mockResolvedValueOnce([node(1, 'https://mainnet.infura.io/v3/key')])
+        .mockResolvedValueOnce([node(2, 'https://optimism-mainnet.infura.io/v3/key')]);
+
+      const { refresh, usages } = useRpcProviderRemoval();
+      await refresh([Blockchain.ETH, Blockchain.OPTIMISM]);
+
+      expect(get(usages)).toHaveLength(1);
+      expect(get(usages)[0].nodes).toHaveLength(2);
+    });
+
+    it('should hold nothing when no provider node is found', async () => {
+      fetchEvmNodes.mockResolvedValue([node(1, 'https://eth-rpc.publicnode.com')]);
+
+      const { refresh, usages } = useRpcProviderRemoval();
+      await refresh([Blockchain.ETH]);
+
+      expect(get(usages)).toEqual([]);
+    });
+  });
+
+  describe('removeAll', () => {
+    const usage: RpcProviderUsage = {
+      id: 'infura',
+      key: '0123…cdef',
+      name: 'Infura',
+      nodes: [
+        { chain: Blockchain.ETH, identifier: 1, name: 'Infura' },
+        { chain: Blockchain.OPTIMISM, identifier: 2, name: 'Infura' },
+      ],
+    };
+
+    it('should delete every node of the provider, on its own chain', async () => {
+      const { removeAll } = useRpcProviderRemoval();
+
+      expect(await removeAll(usage)).toEqual({ failed: 0, removed: 2 });
+      expect(deleteEvmNode).toHaveBeenCalledWith(1);
+      expect(deleteEvmNode).toHaveBeenCalledWith(2);
+      expect(chainsGivenToApi).toHaveBeenCalledWith(Blockchain.OPTIMISM);
+    });
+
+    it('should keep going when one chain refuses, and count it', async () => {
+      deleteEvmNode.mockRejectedValueOnce(new Error('nope')).mockResolvedValueOnce(true);
+
+      const { removeAll } = useRpcProviderRemoval();
+
+      expect(await removeAll(usage)).toEqual({ failed: 1, removed: 1 });
+      expect(deleteEvmNode).toHaveBeenCalledTimes(2);
+    });
+
+    it('should hold the in-flight flag for the whole removal', async () => {
+      const { removeAll, removing } = useRpcProviderRemoval();
+      const pending = removeAll(usage);
+
+      expect(get(removing)).toBe(true);
+      await pending;
+      expect(get(removing)).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-provider-removal.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-provider-removal.ts
@@ -1,0 +1,67 @@
+import type { Ref } from 'vue';
+import { useEvmNodesApi } from '@/modules/settings/api/use-evm-nodes-api';
+import { groupNodesByProvider, type RpcProviderUsage } from '@/modules/settings/general/rpc/providers/rpc-provider-usage';
+import { useRpcNodesByChain } from '@/modules/settings/general/rpc/providers/use-rpc-nodes-by-chain';
+
+interface RpcRemovalResult {
+  failed: number;
+  removed: number;
+}
+
+interface UseRpcProviderRemovalReturn {
+  /** Whether a removal is in flight. */
+  removing: Readonly<Ref<boolean>>;
+  /** Re-reads the chains and regroups what each provider holds. */
+  refresh: (chains: string[]) => Promise<void>;
+  /** Deletes every node of one provider, and reports what could not be deleted. */
+  removeAll: (usage: RpcProviderUsage) => Promise<RpcRemovalResult>;
+  /** The providers that hold at least one node right now. */
+  usages: Readonly<Ref<RpcProviderUsage[]>>;
+}
+
+/**
+ * Tracks which providers hold nodes, and takes one out in a single action.
+ *
+ * @remarks
+ * The counterpart to the fan-out: a key spread over a dozen chains would otherwise have to be
+ * removed a dozen times, one chain tab at a time. Deletes are independent, so one failure does not
+ * stop the rest — the count that comes back says how many survived.
+ */
+export function useRpcProviderRemoval(): UseRpcProviderRemovalReturn {
+  const { readNodes } = useRpcNodesByChain();
+  const usages = ref<RpcProviderUsage[]>([]);
+  const removing = shallowRef<boolean>(false);
+
+  async function refresh(chains: string[]): Promise<void> {
+    const { nodes } = await readNodes(chains);
+    set(usages, groupNodesByProvider(nodes));
+  }
+
+  async function removeAll(usage: RpcProviderUsage): Promise<RpcRemovalResult> {
+    set(removing, true);
+    let removed = 0;
+    try {
+      for (const node of usage.nodes) {
+        try {
+          await useEvmNodesApi(node.chain).deleteEvmNode(node.identifier);
+          removed += 1;
+        }
+        catch {
+          // counted as failed below; one chain refusing must not strand the others
+        }
+      }
+    }
+    finally {
+      set(removing, false);
+    }
+
+    return { failed: usage.nodes.length - removed, removed };
+  }
+
+  return {
+    refresh,
+    removeAll,
+    removing: readonly(removing),
+    usages: shallowReadonly(usages),
+  };
+}

--- a/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-provider-setup.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-provider-setup.spec.ts
@@ -1,0 +1,331 @@
+import type { RpcProviderCandidate } from '@/modules/settings/general/rpc/providers/rpc-provider-plan';
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { Blockchain } from '@rotki/common';
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  RPC_SETUP_STATUS,
+  useRpcProviderSetup,
+} from '@/modules/settings/general/rpc/providers/use-rpc-provider-setup';
+
+const { addEvmNode, chainsGivenToApi, deleteEvmNode, editEvmNode, fetchEvmNodes, reConnectNode } = vi.hoisted(() => ({
+  addEvmNode: vi.fn(),
+  chainsGivenToApi: vi.fn(),
+  deleteEvmNode: vi.fn(),
+  editEvmNode: vi.fn(),
+  fetchEvmNodes: vi.fn(),
+  reConnectNode: vi.fn(),
+}));
+
+vi.mock('@/modules/settings/api/use-evm-nodes-api', () => ({
+  useEvmNodesApi: (chain: string): Record<string, unknown> => {
+    chainsGivenToApi(chain);
+    return { addEvmNode, deleteEvmNode, editEvmNode, fetchEvmNodes, reConnectNode };
+  },
+}));
+
+function node(partial: Partial<BlockchainRpcNode>): BlockchainRpcNode {
+  return {
+    active: true,
+    blockchain: Blockchain.ETH,
+    endpoint: 'https://mainnet.infura.io/v3/abcdef',
+    identifier: 7,
+    name: 'Infura',
+    owned: true,
+    weight: 0,
+    ...partial,
+  };
+}
+
+function candidate(partial: Partial<RpcProviderCandidate> = {}): RpcProviderCandidate {
+  return {
+    chain: Blockchain.ETH,
+    endpoint: 'https://mainnet.infura.io/v3/abcdef',
+    name: 'Infura',
+    ...partial,
+  };
+}
+
+describe('settings/general/rpc/providers/use-rpc-provider-setup', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    addEvmNode.mockResolvedValue(true);
+    deleteEvmNode.mockResolvedValue(true);
+    editEvmNode.mockResolvedValue(true);
+    reConnectNode.mockResolvedValue({ errors: [] });
+    fetchEvmNodes.mockResolvedValue([node({})]);
+  });
+
+  describe('run', () => {
+    it('should add, connect and keep a node that answers', async () => {
+      fetchEvmNodes.mockResolvedValue([node({ isArchive: true })]);
+
+      const { rows, run, summary } = useRpcProviderSetup();
+      await run([candidate()]);
+
+      expect(addEvmNode).toHaveBeenCalledWith({
+        active: true,
+        blockchain: Blockchain.ETH,
+        endpoint: 'https://mainnet.infura.io/v3/abcdef',
+        name: 'Infura',
+        owned: true,
+        weight: 0,
+      });
+      expect(reConnectNode).toHaveBeenCalledWith(7);
+      expect(deleteEvmNode).not.toHaveBeenCalled();
+      expect(get(rows)[0]).toMatchObject({ archive: true, status: RPC_SETUP_STATUS.ADDED });
+      expect(get(summary)).toEqual({ added: 1, archive: 1, failed: 0, total: 1 });
+    });
+
+    it('should mark a connected node without archive support', async () => {
+      fetchEvmNodes.mockResolvedValue([node({ isArchive: false })]);
+
+      const { rows, summary, run } = useRpcProviderSetup();
+      await run([candidate()]);
+
+      expect(get(rows)[0]).toMatchObject({ archive: false, status: RPC_SETUP_STATUS.ADDED });
+      expect(get(summary).archive).toBe(0);
+    });
+
+    it('should delete the node again when the connect reports an error', async () => {
+      reConnectNode.mockResolvedValue({ errors: [{ error: 'not enabled for this key', name: 'Infura' }] });
+
+      const { rows, summary, run } = useRpcProviderSetup();
+      await run([candidate()]);
+
+      expect(deleteEvmNode).toHaveBeenCalledWith(7);
+      expect(get(rows)[0]).toMatchObject({
+        error: 'not enabled for this key',
+        status: RPC_SETUP_STATUS.FAILED,
+      });
+      expect(get(summary)).toEqual({ added: 0, archive: 0, failed: 1, total: 1 });
+    });
+
+    it('should delete the node again when the connect itself throws', async () => {
+      reConnectNode.mockRejectedValue(new Error('backend is gone'));
+
+      const { rows, run } = useRpcProviderSetup();
+      await run([candidate()]);
+
+      expect(deleteEvmNode).toHaveBeenCalledWith(7);
+      expect(get(rows)[0]).toMatchObject({ error: 'backend is gone', status: RPC_SETUP_STATUS.FAILED });
+    });
+
+    it('should not connect or delete anything when the add fails', async () => {
+      addEvmNode.mockRejectedValue(new Error('the backend is gone'));
+      fetchEvmNodes.mockResolvedValue([]);
+
+      const { rows, run } = useRpcProviderSetup();
+      await run([candidate()]);
+
+      expect(reConnectNode).not.toHaveBeenCalled();
+      expect(deleteEvmNode).not.toHaveBeenCalled();
+      expect(get(rows)[0]).toMatchObject({ error: 'the backend is gone', status: RPC_SETUP_STATUS.FAILED });
+    });
+
+    it('should adopt a node an earlier attempt left behind rather than fail on the duplicate', async () => {
+      addEvmNode.mockRejectedValue(new Error('already exists in db'));
+
+      const { rows, run } = useRpcProviderSetup();
+      await run([candidate()]);
+
+      expect(reConnectNode).toHaveBeenCalledWith(7);
+      expect(get(rows)[0].status).toBe(RPC_SETUP_STATUS.ADDED);
+    });
+
+    it('should update the endpoint of a node holding an older key instead of adding a second one', async () => {
+      const older = node({ endpoint: 'https://mainnet.infura.io/v3/older', name: 'Infura', weight: 25 });
+
+      const { rows, run } = useRpcProviderSetup();
+      await run([candidate({ outdated: older })]);
+
+      expect(addEvmNode).not.toHaveBeenCalled();
+      expect(editEvmNode).toHaveBeenCalledWith({ ...older, endpoint: 'https://mainnet.infura.io/v3/abcdef' });
+      expect(get(rows)[0].status).toBe(RPC_SETUP_STATUS.UPDATED);
+    });
+
+    it('should put the older key back when the updated endpoint cannot connect', async () => {
+      const older = node({ endpoint: 'https://mainnet.infura.io/v3/older', name: 'Infura', weight: 25 });
+      reConnectNode.mockResolvedValue({ errors: [{ error: 'nope', name: 'Infura' }] });
+
+      const { rows, run } = useRpcProviderSetup();
+      await run([candidate({ outdated: older })]);
+
+      expect(editEvmNode).toHaveBeenLastCalledWith(older);
+      expect(deleteEvmNode).not.toHaveBeenCalled();
+      expect(get(rows)[0].status).toBe(RPC_SETUP_STATUS.FAILED);
+    });
+
+    it('should fail the row when the added node cannot be found again', async () => {
+      fetchEvmNodes.mockResolvedValue([node({ endpoint: 'https://something.else' })]);
+
+      const { rows, run } = useRpcProviderSetup();
+      await run([candidate()]);
+
+      expect(reConnectNode).not.toHaveBeenCalled();
+      expect(get(rows)[0].status).toBe(RPC_SETUP_STATUS.FAILED);
+    });
+
+    it('should keep going after a failure and report each chain on its own', async () => {
+      fetchEvmNodes.mockImplementation(async () => [node({})]);
+      reConnectNode
+        .mockResolvedValueOnce({ errors: [{ error: 'nope', name: 'Infura' }] })
+        .mockResolvedValueOnce({ errors: [] });
+
+      const { rows, summary, run } = useRpcProviderSetup();
+      await run([candidate(), candidate({ chain: Blockchain.OPTIMISM })]);
+
+      expect(get(rows).map(row => row.status)).toEqual([RPC_SETUP_STATUS.FAILED, RPC_SETUP_STATUS.ADDED]);
+      expect(get(summary)).toEqual({ added: 1, archive: 0, failed: 1, total: 2 });
+      expect(chainsGivenToApi).toHaveBeenCalledWith(Blockchain.OPTIMISM);
+    });
+
+    it('should walk the chains one at a time', async () => {
+      const order: string[] = [];
+      addEvmNode.mockImplementation(async () => {
+        order.push('add');
+        return true;
+      });
+      reConnectNode.mockImplementation(async () => {
+        order.push('connect');
+        return { errors: [] };
+      });
+
+      const { run } = useRpcProviderSetup();
+      await run([candidate(), candidate({ chain: Blockchain.OPTIMISM })]);
+
+      expect(order).toEqual(['add', 'connect', 'add', 'connect']);
+    });
+
+    it('should hold the in-flight flag for the whole run and clear it at the end', async () => {
+      const { run, running } = useRpcProviderSetup();
+      const pending = run([candidate()]);
+
+      expect(get(running)).toBe(true);
+      await pending;
+      expect(get(running)).toBe(false);
+    });
+
+    it('should start every row as pending', async () => {
+      const { rows, run } = useRpcProviderSetup();
+      const pending = run([candidate(), candidate({ chain: Blockchain.OPTIMISM })]);
+
+      expect(get(rows).map(row => row.status)).toEqual([RPC_SETUP_STATUS.RUNNING, RPC_SETUP_STATUS.PENDING]);
+      await pending;
+    });
+  });
+
+  describe('retry', () => {
+    it('should keep the rows of the chains it is not retrying', async () => {
+      reConnectNode
+        .mockResolvedValueOnce({ errors: [] })
+        .mockResolvedValueOnce({ errors: [{ error: 'nope', name: 'Infura' }] });
+
+      const { retry, rows, run, summary } = useRpcProviderSetup();
+      await run([candidate(), candidate({ chain: Blockchain.OPTIMISM })]);
+      expect(get(summary)).toEqual({ added: 1, archive: 0, failed: 1, total: 2 });
+
+      reConnectNode.mockResolvedValue({ errors: [] });
+      await retry([candidate({ chain: Blockchain.OPTIMISM })]);
+
+      expect(get(rows).map(row => row.status)).toEqual([RPC_SETUP_STATUS.ADDED, RPC_SETUP_STATUS.ADDED]);
+      expect(get(summary)).toEqual({ added: 2, archive: 0, failed: 0, total: 2 });
+    });
+  });
+
+  describe('stop', () => {
+    it('should leave the chains behind the one it is on untouched', async () => {
+      const { rows, run, stop } = useRpcProviderSetup();
+      addEvmNode.mockImplementation(async () => {
+        stop();
+        return true;
+      });
+
+      await run([candidate(), candidate({ chain: Blockchain.OPTIMISM })]);
+
+      expect(addEvmNode).toHaveBeenCalledOnce();
+      expect(get(rows)[1].status).toBe(RPC_SETUP_STATUS.PENDING);
+    });
+
+    it('should clear the in-flight flag it abandons', async () => {
+      const { run, running, stop } = useRpcProviderSetup();
+      addEvmNode.mockImplementation(async () => {
+        stop();
+        return true;
+      });
+
+      await run([candidate()]);
+
+      expect(get(running)).toBe(false);
+    });
+
+    it('should not carry a stop into the next run', async () => {
+      const { run, stop } = useRpcProviderSetup();
+      stop();
+
+      await run([candidate(), candidate({ chain: Blockchain.OPTIMISM })]);
+
+      expect(addEvmNode).toHaveBeenCalledTimes(2);
+    });
+
+    it('should drop the writes of an abandoned run that is still in flight', async () => {
+      const { rows, run, stop } = useRpcProviderSetup();
+      let releaseAbandoned = (): void => {};
+      const abandonedConnect = new Promise<{ errors: { error: string; name: string }[] }>((resolve) => {
+        releaseAbandoned = (): void => resolve({ errors: [{ error: 'from the abandoned run', name: 'Infura' }] });
+      });
+      reConnectNode.mockReturnValueOnce(abandonedConnect).mockResolvedValue({ errors: [] });
+
+      const abandoned = run([candidate()]);
+      await flushPromises();
+      stop();
+
+      await run([candidate()]);
+      expect(get(rows)[0].status).toBe(RPC_SETUP_STATUS.ADDED);
+
+      releaseAbandoned();
+      await abandoned;
+
+      expect(get(rows)[0]).toMatchObject({ chain: Blockchain.ETH, status: RPC_SETUP_STATUS.ADDED });
+    });
+  });
+
+  describe('loadExisting', () => {
+    it('should read the nodes of every chain', async () => {
+      const eth = node({});
+      const optimism = node({ blockchain: Blockchain.OPTIMISM, identifier: 8 });
+      fetchEvmNodes.mockResolvedValueOnce([eth]).mockResolvedValueOnce([optimism]);
+
+      const { loadExisting } = useRpcProviderSetup();
+
+      expect(await loadExisting([Blockchain.ETH, Blockchain.OPTIMISM])).toEqual({
+        nodes: {
+          [Blockchain.ETH]: [eth],
+          [Blockchain.OPTIMISM]: [optimism],
+        },
+        unreadable: [],
+      });
+    });
+
+    it('should name a chain whose nodes cannot be read rather than call it empty', async () => {
+      fetchEvmNodes.mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce([node({})]);
+
+      const { loadExisting } = useRpcProviderSetup();
+      const existing = await loadExisting([Blockchain.ETH, Blockchain.OPTIMISM]);
+
+      expect(existing.unreadable).toEqual([Blockchain.ETH]);
+      expect(existing.nodes[Blockchain.ETH]).toBeUndefined();
+      expect(existing.nodes[Blockchain.OPTIMISM]).toHaveLength(1);
+    });
+  });
+
+  describe('reset', () => {
+    it('should drop the rows of a finished run', async () => {
+      const { reset, rows, run } = useRpcProviderSetup();
+      await run([candidate()]);
+      reset();
+
+      expect(get(rows)).toEqual([]);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-provider-setup.ts
+++ b/frontend/app/src/modules/settings/general/rpc/providers/use-rpc-provider-setup.ts
@@ -1,0 +1,241 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { BlockchainRpcNode } from '@/modules/settings/types/rpc';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useEvmNodesApi } from '@/modules/settings/api/use-evm-nodes-api';
+import { type RpcProviderCandidate, toRpcNodePayload } from '@/modules/settings/general/rpc/providers/rpc-provider-plan';
+import { type RpcNodesByChain, useRpcNodesByChain } from '@/modules/settings/general/rpc/providers/use-rpc-nodes-by-chain';
+
+export const RPC_SETUP_STATUS = {
+  ADDED: 'added',
+  FAILED: 'failed',
+  PENDING: 'pending',
+  RUNNING: 'running',
+  UPDATED: 'updated',
+} as const;
+
+type RpcSetupStatus = typeof RPC_SETUP_STATUS[keyof typeof RPC_SETUP_STATUS];
+
+export interface RpcSetupRow {
+  /** Whether the node reported archive support once connected, known only for a kept node. */
+  archive?: boolean;
+  chain: string;
+  endpoint: string;
+  /** Why the chain was left without the node, taken from the backend's own message. */
+  error?: string;
+  name: string;
+  status: RpcSetupStatus;
+}
+
+export interface RpcSetupSummary {
+  added: number;
+  archive: number;
+  failed: number;
+  total: number;
+}
+
+/** Undoes whatever put the endpoint in place, so a node that cannot connect leaves no trace. */
+interface RpcNodePlacement {
+  identifier: number;
+  revert: () => Promise<unknown>;
+}
+
+interface UseRpcProviderSetupReturn {
+  /** Reads the nodes each chain already has, so the plan can tell which are already covered. */
+  loadExisting: (chains: string[]) => Promise<RpcNodesByChain>;
+  /** Resets the rows, so the dialog can be reopened on a different key. */
+  reset: () => void;
+  /** Runs a subset again, keeping the rows of the chains it is not retrying. */
+  retry: (candidates: RpcProviderCandidate[]) => Promise<void>;
+  /** One row per candidate, updated in place as the run walks them. */
+  rows: Readonly<Ref<RpcSetupRow[]>>;
+  /** Whether a run is in flight. */
+  running: Readonly<Ref<boolean>>;
+  /** Adds each candidate, connects it, and undoes it again when it cannot be reached. */
+  run: (candidates: RpcProviderCandidate[]) => Promise<void>;
+  /** Abandons the run in flight, leaving the chains behind the one it is on untouched. */
+  stop: () => void;
+  /** What the run ended up doing, for the dialog's footer. */
+  summary: ComputedRef<RpcSetupSummary>;
+}
+
+/**
+ * Applies a provider fan-out one chain at a time.
+ *
+ * @remarks
+ * Each chain is placed, then connected, and one that cannot be reached is undone again: the backend
+ * only reports archive support and the chain id a node actually answers on once connected, so a
+ * node that is never connected is both unverified and invisible. Chains are walked sequentially
+ * because every connect does real network work against the provider.
+ */
+export function useRpcProviderSetup(): UseRpcProviderSetupReturn {
+  const { readNodes: loadExisting } = useRpcNodesByChain();
+  const rows = ref<RpcSetupRow[]>([]);
+  const running = shallowRef<boolean>(false);
+
+  /**
+   * Identifies the run allowed to write.
+   *
+   * @remarks
+   * Closing the dialog abandons a run that is still awaiting the network, so both `stop` and the
+   * next `run` bump this and every write from the older loop is dropped on the way in.
+   */
+  let currentRun = 0;
+
+  const summary = computed<RpcSetupSummary>(() => {
+    const list = get(rows);
+    const kept = list.filter(row => row.status === RPC_SETUP_STATUS.ADDED || row.status === RPC_SETUP_STATUS.UPDATED);
+    return {
+      added: kept.length,
+      archive: list.filter(row => row.archive).length,
+      failed: list.filter(row => row.status === RPC_SETUP_STATUS.FAILED).length,
+      total: list.length,
+    };
+  });
+
+  function update(token: number, chain: string, patch: Partial<RpcSetupRow>): void {
+    if (token !== currentRun)
+      return;
+
+    set(rows, get(rows).map(row => row.chain === chain ? { ...row, ...patch } : row));
+  }
+
+  function pendingRow(candidate: RpcProviderCandidate): RpcSetupRow {
+    return {
+      chain: candidate.chain,
+      endpoint: candidate.endpoint,
+      name: candidate.name,
+      status: RPC_SETUP_STATUS.PENDING,
+    };
+  }
+
+  /**
+   * Undoes a placement.
+   *
+   * @remarks
+   * A failed revert is swallowed on purpose: the row already carries the reason the chain has no
+   * working node, and a second error about the cleanup would bury it.
+   */
+  async function rollback(placement: RpcNodePlacement): Promise<void> {
+    await placement.revert().catch(() => undefined);
+  }
+
+  /**
+   * Puts the candidate's endpoint on its chain, as an update of the key it replaces or as a new
+   * node, and hands back the way to undo that.
+   *
+   * @remarks
+   * An add that fails because the endpoint is already there is not an error: an earlier attempt can
+   * leave a node behind that was never connected, and adopting it is what lets a retry get past it.
+   */
+  async function place(
+    api: ReturnType<typeof useEvmNodesApi>,
+    candidate: RpcProviderCandidate,
+  ): Promise<RpcNodePlacement | undefined> {
+    const find = async (): Promise<BlockchainRpcNode | undefined> =>
+      (await api.fetchEvmNodes()).find(node => node.endpoint === candidate.endpoint);
+
+    const previous = candidate.outdated;
+    if (previous) {
+      await api.editEvmNode({ ...previous, endpoint: candidate.endpoint });
+      return { identifier: previous.identifier, revert: async () => api.editEvmNode(previous) };
+    }
+
+    try {
+      await api.addEvmNode(toRpcNodePayload(candidate));
+    }
+    catch (error: unknown) {
+      if (!await find())
+        throw error;
+    }
+
+    const added = await find();
+    return added ? { identifier: added.identifier, revert: async () => api.deleteEvmNode(added.identifier) } : undefined;
+  }
+
+  async function apply(token: number, candidate: RpcProviderCandidate): Promise<void> {
+    const api = useEvmNodesApi(candidate.chain);
+    update(token, candidate.chain, { status: RPC_SETUP_STATUS.RUNNING });
+
+    let placement: RpcNodePlacement | undefined;
+    try {
+      placement = await place(api, candidate);
+    }
+    catch (error: unknown) {
+      update(token, candidate.chain, { error: getErrorMessage(error), status: RPC_SETUP_STATUS.FAILED });
+      return;
+    }
+
+    if (!placement) {
+      update(token, candidate.chain, { status: RPC_SETUP_STATUS.FAILED });
+      return;
+    }
+
+    const kept = candidate.outdated ? RPC_SETUP_STATUS.UPDATED : RPC_SETUP_STATUS.ADDED;
+    try {
+      const { errors } = await api.reConnectNode(placement.identifier);
+      if (errors.length > 0) {
+        await rollback(placement);
+        update(token, candidate.chain, { error: errors[0].error, status: RPC_SETUP_STATUS.FAILED });
+        return;
+      }
+
+      const connected = (await api.fetchEvmNodes()).find(node => node.identifier === placement.identifier);
+      update(token, candidate.chain, { archive: connected?.isArchive === true, status: kept });
+    }
+    catch (error: unknown) {
+      await rollback(placement);
+      update(token, candidate.chain, { error: getErrorMessage(error), status: RPC_SETUP_STATUS.FAILED });
+    }
+  }
+
+  async function walk(candidates: RpcProviderCandidate[]): Promise<void> {
+    const token = ++currentRun;
+    set(running, true);
+    try {
+      for (const candidate of candidates) {
+        if (token !== currentRun)
+          return;
+
+        await apply(token, candidate);
+      }
+    }
+    finally {
+      if (token === currentRun)
+        set(running, false);
+    }
+  }
+
+  async function run(candidates: RpcProviderCandidate[]): Promise<void> {
+    set(rows, candidates.map(pendingRow));
+    await walk(candidates);
+  }
+
+  async function retry(candidates: RpcProviderCandidate[]): Promise<void> {
+    const retried = new Map(candidates.map(candidate => [candidate.chain, candidate]));
+    set(rows, get(rows).map((row) => {
+      const candidate = retried.get(row.chain);
+      return candidate ? pendingRow(candidate) : row;
+    }));
+    await walk(candidates);
+  }
+
+  function stop(): void {
+    currentRun += 1;
+    set(running, false);
+  }
+
+  function reset(): void {
+    set(rows, []);
+  }
+
+  return {
+    loadExisting,
+    reset,
+    retry,
+    rows: shallowReadonly(rows),
+    running: readonly(running),
+    run,
+    stop,
+    summary,
+  };
+}

--- a/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.spec.ts
@@ -28,7 +28,7 @@ const {
   editEvmNode: vi.fn(async () => Promise.resolve(true)),
   fetchEvmNodes: vi.fn(),
   notify: vi.fn(),
-  reConnectNode: vi.fn(async () => Promise.resolve(true)),
+  reConnectNode: vi.fn(async (): Promise<{ errors: { error: string; name: string }[] }> => ({ errors: [] })),
   setMessage: vi.fn(),
 }));
 
@@ -308,13 +308,24 @@ describe('modules/settings/general/rpc/useBlockchainRpcNodeManager', () => {
       expect(reConnectNode).toHaveBeenCalledWith(undefined);
     });
 
-    it('should not re-read the list when the reconnect fails', async () => {
-      reConnectNode.mockResolvedValue(false);
+    it('should notify with the nodes that failed, and still re-read the list', async () => {
+      reConnectNode.mockResolvedValue({ errors: [{ error: 'refused', name: 'my node' }] });
 
       const { reConnect, reconnecting } = manager();
       await reConnect(6);
 
-      expect(fetchEvmNodes).not.toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'my node: refused' }));
+      expect(fetchEvmNodes).toHaveBeenCalledOnce();
+      expect(get(reconnecting)).toBe(false);
+    });
+
+    it('should notify and clear the in-flight flag when the reconnect throws', async () => {
+      reConnectNode.mockRejectedValue(new Error('offline'));
+
+      const { reConnect, reconnecting } = manager();
+      await reConnect(6);
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ message: 'offline' }));
       expect(get(reconnecting)).toBe(false);
     });
   });

--- a/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
@@ -171,13 +171,28 @@ export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>)
     }
   }
 
+  function notifyConnectFailures(messages: string[]): void {
+    notify({
+      message: messages.join('\n'),
+      title: t('evm_rpc_node_manager.connect_error.title', { chain: get(chainName) }),
+    });
+  }
+
   async function reConnect(identifier?: number): Promise<void> {
     set(reconnecting, true);
-    const success = await api.reConnectNode(identifier);
-    set(reconnecting, false);
+    try {
+      const { errors } = await api.reConnectNode(identifier);
+      if (errors.length > 0)
+        notifyConnectFailures(errors.map(({ error, name }) => `${name}: ${error}`));
 
-    if (success)
       await loadNodes();
+    }
+    catch (error: unknown) {
+      notifyConnectFailures([getErrorMessage(error)]);
+    }
+    finally {
+      set(reconnecting, false);
+    }
   }
 
   return {

--- a/frontend/app/src/modules/settings/general/rpc/use-rpc-settings-tabs.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-rpc-settings-tabs.spec.ts
@@ -199,6 +199,14 @@ describe('useRpcSettingsTabs', () => {
     });
   });
 
+  describe('nodeChains', () => {
+    it('should list the chains that hold a node list, and no single-value endpoint', () => {
+      const { result } = mountWithComposable();
+
+      expect(result.nodeChains.value).toEqual(['eth', 'optimism', 'base', Blockchain.SOLANA]);
+    });
+  });
+
   describe('tabKey helper', () => {
     it('should return chain id for chain tabs', () => {
       expect(tabKey({ chain: Blockchain.ETH })).toBe(Blockchain.ETH);

--- a/frontend/app/src/modules/settings/general/rpc/use-rpc-settings-tabs.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-rpc-settings-tabs.ts
@@ -52,6 +52,8 @@ export interface UseRpcSettingsTabsReturn {
   firstOtherKey: ComputedRef<string | undefined>;
   activeTab: ComputedRef<RpcSettingTab | undefined>;
   canAddNode: ComputedRef<boolean>;
+  /** The chains that hold a list of nodes, which is what a provider key can be fanned out over. */
+  nodeChains: ComputedRef<string[]>;
   selectTab: (key: string | null | undefined) => void;
 }
 
@@ -129,6 +131,10 @@ export function useRpcSettingsTabs(): UseRpcSettingsTabsReturn {
     return !!tab && !tab.setting;
   });
 
+  const nodeChains = computed<string[]>(() => get(rpcSettingTabs)
+    .filter(tab => isChainTab(tab) && !tab.setting)
+    .map(tab => tabKey(tab)));
+
   function selectTab(key: string | null | undefined): void {
     if (key)
       set(selectedKey, key);
@@ -162,6 +168,7 @@ export function useRpcSettingsTabs(): UseRpcSettingsTabsReturn {
     firstOtherKey,
     activeTab,
     canAddNode,
+    nodeChains,
     selectTab,
   };
 }

--- a/frontend/app/src/modules/settings/types/rpc.ts
+++ b/frontend/app/src/modules/settings/types/rpc.ts
@@ -38,6 +38,22 @@ export const BlockchainRpcNodeEditPayload = BlockchainRpcNode.pick({
 
 export const BlockchainRpcNodeAddPayload = BlockchainRpcNodeEditPayload.omit({ identifier: true });
 
+/**
+ * What a connect attempt reports back.
+ *
+ * @remarks
+ * The backend connects synchronously and answers with the nodes it could not reach, so an empty
+ * `errors` is the only success. A node that answers on the wrong chain is reported here too.
+ */
+export const RpcNodeConnectResult = z.object({
+  errors: z.array(z.object({
+    error: z.string(),
+    name: z.string(),
+  })),
+});
+
+export type RpcNodeConnectResult = z.infer<typeof RpcNodeConnectResult>;
+
 export function getPlaceholderNode(chain: Blockchain): BlockchainRpcNode {
   return {
     active: true,

--- a/frontend/app/src/modules/shell/components/dialogs/BigDialog.vue
+++ b/frontend/app/src/modules/shell/components/dialogs/BigDialog.vue
@@ -20,7 +20,7 @@ interface BigDialogErrors {
 }
 
 /** Visual knobs a couple of callers tweak; dismissal behaviour is `persistent`/`promptOnClose`. */
-interface BigDialogLayout {
+export interface BigDialogLayout {
   maxWidth?: string;
   divide?: boolean;
   /** Drop the 50vh minimum on the content area. */


### PR DESCRIPTION
Closes #12640.

Adding a provider key today means repeating the per-chain form a dozen times with a hand-edited hostname. This recognises Infura, Alchemy and QuickNode from the endpoint you paste into the ordinary add-node form and offers the same key on every chain rotki and the provider both support, then verifies each one before keeping it.

Frontend only, no backend change. Three commits: the connect-failure fix, the provider catalog and plan, then the feature.

## How it works

**One entry point.** Adding a node has a single button, and the fan-out is part of that flow rather than a second dialog beside it: paste an endpoint, and if it belongs to a provider the dialog offers `Also add this key to the 9 other chains Infura serves`, with the picker behind a `Choose chains · 9 of 9` disclosure. The offer is unticked by default, so Save without touching it adds exactly the one node it always did.

**Save keeps the dialog open and reports each chain.** The node you filled in is added by the form; the other chains are then walked one at a time, and the dialog becomes a progress line naming the chain being connected, then a summary — `3 added`, `6 failed` — with the per-chain reasons behind `Expand to see why 6 chains failed` and a `Retry failed` button.

**Each chain is placed, connected, and dropped again if it cannot be reached.** The connect endpoint already does the work a probe would: it checks the chain id the node answers on and detects archive support, so a node that never connects is both unverified and invisible. That makes rollback the honest default rather than leaving a dead row behind.

**A chain already holding an older key of the same provider is updated in place**, rather than gaining a second node that no longer authenticates. Rollback restores the previous endpoint.

**Provider chips** under the header list the keys in use and remove one across every chain in a single confirmed action. Nodes are grouped by *credential*, not by provider, so two keys of one provider stay two entries and removing one leaves the other alone.

## Notes for review

- **The offer owns weight, owned and active while it is ticked.** Every chain in a fan-out is added on the same terms, so the chain on screen cannot be an exception: the three fields are held (not cleared) while the offer is on, and unticking gives them back. Weight needs no lock of its own, since the slider is already disabled for an owned node.
- **Nodes are added `owned` with weight 0.** Owned nodes are tried first whatever their weight, so nothing has to be taken from the user's own nodes. One caveat worth knowing: `add_rpc_node` rescales the chain's other weights to sum to 100, which is a no-op only when they already do — rotki's shipped ethereum defaults sum to 115, so the first insert renormalises them and removing the node does not put the old numbers back. Proportions are preserved exactly; the copy says "relative to each other" for that reason.
- **Network slugs are per-provider data with a source and a date in the code.** They are not derivable from rotki's chain ids (gnosis is `xdai` on QuickNode, hyperliquid is `hyperevm-mainnet` on Infura). QuickNode's were each confirmed against the chain id in their own `eth_chainId` docs page. A chain a provider is not confirmed to serve is left out rather than guessed — an absent entry is simply not offered, a wrong one tells the user their key failed when the url was wrong. Ink and Hyperliquid are omitted for QuickNode: the first is only documented on sepolia, the second needs an `/evm` path segment this url shape cannot express.
- **The first commit is a bug fix that stands on its own.** `reConnectNode` was typed as returning a boolean, but the endpoint answers with the nodes it could not reach. The manager tested an object — always truthy — so every connect failure was silently dropped, and the api spec asserted a shape the backend never sends.
- **A failed chain's message is trimmed for display.** The backend answers with a Python repr of the node and then quotes the endpoint a second time, so one failure cost three wrapped lines of internals per chain. `tidyRpcConnectMessage` drops the repr, the chain the row already names and the repeated endpoint, keeping the cause; a message of another shape is passed through untouched. It can go once the backend's message is fixed.
- **Provenance is not recorded anywhere**, and `owned` does not separate a key the user added from a node rotki shipped. Rather than guess, the removal confirmation names every chain that will lose a node.
- **Accessibility.** The chain rides inside the checkbox's own label, so it names the control instead of sitting beside it as a dead zone; the run's summary is a polite live region, which is the only place its state is told; and focus goes back into the dialog when a step swaps the body out.
- Changelog: a `:feature:` line for the fan-out and a `:bug:` line for the dropped connect failures.

## Verified

Unit, typecheck, lint, stylelint, knip and the linked-key check all pass.

Beyond that, driven in the app against a real backend: detection and masking, the chain list, the fan-out with a bogus key (every chain failed the connect probe, every one rolled back, node lists and counts back to baseline), a rename landing on all chains, removal of one provider taking only its nodes, and the fused flow end to end — Ethereum added by the form, the other nine walked and reported, the current chain excluded from the picker.

Two defects came out of that driving rather than out of the tests: the backend's failure message quotes the endpoint twice, so the raw API key was rendered on screen (masking it needed `replaceAll`), and a confirmation read "Remove the 1 Alchemy nodes".

## Related

Testing this with a real Alchemy key is what turned up the Arbitrum archive check: `attempt_connect` asked for a balance at Arbitrum block **42**, which is pre-Nitro state. Alchemy gives up on it at ~10s (measured: 10.133s, `-32001`), rotki's own `rpc_timeout` is 10s, and web3's `HTTPProvider` retries a timeout **5 times** by default, so one call became ~52s and the frontend's 30s abort fired first — the one chain that failed with a client timeout rather than a backend message. #13085 moved the check to a post-Nitro block and is already on develop, which this branch is rebased on; with it the same probe finishes in 0.2s and reports the node as archive. The pruned check still points at a transaction in block 42, so that is the remaining call on the path that could stall.

## Open question

Entry point from the historical-balances empty state is not built. `BalanceDivergenceView` already tells the user a chain has no archive node, and that is the moment this feature is most useful — but it needs a route push plus a preselected chain with no pasted key, which is a different flow from the one here. Happy to add it in this PR or leave it for a follow-up.
