### PR TITLE
fix(notifications): stop toasting backend errors

### DIFF
--- a/frontend/app/src/modules/core/messaging/handlers/legacy.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/legacy.spec.ts
@@ -1,0 +1,49 @@
+import { NotificationCategory, Priority, Severity } from '@rotki/common';
+import { mockT } from '@test/i18n';
+import { describe, expect, it } from 'vitest';
+import { createLegacyHandler } from '@/modules/core/messaging/handlers/legacy';
+import { createNotification } from '@/modules/core/notifications/notification-utils';
+
+describe('createLegacyHandler', () => {
+  it('should map an error to a bulk error notification with the backend title', async () => {
+    const handler = createLegacyHandler(mockT);
+
+    const result = await handler.handle({ value: 'Failed to query kraken balances', verbosity: 'error' });
+
+    expect(result).toMatchObject({
+      category: NotificationCategory.DEFAULT,
+      message: 'Failed to query kraken balances',
+      priority: Priority.BULK,
+      severity: Severity.ERROR,
+      title: 'notification_messages.backend.title',
+    });
+  });
+
+  it('should map a warning to its own severity and title', async () => {
+    const handler = createLegacyHandler(mockT);
+
+    const result = await handler.handle({ value: 'Ignoring it.', verbosity: 'warning' });
+
+    expect(result).toMatchObject({
+      priority: Priority.BULK,
+      severity: Severity.WARNING,
+      title: 'notification_messages.backend.warning_title',
+    });
+  });
+
+  it.each(['error', 'warning'] as const)('should leave display unset for a %s', async (verbosity) => {
+    const handler = createLegacyHandler(mockT);
+
+    const result = await handler.handle({ value: 'Skipping balance result.', verbosity });
+
+    expect(result.display).toBeUndefined();
+  });
+
+  it.each(['error', 'warning'] as const)('should not reach the popup queue for a %s', async (verbosity) => {
+    const handler = createLegacyHandler(mockT);
+
+    const result = await handler.handle({ value: 'Check logs for details.', verbosity });
+
+    expect(createNotification(1, result).display).toBe(false);
+  });
+});

--- a/frontend/app/src/modules/core/messaging/handlers/legacy.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/legacy.ts
@@ -3,10 +3,20 @@ import { NotificationCategory, Priority, Severity } from '@rotki/common';
 import { type LegacyMessageData, MESSAGE_WARNING } from '../types/base';
 import { createNotificationHandler } from '../utils/handler-factories';
 
+/**
+ * Renders a bare `add_error` / `add_warning` string from the backend.
+ *
+ * @remarks
+ * The lane never interrupts. It carries no type, group or actionability, so all ~150 backend
+ * call sites arrive indistinguishable and a popup cannot say anything the drawer does not say
+ * better. The bulk of the corpus is self-describing as ignorable ("Ignoring it", "Skipping
+ * balance result", "Check logs for details and open a bug report"), and a condition that does
+ * warrant an interrupt earns it by getting a structured `WSMessageType`, not by being a longer
+ * string. Omitting `display` leaves `createNotification` to store it silently.
+ */
 export function createLegacyHandler(t: ReturnType<typeof useI18n>['t']): NotificationHandler<LegacyMessageData> {
   return createNotificationHandler<LegacyMessageData>(({ value, verbosity }) => ({
     category: NotificationCategory.DEFAULT,
-    display: verbosity !== MESSAGE_WARNING,
     message: value,
     priority: Priority.BULK,
     severity: verbosity === MESSAGE_WARNING ? Severity.WARNING : Severity.ERROR,


### PR DESCRIPTION
Phase 1 of #12942, first of two PRs. This one stops the legacy backend
message lane from interrupting the user. The second will make priority
authoritative over `display`.

## The problem

`modules/core/messaging/handlers/legacy.ts` renders every bare string the
backend emits through `add_error` / `add_warning`. Non-test counts on
`develop` at `d5925914b9`: **151 `add_error`, 38 `add_warning`**. All of
them arrive in the same shape:

```ts
display: verbosity !== MESSAGE_WARNING,   // every error toasts
priority: Priority.BULK,
title: t('notification_messages.backend.title'),   // one generic title
message: value,                                    // raw python string
```

One title, one priority, the raw python string as the body, and for
errors an unconditional popup. It is the single largest source of
unactionable interruptions in the app. Warnings already did not toast,
which was the right call.

The payload carries no type, no group, no severity beyond warn/error, no
actionability and no dedupe key, so 151 distinct failure conditions are
indistinguishable at the point where the UI has to decide whether to
interrupt. A popup cannot say anything the drawer does not say better.

## The change

Drop the `display` field. `createNotification` already defaults it to
`false`, so these store silently. They keep their place in the
notification drawer and still move the count; only the interruption
goes.

A condition that genuinely warrants an interrupt earns it by getting a
structured `WSMessageType`, not by being a longer string.

## Why this is safe ahead of per-site triage

Of ~148 non-test `add_error` call sites, **111 are in
`rotkehlchen/exchanges/`**, and that corpus is two families:

| Family | Shape |
|---|---|
| Skipped entry | "Failed to deserialize a `<exchange>` `<thing>`. Check logs for details and open a bug report." / "Ignoring it." / "Skipping balance result." |
| Transient remote | "Got remote error while querying `<exchange>` `<case>`" / "Failed to query `<exchange>` transactions" |

Both already describe themselves as ignorable. Neither should interrupt.

**Accepted residual:** the ~37 sites outside `exchanges/`, mostly `db/`
and `chain/evm/`, include conditions that are genuinely persistent (a
revoked key, permanently rejected credentials). Those go quiet until
they are promoted to structured message types. That promotion is
tracked as later phase work on #12942 rather than held up here, because
the string they currently arrive as cannot express persistence either.

## Tests

`legacy.ts` had **no spec and zero coverage**. This adds one covering
the severity and title mapping per verbosity, that `display` stays
unset, and that the notification `createNotification` builds from the
handler output does not reach the popup queue.

Negative control: restoring the old `display` line turns 3 of the 6 red
and leaves the right 3 green. Both mapping tests still pass, and so does
the *warning* popup-queue case, because warnings never toasted. Only the
error path and the two `display`-unset assertions fail, so the spec
discriminates the actual behaviour change rather than agreeing with both
versions.

324 tests pass across `modules/core/notifications/` and
`modules/core/messaging/`. `typecheck`, `knip`, `lint:style`,
`check:linked-keys` and `test:proxy` all green.
