### PR TITLE
Share the ?add= and row-deletion helpers, extract SFC logic, stop the unit suite dialling out

### DIFF
--- a/frontend/app/src/modules/accounts/AccountBalancesDefaultPage.vue
+++ b/frontend/app/src/modules/accounts/AccountBalancesDefaultPage.vue
@@ -9,6 +9,7 @@ import { useAccountCategoryHelper } from '@/modules/accounts/use-account-categor
 import { useAccountImportProgressStore } from '@/modules/accounts/use-account-import-progress-store';
 import { useBlockchainAccountLoading } from '@/modules/accounts/use-blockchain-account-loading';
 import BlockchainBalanceStalenessIndicator from '@/modules/balances/BlockchainBalanceStalenessIndicator.vue';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
 const { category, title } = defineProps<{
@@ -24,9 +25,6 @@ const { importingAccounts } = storeToRefs(useAccountImportProgressStore());
 const { isSectionLoading, refreshDisabled } = useBlockchainAccountLoading(() => category);
 
 const { chainIds } = useAccountCategoryHelper(() => category);
-
-const route = useRoute();
-const router = useRouter();
 
 function createNewBlockchainAccount(): void {
   set(account, {
@@ -47,12 +45,10 @@ function refresh() {
     get(table).refresh();
 }
 
+const { consumeAddQuery } = useAddQuery(createNewBlockchainAccount);
+
 onMounted(async () => {
-  const { query } = get(route);
-  if (query.add) {
-    createNewBlockchainAccount();
-    await router.replace({ query: {} });
-  }
+  await consumeAddQuery();
 });
 </script>
 

--- a/frontend/app/src/modules/accounts/BlockchainAccountSelector.vue
+++ b/frontend/app/src/modules/accounts/BlockchainAccountSelector.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
-import { type Account, Blockchain, getTextToken } from '@rotki/common';
-import { omit, uniqBy } from 'es-toolkit';
+import { type Account, Blockchain } from '@rotki/common';
+import { omit } from 'es-toolkit';
 import { hasAccountAddress } from '@/modules/accounts/account-helpers';
+import { matchesAccountQuery, selectableAccounts } from '@/modules/accounts/account-selection';
 import { getAccountAddress, getAccountId } from '@/modules/accounts/account-utils';
 import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
-import { createAccount } from '@/modules/accounts/create-account';
 import { useBlockchainAccountsStore } from '@/modules/accounts/use-blockchain-accounts-store';
 import { getNonRootAttrs, getRootAttrs } from '@/modules/core/common/helpers/attrs';
 import AccountDisplay from '@/modules/shell/components/display/AccountDisplay.vue';
@@ -90,53 +90,14 @@ const internalValue = computed<AccountWithExtra | undefined>(() => {
   return { ...first, address: getAccountAddress(first), key: getAccountId(first) };
 });
 
-const selectableAccounts = computed<AccountWithAddressData[]>(() => {
-  const accountData = get(accounts);
-  const selectedChains = get(chains);
-
-  const filteredAccounts = selectedChains.length === 0
-    ? accountData
-    : accountData.filter(({ chain }) => chain === 'ALL' || selectedChains.includes(chain));
-
-  const filteredByUnique: AccountWithAddressData[] = source?.unique
-    ? uniqBy(filteredAccounts, account => getAccountAddress(account))
-    : filteredAccounts;
-
-  if (source?.multichain) {
-    const entries: Record<string, number> = {};
-    filteredByUnique.forEach((account) => {
-      const address = getAccountAddress(account);
-      if (entries[address])
-        entries[address] += 1;
-      else entries[address] = 1;
-    });
-
-    for (const address in entries) {
-      const count = entries[address];
-      if (count <= 1)
-        continue;
-
-      filteredByUnique.push(
-        createAccount(
-          {
-            address,
-            label: null,
-            tags: null,
-          },
-          {
-            chain: 'ALL',
-            nativeAsset: '',
-          },
-        ),
-      );
-    }
-  }
-
-  return filteredByUnique;
-});
+const offeredAccounts = computed<AccountWithAddressData[]>(() => selectableAccounts(get(accounts), {
+  chains: get(chains),
+  multichain: source?.multichain,
+  unique: source?.unique,
+}));
 
 const displayedAccounts = computed<AccountWithExtra[]>(() => {
-  const accounts = Array.from(get(selectableAccounts), item => ({
+  const accounts = Array.from(get(offeredAccounts), item => ({
     ...item,
     address: getAccountAddress(item),
     key: getAccountId(item),
@@ -148,24 +109,9 @@ const displayedAccounts = computed<AccountWithExtra[]>(() => {
   return get(hideOnEmptyUsable) ? [] : accounts;
 });
 
-function filter(item: BlockchainAccount, queryText: string) {
-  const chain = item.chain === 'ALL' ? Blockchain.ETH : item.chain;
-  const text = getTextToken(getAddressName(getAccountAddress(item), chain) ?? '');
-  const address = getTextToken(getAccountAddress(item));
-  const query = getTextToken(queryText);
-
-  const labelMatches = text.includes(query);
-  const addressMatches = address.includes(query);
-
-  if (labelMatches || addressMatches)
-    return true;
-
-  return item.tags
-    ? item.tags
-        .map(tag => getTextToken(tag))
-        .join(' ')
-        .includes(query)
-    : false;
+function filter(item: BlockchainAccount, queryText: string): boolean {
+  return matchesAccountQuery(item, queryText, account =>
+    getAddressName(getAccountAddress(account), account.chain === 'ALL' ? Blockchain.ETH : account.chain));
 }
 
 /**

--- a/frontend/app/src/modules/accounts/account-selection.spec.ts
+++ b/frontend/app/src/modules/accounts/account-selection.spec.ts
@@ -1,0 +1,156 @@
+import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import { describe, expect, it } from 'vitest';
+import { matchesAccountQuery, selectableAccounts } from '@/modules/accounts/account-selection';
+import { getAccountAddress } from '@/modules/accounts/account-utils';
+import { createAccount } from '@/modules/accounts/create-account';
+
+const ADDRESS_A = '0x1111111111111111111111111111111111111111';
+const ADDRESS_B = '0x2222222222222222222222222222222222222222';
+
+function account(address: string, chain: string, tags?: string[]): BlockchainAccount<AddressData> {
+  return createAccount({ address, label: null, tags: tags ?? null }, { chain, nativeAsset: '' });
+}
+
+function chainsOf(accounts: BlockchainAccount<AddressData>[]): string[] {
+  return accounts.map(item => item.chain);
+}
+
+describe('selectableAccounts', () => {
+  describe('narrowing by chain', () => {
+    it('should offer every account when no chain is named', () => {
+      const accounts = [account(ADDRESS_A, 'eth'), account(ADDRESS_B, 'optimism')];
+
+      expect(selectableAccounts(accounts)).toHaveLength(2);
+    });
+
+    it('should offer only the accounts on a named chain', () => {
+      const accounts = [account(ADDRESS_A, 'eth'), account(ADDRESS_B, 'optimism')];
+
+      expect(chainsOf(selectableAccounts(accounts, { chains: ['eth'] }))).toEqual(['eth']);
+    });
+
+    /** An all-chains account belongs to every chain, so narrowing must not filter it out. */
+    it('should keep an all-chains account whatever chain is named', () => {
+      const accounts = [account(ADDRESS_A, 'ALL'), account(ADDRESS_B, 'optimism')];
+
+      expect(chainsOf(selectableAccounts(accounts, { chains: ['eth'] }))).toEqual(['ALL']);
+    });
+  });
+
+  describe('collapsing an address tracked on several chains', () => {
+    it('should offer one entry per address when unique', () => {
+      const accounts = [account(ADDRESS_A, 'eth'), account(ADDRESS_A, 'optimism'), account(ADDRESS_B, 'eth')];
+
+      const offered = selectableAccounts(accounts, { unique: true });
+
+      expect(offered).toHaveLength(2);
+      expect(offered.map(getAccountAddress)).toEqual([ADDRESS_A, ADDRESS_B]);
+    });
+
+    it('should offer every entry when not unique', () => {
+      const accounts = [account(ADDRESS_A, 'eth'), account(ADDRESS_A, 'optimism')];
+
+      expect(selectableAccounts(accounts)).toHaveLength(2);
+    });
+  });
+
+  describe('the extra all-chains entry', () => {
+    it('should add one for an address tracked on more than one chain', () => {
+      const accounts = [account(ADDRESS_A, 'eth'), account(ADDRESS_A, 'optimism')];
+
+      const offered = selectableAccounts(accounts, { multichain: true });
+
+      expect(chainsOf(offered)).toEqual(['eth', 'optimism', 'ALL']);
+      expect(getAccountAddress(offered[2])).toBe(ADDRESS_A);
+    });
+
+    it('should not add one for an address tracked on a single chain', () => {
+      const accounts = [account(ADDRESS_A, 'eth'), account(ADDRESS_B, 'optimism')];
+
+      expect(chainsOf(selectableAccounts(accounts, { multichain: true }))).toEqual(['eth', 'optimism']);
+    });
+
+    it('should add none when not asked for', () => {
+      const accounts = [account(ADDRESS_A, 'eth'), account(ADDRESS_A, 'optimism')];
+
+      expect(chainsOf(selectableAccounts(accounts))).toEqual(['eth', 'optimism']);
+    });
+
+    it('should add one per multi-chain address', () => {
+      const accounts = [
+        account(ADDRESS_A, 'eth'),
+        account(ADDRESS_A, 'optimism'),
+        account(ADDRESS_B, 'eth'),
+        account(ADDRESS_B, 'base'),
+      ];
+
+      expect(chainsOf(selectableAccounts(accounts, { multichain: true }))).toEqual([
+        'eth',
+        'optimism',
+        'eth',
+        'base',
+        'ALL',
+        'ALL',
+      ]);
+    });
+  });
+
+  /**
+   * The extra entries are synthesized rather than tracked, so appending them to the array the
+   * caller passed would grow the list again on every pass.
+   */
+  describe('leaving the given accounts alone', () => {
+    it('should not append the extra entries to the array it was given', () => {
+      const accounts = [account(ADDRESS_A, 'eth'), account(ADDRESS_A, 'optimism')];
+
+      selectableAccounts(accounts, { multichain: true });
+
+      expect(accounts).toHaveLength(2);
+    });
+
+    it('should offer the same list however often it is called', () => {
+      const accounts = [account(ADDRESS_A, 'eth'), account(ADDRESS_A, 'optimism')];
+
+      const first = selectableAccounts(accounts, { multichain: true });
+      const second = selectableAccounts(accounts, { multichain: true });
+
+      expect(second).toHaveLength(first.length);
+    });
+  });
+});
+
+describe('matchesAccountQuery', () => {
+  const noName = (): undefined => undefined;
+
+  it('should match on the address', () => {
+    expect(matchesAccountQuery(account(ADDRESS_A, 'eth'), ADDRESS_A, noName)).toBe(true);
+  });
+
+  it('should match on part of the address', () => {
+    expect(matchesAccountQuery(account(ADDRESS_A, 'eth'), '1111', noName)).toBe(true);
+  });
+
+  it('should match on the resolved name', () => {
+    expect(matchesAccountQuery(account(ADDRESS_A, 'eth'), 'alice', () => 'Alice ETH')).toBe(true);
+  });
+
+  it('should match a name whatever its case and spacing', () => {
+    expect(matchesAccountQuery(account(ADDRESS_A, 'eth'), 'ALICE ETH', () => 'alice eth')).toBe(true);
+  });
+
+  it('should match on a tag', () => {
+    expect(matchesAccountQuery(account(ADDRESS_A, 'eth', ['cold storage']), 'cold', noName)).toBe(true);
+  });
+
+  it('should not match an unrelated query', () => {
+    expect(matchesAccountQuery(account(ADDRESS_A, 'eth', ['cold']), 'zzz', noName)).toBe(false);
+  });
+
+  it('should not match on a tag another account carries', () => {
+    expect(matchesAccountQuery(account(ADDRESS_A, 'eth'), 'cold', noName)).toBe(false);
+  });
+
+  it('should match everything on an empty query', () => {
+    expect(matchesAccountQuery(account(ADDRESS_A, 'eth'), '', noName)).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/accounts/account-selection.ts
+++ b/frontend/app/src/modules/accounts/account-selection.ts
@@ -1,0 +1,86 @@
+import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import { getTextToken } from '@rotki/common';
+import { uniqBy } from 'es-toolkit';
+import { getAccountAddress } from '@/modules/accounts/account-utils';
+import { createAccount } from '@/modules/accounts/create-account';
+
+type AccountWithAddressData = BlockchainAccount<AddressData>;
+
+/** How the caller wants the offered accounts narrowed. */
+export interface AccountSelectionOptions {
+  /** Offer only these chains; empty offers every chain. */
+  readonly chains?: string[];
+  /** Collapse an address tracked on several chains into one entry. */
+  readonly unique?: boolean;
+  /** Offer an extra all-chains entry for an address tracked on more than one. */
+  readonly multichain?: boolean;
+}
+
+/**
+ * Narrows the tracked accounts to the ones the selector should offer.
+ *
+ * @remarks
+ * With `multichain`, an address tracked on more than one chain gains an extra entry standing for
+ * all of them, alongside its per-chain entries. That entry is synthesized here rather than being
+ * a real account, so the result is always a new array: appending to the caller's would grow the
+ * list again on every pass.
+ *
+ * @param accounts - every tracked account that has an address
+ * @param options - how to narrow them
+ * @returns the accounts to offer, in the order they were tracked
+ */
+export function selectableAccounts(
+  accounts: AccountWithAddressData[],
+  options: AccountSelectionOptions = {},
+): AccountWithAddressData[] {
+  const { chains = [], multichain = false, unique = false } = options;
+
+  const byChain = chains.length === 0
+    ? accounts
+    : accounts.filter(({ chain }) => chain === 'ALL' || chains.includes(chain));
+
+  const selected = unique
+    ? uniqBy(byChain, account => getAccountAddress(account))
+    : byChain;
+
+  return multichain ? [...selected, ...allChainsEntries(selected)] : [...selected];
+}
+
+/** An all-chains entry for each address that appears on more than one chain. */
+function allChainsEntries(accounts: AccountWithAddressData[]): AccountWithAddressData[] {
+  const perAddress = new Map<string, number>();
+  for (const account of accounts) {
+    const address = getAccountAddress(account);
+    perAddress.set(address, (perAddress.get(address) ?? 0) + 1);
+  }
+
+  return [...perAddress]
+    .filter(([, count]) => count > 1)
+    .map(([address]) => createAccount({ address, label: null, tags: null }, { chain: 'ALL', nativeAsset: '' }));
+}
+
+/**
+ * Whether an account matches what the user typed, which is the address, the name it resolves to,
+ * or any of its tags.
+ *
+ * @param account - the account being offered
+ * @param query - what the user typed
+ * @param resolveName - the tracked or ENS name for an address, absent when it has none
+ * @returns whether the account should stay in the list
+ */
+export function matchesAccountQuery(
+  account: BlockchainAccount,
+  query: string,
+  resolveName: (account: BlockchainAccount) => string | undefined,
+): boolean {
+  const token = getTextToken(query);
+  const address = getTextToken(getAccountAddress(account));
+  const name = getTextToken(resolveName(account) ?? '');
+
+  if (address.includes(token) || name.includes(token))
+    return true;
+
+  return account.tags
+    ? account.tags.map(tag => getTextToken(tag)).join(' ').includes(token)
+    : false;
+}

--- a/frontend/app/src/modules/accounts/management/AccountDialog.vue
+++ b/frontend/app/src/modules/accounts/management/AccountDialog.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { assert } from '@rotki/common';
 import { externalLinks } from '@shared/external-links';
-import { isEqual } from 'es-toolkit';
 import { type AccountManageState, useAccountManage } from '@/modules/accounts/blockchain/use-account-manage';
+import { hasAccountChanged, isAddingValidator } from '@/modules/accounts/management/account-dialog-state';
 import AccountForm from '@/modules/accounts/management/AccountForm.vue';
 import { useAccountLoading } from '@/modules/accounts/use-account-loading';
 import { useEthStaking } from '@/modules/accounts/use-eth-staking';
@@ -40,13 +40,9 @@ const { loading } = useAccountLoading();
 const { validatorsLimitInfo } = useEthStaking();
 const { currentTier, ethStakedLimit, premium } = usePremiumHelper();
 
-const isValidatorLimitReached = computed<boolean>(() => {
-  const state = get(model);
-  if (!state || state.mode === 'edit')
-    return false;
-
-  return state.type === 'validator' && get(validatorsLimitInfo).showWarning;
-});
+const isValidatorLimitReached = computed<boolean>(() =>
+  isAddingValidator(get(model)) && get(validatorsLimitInfo).showWarning,
+);
 
 const upgradeLinkText = computed<string>(() =>
   get(premium)
@@ -57,14 +53,6 @@ const upgradeLinkText = computed<string>(() =>
 const upgradeLinkUrl = computed<string | undefined>(() =>
   get(premium) ? externalLinks.manageSubscriptions : undefined,
 );
-
-const isSaveDisabled = computed<boolean>(() => {
-  const state = get(model);
-  if (!state || state.mode === 'edit')
-    return false;
-
-  return get(isValidatorLimitReached);
-});
 
 function dismiss(): void {
   resetSaveError();
@@ -94,14 +82,10 @@ async function confirm(): Promise<void> {
   }
 }
 watch(model, (model, oldModel) => {
-  if (!model || !oldModel) {
-    set(stateUpdated, false);
-    return;
-  }
-
-  if (model.chain === oldModel.chain && !isEqual(model.data, oldModel.data)) {
+  if (hasAccountChanged(model, oldModel))
     set(stateUpdated, true);
-  }
+  else if (!model || !oldModel)
+    set(stateUpdated, false);
 }, { deep: true });
 </script>
 
@@ -110,7 +94,7 @@ watch(model, (model, oldModel) => {
     :display="!!model"
     :title="title"
     :subtitle="subtitle"
-    :action="{ disabled: isSaveDisabled, primary: t('common.actions.save') }"
+    :action="{ disabled: isValidatorLimitReached, primary: t('common.actions.save') }"
     :loading="loading || pending"
     :prompt-on-close="stateUpdated"
     @confirm="confirm()"

--- a/frontend/app/src/modules/accounts/management/account-dialog-state.spec.ts
+++ b/frontend/app/src/modules/accounts/management/account-dialog-state.spec.ts
@@ -1,0 +1,82 @@
+import type { AccountManageState } from '@/modules/accounts/blockchain/use-account-manage';
+import { Blockchain } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { hasAccountChanged, isAddingValidator } from '@/modules/accounts/management/account-dialog-state';
+
+function addAccount(chain: string, address: string): AccountManageState {
+  return { chain, data: [{ address, tags: null }], mode: 'add', type: 'account' };
+}
+
+function editAccount(chain: string, address: string): AccountManageState {
+  return { chain, data: { address, tags: null }, mode: 'edit', type: 'account' };
+}
+
+function validator(mode: 'add' | 'edit'): AccountManageState {
+  return {
+    chain: Blockchain.ETH2,
+    data: { ownershipPercentage: '100', publicKey: '0xabc' },
+    mode,
+    type: 'validator',
+  };
+}
+
+describe('isAddingValidator', () => {
+  it('should recognise a validator being added', () => {
+    expect(isAddingValidator(validator('add'))).toBe(true);
+  });
+
+  it('should not count adding an account', () => {
+    expect(isAddingValidator(addAccount('eth', '0x1'))).toBe(false);
+  });
+
+  /** The limit counts tracked validators, and editing one does not add another. */
+  it('should not count editing an existing validator', () => {
+    expect(isAddingValidator(validator('edit'))).toBe(false);
+  });
+
+  it('should not count a closed dialog', () => {
+    expect(isAddingValidator(undefined)).toBe(false);
+  });
+});
+
+describe('hasAccountChanged', () => {
+  it('should report a change when the data was edited', () => {
+    const before = editAccount('eth', '0x1');
+    const after = editAccount('eth', '0x2');
+
+    expect(hasAccountChanged(after, before)).toBe(true);
+  });
+
+  it('should report no change when the data is the same', () => {
+    expect(hasAccountChanged(editAccount('eth', '0x1'), editAccount('eth', '0x1'))).toBe(false);
+  });
+
+  /**
+   * A different chain means the dialog was pointed at another account, so the data differing says
+   * nothing about the user having typed anything.
+   */
+  it('should report no change when the chain differs', () => {
+    expect(hasAccountChanged(editAccount('optimism', '0x2'), editAccount('eth', '0x1'))).toBe(false);
+  });
+
+  it('should report no change when the dialog is opening', () => {
+    expect(hasAccountChanged(addAccount('eth', '0x1'), undefined)).toBe(false);
+  });
+
+  it('should report no change when the dialog is closing', () => {
+    expect(hasAccountChanged(undefined, editAccount('eth', '0x1'))).toBe(false);
+  });
+
+  it('should report no change while the dialog stays closed', () => {
+    expect(hasAccountChanged(undefined, undefined)).toBe(false);
+  });
+
+  it('should compare the data deeply rather than by reference', () => {
+    const data = { address: '0x1', tags: null };
+
+    expect(hasAccountChanged(
+      { chain: 'eth', data: { ...data }, mode: 'edit', type: 'account' },
+      { chain: 'eth', data: { ...data }, mode: 'edit', type: 'account' },
+    )).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/accounts/management/account-dialog-state.ts
+++ b/frontend/app/src/modules/accounts/management/account-dialog-state.ts
@@ -1,0 +1,39 @@
+import type { AccountManageState } from '@/modules/accounts/blockchain/use-account-manage';
+import { isEqual } from 'es-toolkit';
+
+/**
+ * Whether the dialog is adding a validator, which is the only case a premium limit applies to.
+ *
+ * @remarks
+ * Editing an existing validator is always allowed: the limit is on how many are tracked, and an
+ * edit does not add one.
+ *
+ * @param state - what the dialog is showing, absent while it is closed
+ * @returns whether a new validator is being added
+ */
+export function isAddingValidator(state: AccountManageState | undefined): boolean {
+  return !!state && state.mode !== 'edit' && state.type === 'validator';
+}
+
+/**
+ * Whether the account being edited was changed by the user rather than replaced by the dialog
+ * opening on something else.
+ *
+ * @remarks
+ * Switching chain means the dialog was pointed at a different account, so its data differing says
+ * nothing about the user having edited anything. Opening or closing the dialog is not a change
+ * either, which is why an absent side on either end reads as untouched.
+ *
+ * @param next - the state after the change
+ * @param previous - the state before it
+ * @returns whether the user edited the account in place
+ */
+export function hasAccountChanged(
+  next: AccountManageState | undefined,
+  previous: AccountManageState | undefined,
+): boolean {
+  if (!next || !previous)
+    return false;
+
+  return next.chain === previous.chain && !isEqual(next.data, previous.data);
+}

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalancesPriceForm.vue
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalancesPriceForm.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
-import type { BigNumber } from '@rotki/common';
+import { useManualBalancePrice } from '@/modules/accounts/manual-balances/use-manual-balance-price';
 import { FiatDisplay } from '@/modules/assets/amount-display/components';
-import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
-import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
-import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
 import { useSetting } from '@/modules/settings/use-setting';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 import AssetSelect from '@/modules/shell/components/inputs/AssetSelect.vue';
@@ -13,110 +10,17 @@ const { asset = '', pending } = defineProps<{
   asset?: string;
 }>();
 
-const price = ref<string>('');
-const priceAsset = ref<string>('');
-const fetchingPrice = ref<boolean>(false);
-const fetchedPrice = ref<string>('');
-const isCustomPrice = ref<boolean>(false);
-const fiatPriceHint = ref<BigNumber | null>();
-
 const currencySymbol = useSetting('currencySymbol');
-const { getAssetPrice } = usePriceUtils();
-const { fetchPrices } = usePriceTaskManager();
-const { addLatestPrice } = useAssetPricesApi();
 
-const { fetchLatestPrices } = useAssetPricesApi();
-
-async function getAssetPriceInFiat(asset: string): Promise<BigNumber | null> {
-  set(fetchingPrice, true);
-  await fetchPrices({
-    ignoreCache: true,
-    selectedAssets: [asset],
-  });
-  set(fetchingPrice, false);
-
-  const priceInFiat = getAssetPrice(asset);
-
-  if (priceInFiat && !priceInFiat.eq(0)) {
-    return priceInFiat;
-  }
-
-  return null;
-}
-
-function setPriceAndPriceAsset(newPrice = '', newPriceAsset = '') {
-  set(price, newPrice);
-  set(priceAsset, newPriceAsset);
-  set(fetchedPrice, newPrice);
-  set(isCustomPrice, !newPrice || !newPriceAsset);
-  set(fiatPriceHint, null);
-}
-
-async function searchAssetPrice() {
-  if (!asset) {
-    setPriceAndPriceAsset();
-    return;
-  }
-
-  const mainCurrency = get(currencySymbol);
-
-  const customLatestPrices = await fetchLatestPrices({ fromAsset: asset });
-  if (customLatestPrices.length > 0) {
-    const customLatestPrice = customLatestPrices[0];
-    const newPrice = customLatestPrice.price.toFixed();
-    const newPriceAsset = customLatestPrice.toAsset;
-
-    setPriceAndPriceAsset(newPrice, newPriceAsset);
-
-    if (mainCurrency !== newPriceAsset) {
-      const priceInFiat = await getAssetPriceInFiat(asset);
-      if (priceInFiat)
-        set(fiatPriceHint, priceInFiat);
-    }
-
-    return;
-  }
-
-  if (mainCurrency === asset) {
-    setPriceAndPriceAsset('1', mainCurrency);
-    return;
-  }
-
-  const priceInFiat = await getAssetPriceInFiat(asset);
-  if (priceInFiat) {
-    setPriceAndPriceAsset(priceInFiat.toFixed(), mainCurrency);
-    return;
-  }
-
-  setPriceAndPriceAsset();
-}
-
-async function savePrice(asset: string): Promise<boolean> {
-  if (get(isCustomPrice) && get(price) && get(priceAsset)) {
-    return await addLatestPrice({
-      fromAsset: asset,
-      price: get(price),
-      toAsset: get(priceAsset),
-    });
-  }
-
-  return false;
-}
-
-watch(isCustomPrice, (isCustomPrice) => {
-  if (isCustomPrice) {
-    set(price, '');
-    set(priceAsset, '');
-    set(fiatPriceHint, null);
-  }
-  else {
-    searchAssetPrice();
-  }
-});
-
-watchImmediate(() => asset, () => {
-  searchAssetPrice();
-});
+const {
+  fetchedPrice,
+  fetchingPrice,
+  fiatPriceHint,
+  modelIsCustomPrice: isCustomPrice,
+  modelPrice: price,
+  modelPriceAsset: priceAsset,
+  savePrice,
+} = useManualBalancePrice(() => asset, currencySymbol);
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/app/src/modules/accounts/manual-balances/use-manual-balance-price.spec.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/use-manual-balance-price.spec.ts
@@ -1,0 +1,188 @@
+import { type BigNumber, bigNumberify, Zero } from '@rotki/common';
+import { flushPromises } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useManualBalancePrice } from '@/modules/accounts/manual-balances/use-manual-balance-price';
+
+const addLatestPrice = vi.fn<(payload: { fromAsset: string; price: string; toAsset: string }) => Promise<boolean>>();
+const fetchLatestPrices = vi.fn<(payload: { fromAsset: string }) => Promise<{ price: BigNumber; toAsset: string }[]>>();
+const fetchPrices = vi.fn(async (): Promise<void> => Promise.resolve());
+const getAssetPrice = vi.fn<(asset: string) => BigNumber | undefined>();
+
+vi.mock('@/modules/assets/api/use-asset-prices-api', () => ({
+  useAssetPricesApi: (): Record<string, unknown> => ({ addLatestPrice, fetchLatestPrices }),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-task-manager', () => ({
+  usePriceTaskManager: (): Record<string, unknown> => ({ fetchPrices }),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-utils', () => ({
+  usePriceUtils: (): Record<string, unknown> => ({ getAssetPrice }),
+}));
+
+describe('useManualBalancePrice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchLatestPrices.mockResolvedValue([]);
+    getAssetPrice.mockReturnValue(undefined);
+    addLatestPrice.mockResolvedValue(true);
+  });
+
+  describe('looking a price up', () => {
+    it('should use a price the user saved before', async () => {
+      fetchLatestPrices.mockResolvedValue([{ price: bigNumberify('42'), toAsset: 'EUR' }]);
+      const { modelPrice, modelPriceAsset } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+
+      expect(get(modelPrice)).toBe('42');
+      expect(get(modelPriceAsset)).toBe('EUR');
+    });
+
+    /** An asset priced in the main currency is worth exactly one of it. */
+    it('should price the main currency at one of itself', async () => {
+      const { modelPrice, modelPriceAsset } = useManualBalancePrice('EUR', 'EUR');
+      await flushPromises();
+
+      expect(get(modelPrice)).toBe('1');
+      expect(get(modelPriceAsset)).toBe('EUR');
+      expect(fetchPrices).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the oracle price in the main currency', async () => {
+      getAssetPrice.mockReturnValue(bigNumberify('1500'));
+      const { modelPrice, modelPriceAsset } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+
+      expect(get(modelPrice)).toBe('1500');
+      expect(get(modelPriceAsset)).toBe('EUR');
+    });
+
+    it('should leave the fields blank when no price can be found', async () => {
+      const { modelIsCustomPrice, modelPrice } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+
+      expect(get(modelPrice)).toBe('');
+      expect(get(modelIsCustomPrice)).toBe(true);
+    });
+
+    /** A zero oracle price is no price at all, not a valuation of nothing. */
+    it('should treat a zero oracle price as no price', async () => {
+      getAssetPrice.mockReturnValue(Zero);
+      const { modelIsCustomPrice, modelPrice } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+
+      expect(get(modelPrice)).toBe('');
+      expect(get(modelIsCustomPrice)).toBe(true);
+    });
+
+    it('should look nothing up without an asset', async () => {
+      const { modelPrice } = useManualBalancePrice('', 'EUR');
+      await flushPromises();
+
+      expect(get(modelPrice)).toBe('');
+      expect(fetchLatestPrices).not.toHaveBeenCalled();
+    });
+
+    it('should look the price up again when the asset changes', async () => {
+      const asset = ref('ETH');
+      useManualBalancePrice(asset, 'EUR');
+      await flushPromises();
+
+      set(asset, 'BTC');
+      await flushPromises();
+
+      expect(fetchLatestPrices).toHaveBeenLastCalledWith({ fromAsset: 'BTC' });
+    });
+  });
+
+  describe('the fiat hint', () => {
+    it('should show the fiat value for a price quoted in something else', async () => {
+      fetchLatestPrices.mockResolvedValue([{ price: bigNumberify('1'), toAsset: 'BTC' }]);
+      getAssetPrice.mockReturnValue(bigNumberify('1500'));
+      const { fiatPriceHint } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+
+      expect(get(fiatPriceHint)?.toFixed()).toBe('1500');
+    });
+
+    it('should show no hint for a price already in the main currency', async () => {
+      fetchLatestPrices.mockResolvedValue([{ price: bigNumberify('42'), toAsset: 'EUR' }]);
+      const { fiatPriceHint } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+
+      expect(get(fiatPriceHint)).toBeNull();
+      expect(fetchPrices).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('entering a price by hand', () => {
+    it('should empty the fields when the toggle goes on', async () => {
+      getAssetPrice.mockReturnValue(bigNumberify('1500'));
+      const { modelIsCustomPrice, modelPrice, modelPriceAsset } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+
+      set(modelIsCustomPrice, true);
+      await flushPromises();
+
+      expect(get(modelPrice)).toBe('');
+      expect(get(modelPriceAsset)).toBe('');
+    });
+
+    it('should look the price up again when the toggle goes off', async () => {
+      getAssetPrice.mockReturnValue(bigNumberify('1500'));
+      const { modelIsCustomPrice } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+      set(modelIsCustomPrice, true);
+      await flushPromises();
+      fetchLatestPrices.mockClear();
+
+      set(modelIsCustomPrice, false);
+      await flushPromises();
+
+      expect(fetchLatestPrices).toHaveBeenCalledWith({ fromAsset: 'ETH' });
+    });
+  });
+
+  describe('saving a price', () => {
+    it('should save what the user typed', async () => {
+      const { modelIsCustomPrice, modelPrice, modelPriceAsset, savePrice } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+      set(modelIsCustomPrice, true);
+      set(modelPrice, '99');
+      set(modelPriceAsset, 'EUR');
+
+      expect(await savePrice('ETH')).toBe(true);
+      expect(addLatestPrice).toHaveBeenCalledWith({ fromAsset: 'ETH', price: '99', toAsset: 'EUR' });
+    });
+
+    /** A price the app found is already known, so re-saving it would add a custom price nobody asked for. */
+    it('should not save a price the lookup found', async () => {
+      getAssetPrice.mockReturnValue(bigNumberify('1500'));
+      const { savePrice } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+
+      expect(await savePrice('ETH')).toBe(false);
+      expect(addLatestPrice).not.toHaveBeenCalled();
+    });
+
+    it('should not save without a price', async () => {
+      const { modelIsCustomPrice, modelPriceAsset, savePrice } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+      set(modelIsCustomPrice, true);
+      set(modelPriceAsset, 'EUR');
+
+      expect(await savePrice('ETH')).toBe(false);
+      expect(addLatestPrice).not.toHaveBeenCalled();
+    });
+
+    it('should not save without a price asset', async () => {
+      const { modelIsCustomPrice, modelPrice, savePrice } = useManualBalancePrice('ETH', 'EUR');
+      await flushPromises();
+      set(modelIsCustomPrice, true);
+      set(modelPrice, '99');
+
+      expect(await savePrice('ETH')).toBe(false);
+      expect(addLatestPrice).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/manual-balances/use-manual-balance-price.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/use-manual-balance-price.ts
@@ -1,0 +1,138 @@
+import type { BigNumber } from '@rotki/common';
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import { startPromise } from '@shared/utils';
+import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
+import { usePriceTaskManager } from '@/modules/assets/prices/use-price-task-manager';
+import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
+
+interface UseManualBalancePriceReturn {
+  /** The price the form shows; the user types over it once the custom toggle is on. */
+  modelPrice: Ref<string>;
+  /** What the price is quoted in. */
+  modelPriceAsset: Ref<string>;
+  /** Whether the user is entering their own price rather than the one that was found. */
+  modelIsCustomPrice: Ref<boolean>;
+  /** Whether a price lookup is in flight. */
+  fetchingPrice: Readonly<Ref<boolean>>;
+  /** The price the lookup found, kept so the form can offer it back after a custom one. */
+  fetchedPrice: Readonly<Ref<string>>;
+  /** The fiat value shown beside a price quoted in something other than the main currency. */
+  fiatPriceHint: Readonly<Ref<BigNumber | null>>;
+  /** Looks the asset's price up and fills the form in with what it finds. */
+  searchAssetPrice: () => Promise<void>;
+  /** Saves the typed price as a custom one; does nothing unless the user entered one. */
+  savePrice: (asset: string) => Promise<boolean>;
+}
+
+/**
+ * The price a manual balance is valued at: what the app already knows, and what the user may
+ * override it with.
+ *
+ * @remarks
+ * The lookup prefers a custom price the user saved before, then the asset being the main currency
+ * itself, then the oracle price. Anything else leaves the form blank, which turns the custom
+ * toggle on so the user can supply one.
+ *
+ * @param asset - the asset the balance is in, re-read whenever it changes
+ * @param currencySymbol - the user's main currency
+ * @returns the price fields and the two actions over them
+ */
+export function useManualBalancePrice(
+  asset: MaybeRefOrGetter<string>,
+  currencySymbol: MaybeRefOrGetter<string>,
+): UseManualBalancePriceReturn {
+  const { addLatestPrice, fetchLatestPrices } = useAssetPricesApi();
+  const { fetchPrices } = usePriceTaskManager();
+  const { getAssetPrice } = usePriceUtils();
+
+  const modelPrice = shallowRef<string>('');
+  const modelPriceAsset = shallowRef<string>('');
+  const modelIsCustomPrice = shallowRef<boolean>(false);
+  const fetchedPrice = shallowRef<string>('');
+  const fetchingPrice = shallowRef<boolean>(false);
+  const fiatPriceHint = shallowRef<BigNumber | null>(null);
+
+  async function oraclePrice(asset: string): Promise<BigNumber | null> {
+    set(fetchingPrice, true);
+    await fetchPrices({ ignoreCache: true, selectedAssets: [asset] });
+    set(fetchingPrice, false);
+
+    const price = getAssetPrice(asset);
+    return price && !price.eq(0) ? price : null;
+  }
+
+  /** A blank price leaves the custom toggle on, since the form has nothing else to offer. */
+  function setPrice(price = '', priceAsset = ''): void {
+    set(modelPrice, price);
+    set(modelPriceAsset, priceAsset);
+    set(fetchedPrice, price);
+    set(modelIsCustomPrice, !price || !priceAsset);
+    set(fiatPriceHint, null);
+  }
+
+  async function searchAssetPrice(): Promise<void> {
+    const current = toValue(asset);
+    if (!current) {
+      setPrice();
+      return;
+    }
+
+    const mainCurrency = toValue(currencySymbol);
+
+    const [saved] = await fetchLatestPrices({ fromAsset: current });
+    if (saved) {
+      setPrice(saved.price.toFixed(), saved.toAsset);
+
+      if (mainCurrency !== saved.toAsset)
+        set(fiatPriceHint, await oraclePrice(current));
+
+      return;
+    }
+
+    if (mainCurrency === current) {
+      setPrice('1', mainCurrency);
+      return;
+    }
+
+    const price = await oraclePrice(current);
+    setPrice(price ? price.toFixed() : undefined, price ? mainCurrency : undefined);
+  }
+
+  async function savePrice(asset: string): Promise<boolean> {
+    if (!get(modelIsCustomPrice) || !get(modelPrice) || !get(modelPriceAsset))
+      return false;
+
+    return addLatestPrice({
+      fromAsset: asset,
+      price: get(modelPrice),
+      toAsset: get(modelPriceAsset),
+    });
+  }
+
+  /** Turning the toggle on empties the fields to type into; turning it off looks the price up again. */
+  watch(modelIsCustomPrice, (isCustom) => {
+    if (!isCustom) {
+      startPromise(searchAssetPrice());
+      return;
+    }
+
+    set(modelPrice, '');
+    set(modelPriceAsset, '');
+    set(fiatPriceHint, null);
+  });
+
+  watchImmediate(() => toValue(asset), () => {
+    startPromise(searchAssetPrice());
+  });
+
+  return {
+    fetchedPrice: readonly(fetchedPrice),
+    fetchingPrice: readonly(fetchingPrice),
+    fiatPriceHint: shallowReadonly(fiatPriceHint),
+    modelIsCustomPrice,
+    modelPrice,
+    modelPriceAsset,
+    savePrice,
+    searchAssetPrice,
+  };
+}

--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingContent.vue
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingContent.vue
@@ -58,8 +58,10 @@ const { showDeleteConfirmation } = useTableRowDeletion<CexMapping>({
     title: t('asset_management.cex_mapping.confirm_delete.title'),
   }),
   deleteItem: mapping => deleteCexMapping(omit(mapping, ['asset'])),
-  errorMessage: (_item, error) => t('asset_management.cex_mapping.delete_error', {
-    message: getErrorMessage(error),
+  errorMessage: (_item, error) => ({
+    description: t('asset_management.cex_mapping.delete_error', {
+      message: getErrorMessage(error),
+    }),
   }),
   onDeleted: refetch,
 });

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.vue
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMapping.vue
@@ -59,8 +59,10 @@ const { showDeleteConfirmation } = useTableRowDeletion<CounterpartyMapping>({
     title: t('asset_management.counterparty_mapping.confirm_delete.title'),
   }),
   deleteItem: mapping => deleteCounterpartyMapping(omit(mapping, ['asset'])),
-  errorMessage: (_item, error) => t('asset_management.cex_mapping.delete_error', {
-    message: getErrorMessage(error),
+  errorMessage: (_item, error) => ({
+    description: t('asset_management.cex_mapping.delete_error', {
+      message: getErrorMessage(error),
+    }),
   }),
   onDeleted: refetch,
 });

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-asset-dialog.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-asset-dialog.ts
@@ -1,6 +1,7 @@
 import type { Nullable } from '@rotki/common';
 import type { MaybeRefOrGetter, Ref } from 'vue';
 import type { CustomAsset } from '@/modules/assets/types';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 
 interface UseCustomAssetDialogOptions {
   /** The assets currently on the page, searched when the route names one to edit. */
@@ -15,10 +16,9 @@ interface UseCustomAssetDialogReturn {
   /**
    * Consumes an `?add=` query, opening the dialog on a blank asset.
    *
-   * @remarks
-   * The query is cleared afterwards, so a reload does not reopen the dialog.
+   * @returns whether the query asked for the dialog
    */
-  consumeAddQuery: () => Promise<void>;
+  consumeAddQuery: () => Promise<boolean>;
   /** Opens the dialog on an existing asset. */
   edit: (asset: CustomAsset) => void;
   /**
@@ -44,9 +44,6 @@ interface UseCustomAssetDialogReturn {
 export function useCustomAssetDialog(options: UseCustomAssetDialogOptions): UseCustomAssetDialogReturn {
   const { assets, identifier } = options;
 
-  const router = useRouter();
-  const route = useRoute();
-
   const modelEditableItem = shallowRef<CustomAsset | null>(null);
   const modelOpenDialog = shallowRef<boolean>(false);
 
@@ -69,13 +66,7 @@ export function useCustomAssetDialog(options: UseCustomAssetDialogOptions): UseC
       edit(asset);
   }
 
-  async function consumeAddQuery(): Promise<void> {
-    if (!get(route).query.add)
-      return;
-
-    add();
-    await router.replace({ query: {} });
-  }
+  const { consumeAddQuery } = useAddQuery(add);
 
   watch(() => toValue(identifier), (assetId) => {
     editAsset(assetId);

--- a/frontend/app/src/modules/assets/admin/custom/use-custom-assets-table.ts
+++ b/frontend/app/src/modules/assets/admin/custom/use-custom-assets-table.ts
@@ -95,9 +95,11 @@ export function useCustomAssetsTable(options: UseCustomAssetsTableOptions): UseC
       title: t('asset_management.confirm_delete.title'),
     }),
     deleteItem: async item => deleteCustomAsset(item.identifier),
-    errorMessage: (item, error) => t('asset_management.delete_error', {
-      address: item.identifier,
-      message: getErrorMessage(error),
+    errorMessage: (item, error) => ({
+      description: t('asset_management.delete_error', {
+        address: item.identifier,
+        message: getErrorMessage(error),
+      }),
     }),
     onDeleted: refresh,
   });

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetContent.vue
@@ -5,6 +5,7 @@ import { useManagedAssetForm } from '@/modules/assets/admin/managed/use-managed-
 import { useManagedAssetsTable } from '@/modules/assets/admin/managed/use-managed-assets-table';
 import MergeDialog from '@/modules/assets/admin/MergeDialog.vue';
 import RestoreAssetDbButton from '@/modules/assets/admin/RestoreAssetDbButton.vue';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
 const { identifier = null, mainPage = false } = defineProps<{
@@ -18,7 +19,6 @@ const mergeTool = ref<boolean>(false);
 const openAction = ref<boolean>(false);
 
 const router = useRouter();
-const route = useRoute();
 
 const { add, assetTypes, edit, editAsset, editMode, modelValue } = useManagedAssetForm(() => identifier);
 
@@ -38,17 +38,18 @@ const {
   sort,
 } = useManagedAssetsTable(() => mainPage, assetTypes);
 
+const { consumeAddQuery } = useAddQuery(add);
+
 onMounted(async () => {
   await refetch();
-  const query = get(route).query;
 
-  if (identifier || query.add) {
-    if (identifier)
-      await editAsset(identifier);
-    else add();
-
+  if (identifier) {
+    await editAsset(identifier);
     await router.replace({ query: {} });
+    return;
   }
+
+  await consumeAddQuery();
 });
 </script>
 

--- a/frontend/app/src/modules/assets/admin/managed/use-managed-assets-table.ts
+++ b/frontend/app/src/modules/assets/admin/managed/use-managed-assets-table.ts
@@ -118,9 +118,11 @@ export function useManagedAssetsTable(
       title: t('asset_management.confirm_delete.title'),
     }),
     deleteItem: async item => deleteAsset(item.identifier),
-    errorMessage: (item, error) => t('asset_management.delete_error', {
-      address: item.identifier,
-      message: getErrorMessage(error),
+    errorMessage: (item, error) => ({
+      description: t('asset_management.delete_error', {
+        address: item.identifier,
+        message: getErrorMessage(error),
+      }),
     }),
     onDeleted: async (item) => {
       await refetch();

--- a/frontend/app/src/modules/assets/admin/use-mapping-admin.ts
+++ b/frontend/app/src/modules/assets/admin/use-mapping-admin.ts
@@ -1,6 +1,7 @@
 import type { Ref } from 'vue';
 import type { LocationQuery } from 'vue-router';
 import { objectKeys } from '@/modules/core/common/data/array';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 import { firstQueryValue } from '@/modules/core/table/route';
 
 /** A filter bag value: the pill bar types every key as one-or-many, and some keys are toggles. */
@@ -58,9 +59,6 @@ export function useMappingAdmin<T extends object, TFilters extends Record<string
 ): UseMappingAdminReturn<T> {
   const { blank, filter, seedFromFilter, seedFromQuery } = options;
 
-  const router = useRouter();
-  const route = useRoute();
-
   const modelValue = ref<T>();
   const editMode = shallowRef<boolean>(false);
 
@@ -103,15 +101,9 @@ export function useMappingAdmin<T extends object, TFilters extends Record<string
     set(editMode, true);
   }
 
-  async function consumeAddQuery(): Promise<boolean> {
-    const { query } = get(route);
-    if (!query.add)
-      return false;
-
-    await router.replace({ query: {} });
+  const { consumeAddQuery } = useAddQuery((query) => {
     add(seededFromQuery(query));
-    return true;
-  }
+  });
 
   return {
     add,

--- a/frontend/app/src/modules/assets/prices/historic/HistoricPriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/historic/HistoricPriceContent.vue
@@ -8,6 +8,7 @@ import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import HistoricPriceFormDialog from '@/modules/assets/prices/historic/HistoricPriceFormDialog.vue';
 import { HistoricPriceFilterKeys, useHistoricPriceFields } from '@/modules/assets/prices/use-historic-price-fields';
 import { useHistoricPrices } from '@/modules/assets/prices/use-historic-price-manager';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
@@ -103,9 +104,6 @@ const filter = computed<{ fromAsset?: string; toAsset?: string }>(() => {
   };
 });
 
-const router = useRouter();
-const route = useRoute();
-
 const { deletePrice, items, loading, refresh } = useHistoricPrices(t, filter);
 
 function add() {
@@ -138,13 +136,10 @@ function showDeleteConfirmation(item: HistoricalPrice) {
   );
 }
 
-onMounted(async () => {
-  const query = get(route).query;
+const { consumeAddQuery } = useAddQuery(add);
 
-  if (query.add) {
-    add();
-    await router.replace({ query: {} });
-  }
+onMounted(async () => {
+  await consumeAddQuery();
 });
 </script>
 

--- a/frontend/app/src/modules/assets/prices/latest/LatestPriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/latest/LatestPriceContent.vue
@@ -8,6 +8,7 @@ import { isNft } from '@/modules/assets/nft-utils';
 import LatestPriceFormDialog from '@/modules/assets/prices/latest/LatestPriceFormDialog.vue';
 import { useLatestPrices } from '@/modules/assets/prices/use-latest-price-manager';
 import NftDetails from '@/modules/balances/nft/NftDetails.vue';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useCommonTableProps } from '@/modules/core/table/use-common-table-props';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
@@ -63,8 +64,6 @@ const headers = computed<DataTableColumn<ManualPriceWithUsd>[]>(() => [
 
 useRememberTableSorting<ManualPriceWithUsd>(TableId.LATEST_PRICES, sort, headers);
 
-const router = useRouter();
-const route = useRoute();
 const { deletePrice, items, loading, refreshCurrentPrices, refreshing } = useLatestPrices(t, filter);
 
 const { show } = useConfirmStore();
@@ -92,14 +91,11 @@ function edit(item: ManualPriceWithUsd) {
   set(openDialog, true);
 }
 
+const { consumeAddQuery } = useAddQuery(add);
+
 onMounted(async () => {
   await refreshCurrentPrices();
-  const query = get(route).query;
-
-  if (query.add) {
-    add();
-    await router.replace({ query: {} });
-  }
+  await consumeAddQuery();
 });
 </script>
 

--- a/frontend/app/src/modules/core/common/use-add-query.spec.ts
+++ b/frontend/app/src/modules/core/common/use-add-query.spec.ts
@@ -1,0 +1,75 @@
+import type { ComputedRef } from 'vue';
+import type { LocationQuery } from 'vue-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
+
+/**
+ * A local `vue-router` double, narrower than the global one, so the route the composable reads can
+ * be set to a bare query without standing up a whole `RouteLocationNormalizedLoaded`.
+ */
+const router = vi.hoisted(() => {
+  const state: { query: LocationQuery } = { query: {} };
+  return {
+    replace: vi.fn(({ query }: { query: LocationQuery }) => {
+      state.query = query;
+    }),
+    state,
+  };
+});
+
+vi.mock('vue-router', () => ({
+  useRoute: (): ComputedRef<{ query: LocationQuery }> => computed(() => ({ query: router.state.query })),
+  useRouter: (): { replace: typeof router.replace } => ({ replace: router.replace }),
+}));
+
+describe('useAddQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    router.state.query = {};
+  });
+
+  it('should do nothing when the route carries no add query', async () => {
+    const onAdd = vi.fn();
+
+    const consumed = await useAddQuery(onAdd).consumeAddQuery();
+
+    expect(consumed).toBe(false);
+    expect(onAdd).not.toHaveBeenCalled();
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('should open the dialog and clear the query', async () => {
+    const onAdd = vi.fn();
+    router.state.query = { add: 'true' };
+
+    const consumed = await useAddQuery(onAdd).consumeAddQuery();
+
+    expect(consumed).toBe(true);
+    expect(onAdd).toHaveBeenCalledWith({ add: 'true' });
+    expect(router.replace).toHaveBeenCalledWith({ query: {} });
+    expect(router.state.query).toEqual({});
+  });
+
+  it('should hand the handler the query the link carried, not the cleared one', async () => {
+    const seen: LocationQuery[] = [];
+    router.state.query = { add: 'true', addressToAdd: '0x1' };
+
+    await useAddQuery((query) => {
+      seen.push({ ...query });
+    }).consumeAddQuery();
+
+    expect(seen).toEqual([{ add: 'true', addressToAdd: '0x1' }]);
+  });
+
+  it('should await an async handler before resolving', async () => {
+    let opened = false;
+    router.state.query = { add: 'true' };
+
+    await useAddQuery(async () => {
+      await nextTick();
+      opened = true;
+    }).consumeAddQuery();
+
+    expect(opened).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/core/common/use-add-query.ts
+++ b/frontend/app/src/modules/core/common/use-add-query.ts
@@ -1,0 +1,39 @@
+import type { LocationQuery } from 'vue-router';
+
+interface UseAddQueryReturn {
+  /**
+   * Opens the dialog when the route carries `?add=`, and clears the query either way.
+   *
+   * @returns whether the query asked for the dialog
+   */
+  consumeAddQuery: () => Promise<boolean>;
+}
+
+/**
+ * The `?add=` deep link the add/edit pages share: the query opens the page's create dialog, and is
+ * cleared so a reload does not reopen it.
+ *
+ * @remarks
+ * The query is read and cleared before `onAdd` runs, so a handler seeding the dialog from the link
+ * gets the snapshot rather than re-reading a route that is already being replaced. Clearing first
+ * also means a handler that throws still leaves a clean url.
+ *
+ * @param onAdd - opens the dialog, receiving the query the link carried
+ * @returns the one call the page makes, usually from `onMounted`
+ */
+export function useAddQuery(onAdd: (query: LocationQuery) => void | Promise<void>): UseAddQueryReturn {
+  const router = useRouter();
+  const route = useRoute();
+
+  async function consumeAddQuery(): Promise<boolean> {
+    const { query } = get(route);
+    if (!query.add)
+      return false;
+
+    await router.replace({ query: {} });
+    await onAdd(query);
+    return true;
+  }
+
+  return { consumeAddQuery };
+}

--- a/frontend/app/src/modules/core/table/use-table-row-deletion.spec.ts
+++ b/frontend/app/src/modules/core/table/use-table-row-deletion.spec.ts
@@ -75,13 +75,28 @@ describe('useTableRowDeletion', () => {
     const { showDeleteConfirmation } = useTableRowDeletion<Row>({
       confirm: (): { message: string; title: string } => ({ message: 'm', title: 't' }),
       deleteItem: vi.fn().mockRejectedValue(new Error('boom')),
-      errorMessage: (item, error): string => `failed ${item.id}: ${error instanceof Error ? error.message : String(error)}`,
+      errorMessage: (item, error): { description: string } => ({
+        description: `failed ${item.id}: ${error instanceof Error ? error.message : String(error)}`,
+      }),
     });
 
     showDeleteConfirmation({ id: 'a' });
     await capturedOnConfirm()();
 
     expect(setMessage).toHaveBeenCalledWith({ description: 'failed a: boom' });
+  });
+
+  it('should pass through a title the table gives the toast', async (): Promise<void> => {
+    const { showDeleteConfirmation } = useTableRowDeletion<Row>({
+      confirm: (): { message: string; title: string } => ({ message: 'm', title: 't' }),
+      deleteItem: vi.fn().mockRejectedValue(new Error('boom')),
+      errorMessage: (): { description: string; title: string } => ({ description: 'd', title: 'Delete failed' }),
+    });
+
+    showDeleteConfirmation({ id: 'a' });
+    await capturedOnConfirm()();
+
+    expect(setMessage).toHaveBeenCalledWith({ description: 'd', title: 'Delete failed' });
   });
 
   it('should fall back to the raw error message when none is provided', async (): Promise<void> => {

--- a/frontend/app/src/modules/core/table/use-table-row-deletion.ts
+++ b/frontend/app/src/modules/core/table/use-table-row-deletion.ts
@@ -1,3 +1,4 @@
+import type { Message, SemiPartial } from '@rotki/common';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
@@ -16,10 +17,10 @@ interface UseTableRowDeletionOptions<T> {
   /** Runs after a successful delete, e.g. refetch the table and purge caches. */
   onDeleted?: (item: T) => void | Promise<void>;
   /**
-   * The toast description shown when the delete throws. Each table phrases this
-   * differently, so it is a param; without one the raw error message is used.
+   * The toast shown when the delete throws. Each table phrases this differently, and some
+   * give it their own title, so it is a param; without one the raw error message is used.
    */
-  errorMessage?: (item: T, error: unknown) => string;
+  errorMessage?: (item: T, error: unknown) => SemiPartial<Message, 'description'>;
 }
 
 interface UseTableRowDeletionReturn<T> {
@@ -48,9 +49,7 @@ export function useTableRowDeletion<T>(
           await onDeleted?.(item);
       }
       catch (error: unknown) {
-        setMessage({
-          description: errorMessage ? errorMessage(item, error) : getErrorMessage(error),
-        });
+        setMessage(errorMessage?.(item, error) ?? { description: getErrorMessage(error) });
       }
     });
   }

--- a/frontend/app/src/modules/history/data-issues/DataIssuesView.spec.ts
+++ b/frontend/app/src/modules/history/data-issues/DataIssuesView.spec.ts
@@ -40,6 +40,15 @@ vi.mock('@/modules/core/table/use-server-table', () => ({
   }),
 }));
 
+/* The account pill's options are fetched from the backend when the bar is built, which this spec
+   neither stubs nor asserts on, so without this every mount made a real request. */
+vi.mock('@/modules/history/use-history-data-fetching', () => ({
+  useHistoryDataFetching: (): Record<string, unknown> => ({
+    fetchAssociatedLocations: vi.fn().mockResolvedValue(undefined),
+    fetchLocationLabels: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
 vi.mock('@/modules/history/data-issues/use-data-issues', () => ({
   useDataIssues: (): Record<string, unknown> => ({
     dismiss: vi.fn(),

--- a/frontend/app/src/modules/premium/devices/components/PremiumDeviceList.vue
+++ b/frontend/app/src/modules/premium/devices/components/PremiumDeviceList.vue
@@ -2,8 +2,8 @@
 import type { DataTableColumn } from '@rotki/ui-library';
 import type { PremiumDevice } from '@/modules/premium/devices/premium';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useTableRowDeletion } from '@/modules/core/table/use-table-row-deletion';
 import PremiumDeviceFormDialog from '@/modules/premium/devices/components/PremiumDeviceFormDialog.vue';
 import { usePremiumDevicesApi } from '@/modules/premium/devices/devices';
 import { usePremiumStore } from '@/modules/premium/use-premium-store';
@@ -24,7 +24,6 @@ const { premium } = storeToRefs(usePremiumStore());
 
 const { deletePremiumDevice, fetchPremiumDevices } = usePremiumDevicesApi();
 const { setMessage } = useMessageStore();
-const { show } = useConfirmStore();
 
 const cols = computed<DataTableColumn<PremiumDevice>[]>(() => [{
   key: 'deviceName',
@@ -78,28 +77,18 @@ function edit(device: PremiumDevice): void {
   set(editingDevice, device);
 }
 
-function showDeleteConfirmation(device: PremiumDevice): void {
-  show(
-    {
-      message: t('premium_devices.delete.message', { device: device.deviceName }),
-      title: t('premium_devices.delete.title'),
-    },
-    deleteDevice.bind(null, device),
-  );
-}
-
-async function deleteDevice(device: PremiumDevice): Promise<void> {
-  try {
-    await deletePremiumDevice(device.deviceIdentifier);
-    await fetchDevices();
-  }
-  catch (error: unknown) {
-    setMessage({
-      description: getErrorMessage(error),
-      title: t('premium_devices.delete.error.title'),
-    });
-  }
-}
+const { showDeleteConfirmation } = useTableRowDeletion<PremiumDevice>({
+  confirm: device => ({
+    message: t('premium_devices.delete.message', { device: device.deviceName }),
+    title: t('premium_devices.delete.title'),
+  }),
+  deleteItem: async device => deletePremiumDevice(device.deviceIdentifier),
+  errorMessage: (_device, error) => ({
+    description: getErrorMessage(error),
+    title: t('premium_devices.delete.error.title'),
+  }),
+  onDeleted: fetchDevices,
+});
 
 onMounted(async () => {
   if (get(premium)) {

--- a/frontend/app/src/modules/reports/ReportActionableCard.vue
+++ b/frontend/app/src/modules/reports/ReportActionableCard.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import type { Component } from 'vue';
-import type { DialogType } from '@/modules/core/common/dialogs';
-import type { EditableMissingPrice, MissingAcquisition, MissingPrice, Report } from '@/modules/reports/report-types';
-import { toSentenceCase } from '@rotki/common';
+import type { EditableMissingPrice, Report } from '@/modules/reports/report-types';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import ReportActionableCardActions from '@/modules/reports/ReportActionableCardActions.vue';
+import {
+  summarizeMissingPrices,
+  useMissingPriceFinishPrompt,
+  useReportActionableStepper,
+} from '@/modules/reports/use-report-actionable-items';
 import { useReportsStore } from '@/modules/reports/use-reports-store';
 import { PinnedNames } from '@/modules/session/types';
 import { usePinnedPanel } from '@/modules/shell/pinned/use-pinned-panel';
@@ -37,133 +39,27 @@ function setDialog(dialog: boolean) {
 const reportsStore = useReportsStore();
 const { actionableItems } = storeToRefs(reportsStore);
 
-const step = ref<number>(1);
-
-const actionableItemsLength = computed(() => {
-  let missingAcquisitionsLength = 0;
-  let missingPricesLength = 0;
-  let total = 0;
-
-  const items = get(actionableItems);
-
-  if (items) {
-    missingAcquisitionsLength = items.missingAcquisitions.length;
-    missingPricesLength = items.missingPrices.length;
-    total = missingAcquisitionsLength + missingPricesLength;
-  }
-
-  if (!missingAcquisitionsLength || !missingPricesLength)
-    set(step, 1);
-
-  return {
-    missingAcquisitionsLength,
-    missingPricesLength,
-    total,
-  };
-});
+const { counts: actionableItemsLength, modelStep: step, steps: stepperContents } = useReportActionableStepper(
+  actionableItems,
+  { missingAcquisitions: ReportMissingAcquisitions, missingPrices: ReportMissingPrices },
+);
 
 function pinSection() {
   pinPanel({ isPinned: true, report });
   setDialog(false);
 }
 
-const stepperContents = computed<
-  {
-    key: string;
-    title: string;
-    hint: string;
-    selector: Component;
-    items: MissingAcquisition[] | MissingPrice[];
-  }[]
->(() => {
-  const contents = [];
-
-  const missingAcquisitionsLength = get(actionableItemsLength).missingAcquisitionsLength;
-
-  if (missingAcquisitionsLength > 0) {
-    contents.push({
-      hint: t('profit_loss_report.actionable.missing_acquisitions.hint'),
-      items: get(actionableItems).missingAcquisitions,
-      key: 'missingAcquisitions',
-      selector: ReportMissingAcquisitions,
-      title: t('profit_loss_report.actionable.missing_acquisitions.title', {
-        total: missingAcquisitionsLength,
-      }),
-    });
-  }
-
-  const missingPricesLength = get(actionableItemsLength).missingPricesLength;
-  if (missingPricesLength > 0) {
-    contents.push({
-      hint: t('profit_loss_report.actionable.missing_prices.hint'),
-      items: get(actionableItems).missingPrices,
-      key: 'missingPrices',
-      selector: ReportMissingPrices,
-      title: t('profit_loss_report.actionable.missing_prices.title', {
-        total: missingPricesLength,
-      }),
-    });
-  }
-
-  return contents;
-});
-
-const totalMissingPrices = ref<number>(0);
-const filledMissingPrices = ref<number>(0);
-const skippedMissingPrices = ref<number>(0);
-
 const { show } = useConfirmStore();
-
-function showFinishDialog() {
-  let type: DialogType = 'success';
-  let title = t('profit_loss_report.actionable.missing_prices.all_prices_filled');
-  let message = toSentenceCase(t('profit_loss_report.actionable.missing_prices.regenerate_report_nudge'));
-
-  const filledMissingPricesVal = get(filledMissingPrices);
-  const skippedMissingPricesVal = get(skippedMissingPrices);
-
-  if (filledMissingPricesVal === 0) {
-    type = 'warning';
-    title = t('profit_loss_report.actionable.missing_prices.no_filled_prices');
-    message = t('profit_loss_report.actionable.missing_prices.skipped_all_events_confirmation');
-  }
-  else if (skippedMissingPricesVal) {
-    type = 'warning';
-    title = t('profit_loss_report.actionable.missing_prices.total_skipped_prices', {
-      total: skippedMissingPricesVal,
-    });
-    message = `${t('profit_loss_report.actionable.missing_prices.if_sure')} ${t(
-      'profit_loss_report.actionable.missing_prices.regenerate_report_nudge',
-    )}`;
-  }
-
-  const primaryAction = filledMissingPricesVal
-    ? t('profit_loss_report.actionable.actions.regenerate_report')
-    : t('common.actions.yes');
-
-  show(
-    {
-      message,
-      primaryAction,
-      title,
-      type,
-    },
-    () => {
-      if (filledMissingPricesVal)
-        regenerateReport();
-      else ignoreIssues();
-    },
-  );
-}
+const { promptFor } = useMissingPriceFinishPrompt();
 
 function submitActionableItems(missingPrices: EditableMissingPrice[]) {
-  const total = missingPrices.length;
-  const filled = missingPrices.filter((missingPrice: EditableMissingPrice) => !!missingPrice.price).length;
-  set(totalMissingPrices, total);
-  set(filledMissingPrices, filled);
-  set(skippedMissingPrices, total - filled);
+  const { message, outcome, primaryAction, title, type } = promptFor(summarizeMissingPrices(missingPrices));
 
-  showFinishDialog();
+  show({ message, primaryAction, title, type }, () => {
+    if (outcome === 'regenerate')
+      regenerateReport();
+    else ignoreIssues();
+  });
 }
 
 function ignoreIssues() {

--- a/frontend/app/src/modules/reports/ReportGenerator.vue
+++ b/frontend/app/src/modules/reports/ReportGenerator.vue
@@ -2,12 +2,12 @@
 import type { RouteLocationRaw } from 'vue-router';
 import type { ProfitLossReportPeriod } from '@/modules/reports/report-types';
 import { startPromise } from '@shared/utils';
-import { useExchangeApi } from '@/modules/balances/api/use-exchange-api';
 import { useConnectedExchangesStore } from '@/modules/balances/exchanges/use-connected-exchanges-store';
 import { useTransactionStatusCheck } from '@/modules/dashboard/progress/use-transaction-status-check';
 import { useHistoryTransactions } from '@/modules/history/events/tx/use-history-transactions';
 import RangeSelector from '@/modules/reports/RangeSelector.vue';
 import ReportDebugMenu from '@/modules/reports/ReportDebugMenu.vue';
+import { useBinanceMarketCheck } from '@/modules/reports/use-binance-market-check';
 import CardTitle from '@/modules/shell/components/CardTitle.vue';
 import { useSyncProgress } from '@/modules/shell/sync-progress/use-sync-progress';
 
@@ -22,39 +22,18 @@ const { t } = useI18n({ useScope: 'global' });
 const { isOutOfSync, processing } = useTransactionStatusCheck();
 const { overallProgress } = useSyncProgress();
 const { refreshTransactions } = useHistoryTransactions();
-const { queryBinanceUserMarkets } = useExchangeApi();
 const { connectedExchanges } = storeToRefs(useConnectedExchangesStore());
+
+const {
+  checkMarketPairs,
+  exchangesWithoutMarkets: binanceExchangesWithoutMarkets,
+  hasExchangesWithoutMarkets: hasBinanceWithoutMarkets,
+} = useBinanceMarketCheck(connectedExchanges);
 
 const range = ref<{ start: number | undefined; end: number }>({ end: 0, start: undefined });
 const valid = ref<boolean>(false);
-const binanceExchangesWithoutMarkets = ref<string[]>([]);
-
-const hasBinanceWithoutMarkets = computed<boolean>(() => get(binanceExchangesWithoutMarkets).length > 0);
 
 const canGenerate = computed<boolean>(() => get(valid) && !get(processing) && !get(isOutOfSync) && !get(hasBinanceWithoutMarkets));
-
-async function checkBinanceMarketPairs(): Promise<void> {
-  const exchanges = get(connectedExchanges);
-  const binanceExchanges = exchanges.filter(
-    exchange => exchange.location === 'binance' || exchange.location === 'binanceus',
-  );
-
-  const exchangesWithoutMarkets: string[] = [];
-
-  for (const exchange of binanceExchanges) {
-    try {
-      const markets = await queryBinanceUserMarkets(exchange.name, exchange.location);
-      if (!markets || markets.length === 0)
-        exchangesWithoutMarkets.push(exchange.name);
-    }
-    catch {
-      // If we can't fetch markets, assume they're not set
-      exchangesWithoutMarkets.push(exchange.name);
-    }
-  }
-
-  set(binanceExchangesWithoutMarkets, exchangesWithoutMarkets);
-}
 
 function toReportPeriod(): ProfitLossReportPeriod {
   const { end, start } = get(range);
@@ -81,7 +60,7 @@ const accountSettingsRoute: RouteLocationRaw = { name: '/settings/accounting/' }
 const exchangeSettingsRoute: RouteLocationRaw = { name: '/api-keys/exchanges/' };
 
 onMounted(async () => {
-  await checkBinanceMarketPairs();
+  await checkMarketPairs();
 });
 </script>
 

--- a/frontend/app/src/modules/reports/ReportMissingAcquisitions.vue
+++ b/frontend/app/src/modules/reports/ReportMissingAcquisitions.vue
@@ -1,26 +1,15 @@
 <script setup lang="ts">
 import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
 import type { MissingAcquisition } from '@/modules/reports/report-types';
-import { assert, type BigNumber } from '@rotki/common';
 import { ValueDisplay } from '@/modules/assets/amount-display/components';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import { useIgnoredAssetOperations } from '@/modules/assets/use-ignored-asset-operations';
-import { bigNumberSum } from '@/modules/core/common/data/calculation';
 import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
+import { type GroupedMissingAcquisition, groupMissingAcquisitions } from '@/modules/reports/missing-acquisitions';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
-
-type GroupedItems = Record<string, MissingAcquisition[]>;
-
-interface MappedGroupedItems {
-  asset: string;
-  startDate: number;
-  endDate: number;
-  totalAmountMissing: BigNumber;
-  acquisitions: MissingAcquisition[];
-}
 
 const { items, isPinned } = defineProps<{
   items: MissingAcquisition[];
@@ -39,36 +28,11 @@ const router = useRouter();
 const { ignoreAsset } = useIgnoredAssetOperations();
 const { isAssetIgnored } = useAssetsStore();
 
-const groupedMissingAcquisitions = computed<MappedGroupedItems[]>(() => {
-  const grouped: GroupedItems = {};
+const groupedMissingAcquisitions = computed<GroupedMissingAcquisition[]>(() => groupMissingAcquisitions(items));
 
-  items.forEach((item: MissingAcquisition) => {
-    if (grouped[item.asset])
-      grouped[item.asset].push(item);
-    else grouped[item.asset] = [item];
-  });
+const expanded = ref<GroupedMissingAcquisition[]>([]);
 
-  return Object.keys(grouped).map((key) => {
-    const sortedAcquisitions = grouped[key].sort((a, b) => a.time - b.time);
-    const startDate = sortedAcquisitions[0].time;
-    const endDate = sortedAcquisitions.at(-1)?.time;
-    assert(endDate, 'end date is missing');
-
-    const totalAmountMissing = bigNumberSum(sortedAcquisitions.map(({ missingAmount }) => missingAmount));
-
-    return {
-      acquisitions: sortedAcquisitions,
-      asset: key,
-      endDate,
-      startDate,
-      totalAmountMissing,
-    };
-  });
-});
-
-const expanded = ref<MappedGroupedItems[]>([]);
-
-const sort = ref<DataTableSortData<MappedGroupedItems>>([]);
+const sort = ref<DataTableSortData<GroupedMissingAcquisition>>([]);
 const childSort = ref<DataTableSortData<MissingAcquisition>>({
   column: 'time',
   direction: 'asc' as const,
@@ -76,7 +40,7 @@ const childSort = ref<DataTableSortData<MissingAcquisition>>({
 
 const { t } = useI18n({ useScope: 'global' });
 
-const headers = computed<DataTableColumn<MappedGroupedItems>[]>(() => [{
+const headers = computed<DataTableColumn<GroupedMissingAcquisition>[]>(() => [{
   cellClass: '!py-0 !pr-0 !pl-3',
   class: '!py-0 !pr-0 !pl-3',
   key: 'expand',
@@ -102,7 +66,7 @@ const headers = computed<DataTableColumn<MappedGroupedItems>[]>(() => [{
       label: t('profit_loss_report.actionable.missing_acquisitions.headers.missing_acquisitions'),
       sortable: true,
     },
-  ] satisfies DataTableColumn<MappedGroupedItems>[]), {
+  ] satisfies DataTableColumn<GroupedMissingAcquisition>[]), {
   align: 'end',
   key: 'total_amount_missing',
   label: t('profit_loss_report.actionable.missing_acquisitions.headers.total_missing'),
@@ -132,12 +96,12 @@ const childHeaders = computed<DataTableColumn<MissingAcquisition>[]>(() => [{
   sortable: true,
 }]);
 
-useRememberTableSorting<MappedGroupedItems>(TableId.REPORT_MISSING_ACQUISITIONS, sort, headers);
+useRememberTableSorting<GroupedMissingAcquisition>(TableId.REPORT_MISSING_ACQUISITIONS, sort, headers);
 useRememberTableSorting<MissingAcquisition>(TableId.REPORT_MISSING_ACQUISITIONS_DETAIL, childSort, childHeaders);
 
 const isIgnored = (asset: string): boolean => isAssetIgnored(asset);
 
-const [CreateDate, ReuseDate] = createReusableTemplate<{ row: MappedGroupedItems }>();
+const [CreateDate, ReuseDate] = createReusableTemplate<{ row: GroupedMissingAcquisition }>();
 
 async function showInHistoryEvent(identifier: number) {
   emit('pin');

--- a/frontend/app/src/modules/reports/missing-acquisitions.spec.ts
+++ b/frontend/app/src/modules/reports/missing-acquisitions.spec.ts
@@ -1,0 +1,99 @@
+import type { MissingAcquisition } from '@/modules/reports/report-types';
+import { bigNumberify, Zero } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { groupMissingAcquisitions } from '@/modules/reports/missing-acquisitions';
+
+function acquisition(asset: string, time: number, missingAmount = '1'): MissingAcquisition {
+  return {
+    asset,
+    foundAmount: Zero,
+    missingAmount: bigNumberify(missingAmount),
+    time,
+  };
+}
+
+describe('groupMissingAcquisitions', () => {
+  it('should return nothing for an empty report', () => {
+    expect(groupMissingAcquisitions([])).toEqual([]);
+  });
+
+  it('should collapse every gap in one asset into a single row', () => {
+    const grouped = groupMissingAcquisitions([
+      acquisition('ETH', 10),
+      acquisition('ETH', 20),
+      acquisition('ETH', 30),
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].acquisitions).toHaveLength(3);
+  });
+
+  it('should keep the assets apart', () => {
+    const grouped = groupMissingAcquisitions([
+      acquisition('ETH', 10),
+      acquisition('BTC', 20),
+      acquisition('ETH', 30),
+    ]);
+
+    expect(grouped.map(row => row.asset)).toEqual(['ETH', 'BTC']);
+    expect(grouped[0].acquisitions).toHaveLength(2);
+    expect(grouped[1].acquisitions).toHaveLength(1);
+  });
+
+  it('should order the rows by the asset first seen', () => {
+    const grouped = groupMissingAcquisitions([acquisition('BTC', 30), acquisition('ETH', 10)]);
+
+    expect(grouped.map(row => row.asset)).toEqual(['BTC', 'ETH']);
+  });
+
+  describe('the period a row spans', () => {
+    it('should read the bounds from the oldest and newest gap', () => {
+      const grouped = groupMissingAcquisitions([
+        acquisition('ETH', 30),
+        acquisition('ETH', 10),
+        acquisition('ETH', 20),
+      ]);
+
+      expect(grouped[0].startDate).toBe(10);
+      expect(grouped[0].endDate).toBe(30);
+    });
+
+    it('should give a single gap the same start and end', () => {
+      const grouped = groupMissingAcquisitions([acquisition('ETH', 42)]);
+
+      expect(grouped[0].startDate).toBe(42);
+      expect(grouped[0].endDate).toBe(42);
+    });
+
+    it('should order the acquisitions oldest first whatever order they arrived in', () => {
+      const grouped = groupMissingAcquisitions([
+        acquisition('ETH', 30),
+        acquisition('ETH', 10),
+        acquisition('ETH', 20),
+      ]);
+
+      expect(grouped[0].acquisitions.map(item => item.time)).toEqual([10, 20, 30]);
+    });
+  });
+
+  describe('the amount a row is missing', () => {
+    it('should add up every gap in the asset', () => {
+      const grouped = groupMissingAcquisitions([
+        acquisition('ETH', 10, '1.5'),
+        acquisition('ETH', 20, '2.25'),
+      ]);
+
+      expect(grouped[0].totalAmountMissing.toString()).toBe('3.75');
+    });
+
+    it('should not mix the assets together', () => {
+      const grouped = groupMissingAcquisitions([
+        acquisition('ETH', 10, '1'),
+        acquisition('BTC', 20, '5'),
+      ]);
+
+      expect(grouped[0].totalAmountMissing.toString()).toBe('1');
+      expect(grouped[1].totalAmountMissing.toString()).toBe('5');
+    });
+  });
+});

--- a/frontend/app/src/modules/reports/missing-acquisitions.ts
+++ b/frontend/app/src/modules/reports/missing-acquisitions.ts
@@ -1,0 +1,47 @@
+import type { MissingAcquisition } from '@/modules/reports/report-types';
+import { assert, type BigNumber } from '@rotki/common';
+import { bigNumberSum } from '@/modules/core/common/data/calculation';
+
+/** One asset's missing acquisitions, collapsed into the row the table shows. */
+export interface GroupedMissingAcquisition {
+  readonly asset: string;
+  readonly startDate: number;
+  readonly endDate: number;
+  readonly totalAmountMissing: BigNumber;
+  readonly acquisitions: MissingAcquisition[];
+}
+
+/**
+ * Collapses the report's missing acquisitions into one row per asset.
+ *
+ * @remarks
+ * Each row carries the period the gaps span and how much is missing across all of them, so the
+ * table can be read without expanding it. The acquisitions within a row are ordered oldest first,
+ * which is what makes the first and last of them the period's bounds.
+ *
+ * @param items - every missing acquisition the report reported, in any order
+ * @returns one row per asset, in the order the assets first appear
+ */
+export function groupMissingAcquisitions(items: MissingAcquisition[]): GroupedMissingAcquisition[] {
+  const grouped: Record<string, MissingAcquisition[]> = {};
+
+  for (const item of items) {
+    if (grouped[item.asset])
+      grouped[item.asset].push(item);
+    else grouped[item.asset] = [item];
+  }
+
+  return Object.keys(grouped).map((asset) => {
+    const acquisitions = grouped[asset].sort((a, b) => a.time - b.time);
+    const endDate = acquisitions.at(-1)?.time;
+    assert(endDate, 'end date is missing');
+
+    return {
+      acquisitions,
+      asset,
+      endDate,
+      startDate: acquisitions[0].time,
+      totalAmountMissing: bigNumberSum(acquisitions.map(({ missingAmount }) => missingAmount)),
+    };
+  });
+}

--- a/frontend/app/src/modules/reports/use-binance-market-check.spec.ts
+++ b/frontend/app/src/modules/reports/use-binance-market-check.spec.ts
@@ -1,0 +1,153 @@
+import type { Exchange } from '@/modules/balances/types/exchanges';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBinanceMarketCheck } from '@/modules/reports/use-binance-market-check';
+
+const queryBinanceUserMarkets = vi.fn<(name: string, location: string) => Promise<string[]>>();
+
+vi.mock('@/modules/balances/api/use-exchange-api', () => ({
+  useExchangeApi: (): { queryBinanceUserMarkets: typeof queryBinanceUserMarkets } => ({
+    queryBinanceUserMarkets,
+  }),
+}));
+
+function exchange(name: string, location: string): Exchange {
+  return { location, name };
+}
+
+describe('useBinanceMarketCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryBinanceUserMarkets.mockResolvedValue(['ETHEUR']);
+  });
+
+  describe('which exchanges it asks about', () => {
+    it('should ask about both binance flavours', async () => {
+      const { checkMarketPairs } = useBinanceMarketCheck([
+        exchange('Binance 1', 'binance'),
+        exchange('Binance US 1', 'binanceus'),
+      ]);
+
+      await checkMarketPairs();
+
+      expect(queryBinanceUserMarkets).toHaveBeenCalledWith('Binance 1', 'binance');
+      expect(queryBinanceUserMarkets).toHaveBeenCalledWith('Binance US 1', 'binanceus');
+    });
+
+    it('should leave every other exchange alone', async () => {
+      const { checkMarketPairs } = useBinanceMarketCheck([
+        exchange('Kraken 1', 'kraken'),
+        exchange('Coinbase 1', 'coinbase'),
+      ]);
+
+      await checkMarketPairs();
+
+      expect(queryBinanceUserMarkets).not.toHaveBeenCalled();
+    });
+
+    it('should ask about nothing when no exchange is connected', async () => {
+      const { checkMarketPairs, hasExchangesWithoutMarkets } = useBinanceMarketCheck([]);
+
+      await checkMarketPairs();
+
+      expect(queryBinanceUserMarkets).not.toHaveBeenCalled();
+      expect(get(hasExchangesWithoutMarkets)).toBe(false);
+    });
+  });
+
+  describe('what counts as missing its pairs', () => {
+    it('should accept an exchange that has pairs', async () => {
+      const { checkMarketPairs, exchangesWithoutMarkets } = useBinanceMarketCheck([
+        exchange('Binance 1', 'binance'),
+      ]);
+
+      await checkMarketPairs();
+
+      expect(get(exchangesWithoutMarkets)).toEqual([]);
+    });
+
+    it('should flag an exchange with an empty pair list', async () => {
+      queryBinanceUserMarkets.mockResolvedValue([]);
+      const { checkMarketPairs, exchangesWithoutMarkets } = useBinanceMarketCheck([
+        exchange('Binance 1', 'binance'),
+      ]);
+
+      await checkMarketPairs();
+
+      expect(get(exchangesWithoutMarkets)).toEqual(['Binance 1']);
+    });
+
+    /**
+     * The check exists to stop a report being generated from incomplete data, so failing to prove
+     * the pairs are there has to be treated the same as their absence.
+     */
+    it('should flag an exchange whose pairs could not be read', async () => {
+      queryBinanceUserMarkets.mockRejectedValue(new Error('network'));
+      const { checkMarketPairs, exchangesWithoutMarkets } = useBinanceMarketCheck([
+        exchange('Binance 1', 'binance'),
+      ]);
+
+      await checkMarketPairs();
+
+      expect(get(exchangesWithoutMarkets)).toEqual(['Binance 1']);
+    });
+
+    it('should flag only the exchange that is missing them', async () => {
+      queryBinanceUserMarkets.mockImplementation(async name =>
+        name === 'Binance 1' ? [] : ['ETHEUR'],
+      );
+      const { checkMarketPairs, exchangesWithoutMarkets } = useBinanceMarketCheck([
+        exchange('Binance 1', 'binance'),
+        exchange('Binance 2', 'binance'),
+      ]);
+
+      await checkMarketPairs();
+
+      expect(get(exchangesWithoutMarkets)).toEqual(['Binance 1']);
+    });
+
+    it('should not let one failure hide another exchange', async () => {
+      queryBinanceUserMarkets.mockRejectedValue(new Error('network'));
+      const { checkMarketPairs, exchangesWithoutMarkets } = useBinanceMarketCheck([
+        exchange('Binance 1', 'binance'),
+        exchange('Binance 2', 'binance'),
+      ]);
+
+      await checkMarketPairs();
+
+      expect(get(exchangesWithoutMarkets)).toEqual(['Binance 1', 'Binance 2']);
+    });
+  });
+
+  describe('re-reading', () => {
+    it('should clear an earlier complaint once the pairs are selected', async () => {
+      queryBinanceUserMarkets.mockResolvedValue([]);
+      const { checkMarketPairs, hasExchangesWithoutMarkets } = useBinanceMarketCheck([
+        exchange('Binance 1', 'binance'),
+      ]);
+
+      await checkMarketPairs();
+
+      expect(get(hasExchangesWithoutMarkets)).toBe(true);
+
+      queryBinanceUserMarkets.mockResolvedValue(['ETHEUR']);
+      await checkMarketPairs();
+
+      expect(get(hasExchangesWithoutMarkets)).toBe(false);
+    });
+
+    it('should follow a changing list of connected exchanges', async () => {
+      queryBinanceUserMarkets.mockResolvedValue([]);
+      const exchanges = ref<Exchange[]>([]);
+      const { checkMarketPairs, exchangesWithoutMarkets } = useBinanceMarketCheck(exchanges);
+
+      await checkMarketPairs();
+
+      expect(get(exchangesWithoutMarkets)).toEqual([]);
+
+      set(exchanges, [exchange('Binance 1', 'binance')]);
+      await checkMarketPairs();
+
+      expect(get(exchangesWithoutMarkets)).toEqual(['Binance 1']);
+    });
+  });
+});

--- a/frontend/app/src/modules/reports/use-binance-market-check.ts
+++ b/frontend/app/src/modules/reports/use-binance-market-check.ts
@@ -1,0 +1,64 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { Exchange } from '@/modules/balances/types/exchanges';
+import { useExchangeApi } from '@/modules/balances/api/use-exchange-api';
+
+/** The two binance connections that need their traded pairs selected before a report is accurate. */
+const BINANCE_LOCATIONS: readonly string[] = ['binance', 'binanceus'];
+
+interface UseBinanceMarketCheckReturn {
+  /** The names of the connected binance accounts with no market pairs selected. */
+  exchangesWithoutMarkets: Readonly<Ref<readonly string[]>>;
+  /** Whether any connected binance account is still missing its pairs. */
+  hasExchangesWithoutMarkets: ComputedRef<boolean>;
+  /** Re-reads every connected binance account's pairs. */
+  checkMarketPairs: () => Promise<void>;
+}
+
+/**
+ * Which connected binance accounts have no traded pairs selected, since a report generated
+ * without them silently misses those trades.
+ *
+ * @remarks
+ * An account whose pairs cannot be read counts as missing them. The check exists to stop a report
+ * being generated from incomplete data, so failing to prove the pairs are there is treated the
+ * same as their absence rather than waved through.
+ *
+ * @param connectedExchanges - every exchange the user has connected, binance or not
+ * @returns the accounts missing their pairs and the way to re-read them
+ */
+export function useBinanceMarketCheck(
+  connectedExchanges: MaybeRefOrGetter<Exchange[]>,
+): UseBinanceMarketCheckReturn {
+  const { queryBinanceUserMarkets } = useExchangeApi();
+
+  const exchangesWithoutMarkets = ref<string[]>([]);
+
+  const hasExchangesWithoutMarkets = computed<boolean>(() => get(exchangesWithoutMarkets).length > 0);
+
+  async function hasMarkets(exchange: Exchange): Promise<boolean> {
+    try {
+      const markets = await queryBinanceUserMarkets(exchange.name, exchange.location);
+      return !!markets && markets.length > 0;
+    }
+    catch {
+      return false;
+    }
+  }
+
+  async function checkMarketPairs(): Promise<void> {
+    const binanceExchanges = toValue(connectedExchanges)
+      .filter(exchange => BINANCE_LOCATIONS.includes(exchange.location));
+
+    const checked = await Promise.all(
+      binanceExchanges.map(async exchange => ({ name: exchange.name, ok: await hasMarkets(exchange) })),
+    );
+
+    set(exchangesWithoutMarkets, checked.filter(({ ok }) => !ok).map(({ name }) => name));
+  }
+
+  return {
+    checkMarketPairs,
+    exchangesWithoutMarkets: readonly(exchangesWithoutMarkets),
+    hasExchangesWithoutMarkets,
+  };
+}

--- a/frontend/app/src/modules/reports/use-report-actionable-items.spec.ts
+++ b/frontend/app/src/modules/reports/use-report-actionable-items.spec.ts
@@ -1,0 +1,218 @@
+import type { Component } from 'vue';
+import type {
+  EditableMissingPrice,
+  MissingAcquisition,
+  MissingPrice,
+} from '@/modules/reports/report-types';
+import { One, Zero } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import {
+  summarizeMissingPrices,
+  useMissingPriceFinishPrompt,
+  useReportActionableStepper,
+} from '@/modules/reports/use-report-actionable-items';
+
+function missingPrice(price: string): EditableMissingPrice {
+  return {
+    fromAsset: 'ETH',
+    price,
+    saved: false,
+    time: 1,
+    toAsset: 'EUR',
+    useRefreshedHistoricalPrice: false,
+  };
+}
+
+function acquisitions(count: number): MissingAcquisition[] {
+  return Array.from({ length: count }, (_, index) => ({
+    asset: 'ETH',
+    foundAmount: Zero,
+    missingAmount: One,
+    originatingEventId: index,
+    time: index,
+  }));
+}
+
+function prices(count: number): MissingPrice[] {
+  return Array.from({ length: count }, (_, index) => ({
+    fromAsset: 'ETH',
+    time: index,
+    toAsset: 'EUR',
+  }));
+}
+
+const selectors: Record<'missingAcquisitions' | 'missingPrices', Component> = {
+  missingAcquisitions: { name: 'MissingAcquisitionsStub', template: '<div />' },
+  missingPrices: { name: 'MissingPricesStub', template: '<div />' },
+};
+
+describe('summarizeMissingPrices', () => {
+  it('should count a price the user entered as filled', () => {
+    expect(summarizeMissingPrices([missingPrice('100'), missingPrice('200')])).toEqual({
+      filled: 2,
+      skipped: 0,
+      total: 2,
+    });
+  });
+
+  it('should count an empty price as skipped', () => {
+    expect(summarizeMissingPrices([missingPrice('100'), missingPrice('')])).toEqual({
+      filled: 1,
+      skipped: 1,
+      total: 2,
+    });
+  });
+
+  /** The price is the text of a field, so "0" is something the user typed rather than a blank. */
+  it('should count a zero price as filled', () => {
+    expect(summarizeMissingPrices([missingPrice('0')])).toEqual({ filled: 1, skipped: 0, total: 1 });
+  });
+
+  it('should summarize an empty list', () => {
+    expect(summarizeMissingPrices([])).toEqual({ filled: 0, skipped: 0, total: 0 });
+  });
+});
+
+describe('useMissingPriceFinishPrompt', () => {
+  it('should offer to regenerate when every price was filled', () => {
+    const { promptFor } = useMissingPriceFinishPrompt();
+
+    const prompt = promptFor({ filled: 3, skipped: 0, total: 3 });
+
+    expect(prompt.type).toBe('success');
+    expect(prompt.outcome).toBe('regenerate');
+    expect(prompt.title).toBe('profit_loss_report.actionable.missing_prices.all_prices_filled');
+  });
+
+  it('should warn but still offer to regenerate when some were skipped', () => {
+    const { promptFor } = useMissingPriceFinishPrompt();
+
+    const prompt = promptFor({ filled: 2, skipped: 1, total: 3 });
+
+    expect(prompt.type).toBe('warning');
+    expect(prompt.outcome).toBe('regenerate');
+    expect(prompt.title).toBe('profit_loss_report.actionable.missing_prices.total_skipped_prices::1');
+  });
+
+  /**
+   * Regenerating a report that would come back identical is the wrong offer, so with nothing
+   * filled in the prompt asks to dismiss the issues instead.
+   */
+  it('should offer to ignore the issues when nothing was filled', () => {
+    const { promptFor } = useMissingPriceFinishPrompt();
+
+    const prompt = promptFor({ filled: 0, skipped: 3, total: 3 });
+
+    expect(prompt.type).toBe('warning');
+    expect(prompt.outcome).toBe('ignore');
+    expect(prompt.primaryAction).toBe('common.actions.yes');
+    expect(prompt.title).toBe('profit_loss_report.actionable.missing_prices.no_filled_prices');
+  });
+
+  it('should offer to ignore when there was nothing to fill in at all', () => {
+    const { promptFor } = useMissingPriceFinishPrompt();
+
+    expect(promptFor({ filled: 0, skipped: 0, total: 0 }).outcome).toBe('ignore');
+  });
+});
+
+describe('useReportActionableStepper', () => {
+  describe('counting what the report left', () => {
+    it('should count both kinds and their total', () => {
+      const { counts } = useReportActionableStepper(
+        { missingAcquisitions: acquisitions(2), missingPrices: prices(3) },
+        selectors,
+      );
+
+      expect(get(counts)).toEqual({ missingAcquisitionsLength: 2, missingPricesLength: 3, total: 5 });
+    });
+
+    it('should count nothing before a report has been generated', () => {
+      const { counts } = useReportActionableStepper(undefined, selectors);
+
+      expect(get(counts)).toEqual({ missingAcquisitionsLength: 0, missingPricesLength: 0, total: 0 });
+    });
+  });
+
+  describe('the steps it offers', () => {
+    it('should offer a step for each kind that has something to show', () => {
+      const { steps } = useReportActionableStepper(
+        { missingAcquisitions: acquisitions(1), missingPrices: prices(1) },
+        selectors,
+      );
+
+      expect(get(steps).map(step => step.key)).toEqual(['missingAcquisitions', 'missingPrices']);
+    });
+
+    it('should skip the acquisitions step when there are none', () => {
+      const { steps } = useReportActionableStepper(
+        { missingAcquisitions: [], missingPrices: prices(2) },
+        selectors,
+      );
+
+      expect(get(steps).map(step => step.key)).toEqual(['missingPrices']);
+    });
+
+    it('should skip the prices step when there are none', () => {
+      const { steps } = useReportActionableStepper(
+        { missingAcquisitions: acquisitions(2), missingPrices: [] },
+        selectors,
+      );
+
+      expect(get(steps).map(step => step.key)).toEqual(['missingAcquisitions']);
+    });
+
+    it('should offer no steps before a report has been generated', () => {
+      const { steps } = useReportActionableStepper(undefined, selectors);
+
+      expect(get(steps)).toEqual([]);
+    });
+
+    it('should give a step the items and the component that shows them', () => {
+      const missingPrices = prices(2);
+      const { steps } = useReportActionableStepper({ missingAcquisitions: [], missingPrices }, selectors);
+
+      expect(get(steps)[0]).toMatchObject({
+        items: missingPrices,
+        selector: selectors.missingPrices,
+      });
+    });
+  });
+
+  describe('which step is showing', () => {
+    it('should start on the first step', () => {
+      const { modelStep } = useReportActionableStepper(
+        { missingAcquisitions: acquisitions(1), missingPrices: prices(1) },
+        selectors,
+      );
+
+      expect(get(modelStep)).toBe(1);
+    });
+
+    it('should stay where it is put while both kinds have something', () => {
+      const { modelStep } = useReportActionableStepper(
+        { missingAcquisitions: acquisitions(1), missingPrices: prices(1) },
+        selectors,
+      );
+
+      set(modelStep, 2);
+
+      expect(get(modelStep)).toBe(2);
+    });
+
+    /**
+     * A second step that no longer exists would leave the stepper showing an empty panel, so the
+     * step comes back to the first as soon as one of the two kinds is emptied.
+     */
+    it('should return to the first step once only one kind is left', async () => {
+      const items = ref({ missingAcquisitions: acquisitions(1), missingPrices: prices(1) });
+      const { modelStep } = useReportActionableStepper(items, selectors);
+
+      set(modelStep, 2);
+      set(items, { missingAcquisitions: acquisitions(1), missingPrices: [] });
+      await nextTick();
+
+      expect(get(modelStep)).toBe(1);
+    });
+  });
+});

--- a/frontend/app/src/modules/reports/use-report-actionable-items.ts
+++ b/frontend/app/src/modules/reports/use-report-actionable-items.ts
@@ -1,0 +1,189 @@
+import type { Component, ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { DialogType } from '@/modules/core/common/dialogs';
+import type {
+  EditableMissingPrice,
+  MissingAcquisition,
+  MissingPrice,
+} from '@/modules/reports/report-types';
+import { toSentenceCase } from '@rotki/common';
+
+/** The two kinds of issue a report can leave for the user to act on. */
+export type ActionableStepKey = 'missingAcquisitions' | 'missingPrices';
+
+/** What the report left outstanding, absent until a report has been generated. */
+interface ActionableItems {
+  readonly missingAcquisitions: MissingAcquisition[];
+  readonly missingPrices: MissingPrice[];
+}
+
+interface ActionableCounts {
+  readonly missingAcquisitionsLength: number;
+  readonly missingPricesLength: number;
+  readonly total: number;
+}
+
+/** One step of the card, which is only present when it has something to show. */
+interface ActionableStep {
+  readonly key: ActionableStepKey;
+  readonly title: string;
+  readonly hint: string;
+  readonly selector: Component;
+  readonly items: MissingAcquisition[] | MissingPrice[];
+}
+
+interface UseReportActionableStepperReturn {
+  /** Which step is showing; the stepper's own controls move it. */
+  modelStep: Ref<number>;
+  /** How much of each kind the report left, which the header counts. */
+  counts: ComputedRef<ActionableCounts>;
+  /** The steps that have something to show, in order. */
+  steps: ComputedRef<ActionableStep[]>;
+}
+
+/** How the user left the missing prices they were asked to fill in. */
+export interface MissingPriceSummary {
+  readonly total: number;
+  readonly filled: number;
+  readonly skipped: number;
+}
+
+/** The confirmation shown after the prices were submitted, and what confirming it does. */
+export interface FinishPrompt {
+  readonly type: DialogType;
+  readonly title: string;
+  readonly message: string;
+  readonly primaryAction: string;
+  /** Regenerating is only worth offering when something was actually filled in. */
+  readonly outcome: 'regenerate' | 'ignore';
+}
+
+/**
+ * Counts how the missing prices were left, since what the confirmation says depends on it.
+ *
+ * @param missingPrices - the rows as the form last had them
+ * @returns how many there were, how many carry a price, and how many were skipped
+ */
+export function summarizeMissingPrices(missingPrices: EditableMissingPrice[]): MissingPriceSummary {
+  const total = missingPrices.length;
+  const filled = missingPrices.filter(missingPrice => !!missingPrice.price).length;
+  return { filled, skipped: total - filled, total };
+}
+
+/**
+ * The confirmation the card shows once the missing prices are submitted.
+ *
+ * @returns the prompt for a given summary
+ */
+export function useMissingPriceFinishPrompt(): { promptFor: (summary: MissingPriceSummary) => FinishPrompt } {
+  const { t } = useI18n({ useScope: 'global' });
+
+  function promptFor(summary: MissingPriceSummary): FinishPrompt {
+    const nudge = t('profit_loss_report.actionable.missing_prices.regenerate_report_nudge');
+
+    if (summary.filled === 0) {
+      return {
+        message: t('profit_loss_report.actionable.missing_prices.skipped_all_events_confirmation'),
+        outcome: 'ignore',
+        primaryAction: t('common.actions.yes'),
+        title: t('profit_loss_report.actionable.missing_prices.no_filled_prices'),
+        type: 'warning',
+      };
+    }
+
+    const regenerate = {
+      outcome: 'regenerate',
+      primaryAction: t('profit_loss_report.actionable.actions.regenerate_report'),
+    } as const;
+
+    if (summary.skipped > 0) {
+      return {
+        ...regenerate,
+        message: `${t('profit_loss_report.actionable.missing_prices.if_sure')} ${nudge}`,
+        title: t('profit_loss_report.actionable.missing_prices.total_skipped_prices', {
+          total: summary.skipped,
+        }),
+        type: 'warning',
+      };
+    }
+
+    return {
+      ...regenerate,
+      message: toSentenceCase(nudge),
+      title: t('profit_loss_report.actionable.missing_prices.all_prices_filled'),
+      type: 'success',
+    };
+  }
+
+  return { promptFor };
+}
+
+/**
+ * The card's steps: one per kind of issue the report left, skipping a kind with nothing in it.
+ *
+ * @remarks
+ * The step returns to the first whenever only one kind is left, so a stepper standing on a second
+ * step that no longer exists does not show an empty panel.
+ *
+ * @param actionableItems - what the report left outstanding
+ * @param selectors - the component each kind is shown with
+ * @returns the current step, the counts and the steps to render
+ */
+export function useReportActionableStepper(
+  actionableItems: MaybeRefOrGetter<ActionableItems | undefined>,
+  selectors: Record<ActionableStepKey, Component>,
+): UseReportActionableStepperReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const modelStep = shallowRef<number>(1);
+
+  const counts = computed<ActionableCounts>(() => {
+    const items = toValue(actionableItems);
+    const missingAcquisitionsLength = items?.missingAcquisitions.length ?? 0;
+    const missingPricesLength = items?.missingPrices.length ?? 0;
+
+    return {
+      missingAcquisitionsLength,
+      missingPricesLength,
+      total: missingAcquisitionsLength + missingPricesLength,
+    };
+  });
+
+  const steps = computed<ActionableStep[]>(() => {
+    const items = toValue(actionableItems);
+    const { missingAcquisitionsLength, missingPricesLength } = get(counts);
+    const contents: ActionableStep[] = [];
+
+    if (items && missingAcquisitionsLength > 0) {
+      contents.push({
+        hint: t('profit_loss_report.actionable.missing_acquisitions.hint'),
+        items: items.missingAcquisitions,
+        key: 'missingAcquisitions',
+        selector: selectors.missingAcquisitions,
+        title: t('profit_loss_report.actionable.missing_acquisitions.title', {
+          total: missingAcquisitionsLength,
+        }),
+      });
+    }
+
+    if (items && missingPricesLength > 0) {
+      contents.push({
+        hint: t('profit_loss_report.actionable.missing_prices.hint'),
+        items: items.missingPrices,
+        key: 'missingPrices',
+        selector: selectors.missingPrices,
+        title: t('profit_loss_report.actionable.missing_prices.title', {
+          total: missingPricesLength,
+        }),
+      });
+    }
+
+    return contents;
+  });
+
+  watchImmediate(counts, ({ missingAcquisitionsLength, missingPricesLength }) => {
+    if (!missingAcquisitionsLength || !missingPricesLength)
+      set(modelStep, 1);
+  });
+
+  return { counts, modelStep, steps };
+}

--- a/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-maintenance.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-maintenance.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue';
 import type { AccountingRuleEntry } from '@/modules/settings/types/accounting';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
-import { useMessageStore } from '@/modules/core/common/use-message-store';
+import { useTableRowDeletion } from '@/modules/core/table/use-table-row-deletion';
 import { useAccountingSettings } from '@/modules/settings/accounting/use-accounting-settings';
 import { useAccountingApi } from '@/modules/settings/api/use-accounting-api';
 import { ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
@@ -37,37 +37,26 @@ export function useAccountingRuleMaintenance(
 
   const { t } = useI18n({ useScope: 'global' });
   const { show } = useConfirmStore();
-  const { setMessage } = useMessageStore();
   const { useIsActive } = useTaskCenter();
   const { exportJSON, resetToDefaults } = useAccountingSettings();
   const { deleteAccountingRule } = useAccountingApi();
 
   const modelImportDialogOpen = shallowRef<boolean>(false);
 
-  async function deleteRule(item: AccountingRuleEntry): Promise<void> {
-    try {
-      const success = await deleteAccountingRule(item.identifier);
-      if (success)
-        await refetch();
-    }
-    catch {
-      setMessage({
-        description: t('accounting_settings.rule.delete_error'),
-      });
-    }
-  }
+  const { showDeleteConfirmation: confirmDelete } = useTableRowDeletion<AccountingRuleEntry>({
+    confirm: () => ({
+      message: t('accounting_settings.rule.confirm_delete'),
+      title: t('accounting_settings.rule.delete'),
+    }),
+    deleteItem: async item => deleteAccountingRule(item.identifier),
+    errorMessage: () => ({ description: t('accounting_settings.rule.delete_error') }),
+    onDeleted: refetch,
+  });
 
   async function resetRulesToDefaults(): Promise<void> {
     const result = await resetToDefaults();
     if (result?.success)
       await refresh();
-  }
-
-  function confirmDelete(item: AccountingRuleEntry): void {
-    show({
-      message: t('accounting_settings.rule.confirm_delete'),
-      title: t('accounting_settings.rule.delete'),
-    }, async () => deleteRule(item));
   }
 
   function confirmReset(): void {

--- a/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-rendering.spec.ts
+++ b/frontend/app/src/modules/settings/api-keys/exchange/exchange-keys-rendering.spec.ts
@@ -63,6 +63,10 @@ describe('settings/api-keys/exchange rendering', () => {
       global: {
         plugins: [pinia],
         stubs: {
+          /* Both binance children query the backend from `onMounted`, and this spec only asks
+             whether they are rendered, so stubbing them keeps the suite off the network. */
+          BinanceHistoryStartDate: true,
+          BinancePairsSelector: true,
           ExchangeInput: true,
           I18nT: { template: '<span><slot name="csvImport" /></span>' },
           // `InternalLink` renders a `RouterLink` with a scoped slot, which needs a real router.

--- a/frontend/app/src/modules/settings/general/nft/NftImageRenderingSetting.vue
+++ b/frontend/app/src/modules/settings/general/nft/NftImageRenderingSetting.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { isEqual } from 'es-toolkit';
-import { uniqueStrings } from '@/modules/core/common/data/data';
-import { getDomain } from '@/modules/core/common/helpers/url';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import {
+  hasWhitelistChanges,
+  mergeWhitelist,
+  parseWhitelistInput,
+} from '@/modules/settings/general/nft/nft-whitelist';
 import { useClearableMessages } from '@/modules/settings/use-clearable-messages';
 import { useSettingModel } from '@/modules/settings/use-setting-model';
 import ConfirmDialog from '@/modules/shell/components/dialogs/ConfirmDialog.vue';
@@ -26,18 +28,15 @@ const renderAllNftImages = ref<RenderOption>(get(renderAllModel) ? 'all' : 'whit
 const whitelistedDomains = ref('');
 const showUpdateWhitelistConfirmation = ref(false);
 
-const decodedDomains = computed<string[]>(() =>
-  get(whitelistedDomains)
-    .split(',')
-    .filter(value => !!value)
-    .map(val => getDomain(val.trim())),
-);
+const decodedDomains = computed<string[]>(() => parseWhitelistInput(get(whitelistedDomains)));
 
 const whitelistedDomainsForNftImages = computed<string[]>(() =>
-  [...get(whitelistModel), ...get(decodedDomains)].filter(uniqueStrings),
+  mergeWhitelist(get(whitelistModel), get(decodedDomains)),
 );
 
-const changed = computed(() => !isEqual(get(whitelistedDomainsForNftImages), get(whitelistModel)));
+const changed = computed<boolean>(() =>
+  hasWhitelistChanges(get(whitelistModel), get(whitelistedDomainsForNftImages)),
+);
 
 function updateRenderingSetting(value: RenderOption | undefined): void {
   clearRenderMessages();

--- a/frontend/app/src/modules/settings/general/nft/nft-whitelist.spec.ts
+++ b/frontend/app/src/modules/settings/general/nft/nft-whitelist.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasWhitelistChanges,
+  mergeWhitelist,
+  parseWhitelistInput,
+} from '@/modules/settings/general/nft/nft-whitelist';
+
+describe('parseWhitelistInput', () => {
+  it('should read a bare domain', () => {
+    expect(parseWhitelistInput('opensea.io')).toEqual(['opensea.io']);
+  });
+
+  it('should read several domains from one comma separated list', () => {
+    expect(parseWhitelistInput('opensea.io,rarible.com')).toEqual(['opensea.io', 'rarible.com']);
+  });
+
+  it('should ignore the spaces around an entry', () => {
+    expect(parseWhitelistInput(' opensea.io , rarible.com ')).toEqual(['opensea.io', 'rarible.com']);
+  });
+
+  /** Pasting the url of an image should whitelist the host it came from, not the url. */
+  it('should reduce a full url to its domain', () => {
+    expect(parseWhitelistInput('https://images.opensea.io/some/nft.png')).toEqual(['opensea.io']);
+  });
+
+  it('should read nothing from an empty field', () => {
+    expect(parseWhitelistInput('')).toEqual([]);
+  });
+
+  it('should skip an empty entry left by a trailing comma', () => {
+    expect(parseWhitelistInput('opensea.io,')).toEqual(['opensea.io']);
+  });
+});
+
+describe('mergeWhitelist', () => {
+  it('should append what was typed to what is saved', () => {
+    expect(mergeWhitelist(['opensea.io'], ['rarible.com'])).toEqual(['opensea.io', 'rarible.com']);
+  });
+
+  it('should not add a domain that is already whitelisted', () => {
+    expect(mergeWhitelist(['opensea.io'], ['opensea.io'])).toEqual(['opensea.io']);
+  });
+
+  it('should add a repeated entry once', () => {
+    expect(mergeWhitelist([], ['opensea.io', 'opensea.io'])).toEqual(['opensea.io']);
+  });
+
+  it('should give back what is saved when nothing was typed', () => {
+    expect(mergeWhitelist(['opensea.io'], [])).toEqual(['opensea.io']);
+  });
+});
+
+describe('hasWhitelistChanges', () => {
+  it('should report a change when a domain was added', () => {
+    expect(hasWhitelistChanges(['opensea.io'], ['opensea.io', 'rarible.com'])).toBe(true);
+  });
+
+  /** Re-adding a domain already on the list is not something to offer a save for. */
+  it('should report no change when the typed domain is already saved', () => {
+    const saved = ['opensea.io'];
+
+    expect(hasWhitelistChanges(saved, mergeWhitelist(saved, parseWhitelistInput('opensea.io')))).toBe(false);
+  });
+
+  it('should report no change for an empty field', () => {
+    const saved = ['opensea.io'];
+
+    expect(hasWhitelistChanges(saved, mergeWhitelist(saved, parseWhitelistInput('')))).toBe(false);
+  });
+
+  it('should report a change when a domain was removed', () => {
+    expect(hasWhitelistChanges(['opensea.io', 'rarible.com'], ['opensea.io'])).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/settings/general/nft/nft-whitelist.ts
+++ b/frontend/app/src/modules/settings/general/nft/nft-whitelist.ts
@@ -1,0 +1,46 @@
+import { isEqual } from 'es-toolkit';
+import { uniqueStrings } from '@/modules/core/common/data/data';
+import { getDomain } from '@/modules/core/common/helpers/url';
+
+/**
+ * Reads the domains out of what the user typed into the field.
+ *
+ * @remarks
+ * The field takes a comma separated list, and each entry is reduced to its domain, so pasting a
+ * full url to an image adds the host it came from rather than the url itself.
+ *
+ * @param input - the raw field text
+ * @returns the domains it named, in the order they were typed
+ */
+export function parseWhitelistInput(input: string): string[] {
+  return input
+    .split(',')
+    .filter(value => !!value)
+    .map(value => getDomain(value.trim()));
+}
+
+/**
+ * The whitelist as it would be after adding what was typed.
+ *
+ * @remarks
+ * A domain already on the list is not added twice, which is what makes re-adding one a no-op
+ * rather than something to save.
+ *
+ * @param saved - the domains already whitelisted
+ * @param added - the domains the field named
+ * @returns the two lists merged, saved ones first
+ */
+export function mergeWhitelist(saved: string[], added: string[]): string[] {
+  return [...saved, ...added].filter(uniqueStrings);
+}
+
+/**
+ * Whether the merged list differs from what is saved, which is what offers the save.
+ *
+ * @param saved - the domains already whitelisted
+ * @param merged - the list after adding what was typed
+ * @returns whether there is anything to save
+ */
+export function hasWhitelistChanges(saved: string[], merged: string[]): boolean {
+  return !isEqual(merged, saved);
+}

--- a/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
@@ -2,10 +2,10 @@ import type { Blockchain } from '@rotki/common';
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import { camelCase } from 'es-toolkit';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { useTableRowDeletion } from '@/modules/core/table/use-table-row-deletion';
 import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
 import { useEvmNodesApi } from '@/modules/settings/api/use-evm-nodes-api';
 import { NODE_STATUS, type NodeStatus } from '@/modules/settings/general/rpc/rpc-node-status';
@@ -70,7 +70,6 @@ export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>)
   const { notify } = useNotificationDispatcher();
   const { setMessage } = useMessageStore();
   const { connectedNodes, coolingDownNodes, failedToConnect } = storeToRefs(useSessionMetadataStore());
-  const { show } = useConfirmStore();
   const { useChainName } = useSupportedChains();
   const api = useEvmNodesApi(() => toValue(chain));
 
@@ -133,21 +132,28 @@ export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>)
     });
   }
 
-  async function deleteNode(node: BlockchainRpcNode): Promise<void> {
-    try {
-      await api.deleteEvmNode(node.identifier);
-      await loadNodes();
-    }
-    catch (error: unknown) {
-      setMessage({
-        description: getErrorMessage(error),
-        success: false,
-        title: t('evm_rpc_node_manager.delete_error.title', {
-          chain: toValue(chain),
+  const { showDeleteConfirmation } = useTableRowDeletion<BlockchainRpcNode>({
+    confirm: (item) => {
+      const chainProp = get(chainName);
+      return {
+        message: t('evm_rpc_node_manager.confirm.message', {
+          chain: chainProp,
+          endpoint: item.endpoint,
+          node: item.name,
         }),
-      });
-    }
-  }
+        title: t('evm_rpc_node_manager.confirm.title', { chain: chainProp }),
+      };
+    },
+    deleteItem: async node => api.deleteEvmNode(node.identifier),
+    errorMessage: (_node, error) => ({
+      description: getErrorMessage(error),
+      success: false,
+      title: t('evm_rpc_node_manager.delete_error.title', {
+        chain: toValue(chain),
+      }),
+    }),
+    onDeleted: loadNodes,
+  });
 
   async function onActiveChange(active: boolean, node: BlockchainRpcNode): Promise<void> {
     try {
@@ -163,21 +169,6 @@ export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>)
         }),
       });
     }
-  }
-
-  function showDeleteConfirmation(item: BlockchainRpcNode): void {
-    const chainProp = get(chainName);
-    show(
-      {
-        message: t('evm_rpc_node_manager.confirm.message', {
-          chain: chainProp,
-          endpoint: item.endpoint,
-          node: item.name,
-        }),
-        title: t('evm_rpc_node_manager.confirm.title', { chain: chainProp }),
-      },
-      async () => deleteNode(item),
-    );
   }
 
   async function reConnect(identifier?: number): Promise<void> {

--- a/frontend/app/src/modules/shell/app/AssetConflictDialog.spec.ts
+++ b/frontend/app/src/modules/shell/app/AssetConflictDialog.spec.ts
@@ -1,0 +1,131 @@
+import type { SupportedAsset } from '@rotki/common';
+import type { AssetUpdateConflictResult } from '@/modules/assets/types';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import AssetConflictDialog from '@/modules/shell/app/AssetConflictDialog.vue';
+
+/**
+ * `BigDialog` teleports and owns the footer buttons, so a pass-through stands in for it: the slots
+ * render inline, and the two buttons stand for confirming and dismissing.
+ */
+const BigDialogStub = {
+  emits: ['confirm', 'cancel'],
+  name: 'BigDialog',
+  props: ['title', 'subtitle', 'display', 'action', 'layout', 'persistent'],
+  template: `<div>
+    <slot name="subtitle" />
+    <slot />
+    <slot name="left-buttons" />
+    <button data-testid="stub-confirm" @click="$emit('confirm')" />
+    <button data-testid="stub-cancel" @click="$emit('cancel')" />
+  </div>`,
+};
+
+function conflict(identifier: string): AssetUpdateConflictResult {
+  const asset: SupportedAsset = { identifier, isRebasing: false, name: identifier };
+  return { identifier, local: asset, remote: { ...asset, name: `${identifier} remote` } };
+}
+
+function createWrapper(conflicts: AssetUpdateConflictResult[]): VueWrapper<InstanceType<typeof AssetConflictDialog>> {
+  return mount(AssetConflictDialog, {
+    global: {
+      stubs: {
+        AssetConflictRow: true,
+        BigDialog: BigDialogStub,
+        // Globally stubbed to `true`, which would swallow the identifiers the warning names.
+        I18nT: { template: '<span><slot name="identifiers" /></span>' },
+        RuiDataTable: true,
+      },
+    },
+    props: {
+      conflicts,
+    },
+  });
+}
+
+describe('assetConflictDialog', () => {
+  describe('confirming', () => {
+    it('should keep the remote asset for every conflict by default', async () => {
+      const wrapper = createWrapper([conflict('eth'), conflict('btc')]);
+
+      await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+
+      expect(wrapper.emitted('resolve')?.[0]?.[0]).toEqual({ btc: 'remote', eth: 'remote' });
+    });
+
+    it('should let the dialog be confirmed once every conflict has a strategy', async () => {
+      const wrapper = createWrapper([conflict('eth')]);
+      await nextTick();
+
+      expect(wrapper.findComponent(BigDialogStub).props('action')).toMatchObject({ disabled: false });
+    });
+  });
+
+  /**
+   * Dismissing the two bulk choices is not abandoning the update: the user is choosing to keep
+   * what they have, so the dialog resolves as local rather than emitting a cancel that would
+   * leave the conflicts unanswered.
+   */
+  describe('dismissing', () => {
+    it('should keep the local asset when the bulk choices are dismissed', async () => {
+      const wrapper = createWrapper([conflict('eth'), conflict('btc')]);
+
+      await wrapper.find('[data-testid=stub-cancel]').trigger('click');
+
+      expect(wrapper.emitted('resolve')?.[0]?.[0]).toEqual({ btc: 'local', eth: 'local' });
+      expect(wrapper.emitted('cancel')).toBeUndefined();
+    });
+
+    it('should abandon the update when dismissed while resolving by hand', async () => {
+      const wrapper = createWrapper([conflict('eth')]);
+
+      await wrapper.find('[data-testid=manage-conflicts]').trigger('click');
+      await wrapper.find('[data-testid=stub-cancel]').trigger('click');
+
+      expect(wrapper.emitted('cancel')).toHaveLength(1);
+      expect(wrapper.emitted('resolve')).toBeUndefined();
+    });
+  });
+
+  describe('resolving by hand', () => {
+    it('should offer the table only after the user asks to manage the conflicts', async () => {
+      const wrapper = createWrapper([conflict('eth')]);
+
+      expect(wrapper.findComponent({ name: 'RuiDataTable' }).exists()).toBe(false);
+
+      await wrapper.find('[data-testid=manage-conflicts]').trigger('click');
+
+      expect(wrapper.findComponent({ name: 'RuiDataTable' }).exists()).toBe(true);
+    });
+
+    it('should stop offering the bulk choices once the table is showing', async () => {
+      const wrapper = createWrapper([conflict('eth')]);
+
+      await wrapper.find('[data-testid=manage-conflicts]').trigger('click');
+
+      expect(wrapper.find('[data-testid=manage-conflicts]').exists()).toBe(false);
+      expect(wrapper.findComponent(BigDialogStub).props('action')).toMatchObject({
+        primary: undefined,
+        secondary: undefined,
+      });
+    });
+  });
+
+  describe('the duplicate warning', () => {
+    it('should name an identifier the update sent twice', () => {
+      const wrapper = createWrapper([conflict('eth'), conflict('eth'), conflict('btc')]);
+
+      const alert = wrapper.find('[data-testid=alert]');
+
+      expect(alert.exists()).toBe(true);
+      expect(alert.text()).toContain('eth');
+      expect(alert.text()).not.toContain('btc');
+    });
+
+    it('should not warn when every identifier is distinct', () => {
+      const wrapper = createWrapper([conflict('eth'), conflict('btc')]);
+
+      expect(wrapper.find('[data-testid=alert]').exists()).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/app/AssetConflictDialog.vue
+++ b/frontend/app/src/modules/shell/app/AssetConflictDialog.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import type { SupportedAsset, Writeable } from '@rotki/common';
 import type { DataTableColumn } from '@rotki/ui-library';
 import type { AssetUpdateConflictResult, ConflictResolution } from '@/modules/assets/types';
-import type { ConflictResolutionStrategy } from '@/modules/core/common/common-types';
-import { objectKeys } from '@/modules/core/common/data/array';
-import { uniqueObjects, uniqueStrings } from '@/modules/core/common/data/data';
 import AssetConflictRow from '@/modules/shell/app/AssetConflictRow.vue';
+import {
+  getConflictFields,
+  isDiff,
+  useAssetConflictResolution,
+} from '@/modules/shell/app/use-asset-conflict-resolution';
 import BigDialog from '@/modules/shell/components/dialogs/BigDialog.vue';
 
 const { conflicts } = defineProps<{
@@ -38,102 +39,33 @@ const tableHeaders = computed<DataTableColumn<AssetUpdateConflictResult>[]>(() =
   },
 ]);
 
-const manualResolution = ref(false);
-const resolution = ref<ConflictResolution>({});
-const strategyModeForAll = ref<ConflictResolutionStrategy>();
-const resolutionLength = computed(() => Object.keys(get(resolution)).length);
-const activeStrategyForAll = computed(() => {
-  if (conflicts.length === 0 || get(resolutionLength) !== conflicts.length)
-    return { local: false, remote: false };
+const {
+  activeStrategyForAll,
+  duplicateIdentifiers,
+  enableManualResolution,
+  hasResolution,
+  manualResolution,
+  modelResolution,
+  onStrategyChange,
+  remaining,
+  setResolution,
+  valid,
+  warnDuplicate,
+} = useAssetConflictResolution(() => conflicts);
 
-  const strategy = get(strategyModeForAll);
+function resolve(): void {
+  emit('resolve', get(modelResolution));
+}
 
-  return { local: strategy === 'local', remote: strategy === 'remote' };
-});
-
-function setResolution(strategy: ConflictResolutionStrategy) {
-  const length = conflicts.length;
-  const resolutionStrategy: Writeable<ConflictResolution> = {};
-  for (let i = 0; i < length; i++) {
-    const conflict = conflicts[i];
-    resolutionStrategy[conflict.identifier] = strategy;
+/** Dismissing the bulk choices keeps what the user already has, rather than abandoning the update. */
+function cancel(): void {
+  if (get(manualResolution)) {
+    emit('cancel');
+    return;
   }
 
-  set(resolution, resolutionStrategy);
-  set(strategyModeForAll, strategy);
-}
-
-function onStrategyChange(strategy?: ConflictResolutionStrategy) {
-  if (Object.values(get(resolution)).every(strat => strat === strategy))
-    set(strategyModeForAll, strategy);
-  else set(strategyModeForAll, undefined);
-}
-
-type AssetKey = keyof SupportedAsset;
-
-function getConflictFields(conflict: AssetUpdateConflictResult): AssetKey[] {
-  function nonNull(key: AssetKey, asset: SupportedAsset): boolean {
-    return asset[key] !== null;
-  }
-  const remote = objectKeys(conflict.remote).filter(key => nonNull(key, conflict.remote));
-  const local = objectKeys(conflict.local).filter(key => nonNull(key, conflict.local));
-  return [...remote, ...local].filter(uniqueStrings);
-}
-
-function isDiff(conflict: AssetUpdateConflictResult, field: AssetKey) {
-  const localElement = conflict.local[field];
-  const remoteElement = conflict.remote[field];
-  return localElement !== remoteElement;
-}
-
-const remaining = computed(() => {
-  const resolved = get(resolutionLength);
-  return uniqueObjects(conflicts, ({ identifier }) => identifier).length - resolved;
-});
-
-const warnDuplicate = computed<boolean>(() => {
-  const identifiers = conflicts
-    .map(({ identifier }) => identifier)
-    .sort();
-  const uniqueIdentifiers = identifiers.filter(uniqueStrings);
-  return identifiers.length > uniqueIdentifiers.length;
-});
-
-const duplicateIdentifiers = computed<string[]>(() =>
-  conflicts
-    .map(({ identifier }) => identifier)
-    .sort()
-    .filter((e, i, a) => a.indexOf(e) !== i),
-);
-
-const valid = computed<boolean>(() => {
-  const identifiers = conflicts
-    .map(({ identifier }) => identifier)
-    .filter(uniqueStrings)
-    .sort();
-
-  const resolved = Object.keys(get(resolution)).sort();
-  if (identifiers.length !== resolved.length)
-    return false;
-
-  for (const [i, element] of resolved.entries()) {
-    if (element !== identifiers[i])
-      return false;
-  }
-
-  return true;
-});
-
-function resolve() {
-  emit('resolve', get(resolution));
-}
-
-function cancel() {
-  if (!get(manualResolution)) {
-    setResolution('local');
-    return resolve();
-  }
-  emit('cancel');
+  setResolution('local');
+  resolve();
 }
 
 onMounted(() => {
@@ -150,7 +82,7 @@ onMounted(() => {
       secondary: !manualResolution ? t('conflict_dialog.keep_local') : undefined,
     }"
     :layout="{ autoHeight: !manualResolution, divide: true, maxWidth: '75rem' }"
-    :persistent="resolutionLength > 0"
+    :persistent="hasResolution"
     display
     @confirm="resolve()"
     @cancel="cancel()"
@@ -273,10 +205,10 @@ onMounted(() => {
           </template>
           <template #item.keep="{ row: conflict }">
             <RuiButtonGroup
-              v-model="resolution[conflict.identifier]"
+              v-model="modelResolution[conflict.identifier]"
               color="primary"
               variant="outlined"
-              @update:model-value="onStrategyChange(resolution[conflict.identifier])"
+              @update:model-value="onStrategyChange(modelResolution[conflict.identifier])"
             >
               <RuiButton model-value="local">
                 {{ t('conflict_dialog.action.local') }}
@@ -297,7 +229,7 @@ onMounted(() => {
         data-testid="manage-conflicts"
         color="primary"
         variant="text"
-        @click="manualResolution = true"
+        @click="enableManualResolution()"
       >
         {{ t('conflict_dialog.manage') }}
       </RuiButton>

--- a/frontend/app/src/modules/shell/app/use-asset-conflict-resolution.spec.ts
+++ b/frontend/app/src/modules/shell/app/use-asset-conflict-resolution.spec.ts
@@ -1,0 +1,237 @@
+import type { SupportedAsset } from '@rotki/common';
+import type { AssetUpdateConflictResult } from '@/modules/assets/types';
+import { describe, expect, it } from 'vitest';
+import {
+  getConflictFields,
+  isDiff,
+  useAssetConflictResolution,
+} from '@/modules/shell/app/use-asset-conflict-resolution';
+
+/**
+ * A real asset, not `createMock`: `getConflictFields` enumerates the keys, and a proxy answers
+ * every property, so a mock reports its own internals as fields of the asset.
+ */
+function asset(overrides: Partial<SupportedAsset>): SupportedAsset {
+  return { identifier: 'eth', isRebasing: false, ...overrides };
+}
+
+function conflict(identifier: string, local: Partial<SupportedAsset> = {}, remote: Partial<SupportedAsset> = {}): AssetUpdateConflictResult {
+  return {
+    identifier,
+    local: asset({ identifier, ...local }),
+    remote: asset({ identifier, ...remote }),
+  };
+}
+
+describe('useAssetConflictResolution', () => {
+  describe('resolving every conflict at once', () => {
+    it('should give every conflict the chosen strategy', () => {
+      const { modelResolution, setResolution } = useAssetConflictResolution([conflict('eth'), conflict('btc')]);
+
+      setResolution('remote');
+
+      expect(get(modelResolution)).toEqual({ btc: 'remote', eth: 'remote' });
+    });
+
+    it('should replace an earlier choice rather than merge into it', () => {
+      const { modelResolution, setResolution } = useAssetConflictResolution([conflict('eth')]);
+
+      setResolution('remote');
+      setResolution('local');
+
+      expect(get(modelResolution)).toEqual({ eth: 'local' });
+    });
+
+    it('should press the button for the strategy applied to all', () => {
+      const { activeStrategyForAll, setResolution } = useAssetConflictResolution([conflict('eth')]);
+
+      setResolution('local');
+
+      expect(get(activeStrategyForAll)).toEqual({ local: true, remote: false });
+    });
+
+    it('should press neither button before anything is chosen', () => {
+      const { activeStrategyForAll } = useAssetConflictResolution([conflict('eth')]);
+
+      expect(get(activeStrategyForAll)).toEqual({ local: false, remote: false });
+    });
+
+    it('should press neither button when a row was changed by hand', () => {
+      const { activeStrategyForAll, modelResolution, onStrategyChange, setResolution } = useAssetConflictResolution([
+        conflict('eth'),
+        conflict('btc'),
+      ]);
+
+      setResolution('remote');
+      set(modelResolution, { ...get(modelResolution), btc: 'local' });
+      onStrategyChange('local');
+
+      expect(get(activeStrategyForAll)).toEqual({ local: false, remote: false });
+    });
+
+    it('should press the button again once every row agrees', () => {
+      const { activeStrategyForAll, modelResolution, onStrategyChange } = useAssetConflictResolution([
+        conflict('eth'),
+        conflict('btc'),
+      ]);
+
+      set(modelResolution, { btc: 'local', eth: 'local' });
+      onStrategyChange('local');
+
+      expect(get(activeStrategyForAll)).toEqual({ local: true, remote: false });
+    });
+  });
+
+  describe('whether the dialog can be confirmed', () => {
+    it('should not be valid while a conflict is unresolved', () => {
+      const { modelResolution, valid } = useAssetConflictResolution([conflict('eth'), conflict('btc')]);
+
+      set(modelResolution, { eth: 'local' });
+
+      expect(get(valid)).toBe(false);
+    });
+
+    it('should be valid once every conflict has a strategy', () => {
+      const { setResolution, valid } = useAssetConflictResolution([conflict('eth'), conflict('btc')]);
+
+      setResolution('local');
+
+      expect(get(valid)).toBe(true);
+    });
+
+    /**
+     * The counts can match while the identifiers do not, which would send a resolution for an
+     * asset the update never reported and leave a real conflict unanswered.
+     */
+    it('should not be valid when a resolution names an asset that is not in conflict', () => {
+      const { modelResolution, valid } = useAssetConflictResolution([conflict('eth'), conflict('btc')]);
+
+      set(modelResolution, { btc: 'local', doge: 'local' });
+
+      expect(get(valid)).toBe(false);
+    });
+
+    it('should be valid with one resolution when the same asset conflicts twice', () => {
+      const { setResolution, valid } = useAssetConflictResolution([conflict('eth'), conflict('eth')]);
+
+      setResolution('local');
+
+      expect(get(valid)).toBe(true);
+    });
+  });
+
+  describe('what is left to do', () => {
+    it('should count every distinct asset before anything is chosen', () => {
+      const { remaining } = useAssetConflictResolution([conflict('eth'), conflict('btc')]);
+
+      expect(get(remaining)).toBe(2);
+    });
+
+    it('should count a repeated asset once', () => {
+      const { remaining } = useAssetConflictResolution([conflict('eth'), conflict('eth'), conflict('btc')]);
+
+      expect(get(remaining)).toBe(2);
+    });
+
+    it('should reach zero once every conflict is resolved', () => {
+      const { remaining, setResolution } = useAssetConflictResolution([conflict('eth'), conflict('btc')]);
+
+      setResolution('remote');
+
+      expect(get(remaining)).toBe(0);
+    });
+  });
+
+  describe('the duplicate warning', () => {
+    it('should not warn when every identifier is distinct', () => {
+      const { duplicateIdentifiers, warnDuplicate } = useAssetConflictResolution([conflict('eth'), conflict('btc')]);
+
+      expect(get(warnDuplicate)).toBe(false);
+      expect(get(duplicateIdentifiers)).toEqual([]);
+    });
+
+    it('should name the identifier that arrived more than once', () => {
+      const { duplicateIdentifiers, warnDuplicate } = useAssetConflictResolution([
+        conflict('eth'),
+        conflict('btc'),
+        conflict('eth'),
+      ]);
+
+      expect(get(warnDuplicate)).toBe(true);
+      expect(get(duplicateIdentifiers)).toEqual(['eth']);
+    });
+  });
+
+  describe('the dialog state', () => {
+    it('should start on the bulk choices and stay dismissable', () => {
+      const { hasResolution, manualResolution } = useAssetConflictResolution([conflict('eth')]);
+
+      expect(get(manualResolution)).toBe(false);
+      expect(get(hasResolution)).toBe(false);
+    });
+
+    it('should stop being dismissable once a strategy is chosen', () => {
+      const { hasResolution, setResolution } = useAssetConflictResolution([conflict('eth')]);
+
+      setResolution('remote');
+
+      expect(get(hasResolution)).toBe(true);
+    });
+
+    it('should switch to resolving by hand', () => {
+      const { enableManualResolution, manualResolution } = useAssetConflictResolution([conflict('eth')]);
+
+      enableManualResolution();
+
+      expect(get(manualResolution)).toBe(true);
+    });
+  });
+
+  describe('reacting to the conflicts it is given', () => {
+    it('should follow a changing list', () => {
+      const conflicts = ref<AssetUpdateConflictResult[]>([conflict('eth')]);
+      const { remaining } = useAssetConflictResolution(conflicts);
+
+      set(conflicts, [conflict('eth'), conflict('btc')]);
+
+      expect(get(remaining)).toBe(2);
+    });
+
+    it('should press neither button when there is nothing to resolve', () => {
+      const { activeStrategyForAll } = useAssetConflictResolution([]);
+
+      expect(get(activeStrategyForAll)).toEqual({ local: false, remote: false });
+    });
+  });
+});
+
+describe('getConflictFields', () => {
+  it('should list a field either side has a value for', () => {
+    const fields = getConflictFields(conflict('eth', { name: 'Ether', symbol: null }, { name: null, symbol: 'ETH' }));
+
+    expect(fields).toContain('name');
+    expect(fields).toContain('symbol');
+  });
+
+  it('should list a field once when both sides have it', () => {
+    const fields = getConflictFields(conflict('eth', { name: 'Ether' }, { name: 'Ethereum' }));
+
+    expect(fields.filter(field => field === 'name')).toHaveLength(1);
+  });
+
+  it('should drop a field neither side has a value for', () => {
+    const fields = getConflictFields(conflict('eth', { coingecko: null }, { coingecko: null }));
+
+    expect(fields).not.toContain('coingecko');
+  });
+});
+
+describe('isDiff', () => {
+  it('should report a field the two sides disagree on', () => {
+    expect(isDiff(conflict('eth', { name: 'Ether' }, { name: 'Ethereum' }), 'name')).toBe(true);
+  });
+
+  it('should report no difference when the values match', () => {
+    expect(isDiff(conflict('eth', { name: 'Ether' }, { name: 'Ether' }), 'name')).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/shell/app/use-asset-conflict-resolution.ts
+++ b/frontend/app/src/modules/shell/app/use-asset-conflict-resolution.ts
@@ -1,0 +1,148 @@
+import type { SupportedAsset, Writeable } from '@rotki/common';
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { AssetUpdateConflictResult, ConflictResolution } from '@/modules/assets/types';
+import type { ConflictResolutionStrategy } from '@/modules/core/common/common-types';
+import { objectKeys } from '@/modules/core/common/data/array';
+import { uniqueObjects, uniqueStrings } from '@/modules/core/common/data/data';
+
+type AssetKey = keyof SupportedAsset;
+
+/** Which of the two bulk buttons reads as pressed. */
+interface StrategyForAll {
+  local: boolean;
+  remote: boolean;
+}
+
+interface UseAssetConflictResolutionReturn {
+  /** Whether the per-asset table is showing rather than the two bulk choices. */
+  manualResolution: Readonly<Ref<boolean>>;
+  /** The strategy chosen per asset identifier; each row binds one entry with `v-model`. */
+  modelResolution: Ref<ConflictResolution>;
+  /** Whether every conflict has been given a strategy, which is what enables confirming. */
+  valid: ComputedRef<boolean>;
+  /** Whether anything has been chosen yet, which is when the dialog stops being dismissable. */
+  hasResolution: ComputedRef<boolean>;
+  /** How many distinct assets are still without a strategy. */
+  remaining: ComputedRef<number>;
+  /** Whether the same identifier arrived more than once, which the dialog warns about. */
+  warnDuplicate: ComputedRef<boolean>;
+  /** The identifiers that arrived more than once, named in the warning. */
+  duplicateIdentifiers: ComputedRef<string[]>;
+  /** Which bulk button is pressed, which is none once a row has been changed by hand. */
+  activeStrategyForAll: ComputedRef<StrategyForAll>;
+  /** Applies one strategy to every conflict. */
+  setResolution: (strategy: ConflictResolutionStrategy) => void;
+  /** Re-reads the bulk selection after a single row changed. */
+  onStrategyChange: (strategy?: ConflictResolutionStrategy) => void;
+  /** Switches to resolving each asset by hand. */
+  enableManualResolution: () => void;
+}
+
+/**
+ * The fields worth showing for a conflict: every key either side has a value for.
+ *
+ * @remarks
+ * A key absent from one side is still shown, so the row makes the difference visible rather than
+ * hiding it; only a key null on both sides drops out.
+ *
+ * @param conflict - the asset as it exists locally and remotely
+ * @returns the keys to render, remote order first
+ */
+export function getConflictFields(conflict: AssetUpdateConflictResult): AssetKey[] {
+  function nonNull(key: AssetKey, asset: SupportedAsset): boolean {
+    return asset[key] !== null;
+  }
+  const remote = objectKeys(conflict.remote).filter(key => nonNull(key, conflict.remote));
+  const local = objectKeys(conflict.local).filter(key => nonNull(key, conflict.local));
+  return [...remote, ...local].filter(uniqueStrings);
+}
+
+/**
+ * Whether the two sides disagree on a field, which is what the row highlights.
+ *
+ * @param conflict - the asset as it exists locally and remotely
+ * @param field - the key being compared
+ * @returns whether the values differ
+ */
+export function isDiff(conflict: AssetUpdateConflictResult, field: AssetKey): boolean {
+  return conflict.local[field] !== conflict.remote[field];
+}
+
+/**
+ * Owns which strategy each conflicting asset is being resolved with, and the rules the dialog
+ * draws from it: whether it can be confirmed, how many assets are left, and whether the update
+ * sent the same identifier twice.
+ *
+ * @param conflicts - the conflicting assets, as the update reported them
+ * @returns the resolution state and the ways it changes
+ */
+export function useAssetConflictResolution(
+  conflicts: MaybeRefOrGetter<AssetUpdateConflictResult[]>,
+): UseAssetConflictResolutionReturn {
+  const manualResolution = shallowRef<boolean>(false);
+  const modelResolution = ref<ConflictResolution>({});
+  const strategyModeForAll = shallowRef<ConflictResolutionStrategy>();
+
+  const identifiers = computed<string[]>(() => toValue(conflicts).map(({ identifier }) => identifier));
+
+  const resolutionLength = computed<number>(() => Object.keys(get(modelResolution)).length);
+
+  const hasResolution = computed<boolean>(() => get(resolutionLength) > 0);
+
+  const activeStrategyForAll = computed<StrategyForAll>(() => {
+    const all = toValue(conflicts);
+    if (all.length === 0 || get(resolutionLength) !== all.length)
+      return { local: false, remote: false };
+
+    const strategy = get(strategyModeForAll);
+    return { local: strategy === 'local', remote: strategy === 'remote' };
+  });
+
+  const remaining = computed<number>(() =>
+    uniqueObjects(toValue(conflicts), ({ identifier }) => identifier).length - get(resolutionLength),
+  );
+
+  const duplicateIdentifiers = computed<string[]>(() =>
+    [...get(identifiers)].sort().filter((identifier, index, all) => all.indexOf(identifier) !== index),
+  );
+
+  const warnDuplicate = computed<boolean>(() => get(duplicateIdentifiers).length > 0);
+
+  const valid = computed<boolean>(() => {
+    const expected = [...get(identifiers)].filter(uniqueStrings).sort();
+    const resolved = Object.keys(get(modelResolution)).sort();
+    return expected.length === resolved.length && expected.every((identifier, index) => identifier === resolved[index]);
+  });
+
+  function setResolution(strategy: ConflictResolutionStrategy): void {
+    const resolutionStrategy: Writeable<ConflictResolution> = {};
+    for (const identifier of get(identifiers))
+      resolutionStrategy[identifier] = strategy;
+
+    set(modelResolution, resolutionStrategy);
+    set(strategyModeForAll, strategy);
+  }
+
+  function onStrategyChange(strategy?: ConflictResolutionStrategy): void {
+    const uniform = Object.values(get(modelResolution)).every(chosen => chosen === strategy);
+    set(strategyModeForAll, uniform ? strategy : undefined);
+  }
+
+  function enableManualResolution(): void {
+    set(manualResolution, true);
+  }
+
+  return {
+    activeStrategyForAll,
+    duplicateIdentifiers,
+    enableManualResolution,
+    hasResolution,
+    manualResolution: readonly(manualResolution),
+    modelResolution,
+    onStrategyChange,
+    remaining,
+    setResolution,
+    valid,
+    warnDuplicate,
+  };
+}

--- a/frontend/app/src/modules/shell/components/About.vue
+++ b/frontend/app/src/modules/shell/components/About.vue
@@ -10,6 +10,7 @@ import AppUpdateIndicator from '@/modules/shell/components/AppUpdateIndicator.vu
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import ExternalLink from '@/modules/shell/components/ExternalLink.vue';
 import RotkiLogo from '@/modules/shell/components/RotkiLogo.vue';
+import { isWebVersion, useVersionText } from '@/modules/shell/components/use-version-text';
 
 const store = useMainStore();
 const { isPackaged, openPath, version: getVersion } = useInterop();
@@ -35,58 +36,22 @@ const componentsVersion = computed(() => {
 
 const webVersion = computed<WebVersion | null>(() => {
   const info = get(versionInfo);
-  if (!info || !('userAgent' in info))
-    return null;
-
-  return info;
+  return info && isWebVersion(info) ? info : null;
 });
 
 const electronVersion = computed<SystemVersion | null>(() => {
   const info = get(versionInfo);
-  if (!info || 'userAgent' in info)
-    return null;
-
-  return info;
+  return info && !isWebVersion(info) ? info : null;
 });
 
 const frontendVersion = __APP_VERSION__;
 
-const versionText = computed(() => {
-  const appVersionLabel = t('about.app_version');
-  const frontendVersionLabel = t('about.frontend_version');
-  let versionText = '';
-  versionText += `${appVersionLabel} ${get(version).version}\r\n`;
-  versionText += `${frontendVersionLabel} ${frontendVersion}\r\n`;
-
-  const web = get(webVersion);
-  const app = get(electronVersion);
-
-  const platform = t('about.platform');
-
-  if (web) {
-    const userAgent = t('about.user_agent');
-    versionText += `${platform} ${web.platform}\r\n`;
-    versionText += `${userAgent} ${web.userAgent}\r\n`;
-  }
-  else if (app) {
-    const electron = t('about.electron');
-    versionText += `${platform} ${app.os} ${app.arch} ${app.osVersion}\r\n`;
-    versionText += `${electron} ${app.electron}\r\n`;
-  }
-
-  if (get(premium)) {
-    const cmp = get(componentsVersion);
-    if (cmp) {
-      const cmpVersion = t('about.components.version');
-      const cmpBuild = t('about.components.build');
-
-      versionText += `${cmpVersion} ${cmp.version}\r\n`;
-      versionText += `${cmpBuild} ${cmp.build}\r\n`;
-    }
-  }
-
-  return versionText;
-});
+const versionText = useVersionText(() => ({
+  appVersion: get(version).version,
+  components: get(componentsVersion) ?? undefined,
+  frontendVersion,
+  system: get(versionInfo) ?? undefined,
+}));
 
 const { copy } = useClipboard({ source: versionText });
 </script>

--- a/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
+++ b/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
@@ -5,13 +5,11 @@ import { useReportIssue } from '@/modules/core/common/use-report-issue';
 import { usePrivacyMode } from '@/modules/settings/use-privacy';
 import { useScrambleSetting } from '@/modules/settings/use-scramble-settings';
 import { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { githubIssueUrl, gmailComposeUrl, googleFormUrl, isSubmittable, type IssueDraft, MAX_DESCRIPTION_LENGTH, MAX_TITLE_LENGTH, supportMailtoUrl } from '@/modules/shell/components/report-issue-links';
 import ReportIssueDiscordTip from '@/modules/shell/components/ReportIssueDiscordTip.vue';
 import ReportIssueEmailButton from '@/modules/shell/components/ReportIssueEmailButton.vue';
 
 const { close, initialDescription: storeDescription, initialTitle: storeTitle, visible } = useReportIssue();
-
-const MAX_TITLE_LENGTH = 100;
-const MAX_DESCRIPTION_LENGTH = 1500;
 
 const uiClasses = {
   tipCard: 'flex items-start gap-3 p-3 bg-rui-grey-100 dark:bg-rui-grey-800 rounded',
@@ -53,13 +51,15 @@ const privacyStatusText = computed<string>(() => {
   return modes.join(', ');
 });
 
-const isFormValid = computed<boolean>(() => get(issueTitle).trim().length > 0);
+const draft = computed<IssueDraft>(() => ({
+  description: get(issueDescription),
+  title: get(issueTitle),
+}));
+
+const isFormValid = computed<boolean>(() => isSubmittable(get(draft)));
 
 const titleCharCount = computed<number>(() => get(issueTitle).length);
 const descriptionCharCount = computed<number>(() => get(issueDescription).length);
-
-const encodedTitle = computed<string>(() => encodeURIComponent(get(issueTitle).slice(0, MAX_TITLE_LENGTH)));
-const encodedDescription = computed<string>(() => encodeURIComponent(get(issueDescription).slice(0, MAX_DESCRIPTION_LENGTH)));
 
 function closeDialog(): void {
   close();
@@ -73,15 +73,19 @@ function openUrlAndClose(url: string): void {
 }
 
 function submitViaGithub(): void {
-  openUrlAndClose(`${externalLinks.githubNewBugReport}&title=${get(encodedTitle)}&body=${get(encodedDescription)}`);
+  openUrlAndClose(githubIssueUrl(get(draft)));
 }
 
 function submitViaGoogleForm(): void {
-  openUrlAndClose(`${GOOGLE_FORM_URL}?${GOOGLE_FORM_TITLE_ENTRY}=${get(encodedTitle)}&${GOOGLE_FORM_DESCRIPTION_ENTRY}=${get(encodedDescription)}`);
+  openUrlAndClose(googleFormUrl(get(draft), {
+    descriptionEntry: GOOGLE_FORM_DESCRIPTION_ENTRY,
+    titleEntry: GOOGLE_FORM_TITLE_ENTRY,
+    url: GOOGLE_FORM_URL,
+  }));
 }
 
 function submitViaEmail(): void {
-  openUrlAndClose(`mailto:${SUPPORT_EMAIL}?subject=${get(encodedTitle)}&body=${get(encodedDescription)}`);
+  openUrlAndClose(supportMailtoUrl(get(draft)));
 }
 
 function openDiscord(): void {
@@ -98,7 +102,7 @@ function copyEmail(): void {
 }
 
 function openGmail(): void {
-  openUrlAndClose(`${externalLinks.gmailCompose}&to=${encodeURIComponent(SUPPORT_EMAIL)}&su=${get(encodedTitle)}&body=${get(encodedDescription)}`);
+  openUrlAndClose(gmailComposeUrl(get(draft)));
 }
 
 onMounted(() => {

--- a/frontend/app/src/modules/shell/components/report-issue-links.spec.ts
+++ b/frontend/app/src/modules/shell/components/report-issue-links.spec.ts
@@ -1,0 +1,115 @@
+import { SUPPORT_EMAIL } from '@shared/external-links';
+import { describe, expect, it } from 'vitest';
+import {
+  encodeIssue,
+  githubIssueUrl,
+  gmailComposeUrl,
+  googleFormUrl,
+  isSubmittable,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_TITLE_LENGTH,
+  supportMailtoUrl,
+} from '@/modules/shell/components/report-issue-links';
+
+const draft = { description: 'it crashed on save', title: 'Crash on save' };
+
+const googleForm = {
+  descriptionEntry: 'entry.2',
+  titleEntry: 'entry.1',
+  url: 'https://docs.google.com/forms/d/e/abc/viewform',
+};
+
+describe('isSubmittable', () => {
+  it('should accept a draft with a title', () => {
+    expect(isSubmittable(draft)).toBe(true);
+  });
+
+  it('should accept a draft with no description', () => {
+    expect(isSubmittable({ description: '', title: 'Crash on save' })).toBe(true);
+  });
+
+  it('should reject a draft with no title', () => {
+    expect(isSubmittable({ description: 'it crashed', title: '' })).toBe(false);
+  });
+
+  /** A title of spaces produces an issue with a blank subject, which is as useless as none. */
+  it('should reject a title of only whitespace', () => {
+    expect(isSubmittable({ description: 'it crashed', title: '   \t ' })).toBe(false);
+  });
+});
+
+describe('encodeIssue', () => {
+  it('should percent encode what the user typed', () => {
+    expect(encodeIssue({ description: 'a & b', title: 'a b' })).toEqual({
+      description: 'a%20%26%20b',
+      title: 'a%20b',
+    });
+  });
+
+  it('should cut a long title to the limit before encoding', () => {
+    const { title } = encodeIssue({ description: '', title: 'a'.repeat(MAX_TITLE_LENGTH + 50) });
+
+    expect(title).toHaveLength(MAX_TITLE_LENGTH);
+  });
+
+  it('should cut a long description to the limit before encoding', () => {
+    const { description } = encodeIssue({
+      description: 'b'.repeat(MAX_DESCRIPTION_LENGTH + 500),
+      title: '',
+    });
+
+    expect(description).toHaveLength(MAX_DESCRIPTION_LENGTH);
+  });
+
+  /**
+   * Truncating after encoding could cut a percent escape in half and produce a url the browser
+   * rejects, so the cut has to happen first.
+   */
+  it('should not leave a half written escape when it cuts', () => {
+    const { title } = encodeIssue({ description: '', title: `${'a'.repeat(MAX_TITLE_LENGTH - 1)}&&&` });
+
+    expect(title).toBe(`${'a'.repeat(MAX_TITLE_LENGTH - 1)}%26`);
+  });
+
+  it('should leave a draft within the limits alone', () => {
+    expect(encodeIssue({ description: 'short', title: 'short' })).toEqual({
+      description: 'short',
+      title: 'short',
+    });
+  });
+});
+
+describe('the submission links', () => {
+  it('should pre-fill the github issue form', () => {
+    const url = githubIssueUrl(draft);
+
+    expect(url).toContain('title=Crash%20on%20save');
+    expect(url).toContain('body=it%20crashed%20on%20save');
+  });
+
+  it('should pre-fill the google form through its configured entries', () => {
+    const url = googleFormUrl(draft, googleForm);
+
+    expect(url).toBe(`${googleForm.url}?entry.1=Crash%20on%20save&entry.2=it%20crashed%20on%20save`);
+  });
+
+  it('should compose a mail to support', () => {
+    const url = supportMailtoUrl(draft);
+
+    expect(url).toBe(`mailto:${SUPPORT_EMAIL}?subject=Crash%20on%20save&body=it%20crashed%20on%20save`);
+  });
+
+  it('should encode the support address for the gmail link', () => {
+    const url = gmailComposeUrl(draft);
+
+    expect(url).toContain(`to=${encodeURIComponent(SUPPORT_EMAIL)}`);
+    expect(url).toContain('su=Crash%20on%20save');
+  });
+
+  it('should apply the length limits to every destination', () => {
+    const long = { description: 'b'.repeat(MAX_DESCRIPTION_LENGTH + 100), title: 'a'.repeat(MAX_TITLE_LENGTH + 100) };
+
+    for (const url of [githubIssueUrl(long), supportMailtoUrl(long), gmailComposeUrl(long), googleFormUrl(long, googleForm)])
+      expect(url).not.toContain('a'.repeat(MAX_TITLE_LENGTH + 1));
+  });
+});

--- a/frontend/app/src/modules/shell/components/report-issue-links.ts
+++ b/frontend/app/src/modules/shell/components/report-issue-links.ts
@@ -1,0 +1,79 @@
+import { externalLinks, SUPPORT_EMAIL } from '@shared/external-links';
+
+/**
+ * The caps the destinations impose. A github url and a mailto both go through the address bar, so
+ * an unbounded description produces a link the browser silently truncates or refuses.
+ */
+export const MAX_TITLE_LENGTH = 100;
+
+export const MAX_DESCRIPTION_LENGTH = 1500;
+
+/** What the user typed, before it is trimmed to fit a url. */
+export interface IssueDraft {
+  readonly title: string;
+  readonly description: string;
+}
+
+/** The same draft, cut to length and percent encoded. */
+interface EncodedIssue {
+  readonly title: string;
+  readonly description: string;
+}
+
+/** Where the google form expects the two answers, which the deployment configures. */
+export interface GoogleFormConfig {
+  readonly url: string;
+  readonly titleEntry: string;
+  readonly descriptionEntry: string;
+}
+
+/**
+ * Cuts a draft to what a url can carry and encodes it.
+ *
+ * @param draft - what the user typed
+ * @returns the title and description, truncated then percent encoded
+ */
+export function encodeIssue(draft: IssueDraft): EncodedIssue {
+  return {
+    description: encodeURIComponent(draft.description.slice(0, MAX_DESCRIPTION_LENGTH)),
+    title: encodeURIComponent(draft.title.slice(0, MAX_TITLE_LENGTH)),
+  };
+}
+
+/**
+ * Whether the draft can be submitted, which asks only for a title.
+ *
+ * @remarks
+ * Whitespace does not count, so a title of spaces is as empty as no title at all. The description
+ * is optional, since a reproducible one-line report is worth more than a padded one.
+ *
+ * @param draft - what the user typed
+ * @returns whether any destination will accept it
+ */
+export function isSubmittable(draft: IssueDraft): boolean {
+  return draft.title.trim().length > 0;
+}
+
+/** The github issue form, pre-filled. */
+export function githubIssueUrl(draft: IssueDraft): string {
+  const { description, title } = encodeIssue(draft);
+  return `${externalLinks.githubNewBugReport}&title=${title}&body=${description}`;
+}
+
+/** The google form, pre-filled through the entry ids the deployment configures. */
+export function googleFormUrl(draft: IssueDraft, config: GoogleFormConfig): string {
+  const { description, title } = encodeIssue(draft);
+  return `${config.url}?${config.titleEntry}=${title}&${config.descriptionEntry}=${description}`;
+}
+
+/** A mail client, composing to support. */
+export function supportMailtoUrl(draft: IssueDraft): string {
+  const { description, title } = encodeIssue(draft);
+  return `mailto:${SUPPORT_EMAIL}?subject=${title}&body=${description}`;
+}
+
+/** Gmail's compose window, for a user with no mail client registered. */
+export function gmailComposeUrl(draft: IssueDraft): string {
+  const { description, title } = encodeIssue(draft);
+  return `${externalLinks.gmailCompose}&to=${encodeURIComponent(SUPPORT_EMAIL)}&su=${title}&body=${description}`;
+}

--- a/frontend/app/src/modules/shell/components/use-version-text.spec.ts
+++ b/frontend/app/src/modules/shell/components/use-version-text.spec.ts
@@ -1,0 +1,94 @@
+import type { SystemVersion } from '@shared/ipc';
+import type { WebVersion } from '@/types';
+import { describe, expect, it } from 'vitest';
+import { isWebVersion, useVersionText, type VersionSummary } from '@/modules/shell/components/use-version-text';
+
+const web: WebVersion = { platform: 'linux', userAgent: 'Mozilla/5.0' };
+const electron: SystemVersion = { arch: 'x64', electron: '43.5.0', os: 'Linux', osVersion: '6.1' };
+
+function lines(text: string): string[] {
+  return text.split('\r\n').filter(line => line.length > 0);
+}
+
+describe('isWebVersion', () => {
+  it('should recognise a browser by its user agent', () => {
+    expect(isWebVersion(web)).toBe(true);
+  });
+
+  it('should not mistake the electron version for a browser', () => {
+    expect(isWebVersion(electron)).toBe(false);
+  });
+});
+
+describe('useVersionText', () => {
+  it('should always name the app and frontend versions', () => {
+    const text = useVersionText({ appVersion: '1.45.0', frontendVersion: '1.45.1' });
+
+    expect(lines(get(text))).toEqual(['about.app_version 1.45.0', 'about.frontend_version 1.45.1']);
+  });
+
+  /** The block is pasted into bug reports, and a windows editor needs the carriage returns. */
+  it('should end every line with a carriage return and newline', () => {
+    const text = useVersionText({ appVersion: '1.45.0', frontendVersion: '1.45.1' });
+
+    expect(get(text)).toBe('about.app_version 1.45.0\r\nabout.frontend_version 1.45.1\r\n');
+  });
+
+  describe('what it is running on', () => {
+    it('should name the platform and user agent in a browser', () => {
+      const text = useVersionText({ appVersion: '1.45.0', frontendVersion: '1.45.1', system: web });
+
+      expect(lines(get(text))).toContain('about.platform linux');
+      expect(lines(get(text))).toContain('about.user_agent Mozilla/5.0');
+    });
+
+    it('should name the os and electron version in the app', () => {
+      const text = useVersionText({ appVersion: '1.45.0', frontendVersion: '1.45.1', system: electron });
+
+      expect(lines(get(text))).toContain('about.platform Linux x64 6.1');
+      expect(lines(get(text))).toContain('about.electron 43.5.0');
+    });
+
+    it('should name neither before the version call comes back', () => {
+      const text = useVersionText({ appVersion: '1.45.0', frontendVersion: '1.45.1' });
+
+      expect(get(text)).not.toContain('about.platform');
+    });
+
+    it('should not describe a browser when running in the app', () => {
+      const text = useVersionText({ appVersion: '1.45.0', frontendVersion: '1.45.1', system: electron });
+
+      expect(get(text)).not.toContain('about.user_agent');
+    });
+  });
+
+  describe('the premium components', () => {
+    it('should name their version and build when they were loaded', () => {
+      const text = useVersionText({
+        appVersion: '1.45.0',
+        components: { build: 1700000000000, version: '16.0.1' },
+        frontendVersion: '1.45.1',
+      });
+
+      expect(lines(get(text))).toContain('about.components.version 16.0.1');
+      expect(lines(get(text))).toContain('about.components.build 1700000000000');
+    });
+
+    it('should say nothing about them for a user without premium', () => {
+      const text = useVersionText({ appVersion: '1.45.0', frontendVersion: '1.45.1' });
+
+      expect(get(text)).not.toContain('about.components');
+    });
+  });
+
+  it('should follow the summary as it fills in', () => {
+    const summary = ref<VersionSummary>({ appVersion: '1.45.0', frontendVersion: '1.45.1' });
+    const text = useVersionText(summary);
+
+    expect(get(text)).not.toContain('about.platform');
+
+    set(summary, { ...get(summary), system: web });
+
+    expect(get(text)).toContain('about.platform linux');
+  });
+});

--- a/frontend/app/src/modules/shell/components/use-version-text.ts
+++ b/frontend/app/src/modules/shell/components/use-version-text.ts
@@ -1,0 +1,74 @@
+import type { SystemVersion } from '@shared/ipc';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import type { WebVersion } from '@/types';
+
+/** The premium components the app loaded, absent for a non-premium user. */
+interface ComponentsVersion {
+  readonly version: string;
+  /** The build timestamp in milliseconds, which the about screen renders as a date. */
+  readonly build: number;
+}
+
+/** Everything the about screen knows about what is running. */
+export interface VersionSummary {
+  readonly appVersion: string;
+  readonly frontendVersion: string;
+  /** What the app is running on, absent until the interop call comes back. */
+  readonly system?: SystemVersion | WebVersion;
+  readonly components?: ComponentsVersion;
+}
+
+/**
+ * Whether the app is running in a browser rather than in electron.
+ *
+ * @remarks
+ * The interop call answers with one shape or the other and nothing labels which, so the presence
+ * of `userAgent` is what separates them.
+ *
+ * @param system - what the interop call returned
+ * @returns whether it describes a browser
+ */
+export function isWebVersion(system: SystemVersion | WebVersion): system is WebVersion {
+  return 'userAgent' in system;
+}
+
+/**
+ * The versions as one block of text, which is what the about screen copies to the clipboard for
+ * pasting into a bug report.
+ *
+ * @remarks
+ * Lines end in CRLF so the block survives being pasted into a windows editor. Only the platform
+ * the app is actually running on contributes lines, and the premium components only appear when
+ * they were loaded.
+ *
+ * @param summary - what is running
+ * @returns the text to copy
+ */
+export function useVersionText(summary: MaybeRefOrGetter<VersionSummary>): ComputedRef<string> {
+  const { t } = useI18n({ useScope: 'global' });
+
+  return computed<string>(() => {
+    const { appVersion, components, frontendVersion, system } = toValue(summary);
+    const lines = [
+      `${t('about.app_version')} ${appVersion}`,
+      `${t('about.frontend_version')} ${frontendVersion}`,
+    ];
+
+    if (system) {
+      if (isWebVersion(system)) {
+        lines.push(`${t('about.platform')} ${system.platform}`, `${t('about.user_agent')} ${system.userAgent}`);
+      }
+      else {
+        lines.push(
+          `${t('about.platform')} ${system.os} ${system.arch} ${system.osVersion}`,
+          `${t('about.electron')} ${system.electron}`,
+        );
+      }
+    }
+
+    if (components)
+      lines.push(`${t('about.components.version')} ${components.version}`, `${t('about.components.build')} ${components.build}`);
+
+    return `${lines.join('\r\n')}\r\n`;
+  });
+}

--- a/frontend/app/src/modules/tags/TagManager.vue
+++ b/frontend/app/src/modules/tags/TagManager.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DataTableColumn, DataTableSortData } from '@rotki/ui-library';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
@@ -16,9 +17,6 @@ const tag = ref<Tag | undefined>(undefined);
 const editMode = ref<boolean>(false);
 const search = ref<string>('');
 const originalName = ref<string>('');
-
-const route = useRoute();
-const router = useRouter();
 
 const { tags } = storeToRefs(useSessionMetadataStore());
 const { deleteTag } = useTagOperations();
@@ -79,12 +77,10 @@ function handleCreateTagClick() {
   set(tag, defaultTag());
 }
 
+const { consumeAddQuery } = useAddQuery(handleCreateTagClick);
+
 onMounted(async () => {
-  const { query } = get(route);
-  if (query.add) {
-    handleCreateTagClick();
-    await router.replace({ query: {} });
-  }
+  await consumeAddQuery();
 });
 </script>
 

--- a/frontend/app/src/modules/user-data/FileUpload.vue
+++ b/frontend/app/src/modules/user-data/FileUpload.vue
@@ -2,6 +2,7 @@
 import type { ImportSourceType } from '@/modules/core/common/upload-types';
 import { size } from '@/modules/core/common/data/data';
 import FadeTransition from '@/modules/shell/components/FadeTransition.vue';
+import { checkFiles, formatFileFilter, useFileUploadFeedback } from '@/modules/user-data/use-file-upload';
 
 const file = defineModel<File | undefined>({ required: true });
 
@@ -25,32 +26,8 @@ const emit = defineEmits<{
 
 const wrapper = useTemplateRef<HTMLDivElement>('wrapper');
 
-const error = ref('');
 const select = useTemplateRef<HTMLInputElement>('select');
 const { t } = useI18n({ useScope: 'global' });
-
-/**
- * Whether a picked file satisfies the `accept` attribute.
- *
- * @remarks
- * `acceptString` is an `accept` attribute value, comma separated. A file matches on either its
- * extension or its MIME type, since a browser reports no type for some files and checking either
- * alone rejects files the user is allowed to pick. `image/*` is the one wildcard handled; other
- * `type/*` forms are compared literally and will not match.
- */
-function isValidFile(file: File, acceptString: string): boolean {
-  const fileName = file.name;
-  const fileExtension = fileName.substring(fileName.lastIndexOf('.')).toLowerCase();
-  const fileType = file.type;
-
-  const acceptTypes = acceptString.split(',').map(type => type.trim().toLowerCase());
-
-  for (const type of acceptTypes) {
-    if (type === fileExtension || type === fileType || (type === 'image/*' && fileType.startsWith('image/')))
-      return true;
-  }
-  return false;
-}
 
 function onDrop(files: File[] | null) {
   if (!files || files.length === 0)
@@ -73,38 +50,11 @@ function onSelect(event: Event) {
   else selected(target.files[0]);
 }
 
-function clearTimeoutHandler(timeout: Ref<NodeJS.Timeout | undefined>) {
-  const timeoutVal = get(timeout);
-  if (timeoutVal) {
-    clearTimeout(timeoutVal);
-    set(timeout, undefined);
-  }
-}
-
-const errorTimeout = ref<NodeJS.Timeout>();
-const uploadedTimeout = ref<NodeJS.Timeout>();
-
-function onError(message: string) {
-  if (!message) {
-    clearError();
-    return;
-  }
-
-  clearTimeoutHandler(errorTimeout);
-  clearTimeoutHandler(uploadedTimeout);
-
-  removeFile();
-  set(error, message);
-  const timeout = setTimeout(() => {
-    clearError();
-  }, 4000);
-  set(errorTimeout, timeout);
-}
-
-function clearError() {
-  set(error, '');
-  emit('update:error-message', '');
-}
+const { acknowledgeUpload, clearError, error, showError } = useFileUploadFeedback({
+  onErrorCleared: () => emit('update:error-message', ''),
+  onUploadedCleared: () => updateUploaded(false),
+  removeFile: () => removeFile(),
+});
 
 function removeFile() {
   const inputFile = get(select);
@@ -115,21 +65,16 @@ function removeFile() {
 }
 
 function check(files: File[] | FileList) {
-  if (files.length !== 1) {
-    onError(t('file_upload.many_files_selected'));
+  const result = checkFiles(files, fileFilter);
+
+  if (result.valid) {
+    selected(result.file);
     return;
   }
 
-  if (!isValidFile(files[0], fileFilter)) {
-    onError(
-      t('file_upload.only_files', {
-        fileFilter,
-      }),
-    );
-    return;
-  }
-
-  selected(files[0]);
+  showError(result.reason === 'many-files'
+    ? t('file_upload.many_files_selected')
+    : t('file_upload.only_files', { fileFilter }));
 }
 
 function selected(selected: File | null) {
@@ -146,42 +91,15 @@ function clickSelect() {
   get(select)?.click();
 }
 
-watch(() => uploaded, (uploaded) => {
-  clearTimeoutHandler(errorTimeout);
-  clearTimeoutHandler(uploadedTimeout);
+watch(() => uploaded, acknowledgeUpload);
 
-  if (!uploaded)
-    return;
-
-  removeFile();
-
-  const timeout = setTimeout(() => {
-    updateUploaded(false);
-  }, 4000);
-
-  set(uploadedTimeout, timeout);
-});
-
-watch(() => errorMessage, message => onError(message));
+watch(() => errorMessage, message => showError(message));
 
 watch(file, (file) => {
   if (!file) {
     removeFile();
   }
 });
-
-function formatFileFilter(fileFilter: string) {
-  return fileFilter
-    .split(',')
-    .map((item) => {
-      let text = item.trim();
-      if (text.startsWith('.'))
-        text = text.slice(1);
-
-      return text;
-    })
-    .join(', ');
-}
 
 defineExpose({
   removeFile,

--- a/frontend/app/src/modules/user-data/use-file-upload.spec.ts
+++ b/frontend/app/src/modules/user-data/use-file-upload.spec.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  checkFiles,
+  formatFileFilter,
+  isValidFile,
+  useFileUploadFeedback,
+} from '@/modules/user-data/use-file-upload';
+
+function file(name: string, type = ''): File {
+  return new File(['content'], name, { type });
+}
+
+describe('isValidFile', () => {
+  it('should accept a file whose extension is listed', () => {
+    expect(isValidFile(file('accounts.csv'), '.csv')).toBe(true);
+  });
+
+  it('should accept a file whose mime type is listed', () => {
+    expect(isValidFile(file('accounts', 'text/csv'), 'text/csv')).toBe(true);
+  });
+
+  /** A browser reports no type for some files, so the extension has to be enough on its own. */
+  it('should accept a listed extension even when the browser reports no type', () => {
+    expect(isValidFile(file('accounts.csv', ''), '.csv')).toBe(true);
+  });
+
+  it('should ignore the case of the extension', () => {
+    expect(isValidFile(file('ACCOUNTS.CSV'), '.csv')).toBe(true);
+  });
+
+  it('should accept any image for the image wildcard', () => {
+    expect(isValidFile(file('logo.png', 'image/png'), 'image/*')).toBe(true);
+  });
+
+  it('should not treat the image wildcard as accepting everything', () => {
+    expect(isValidFile(file('accounts.csv', 'text/csv'), 'image/*')).toBe(false);
+  });
+
+  it('should accept a file matching any entry in a list', () => {
+    expect(isValidFile(file('report.json', 'application/json'), '.csv, .json')).toBe(true);
+  });
+
+  it('should ignore the spaces around a list entry', () => {
+    expect(isValidFile(file('report.json'), '.csv,  .json  ')).toBe(true);
+  });
+
+  it('should reject a file that matches neither extension nor type', () => {
+    expect(isValidFile(file('archive.zip', 'application/zip'), '.csv')).toBe(false);
+  });
+
+  /**
+   * Only `image/*` is understood; every other wildcard is compared as text, so a file is rejected
+   * rather than silently let through by a filter that looks like it should match.
+   */
+  it('should not expand a wildcard other than image', () => {
+    expect(isValidFile(file('notes.txt', 'text/plain'), 'text/*')).toBe(false);
+  });
+
+  it('should reject a file with no extension against an extension filter', () => {
+    expect(isValidFile(file('accounts'), '.csv')).toBe(false);
+  });
+});
+
+describe('checkFiles', () => {
+  it('should return the file when exactly one valid file is given', () => {
+    const picked = file('accounts.csv');
+
+    expect(checkFiles([picked], '.csv')).toEqual({ file: picked, valid: true });
+  });
+
+  it('should refuse more than one file', () => {
+    expect(checkFiles([file('a.csv'), file('b.csv')], '.csv')).toEqual({ reason: 'many-files', valid: false });
+  });
+
+  it('should refuse an empty selection', () => {
+    expect(checkFiles([], '.csv')).toEqual({ reason: 'many-files', valid: false });
+  });
+
+  it('should refuse a file of the wrong type', () => {
+    expect(checkFiles([file('archive.zip')], '.csv')).toEqual({ reason: 'wrong-type', valid: false });
+  });
+});
+
+describe('formatFileFilter', () => {
+  it('should drop the dots and space the list out', () => {
+    expect(formatFileFilter('.csv,.json')).toBe('csv, json');
+  });
+
+  it('should leave a mime type alone', () => {
+    expect(formatFileFilter('text/csv')).toBe('text/csv');
+  });
+
+  it('should trim the entries', () => {
+    expect(formatFileFilter(' .csv , .json ')).toBe('csv, json');
+  });
+});
+
+describe('useFileUploadFeedback', () => {
+  const removeFile = vi.fn();
+  const onErrorCleared = vi.fn();
+  const onUploadedCleared = vi.fn();
+
+  function createFeedback(): ReturnType<typeof useFileUploadFeedback> {
+    return useFileUploadFeedback({ onErrorCleared, onUploadedCleared, removeFile });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('showing an error', () => {
+    it('should show the message and drop the picked file', () => {
+      const { error, showError } = createFeedback();
+
+      showError('too many');
+
+      expect(get(error)).toBe('too many');
+      expect(removeFile).toHaveBeenCalledOnce();
+    });
+
+    it('should clear the error after four seconds', async () => {
+      const { error, showError } = createFeedback();
+
+      showError('too many');
+      await vi.advanceTimersByTimeAsync(4000);
+
+      expect(get(error)).toBe('');
+      expect(onErrorCleared).toHaveBeenCalled();
+    });
+
+    it('should keep the error until then', async () => {
+      const { error, showError } = createFeedback();
+
+      showError('too many');
+      await vi.advanceTimersByTimeAsync(3999);
+
+      expect(get(error)).toBe('too many');
+    });
+
+    /** Without cancelling the first timer the earlier error clears the later one four seconds in. */
+    it('should restart the countdown when a second error replaces the first', async () => {
+      const { error, showError } = createFeedback();
+
+      showError('first');
+      await vi.advanceTimersByTimeAsync(3000);
+      showError('second');
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(get(error)).toBe('second');
+    });
+
+    it('should clear instead of showing when the message is empty', () => {
+      const { error, showError } = createFeedback();
+
+      showError('');
+
+      expect(get(error)).toBe('');
+      expect(onErrorCleared).toHaveBeenCalledOnce();
+      expect(removeFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('acknowledging an upload', () => {
+    it('should drop the picked file when the upload lands', () => {
+      const { acknowledgeUpload } = createFeedback();
+
+      acknowledgeUpload(true);
+
+      expect(removeFile).toHaveBeenCalledOnce();
+    });
+
+    it('should lower the flag after four seconds', async () => {
+      const { acknowledgeUpload } = createFeedback();
+
+      acknowledgeUpload(true);
+      await vi.advanceTimersByTimeAsync(4000);
+
+      expect(onUploadedCleared).toHaveBeenCalledOnce();
+    });
+
+    it('should do nothing when the flag goes down', async () => {
+      const { acknowledgeUpload } = createFeedback();
+
+      acknowledgeUpload(false);
+      await vi.advanceTimersByTimeAsync(4000);
+
+      expect(removeFile).not.toHaveBeenCalled();
+      expect(onUploadedCleared).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('the two kinds of feedback replacing each other', () => {
+    it('should not clear an error raised after an upload was acknowledged', async () => {
+      const { acknowledgeUpload, error, showError } = createFeedback();
+
+      acknowledgeUpload(true);
+      await vi.advanceTimersByTimeAsync(3000);
+      showError('failed');
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(get(error)).toBe('failed');
+      expect(onUploadedCleared).not.toHaveBeenCalled();
+    });
+
+    it('should give the acknowledgement its full four seconds after an error', async () => {
+      const { acknowledgeUpload, showError } = createFeedback();
+
+      showError('failed');
+      await vi.advanceTimersByTimeAsync(3000);
+      acknowledgeUpload(true);
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(onUploadedCleared).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(2500);
+
+      expect(onUploadedCleared).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/frontend/app/src/modules/user-data/use-file-upload.ts
+++ b/frontend/app/src/modules/user-data/use-file-upload.ts
@@ -1,0 +1,152 @@
+import type { Ref } from 'vue';
+
+/** How long an error, or the uploaded acknowledgement, stays on screen. */
+const FEEDBACK_TIMEOUT_MS = 4000;
+
+/** Why a set of picked files cannot be used, or the single file that can. */
+export type FileCheck =
+  | { readonly valid: true; readonly file: File }
+  | { readonly valid: false; readonly reason: 'many-files' | 'wrong-type' };
+
+interface UseFileUploadFeedbackOptions {
+  /** Drops the picked file. The input element belongs to the component, so it does this. */
+  removeFile: () => void;
+  /** Reports that the error is gone, which clears the message the parent passed in. */
+  onErrorCleared: () => void;
+  /** Reports that the acknowledgement is gone, which lowers the parent's uploaded flag. */
+  onUploadedCleared: () => void;
+}
+
+interface UseFileUploadFeedbackReturn {
+  /** The error being shown, empty when there is none. */
+  error: Readonly<Ref<string>>;
+  /** Shows an error, dropping the picked file; an empty message clears instead. */
+  showError: (message: string) => void;
+  /** Clears the error and tells the parent to drop the message that caused it. */
+  clearError: () => void;
+  /** Shows the upload as done for a moment, then lowers the flag. */
+  acknowledgeUpload: (uploaded: boolean) => void;
+}
+
+/**
+ * Whether a picked file satisfies the `accept` attribute.
+ *
+ * @remarks
+ * `acceptString` is an `accept` attribute value, comma separated. A file matches on either its
+ * extension or its MIME type, since a browser reports no type for some files and checking either
+ * alone rejects files the user is allowed to pick. `image/*` is the one wildcard handled; other
+ * `type/*` forms are compared literally and will not match.
+ *
+ * @param file - the file the user picked or dropped
+ * @param acceptString - the `accept` attribute value to match against
+ * @returns whether the file is one the input accepts
+ */
+export function isValidFile(file: File, acceptString: string): boolean {
+  const fileName = file.name;
+  const fileExtension = fileName.substring(fileName.lastIndexOf('.')).toLowerCase();
+  const fileType = file.type;
+
+  const acceptTypes = acceptString.split(',').map(type => type.trim().toLowerCase());
+
+  return acceptTypes.some(type =>
+    type === fileExtension || type === fileType || (type === 'image/*' && fileType.startsWith('image/')),
+  );
+}
+
+/**
+ * Decides whether a drop or a pick can be used, so the component only has to phrase the refusal.
+ *
+ * @param files - what the user dropped or picked, which a drop can make more than one of
+ * @param fileFilter - the `accept` attribute value the file has to satisfy
+ * @returns the single usable file, or why there is not one
+ */
+export function checkFiles(files: File[] | FileList, fileFilter: string): FileCheck {
+  if (files.length !== 1)
+    return { reason: 'many-files', valid: false };
+
+  const file = files[0];
+  if (!isValidFile(file, fileFilter))
+    return { reason: 'wrong-type', valid: false };
+
+  return { file, valid: true };
+}
+
+/**
+ * The accepted types as the hint reads them: `.csv,.json` becomes `csv, json`.
+ *
+ * @param fileFilter - the `accept` attribute value
+ * @returns the same list without the dots, comma separated
+ */
+export function formatFileFilter(fileFilter: string): string {
+  return fileFilter
+    .split(',')
+    .map(item => item.trim().replace(/^\./, ''))
+    .join(', ');
+}
+
+/**
+ * The upload's transient feedback: an error, or the acknowledgement that a file went through.
+ * Both drop the picked file and both clear themselves after a moment, and either one replaces
+ * the other rather than the two overlapping.
+ *
+ * @param options - what the component does on the feedback's behalf
+ * @returns the error being shown and the ways it changes
+ */
+export function useFileUploadFeedback(options: UseFileUploadFeedbackOptions): UseFileUploadFeedbackReturn {
+  const { onErrorCleared, onUploadedCleared, removeFile } = options;
+
+  const error = shallowRef<string>('');
+  const errorTimeout = shallowRef<ReturnType<typeof setTimeout>>();
+  const uploadedTimeout = shallowRef<ReturnType<typeof setTimeout>>();
+
+  function cancel(timeout: Ref<ReturnType<typeof setTimeout> | undefined>): void {
+    const pending = get(timeout);
+    if (pending) {
+      clearTimeout(pending);
+      set(timeout, undefined);
+    }
+  }
+
+  function clearError(): void {
+    set(error, '');
+    onErrorCleared();
+  }
+
+  function showError(message: string): void {
+    if (!message) {
+      clearError();
+      return;
+    }
+
+    cancel(errorTimeout);
+    cancel(uploadedTimeout);
+    removeFile();
+    set(error, message);
+    set(errorTimeout, setTimeout(clearError, FEEDBACK_TIMEOUT_MS));
+  }
+
+  function acknowledgeUpload(uploaded: boolean): void {
+    cancel(errorTimeout);
+    cancel(uploadedTimeout);
+
+    if (!uploaded)
+      return;
+
+    removeFile();
+    set(uploadedTimeout, setTimeout(() => {
+      onUploadedCleared();
+    }, FEEDBACK_TIMEOUT_MS));
+  }
+
+  tryOnScopeDispose(() => {
+    cancel(errorTimeout);
+    cancel(uploadedTimeout);
+  });
+
+  return {
+    acknowledgeUpload,
+    clearError,
+    error: readonly(error),
+    showError,
+  };
+}

--- a/frontend/app/src/pages/accounts/evm/[[tab]].vue
+++ b/frontend/app/src/pages/accounts/evm/[[tab]].vue
@@ -13,6 +13,7 @@ import { useAccountCategoryHelper } from '@/modules/accounts/use-account-categor
 import { useAccountImportProgressStore } from '@/modules/accounts/use-account-import-progress-store';
 import BlockchainBalanceStalenessIndicator from '@/modules/balances/BlockchainBalanceStalenessIndicator.vue';
 import { NoteLocation } from '@/modules/core/common/notes';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 import { Module, useModuleEnabled } from '@/modules/session/use-module-enabled';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 import { useEthStakingAccess } from '@/modules/staking/eth/use-eth-staking-access';
@@ -88,13 +89,13 @@ function getTabLink(category: string): RouteLocationRaw {
   };
 }
 
+const { consumeAddQuery } = useAddQuery((query) => {
+  const addressToAdd = typeof query.addressToAdd === 'string' ? query.addressToAdd : undefined;
+  createNewBlockchainAccount(addressToAdd);
+});
+
 onMounted(async () => {
-  const { query } = get(route);
-  if (query.add) {
-    const addressToAdd = typeof query.addressToAdd === 'string' ? query.addressToAdd : undefined;
-    createNewBlockchainAccount(addressToAdd);
-    await router.replace({ query: {} });
-  }
+  await consumeAddQuery();
 });
 
 watchImmediate(route, (route) => {

--- a/frontend/app/src/pages/balances/blockchain/index.vue
+++ b/frontend/app/src/pages/balances/blockchain/index.vue
@@ -15,6 +15,7 @@ import { useAggregatedBalances } from '@/modules/balances/use-aggregated-balance
 import { useBalanceRefresh } from '@/modules/balances/use-balance-refresh';
 import { useBalanceStatus } from '@/modules/balances/use-balance-status';
 import { NoteLocation } from '@/modules/core/common/notes';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 import SummaryCardRefreshMenu from '@/modules/dashboard/summary/SummaryCardRefreshMenu.vue';
 import VisibleColumnsSelector from '@/modules/dashboard/VisibleColumnsSelector.vue';
 import HideSmallBalances from '@/modules/settings/HideSmallBalances.vue';
@@ -37,8 +38,6 @@ const chainsFilter = ref<string[]>([]);
 
 const { t } = useI18n({ useScope: 'global' });
 
-const route = useRoute('/balances/blockchain/');
-
 const tableType = DashboardTableType.BLOCKCHAIN_ASSET_BALANCES;
 
 const { useBlockchainBalances } = useAggregatedBalances();
@@ -49,16 +48,14 @@ const { handleBlockchainRefresh } = useBalanceRefresh();
 
 const aggregatedBalances = useBlockchainBalances(chainsFilter);
 
-onMounted(() => {
-  const { query } = get(route);
-
-  if (!query.add) {
-    return;
-  }
-
+const { consumeAddQuery } = useAddQuery(() => {
   startPromise(nextTick(() => {
     set(account, createNewBlockchainAccount());
   }));
+});
+
+onMounted(async () => {
+  await consumeAddQuery();
 });
 </script>
 

--- a/frontend/app/src/pages/balances/manual/[[tab]].vue
+++ b/frontend/app/src/pages/balances/manual/[[tab]].vue
@@ -10,6 +10,7 @@ import { useManualBalances } from '@/modules/balances/manual/use-manual-balances
 import { BalanceType } from '@/modules/balances/types/balances';
 import { TRADE_LOCATION_EXTERNAL } from '@/modules/core/common/defaults';
 import { NoteLocation } from '@/modules/core/common/notes';
+import { useAddQuery } from '@/modules/core/common/use-add-query';
 import { useHistoryDataFetching } from '@/modules/history/use-history-data-fetching';
 import HideSmallBalances from '@/modules/settings/HideSmallBalances.vue';
 import { BalanceSource } from '@/modules/settings/types/frontend-settings';
@@ -65,12 +66,12 @@ watchImmediate(route, (route) => {
     router.replace('/balances/manual/assets');
 }, { deep: true });
 
+const { consumeAddQuery } = useAddQuery(() => {
+  startPromise(nextTick(() => add()));
+});
+
 onBeforeMount(async () => {
-  const { query } = get(route);
-  if (query.add) {
-    await router.replace({ query: {} });
-    startPromise(nextTick(() => add()));
-  }
+  await consumeAddQuery();
   await fetchManualBalances();
   await fetchAssociatedLocations();
 });

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -181,9 +181,29 @@ vi.mock('@rotki/ui-library', async () => {
   };
 });
 
+/**
+ * Fails a request to the backend that no handler covers, instead of letting it reach the network.
+ *
+ * @remarks
+ * Under `warn` the message went to a console vitest silences for a passing test, so a component
+ * querying from `onMounted` opened a real socket on every run and the suite still exited 0. The
+ * error has to be thrown: `print.error` only reports, and the request proceeds regardless.
+ *
+ * Only the backend is guarded. A spec may start a server of its own and talk to it, which the
+ * address import server spec does on an ephemeral port.
+ */
+function failUnhandledBackendRequest(request: Request, print: { error: () => void }): void {
+  const backendUrl = process.env.VITE_BACKEND_URL;
+  if (!backendUrl || !request.url.startsWith(backendUrl))
+    return;
+
+  print.error();
+  throw new Error(`No msw handler for ${request.method} ${request.url}`);
+}
+
 beforeAll(() => {
   server.listen({
-    onUnhandledRequest: 'warn',
+    onUnhandledRequest: failUnhandledBackendRequest,
   });
 
   class ResizeObserverMock {


### PR DESCRIPTION
Three strands of frontend work: two shared helpers replacing hand-rolled copies, a fix for the unit suite reaching the network, and eight components whose logic moved into tested modules. One real bug fell out of the last strand.

## Shared helpers

**`useAddQuery`** — ten pages each read `route.query.add` on mount, opened their create dialog and cleared the query by hand; two had already grown a private `consumeAddQuery` inside a larger composable. Nine sites converted.

Two things worth review:

- The **blockchain balances page never cleared the query**, so a reload reopened the add dialog. It does now, which is a behaviour change rather than a pure move.
- The **exchanges page is deliberately left alone**: adding the import puts it at 21 dependencies against the `@rotki/max-dependencies` cap of 20, and the contributor guide says to reduce real imports or leave the file as it is rather than work around it.

The helper clears the query *before* calling the handler and passes it the snapshot, so a page seeding its dialog from the link (the EVM accounts page reads `addressToAdd`) still sees the parameters.

**`useTableRowDeletion`** adopted in three more tables — RPC node manager, premium devices, accounting rules. Two of them give the failure toast its own title, which `errorMessage: () => string` could not express, so it now returns the message object; the four existing callers were updated. The helper only runs `onDeleted` when the delete resolves `true`, where the RPC and premium paths previously refetched unconditionally.

## The unit suite was making real network calls

The suite opened **16 connections to `127.0.0.1:4242` per run** and still exited 0. Traced by instrumenting `globalThis.fetch` for one run.

- `exchange-keys-rendering.spec.ts` mounted both binance children for real, and each queries the backend from `onMounted` — 12 of the 16. The spec only asks whether they render, so they are stubbed.
- `DataIssuesView.spec.ts` mounted the view, whose account pill builds its options from a backend call — the remaining 4.

`onUnhandledRequest` was `warn`, and MSW warns through a console vitest silences for a passing test, which is why this was invisible. It now throws for unhandled requests to the backend. **The error has to be thrown**: `print.error` only reports and the request still goes out. Only the backend is guarded, because the address-import spec talks to a server it starts itself on an ephemeral port.

Honest limit: the guard stops the socket, not the mistake. The app catches its own request errors, so a spec with a missing mock goes quiet rather than red.

## Extractions

Logic moved out of eight components into modules that can be tested without mounting:

| component | extracted to | what it decides |
|---|---|---|
| `AssetConflictDialog` | `use-asset-conflict-resolution` | per-asset strategy, whether the dialog can be confirmed, duplicate identifiers |
| `FileUpload` | `use-file-upload` | accept-matching, and the error/uploaded feedback that replace each other on a timer |
| `ReportActionableCard` | `use-report-actionable-items` | whether confirming regenerates the report or dismisses the issues |
| `ReportMissingAcquisitions` | `missing-acquisitions` | one row per asset, its period and total |
| `ReportGenerator` | `use-binance-market-check` | which accounts are missing traded pairs |
| `About` | `use-version-text` | the copyable version block, web vs electron |
| `ReportIssueDialog` | `report-issue-links` | four destination urls, truncation before encoding |
| `BlockchainAccountSelector` | `account-selection` | chain narrowing, uniqueness, the all-chains entry |
| `NftImageRenderingSetting` | `nft-whitelist` | domain parsing and merging |
| `AccountDialog` | `account-dialog-state` | the validator limit, and whether the account was edited |
| `ManualBalancesPriceForm` | `use-manual-balance-price` | saved price → main currency → oracle → blank |

`AssetConflictDialog` also gained a component spec for the wiring the extraction leaves behind.

## 🐛 One real bug

`BlockchainAccountSelector`'s multichain option **appended the synthesized all-chains entries to the array it was handed**. With no chain filter and no `unique` flag, that array is the one the `accounts` computed had cached, so every recompute appended again.

`CalendarView` is on exactly that path — `:source="{ multichain: true }"`, an inline object with neither `chains` nor `unique`. The literal changes identity on each parent render, the `chains` computed returns a fresh `[]`, the selector recomputes, and another duplicate is appended per multi-chain address. The other two multichain callers pass `unique: true`, so `uniqBy` hands back a new array and they are unaffected.

The synthesized entries are now concatenated onto a new array. Verified at the function level — restoring the in-place append fails the test that asserts the input is unchanged. The link to `CalendarView` is from reading the reactivity and **was not reproduced in the running app**, so it is worth a click-through.

## Gates

`typecheck`, `knip`, `lint`, `lint:style`, `linked-keys` and `test:unit` all green; `rwt check` passes all 7.

- 1052 test files / 11,373 tests
- coverage 70.80% → **71.38%** (`.vue` 46.43% → 47.16%)
- real network calls per run 16 → **0**

Every behavioural claim above has a negative control: the guard was broken, the named test watched to go red, and restored. Three of those controls **passed**, which was the finding rather than the reassurance — twice the assertion held by construction and the test was deleted, once half a guard was untested and the mirror case was added.
