### PR TITLE
Cover the four spec-less dialogs, fixing two bugs they hid

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/AddressBookFormDialog.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookFormDialog.spec.ts
@@ -1,0 +1,314 @@
+import type { AddressBookPayload } from '@/modules/accounts/address-book/eth-names';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { defineComponent, h, nextTick, type VNode } from 'vue';
+import AddressBookFormDialog from '@/modules/accounts/address-book/AddressBookFormDialog.vue';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+
+const { addAddressBook, setMessage, updateAddressBook } = vi.hoisted(() => ({
+  addAddressBook: vi.fn(),
+  setMessage: vi.fn(),
+  updateAddressBook: vi.fn(),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-address-book-operations', () => ({
+  useAddressBookOperations: (): Record<string, Mock> => ({ addAddressBook, updateAddressBook }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, Mock> => ({ setMessage }),
+}));
+
+const validate = vi.fn(async () => true);
+
+/** The dialog validates through a template ref, so the stub has to expose the method it calls. */
+const FormStub = defineComponent({
+  name: 'AddressBookForm',
+  props: ['modelValue', 'errorMessages', 'stateUpdated', 'editMode'],
+  setup(_, { expose }): () => VNode {
+    expose({ validate });
+    return () => h('div');
+  },
+});
+
+/** `BigDialog` teleports and owns the footer buttons; the two here stand for confirm and cancel. */
+const BigDialogStub = {
+  emits: ['confirm', 'cancel'],
+  name: 'BigDialog',
+  props: ['title', 'display', 'action', 'loading', 'promptOnClose'],
+  template: `<div>
+    <slot />
+    <button data-testid="stub-confirm" @click="$emit('confirm')" />
+    <button data-testid="stub-cancel" @click="$emit('cancel')" />
+  </div>`,
+};
+
+function entry(overrides: Partial<AddressBookPayload> = {}): AddressBookPayload {
+  return { address: '0xabc', blockchain: 'eth', location: 'private', name: 'wallet', ...overrides };
+}
+
+function createWrapper(props: Record<string, unknown> = {}): VueWrapper<any> {
+  return mount(AddressBookFormDialog, {
+    global: {
+      stubs: {
+        AddressBookForm: FormStub,
+        BigDialog: BigDialogStub,
+      },
+    },
+    props: { open: true, ...props },
+  });
+}
+
+/** The dialog as the management page opens it to change an entry that already exists. */
+function editing(overrides: Partial<AddressBookPayload> = {}): VueWrapper<any> {
+  return createWrapper({ editMode: true, editableItem: entry(overrides) });
+}
+
+async function confirm(wrapper: VueWrapper<any>): Promise<void> {
+  await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+  await flushPromises();
+}
+
+function formValue(wrapper: VueWrapper<any>): AddressBookPayload {
+  return wrapper.findComponent(FormStub).props('modelValue');
+}
+
+describe('addressBookFormDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validate.mockResolvedValue(true);
+    addAddressBook.mockResolvedValue(true);
+    updateAddressBook.mockResolvedValue(true);
+  });
+
+  describe('seeding the form', () => {
+    it('should start empty when nothing was handed over', () => {
+      const wrapper = createWrapper();
+
+      expect(formValue(wrapper)).toEqual({ address: '', blockchain: 'all', location: 'private', name: '' });
+    });
+
+    it('should preselect the chain the caller was showing', () => {
+      const wrapper = createWrapper({ selectedChain: 'optimism' });
+
+      expect(formValue(wrapper).blockchain).toBe('optimism');
+    });
+
+    it('should open in the location the caller was showing', () => {
+      const wrapper = createWrapper({ location: 'global' });
+
+      expect(formValue(wrapper).location).toBe('global');
+    });
+
+    it('should load the entry handed over', () => {
+      const wrapper = editing({ name: 'exchange' });
+
+      expect(formValue(wrapper).name).toBe('exchange');
+    });
+
+    /** An entry saved for every chain has no blockchain; the picker shows that as `all`. */
+    it('should show an entry without a chain as covering all of them', () => {
+      const wrapper = editing({ blockchain: null });
+
+      expect(formValue(wrapper).blockchain).toBe('all');
+    });
+
+    it('should discard the form once the dialog is closed', async () => {
+      const wrapper = editing();
+
+      await wrapper.setProps({ open: false });
+
+      expect(wrapper.findComponent(FormStub).exists()).toBe(false);
+    });
+  });
+
+  describe('the heading', () => {
+    it('should announce an edit when the entry is being updated', () => {
+      expect(editing().findComponent(BigDialogStub).props('title')).toBe('address_book.dialog.edit_title');
+    });
+
+    /**
+     * The messages dialog seeds the form with the address the backend asked the user to name, and
+     * that is an addition however filled-in the form arrives.
+     */
+    it('should announce an addition when a seeded entry is being added', () => {
+      const wrapper = createWrapper({ editableItem: entry() });
+
+      expect(wrapper.findComponent(BigDialogStub).props('title')).toBe('address_book.dialog.add_title');
+    });
+  });
+
+  describe('saving', () => {
+    it('should not save a form that does not validate', async () => {
+      validate.mockResolvedValue(false);
+      const wrapper = createWrapper();
+
+      await confirm(wrapper);
+
+      expect(addAddressBook).not.toHaveBeenCalled();
+      expect(updateAddressBook).not.toHaveBeenCalled();
+    });
+
+    it('should add an entry the dialog was not told to update', async () => {
+      const wrapper = createWrapper({ root: true });
+
+      await confirm(wrapper);
+
+      expect(addAddressBook).toHaveBeenCalledWith('private', [{ address: '', blockchain: null, name: '' }], true);
+    });
+
+    it('should add a seeded entry rather than update it', async () => {
+      const wrapper = createWrapper({ editableItem: entry() });
+
+      await confirm(wrapper);
+
+      expect(addAddressBook).toHaveBeenCalledTimes(1);
+      expect(updateAddressBook).not.toHaveBeenCalled();
+    });
+
+    it('should update the entry when told to', async () => {
+      const wrapper = editing();
+
+      await confirm(wrapper);
+
+      expect(updateAddressBook).toHaveBeenCalledWith('private', [{
+        address: '0xabc',
+        blockchain: 'eth',
+        name: 'wallet',
+      }]);
+      expect(addAddressBook).not.toHaveBeenCalled();
+    });
+
+    it('should trim the address and the name', async () => {
+      const wrapper = editing({ address: '  0xabc  ', name: '  wallet  ' });
+
+      await confirm(wrapper);
+
+      expect(updateAddressBook).toHaveBeenCalledWith('private', [{
+        address: '0xabc',
+        blockchain: 'eth',
+        name: 'wallet',
+      }]);
+    });
+
+    /** `all` is the picker's word for every chain, which the backend spells as no chain at all. */
+    it('should send no chain for an entry covering all of them', async () => {
+      const wrapper = editing({ blockchain: null });
+
+      await confirm(wrapper);
+
+      expect(updateAddressBook).toHaveBeenCalledWith('private', [expect.objectContaining({ blockchain: null })]);
+    });
+  });
+
+  describe('after a successful save', () => {
+    it('should close the dialog and ask for a refresh', async () => {
+      const wrapper = editing();
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false]);
+      expect(wrapper.emitted('refresh')).toHaveLength(1);
+    });
+
+    it('should switch to the tab the entry was saved into', async () => {
+      const wrapper = createWrapper({ editMode: true, editableItem: entry({ location: 'global' }) });
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('update:tab')?.[0]).toEqual([0]);
+    });
+
+    it('should switch to the private tab for a private entry', async () => {
+      const wrapper = editing();
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('update:tab')?.[0]).toEqual([1]);
+    });
+  });
+
+  describe('after a rejected save', () => {
+    it('should keep the dialog open', async () => {
+      updateAddressBook.mockResolvedValue(false);
+      const wrapper = editing();
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('update:open')).toBeUndefined();
+      expect(wrapper.emitted('refresh')).toBeUndefined();
+    });
+
+    it('should mark the offending fields when the backend named them', async () => {
+      updateAddressBook.mockRejectedValue(new ApiValidationError(JSON.stringify({ address: ['not an address'] })));
+      const wrapper = editing();
+
+      await confirm(wrapper);
+
+      expect(wrapper.findComponent(FormStub).props('errorMessages')).toEqual({ address: ['not an address'] });
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+
+    it('should surface an error that names no field', async () => {
+      updateAddressBook.mockRejectedValue(new Error('the backend said no'));
+      const wrapper = editing();
+
+      await confirm(wrapper);
+
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'address_book.actions.edit.error.description::the backend said no',
+        success: false,
+        title: 'address_book.actions.edit.error.title',
+      });
+    });
+
+    it('should word the error as an addition when the entry is new', async () => {
+      addAddressBook.mockRejectedValue(new Error('the backend said no'));
+
+      await confirm(createWrapper());
+
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'address_book.actions.add.error.description::the backend said no',
+        success: false,
+        title: 'address_book.actions.add.error.title',
+      });
+    });
+  });
+
+  /** The errors belong to the chain they were reported for, so switching chains retires them. */
+  describe('the field errors', () => {
+    async function rejectedWrapper(): Promise<VueWrapper<any>> {
+      updateAddressBook.mockRejectedValue(new ApiValidationError(JSON.stringify({ address: ['not an address'] })));
+      const wrapper = editing();
+      await confirm(wrapper);
+      return wrapper;
+    }
+
+    it('should be cleared when the chain changes', async () => {
+      const wrapper = await rejectedWrapper();
+
+      wrapper.findComponent(FormStub).vm.$emit('update:modelValue', entry({ blockchain: 'optimism' }));
+      await nextTick();
+
+      expect(wrapper.findComponent(FormStub).props('errorMessages')).toEqual({});
+    });
+
+    it('should survive an edit that leaves the chain alone', async () => {
+      const wrapper = await rejectedWrapper();
+
+      wrapper.findComponent(FormStub).vm.$emit('update:modelValue', entry({ name: 'renamed' }));
+      await nextTick();
+
+      expect(wrapper.findComponent(FormStub).props('errorMessages')).toEqual({ address: ['not an address'] });
+    });
+  });
+
+  it('should close without saving when dismissed', async () => {
+    const wrapper = editing();
+
+    await wrapper.find('[data-testid=stub-cancel]').trigger('click');
+
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false]);
+    expect(updateAddressBook).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/accounts/address-book/AddressBookFormDialog.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookFormDialog.vue
@@ -13,12 +13,20 @@ const open = defineModel<boolean>('open', { required: true });
 
 const {
   editableItem = null,
-  editMode,
+  editMode = false,
   location,
   root = false,
   selectedChain,
 } = defineProps<{
+  /** The entry the form starts from, which an addition may also have: see `editMode`. */
   editableItem?: AddressBookPayload | null;
+  /**
+   * Whether the entry is being updated rather than added.
+   *
+   * @remarks
+   * Not derived from `editableItem`: the messages dialog seeds the form with the address the
+   * backend asked the user to name, and that is still an addition.
+   */
   editMode?: boolean;
   selectedChain?: string;
   location?: 'global' | 'private';
@@ -98,7 +106,6 @@ async function save(): Promise<boolean> {
 
   const formValue = get(modelValue);
   const { address, blockchain, location, name } = formValue;
-  const isEdit = editMode ?? !!editableItem;
   const payload = {
     address: address.trim(),
     blockchain: blockchain === 'all' ? null : blockchain,
@@ -108,13 +115,13 @@ async function save(): Promise<boolean> {
   set(loading, true);
   let success;
   try {
-    success = isEdit
+    success = editMode
       ? await updateAddressBook(location, [payload])
       : await addAddressBook(location, [payload], root);
   }
   catch (error: unknown) {
     success = false;
-    handleSaveError(error, isEdit, formValue);
+    handleSaveError(error, editMode, formValue);
   }
 
   set(loading, false);
@@ -128,7 +135,7 @@ async function save(): Promise<boolean> {
 }
 
 const dialogTitle = computed<string>(() =>
-  editableItem
+  editMode
     ? t('address_book.dialog.edit_title')
     : t('address_book.dialog.add_title'),
 );
@@ -172,7 +179,7 @@ watchImmediate([open, () => editableItem], ([open, editableItem]) => {
       v-model="modelValue"
       v-model:error-messages="errorMessages"
       v-model:state-updated="stateUpdated"
-      :edit-mode="editMode ?? !!editableItem"
+      :edit-mode="editMode"
     />
   </BigDialog>
 </template>

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalancesDialog.spec.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalancesDialog.spec.ts
@@ -1,0 +1,238 @@
+import type { ManualBalance, RawManualBalance } from '@/modules/balances/types/manual-balances';
+import { bigNumberify } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { defineComponent, h, type VNode } from 'vue';
+import ManualBalancesDialog from '@/modules/accounts/manual-balances/ManualBalancesDialog.vue';
+import { BalanceType } from '@/modules/balances/types/balances';
+
+const { refreshPrice, refreshPrices, saveBalance, setMessage } = vi.hoisted(() => ({
+  refreshPrice: vi.fn(async () => {}),
+  refreshPrices: vi.fn(async () => {}),
+  saveBalance: vi.fn(),
+  setMessage: vi.fn(),
+}));
+
+vi.mock('@/modules/balances/manual/use-manual-balances', () => ({
+  useManualBalances: (): Record<string, Mock> => ({ save: saveBalance }),
+}));
+
+vi.mock('@/modules/assets/prices/use-price-refresh', () => ({
+  usePriceRefresh: (): Record<string, Mock> => ({ refreshPrice, refreshPrices }),
+}));
+
+vi.mock('@/modules/core/common/use-message-store', () => ({
+  useMessageStore: (): Record<string, Mock> => ({ setMessage }),
+}));
+
+const validate = vi.fn(() => true);
+const savePrice = vi.fn(async () => false);
+
+/**
+ * The dialog reaches into the form through a template ref, so the stub has to expose the two
+ * methods it calls. An auto-stub would leave the ref pointing at a component with neither.
+ */
+const FormStub = defineComponent({
+  name: 'ManualBalancesForm',
+  props: ['modelValue', 'errorMessages', 'stateUpdated', 'submitting'],
+  setup(_, { expose }): () => VNode {
+    expose({ savePrice, validate });
+    return () => h('div');
+  },
+});
+
+/** `BigDialog` teleports and owns the footer buttons; the two here stand for confirm and cancel. */
+const BigDialogStub = {
+  emits: ['confirm', 'cancel'],
+  name: 'BigDialog',
+  props: ['title', 'subtitle', 'display', 'loading', 'action', 'promptOnClose'],
+  template: `<div>
+    <slot />
+    <button data-testid="stub-confirm" @click="$emit('confirm')" />
+    <button data-testid="stub-cancel" @click="$emit('cancel')" />
+  </div>`,
+};
+
+function rawBalance(): RawManualBalance {
+  return {
+    amount: bigNumberify(10),
+    asset: 'ETH',
+    balanceType: BalanceType.ASSET,
+    label: 'savings',
+    location: 'external',
+    tags: null,
+  };
+}
+
+function savedBalance(): ManualBalance {
+  return { ...rawBalance(), identifier: 1 };
+}
+
+function createWrapper(modelValue: ManualBalance | RawManualBalance): VueWrapper<any> {
+  return mount(ManualBalancesDialog, {
+    global: {
+      stubs: {
+        BigDialog: BigDialogStub,
+        ManualBalancesForm: FormStub,
+      },
+    },
+    props: { modelValue },
+  });
+}
+
+async function confirm(wrapper: VueWrapper<any>): Promise<void> {
+  await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+  await flushPromises();
+}
+
+describe('manualBalancesDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    validate.mockReturnValue(true);
+    savePrice.mockResolvedValue(false);
+    saveBalance.mockResolvedValue({ success: true });
+  });
+
+  describe('the heading', () => {
+    it('should announce an edit when the balance has been saved before', () => {
+      const dialog = createWrapper(savedBalance()).findComponent(BigDialogStub);
+
+      expect(dialog.props('title')).toBe('manual_balances.dialog.edit.title');
+      expect(dialog.props('subtitle')).toBe('manual_balances.dialog.edit.subtitle');
+    });
+
+    it('should announce an addition when the balance is new', () => {
+      const dialog = createWrapper(rawBalance()).findComponent(BigDialogStub);
+
+      expect(dialog.props('title')).toBe('manual_balances.dialog.add.title');
+      expect(dialog.props('subtitle')).toBe('');
+    });
+  });
+
+  describe('saving', () => {
+    it('should not save a form that does not validate', async () => {
+      validate.mockReturnValue(false);
+      const wrapper = createWrapper(rawBalance());
+
+      await confirm(wrapper);
+
+      expect(saveBalance).not.toHaveBeenCalled();
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+    });
+
+    it('should send the balance and close on success', async () => {
+      const wrapper = createWrapper(savedBalance());
+
+      await confirm(wrapper);
+
+      expect(saveBalance).toHaveBeenCalledWith(savedBalance());
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([undefined]);
+    });
+
+    it('should keep the dialog open when the save fails', async () => {
+      saveBalance.mockResolvedValue({ message: 'nope', success: false });
+      const wrapper = createWrapper(savedBalance());
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+    });
+
+    it('should discard the balance when the dialog is dismissed', async () => {
+      const wrapper = createWrapper(savedBalance());
+
+      await wrapper.find('[data-testid=stub-cancel]').trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([undefined]);
+      expect(saveBalance).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * A manual price entered alongside the balance changes the value the list shows, so both the
+   * asset's own price and the aggregate are refetched. Nothing was entered means nothing to refetch.
+   */
+  describe('prices saved with the balance', () => {
+    it('should refresh the asset and the aggregate when a price was saved', async () => {
+      savePrice.mockResolvedValue(true);
+
+      await confirm(createWrapper(savedBalance()));
+
+      expect(refreshPrice).toHaveBeenCalledWith('ETH');
+      expect(refreshPrices).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh nothing when no price was saved', async () => {
+      await confirm(createWrapper(savedBalance()));
+
+      expect(refreshPrice).not.toHaveBeenCalled();
+      expect(refreshPrices).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * A balance without an identifier is one the list has never shown, and it lands on the tab its
+   * type belongs to rather than the one the user was looking at.
+   */
+  describe('the tab a new balance lands on', () => {
+    it('should switch to the assets tab for a new asset', async () => {
+      const wrapper = createWrapper(rawBalance());
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('update-tab')?.[0]).toEqual(['assets']);
+    });
+
+    it('should switch to the liabilities tab for a new liability', async () => {
+      const wrapper = createWrapper({ ...rawBalance(), balanceType: BalanceType.LIABILITY });
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('update-tab')?.[0]).toEqual(['liabilities']);
+    });
+
+    it('should leave the tab alone when an existing balance is edited', async () => {
+      const wrapper = createWrapper(savedBalance());
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('update-tab')).toBeUndefined();
+    });
+  });
+
+  describe('reporting a rejected save', () => {
+    it('should mark the offending fields and re-validate the form', async () => {
+      const errors = { label: ['already taken'] };
+      saveBalance.mockResolvedValue({ message: errors, success: false });
+      const wrapper = createWrapper(savedBalance());
+
+      await confirm(wrapper);
+
+      expect(wrapper.findComponent(FormStub).props('errorMessages')).toEqual(errors);
+      expect(validate).toHaveBeenCalledTimes(2);
+      expect(setMessage).not.toHaveBeenCalled();
+    });
+
+    it('should surface a message that names no field', async () => {
+      saveBalance.mockResolvedValue({ message: 'the backend said no', success: false });
+      const wrapper = createWrapper(savedBalance());
+
+      await confirm(wrapper);
+
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'actions.manual_balances.edit.error.description::the backend said no',
+      });
+      expect(wrapper.findComponent(FormStub).props('errorMessages')).toEqual({});
+    });
+
+    it('should word the message as an addition when the balance is new', async () => {
+      saveBalance.mockResolvedValue({ message: 'the backend said no', success: false });
+
+      await confirm(createWrapper(rawBalance()));
+
+      expect(setMessage).toHaveBeenCalledWith({
+        description: 'actions.manual_balances.add.error.description::the backend said no',
+      });
+    });
+  });
+});

--- a/frontend/app/src/modules/auth/create-account/CreateAccountWizard.spec.ts
+++ b/frontend/app/src/modules/auth/create-account/CreateAccountWizard.spec.ts
@@ -1,0 +1,184 @@
+import type { Component, Ref } from 'vue';
+import type { CreateAccountPayload } from '@/modules/auth/login';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import CreateAccountWizard from '@/modules/auth/create-account/CreateAccountWizard.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { hasProfiles, loadProfiles } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return { hasProfiles: ref<boolean>(true), loadProfiles: vi.fn(async () => {}) };
+});
+
+vi.mock('@/modules/auth/use-saved-profiles', () => ({
+  useSavedProfiles: (): { hasProfiles: Ref<boolean>; loadProfiles: Mock } => ({ hasProfiles, loadProfiles }),
+}));
+
+/**
+ * The later steps stand in as pass-throughs that expose their three outward signals; only the
+ * introduction is mounted for real, because the mode choice is the wizard's own first decision.
+ */
+function stepStub(name: string): Component {
+  return {
+    emits: ['back', 'next', 'confirm'],
+    name,
+    props: ['loading', 'mode', 'error'],
+    template: `<div :data-testid="'${name}'">
+      <button data-testid="stub-back" @click="$emit('back')" />
+      <button data-testid="stub-next" @click="$emit('next')" />
+      <button data-testid="stub-confirm" @click="$emit('confirm')" />
+    </div>`,
+  };
+}
+
+function createWrapper(props: Record<string, unknown> = {}): VueWrapper<any> {
+  return mount(CreateAccountWizard, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        CreateAccountCredentials: stepStub('CreateAccountCredentials'),
+        CreateAccountPremium: stepStub('CreateAccountPremium'),
+        CreateAccountSubmitStep: stepStub('CreateAccountSubmitStep'),
+        // Globally stubbed to `true`, which would swallow the introduction's own copy.
+        I18nT: { template: '<div><slot /></div>' },
+        RotkiLogo: true,
+        // The real tabs render nothing without a measured layout, so every step renders at once.
+        RuiTabItem: { template: '<div><slot /></div>' },
+        RuiTabItems: { props: ['modelValue'], template: '<div><slot /></div>' },
+      },
+    },
+    props: { loading: false, step: 1, ...props },
+  });
+}
+
+function lastStep(wrapper: VueWrapper<any>): number | undefined {
+  return wrapper.emitted<[number]>('update:step')?.at(-1)?.[0];
+}
+
+/**
+ * Presses one of a step's three buttons.
+ *
+ * @remarks
+ * Every step renders at once here, so the button is reached through the step's own component
+ * rather than the document, where the first step's copy would answer instead.
+ */
+async function press(wrapper: VueWrapper<any>, step: string, button: string): Promise<void> {
+  await wrapper.findComponent({ name: step }).find(`[data-testid=stub-${button}]`).trigger('click');
+}
+
+describe('createAccountWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(hasProfiles, true);
+  });
+
+  it('should load the saved profiles before it renders', () => {
+    createWrapper();
+
+    expect(loadProfiles).toHaveBeenCalledTimes(1);
+  });
+
+  describe('the heading', () => {
+    it('should offer to create an account by default', () => {
+      expect(createWrapper().find('h4').text()).toBe('create_account.title');
+    });
+
+    it('should offer to restore one once that mode is chosen', () => {
+      const wrapper = createWrapper({ mode: 'restore' });
+
+      expect(wrapper.find('h4').text()).toBe('create_account.title_restore');
+    });
+  });
+
+  describe('choosing a mode', () => {
+    it('should record the choice and move to the next step', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=create-account-introduction-restore]').trigger('click');
+
+      expect(wrapper.emitted<[string]>('update:mode')?.at(-1)?.[0]).toBe('restore');
+      expect(lastStep(wrapper)).toBe(2);
+    });
+
+    it('should move on for a plain create too', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=create-account-introduction-create]').trigger('click');
+
+      expect(wrapper.emitted<[string]>('update:mode')?.at(-1)?.[0]).toBe('create');
+      expect(lastStep(wrapper)).toBe(2);
+    });
+  });
+
+  describe('stepping back', () => {
+    it('should return to the previous step', async () => {
+      const wrapper = createWrapper({ mode: 'create', step: 3 });
+
+      await press(wrapper, 'CreateAccountCredentials', 'back');
+
+      expect(lastStep(wrapper)).toBe(2);
+    });
+
+    /** The error belongs to the submit the user is stepping away from. */
+    it('should clear a submit error on the way back', async () => {
+      const wrapper = createWrapper({ error: 'wrong password', mode: 'create', step: 4 });
+
+      await press(wrapper, 'CreateAccountSubmitStep', 'back');
+
+      expect(wrapper.emitted('clear-error')).toHaveLength(1);
+    });
+
+    it('should not clear an error that was never raised', async () => {
+      const wrapper = createWrapper({ mode: 'create', step: 4 });
+
+      await press(wrapper, 'CreateAccountSubmitStep', 'back');
+
+      expect(wrapper.emitted('clear-error')).toBeUndefined();
+    });
+  });
+
+  describe('submitting', () => {
+    it('should hand the parent the answers collected so far', async () => {
+      const wrapper = createWrapper({ mode: 'create', step: 4 });
+
+      await press(wrapper, 'CreateAccountSubmitStep', 'confirm');
+
+      const payload = wrapper.emitted<[CreateAccountPayload]>('confirm')?.[0]?.[0];
+
+      expect(payload).toEqual({
+        credentials: { password: '', username: '' },
+        initialSettings: { submitUsageAnalytics: true },
+      });
+    });
+
+    it('should carry the premium setup a restore turned on', async () => {
+      const wrapper = createWrapper();
+      await wrapper.find('[data-testid=create-account-introduction-restore]').trigger('click');
+      await wrapper.setProps({ mode: 'restore', step: 4 });
+
+      await press(wrapper, 'CreateAccountSubmitStep', 'confirm');
+
+      expect(wrapper.emitted<[CreateAccountPayload]>('confirm')?.[0]?.[0].premiumSetup).toEqual({
+        apiKey: '',
+        apiSecret: '',
+        syncDatabase: true,
+      });
+    });
+  });
+
+  describe('the log in shortcut', () => {
+    it('should be offered when the machine already has a profile', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=login]').trigger('click');
+
+      expect(wrapper.emitted('cancel')).toHaveLength(1);
+    });
+
+    it('should be withheld when no account has ever been created here', () => {
+      set(hasProfiles, false);
+
+      expect(createWrapper().find('[data-testid=login]').exists()).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/auth/create-account/CreateAccountWizard.vue
+++ b/frontend/app/src/modules/auth/create-account/CreateAccountWizard.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { CreateAccountMode } from '@/modules/auth/create-account/types';
-import type { CreateAccountPayload, LoginCredentials, PremiumSetup } from '@/modules/auth/login';
+import type { CreateAccountPayload } from '@/modules/auth/login';
 import CreateAccountSubmitStep
   from '@/modules/auth/create-account/analytics/CreateAccountSubmitStep.vue';
 import CreateAccountCredentials
@@ -8,6 +8,7 @@ import CreateAccountCredentials
 import CreateAccountIntroduction
   from '@/modules/auth/create-account/introduction/CreateAccountIntroduction.vue';
 import CreateAccountPremium from '@/modules/auth/create-account/premium/CreateAccountPremium.vue';
+import { useCreateAccountWizard } from '@/modules/auth/create-account/use-create-account-wizard';
 import { useSavedProfiles } from '@/modules/auth/use-saved-profiles';
 import RotkiLogo from '@/modules/shell/components/RotkiLogo.vue';
 
@@ -30,24 +31,21 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const premiumEnabled = ref<boolean>(false);
-const premiumSetupForm = ref<PremiumSetup>({
-  apiKey: '',
-  apiSecret: '',
-  syncDatabase: false,
-});
-
-const credentialsForm = ref<LoginCredentials>({
-  password: '',
-  username: '',
-});
-const passwordConfirm = ref<string>('');
-const userPrompted = ref<boolean>(false);
-const submitUsageAnalytics = ref<boolean>(true);
+const {
+  buildPayload,
+  isRestoreMode,
+  modelCredentialsForm,
+  modelPasswordConfirm,
+  modelPremiumEnabled,
+  modelPremiumSetupForm,
+  modelSubmitUsageAnalytics,
+  modelUserPrompted,
+  nextStep,
+  prevStep: rewind,
+  selectMode,
+} = useCreateAccountWizard(step, mode);
 
 const { hasProfiles, loadProfiles } = useSavedProfiles();
-
-const isRestoreMode = computed<boolean>(() => get(mode) === 'restore');
 
 const wizardTitle = computed<string>(() =>
   get(isRestoreMode) ? t('create_account.title_restore') : t('create_account.title'),
@@ -56,47 +54,15 @@ const wizardTitle = computed<string>(() =>
 const cancel = (): void => emit('cancel');
 const errorClear = (): void => emit('clear-error');
 
-function resetPremiumState(): void {
-  set(premiumEnabled, false);
-  set(premiumSetupForm, { apiKey: '', apiSecret: '', syncDatabase: false });
-}
-
+/** The error belongs to the submit the user is stepping away from, so going back clears it. */
 function prevStep(): void {
-  const next = get(step) - 1;
-  set(step, next);
-  if (next === 1) {
-    set(mode, undefined);
-    resetPremiumState();
-  }
+  rewind();
   if (error)
     errorClear();
 }
 
-function nextStep(): void {
-  set(step, get(step) + 1);
-}
-
-function selectMode(selected: CreateAccountMode): void {
-  set(mode, selected);
-  if (selected === 'restore') {
-    set(premiumEnabled, true);
-    set(premiumSetupForm, { ...get(premiumSetupForm), syncDatabase: true });
-  }
-  nextStep();
-}
-
-function confirm() {
-  const payload: CreateAccountPayload = {
-    credentials: get(credentialsForm),
-    initialSettings: {
-      submitUsageAnalytics: get(submitUsageAnalytics),
-    },
-  };
-
-  if (get(premiumEnabled))
-    payload.premiumSetup = get(premiumSetupForm);
-
-  emit('confirm', payload);
+function confirm(): void {
+  emit('confirm', buildPayload());
 }
 
 onBeforeMount(loadProfiles);
@@ -129,8 +95,8 @@ onBeforeMount(loadProfiles);
               </RuiTabItem>
               <RuiTabItem>
                 <CreateAccountPremium
-                  v-model:premium-enabled="premiumEnabled"
-                  v-model:form="premiumSetupForm"
+                  v-model:premium-enabled="modelPremiumEnabled"
+                  v-model:form="modelPremiumSetupForm"
                   :loading="loading"
                   :mode="mode ?? 'create'"
                   @back="prevStep()"
@@ -139,9 +105,9 @@ onBeforeMount(loadProfiles);
               </RuiTabItem>
               <RuiTabItem>
                 <CreateAccountCredentials
-                  v-model:form="credentialsForm"
-                  v-model:password-confirm="passwordConfirm"
-                  v-model:user-prompted="userPrompted"
+                  v-model:form="modelCredentialsForm"
+                  v-model:password-confirm="modelPasswordConfirm"
+                  v-model:user-prompted="modelUserPrompted"
                   :loading="loading"
                   :mode="mode ?? 'create'"
                   @back="prevStep()"
@@ -150,7 +116,7 @@ onBeforeMount(loadProfiles);
               </RuiTabItem>
               <RuiTabItem>
                 <CreateAccountSubmitStep
-                  v-model:submit-usage-analytics="submitUsageAnalytics"
+                  v-model:submit-usage-analytics="modelSubmitUsageAnalytics"
                   :loading="loading"
                   :mode="mode ?? 'create'"
                   :error="error"

--- a/frontend/app/src/modules/auth/create-account/use-create-account-wizard.spec.ts
+++ b/frontend/app/src/modules/auth/create-account/use-create-account-wizard.spec.ts
@@ -1,0 +1,172 @@
+import type { CreateAccountMode } from '@/modules/auth/create-account/types';
+import { describe, expect, it } from 'vitest';
+import { type Ref, ref } from 'vue';
+import { useCreateAccountWizard } from '@/modules/auth/create-account/use-create-account-wizard';
+
+interface Harness {
+  mode: Ref<CreateAccountMode | undefined>;
+  step: Ref<number>;
+  wizard: ReturnType<typeof useCreateAccountWizard>;
+}
+
+function createWizard(step = 1, mode?: CreateAccountMode): Harness {
+  const stepRef = ref<number>(step);
+  const modeRef = ref<CreateAccountMode | undefined>(mode);
+  return { mode: modeRef, step: stepRef, wizard: useCreateAccountWizard(stepRef, modeRef) };
+}
+
+describe('useCreateAccountWizard', () => {
+  describe('moving between the steps', () => {
+    it('should advance to the next step', () => {
+      const { step, wizard } = createWizard(2);
+
+      wizard.nextStep();
+
+      expect(get(step)).toBe(3);
+    });
+
+    it('should return to the previous step', () => {
+      const { step, wizard } = createWizard(3);
+
+      wizard.prevStep();
+
+      expect(get(step)).toBe(2);
+    });
+
+    it('should forget the mode when the first step is reached again', () => {
+      const { mode, wizard } = createWizard(2, 'restore');
+
+      wizard.prevStep();
+
+      expect(get(mode)).toBeUndefined();
+    });
+
+    it('should keep the mode while the first step is not reached', () => {
+      const { mode, wizard } = createWizard(3, 'restore');
+
+      wizard.prevStep();
+
+      expect(get(mode)).toBe('restore');
+    });
+
+    /**
+     * The mode is being chosen again, so the answers the previous choice seeded go with it:
+     * a create started from a discarded restore must not carry its database sync.
+     */
+    it('should drop the premium answers when the first step is reached again', () => {
+      const { wizard } = createWizard(1);
+      wizard.selectMode('restore');
+
+      wizard.prevStep();
+
+      expect(get(wizard.modelPremiumEnabled)).toBe(false);
+      expect(get(wizard.modelPremiumSetupForm)).toEqual({ apiKey: '', apiSecret: '', syncDatabase: false });
+    });
+
+    it('should keep the premium answers when an intermediate step is reached', () => {
+      const { wizard } = createWizard(2);
+      wizard.selectMode('restore');
+      set(wizard.modelPremiumSetupForm, { apiKey: 'key', apiSecret: 'secret', syncDatabase: true });
+
+      wizard.prevStep();
+
+      expect(get(wizard.modelPremiumEnabled)).toBe(true);
+      expect(get(wizard.modelPremiumSetupForm).apiKey).toBe('key');
+    });
+  });
+
+  describe('choosing the mode', () => {
+    it('should record the mode and move on', () => {
+      const { mode, step, wizard } = createWizard(1);
+
+      wizard.selectMode('create');
+
+      expect(get(mode)).toBe('create');
+      expect(get(step)).toBe(2);
+    });
+
+    it('should leave the premium answers alone when creating', () => {
+      const { wizard } = createWizard(1);
+
+      wizard.selectMode('create');
+
+      expect(get(wizard.modelPremiumEnabled)).toBe(false);
+      expect(get(wizard.modelPremiumSetupForm).syncDatabase).toBe(false);
+    });
+
+    /** Restoring an account means restoring it from the premium sync, so both are answered here. */
+    it('should turn on premium and the database sync when restoring', () => {
+      const { wizard } = createWizard(1);
+
+      wizard.selectMode('restore');
+
+      expect(get(wizard.modelPremiumEnabled)).toBe(true);
+      expect(get(wizard.modelPremiumSetupForm).syncDatabase).toBe(true);
+    });
+
+    it('should keep credentials already typed when restoring', () => {
+      const { wizard } = createWizard(1);
+      set(wizard.modelPremiumSetupForm, { apiKey: 'key', apiSecret: 'secret', syncDatabase: false });
+
+      wizard.selectMode('restore');
+
+      expect(get(wizard.modelPremiumSetupForm)).toEqual({ apiKey: 'key', apiSecret: 'secret', syncDatabase: true });
+    });
+  });
+
+  describe('isRestoreMode', () => {
+    it('should follow the mode', () => {
+      const { mode, wizard } = createWizard(1);
+
+      expect(get(wizard.isRestoreMode)).toBe(false);
+
+      set(mode, 'restore');
+
+      expect(get(wizard.isRestoreMode)).toBe(true);
+    });
+
+    it('should not treat creating as restoring', () => {
+      const { wizard } = createWizard(1, 'create');
+
+      expect(get(wizard.isRestoreMode)).toBe(false);
+    });
+  });
+
+  describe('buildPayload', () => {
+    it('should carry the credentials and the analytics answer', () => {
+      const { wizard } = createWizard(4);
+      set(wizard.modelCredentialsForm, { password: 'pass', username: 'user' });
+      set(wizard.modelSubmitUsageAnalytics, false);
+
+      expect(wizard.buildPayload()).toEqual({
+        credentials: { password: 'pass', username: 'user' },
+        initialSettings: { submitUsageAnalytics: false },
+      });
+    });
+
+    it('should omit the premium setup when premium was not asked for', () => {
+      const { wizard } = createWizard(4);
+      set(wizard.modelPremiumSetupForm, { apiKey: 'key', apiSecret: 'secret', syncDatabase: true });
+
+      expect(wizard.buildPayload().premiumSetup).toBeUndefined();
+    });
+
+    it('should send the premium setup when premium was asked for', () => {
+      const { wizard } = createWizard(4);
+      set(wizard.modelPremiumEnabled, true);
+      set(wizard.modelPremiumSetupForm, { apiKey: 'key', apiSecret: 'secret', syncDatabase: true });
+
+      expect(wizard.buildPayload().premiumSetup).toEqual({
+        apiKey: 'key',
+        apiSecret: 'secret',
+        syncDatabase: true,
+      });
+    });
+
+    it('should submit usage analytics unless the user opts out', () => {
+      const { wizard } = createWizard(4);
+
+      expect(wizard.buildPayload().initialSettings.submitUsageAnalytics).toBe(true);
+    });
+  });
+});

--- a/frontend/app/src/modules/auth/create-account/use-create-account-wizard.ts
+++ b/frontend/app/src/modules/auth/create-account/use-create-account-wizard.ts
@@ -1,0 +1,116 @@
+import type { ComputedRef, Ref } from 'vue';
+import type { CreateAccountMode } from '@/modules/auth/create-account/types';
+import type { CreateAccountPayload, LoginCredentials, PremiumSetup } from '@/modules/auth/login';
+
+interface UseCreateAccountWizardReturn {
+  /** Whether the account is being given premium credentials. */
+  modelPremiumEnabled: Ref<boolean>;
+  /** The premium credentials, and whether the database is synced from them. */
+  modelPremiumSetupForm: Ref<PremiumSetup>;
+  /** The username and password the account is created with. */
+  modelCredentialsForm: Ref<LoginCredentials>;
+  /** The repeated password, checked against the one in the credentials form. */
+  modelPasswordConfirm: Ref<string>;
+  /** Whether the user has been warned that a lost password cannot be recovered. */
+  modelUserPrompted: Ref<boolean>;
+  /** Whether anonymous usage analytics are submitted. */
+  modelSubmitUsageAnalytics: Ref<boolean>;
+  /** Whether the account is being restored rather than created. */
+  isRestoreMode: ComputedRef<boolean>;
+  /** Moves to the following step. */
+  nextStep: () => void;
+  /** Moves back one step, forgetting the mode when the first step is reached again. */
+  prevStep: () => void;
+  /** Answers the first step and moves on. */
+  selectMode: (selected: CreateAccountMode) => void;
+  /** Collects the answers into the payload the account is created from. */
+  buildPayload: () => CreateAccountPayload;
+}
+
+function emptyPremiumSetup(): PremiumSetup {
+  return { apiKey: '', apiSecret: '', syncDatabase: false };
+}
+
+/**
+ * The state the create-account wizard carries between its steps, and the transitions that move it.
+ *
+ * @remarks
+ * The wizard owns the answers rather than the steps, because a step is unmounted while another one
+ * is showing: going back and forward again has to find what was typed still there.
+ *
+ * @param step - the wizard's current step, 1-based, shared with the page's stepper
+ * @param mode - whether the account is created or restored, unset until the first step answers
+ * @returns the per-step forms plus the transitions between the steps
+ */
+export function useCreateAccountWizard(
+  step: Ref<number>,
+  mode: Ref<CreateAccountMode | undefined>,
+): UseCreateAccountWizardReturn {
+  const modelPremiumEnabled = shallowRef<boolean>(false);
+  const modelPremiumSetupForm = ref<PremiumSetup>(emptyPremiumSetup());
+  const modelCredentialsForm = ref<LoginCredentials>({ password: '', username: '' });
+  const modelPasswordConfirm = shallowRef<string>('');
+  const modelUserPrompted = shallowRef<boolean>(false);
+  const modelSubmitUsageAnalytics = shallowRef<boolean>(true);
+
+  const isRestoreMode = computed<boolean>(() => get(mode) === 'restore');
+
+  function nextStep(): void {
+    set(step, get(step) + 1);
+  }
+
+  /**
+   * @remarks
+   * Landing back on the first step means the mode is being chosen again, so the premium answers
+   * seeded by the previous choice are dropped: a restore seeds them, and keeping them would carry
+   * a database sync into a plain create.
+   */
+  function prevStep(): void {
+    const next = get(step) - 1;
+    set(step, next);
+    if (next === 1) {
+      set(mode, undefined);
+      set(modelPremiumEnabled, false);
+      set(modelPremiumSetupForm, emptyPremiumSetup());
+    }
+  }
+
+  /** Restoring an account is restoring it from the premium sync, so both are answered up front. */
+  function selectMode(selected: CreateAccountMode): void {
+    set(mode, selected);
+    if (selected === 'restore') {
+      set(modelPremiumEnabled, true);
+      set(modelPremiumSetupForm, { ...get(modelPremiumSetupForm), syncDatabase: true });
+    }
+    nextStep();
+  }
+
+  /** The premium credentials are only sent when the user asked for premium. */
+  function buildPayload(): CreateAccountPayload {
+    const payload: CreateAccountPayload = {
+      credentials: get(modelCredentialsForm),
+      initialSettings: {
+        submitUsageAnalytics: get(modelSubmitUsageAnalytics),
+      },
+    };
+
+    if (get(modelPremiumEnabled))
+      payload.premiumSetup = get(modelPremiumSetupForm);
+
+    return payload;
+  }
+
+  return {
+    buildPayload,
+    isRestoreMode,
+    modelCredentialsForm,
+    modelPasswordConfirm,
+    modelPremiumEnabled,
+    modelPremiumSetupForm,
+    modelSubmitUsageAnalytics,
+    modelUserPrompted,
+    nextStep,
+    prevStep,
+    selectMode,
+  };
+}

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.spec.ts
@@ -1,0 +1,285 @@
+import type { ConflictResolutionStrategy } from '@/modules/core/common/common-types';
+import type { useAccountingRuleConflictResolution } from '@/modules/settings/accounting/rule/use-accounting-rule-conflict-resolution';
+import { type DOMWrapper, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, nextTick, ref } from 'vue';
+import AccountingRuleConflictsDialog from '@/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue';
+import { type AccountingRule, type AccountingRuleConflict, AccountingTreatment } from '@/modules/settings/types/accounting';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { collection, modelResolution, modelSolveAllUsing, onResolved, refetch, save } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    collection: ref<{ data: AccountingRuleConflict[]; found: number; limit: number; total: number }>({
+      data: [],
+      found: 0,
+      limit: 10,
+      total: 0,
+    }),
+    modelResolution: ref<Record<string, ConflictResolutionStrategy>>({}),
+    modelSolveAllUsing: ref<ConflictResolutionStrategy | undefined>(),
+    onResolved: { call: (): void => {} },
+    refetch: vi.fn(async () => {}),
+    save: vi.fn(async () => {}),
+  };
+});
+
+vi.mock('@/modules/settings/accounting/rule/use-accounting-rule-conflict-resolution', () => ({
+  useAccountingRuleConflictResolution: (
+    options: { onResolved: () => void },
+  ): ReturnType<typeof useAccountingRuleConflictResolution> => {
+    onResolved.call = options.onResolved;
+    return {
+      collection,
+      isLoading: ref(false),
+      loading: ref(false),
+      modelResolution,
+      modelSolveAllUsing,
+      pagination: computed({ get: () => ({ limit: 10, page: 1, total: 0 }), set: () => {} }),
+      refetch,
+      remaining: computed(() => collection.value.total - Object.keys(modelResolution.value).length),
+      resolutionLength: computed(() => Object.keys(modelResolution.value).length),
+      save,
+      valid: computed(() => !!modelSolveAllUsing.value || Object.keys(modelResolution.value).length > 0),
+    };
+  },
+}));
+
+vi.mock('@/modules/history/events/mapping/use-history-event-mappings', () => ({
+  useHistoryEventMappings: (): Record<string, (value: string) => unknown> => ({
+    getEventTypeData: () => ({ color: 'success', icon: 'lu-arrow-down', label: 'Receive' }),
+    getHistoryEventSubTypeName: (subtype: string) => subtype,
+    getHistoryEventTypeName: (type: string) => type,
+  }),
+}));
+
+vi.mock('@/modules/settings/accounting/use-accounting-rule-mappings', () => ({
+  useAccountingRuleMappings: (): { accountingRuleLinkedMappingData: () => Ref<never[]> } => ({
+    accountingRuleLinkedMappingData: () => ref([]),
+  }),
+}));
+
+/** `BigDialog` teleports and owns the footer buttons; the two here stand for confirm and cancel. */
+const BigDialogStub = {
+  emits: ['confirm', 'cancel'],
+  name: 'BigDialog',
+  props: ['title', 'display', 'action', 'loading', 'layout', 'persistent'],
+  template: `<div>
+    <slot />
+    <button data-testid="stub-confirm" @click="$emit('confirm')" />
+    <button data-testid="stub-cancel" @click="$emit('cancel')" />
+  </div>`,
+};
+
+function property(value: boolean): { value: boolean } {
+  return { value };
+}
+
+function rule(overrides: Partial<AccountingRule> = {}): AccountingRule {
+  return {
+    accountingTreatment: null,
+    counterparty: null,
+    countCostBasisPnl: property(true),
+    countEntireAmountSpend: property(true),
+    eventSubtype: 'receive',
+    eventType: 'receive',
+    taxable: property(true),
+    ...overrides,
+  };
+}
+
+function conflict(remote: Partial<AccountingRule> = {}): AccountingRuleConflict {
+  return { localData: rule(), localId: 1, remoteData: rule(remote) };
+}
+
+function createWrapper(): VueWrapper<any> {
+  return mount(AccountingRuleConflictsDialog, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        BigDialog: BigDialogStub,
+        // Globally stubbed to `true`, which would swallow the hint the dialog is choosing between.
+        I18nT: { props: ['keypath'], template: '<span>{{ keypath }}<slot name="source" /></span>' },
+      },
+    },
+  });
+}
+
+/** The table renders no column key onto the cell, so the columns are addressed by their order. */
+const COLUMN_INDEX: Record<string, number> = {
+  accountingTreatment: 6,
+  countCostBasisPnl: 5,
+  countEntireAmountSpend: 4,
+  taxable: 3,
+};
+
+function cell(wrapper: VueWrapper<any>, key: string): DOMWrapper<Element> {
+  return wrapper.findAll('tbody td')[COLUMN_INDEX[key]].find('div.w-full');
+}
+
+describe('accountingRuleConflictsDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(collection, { data: [], found: 0, limit: 10, total: 0 });
+    set(modelResolution, {});
+    set(modelSolveAllUsing, undefined);
+  });
+
+  it('should read the first page of conflicts when it opens', () => {
+    createWrapper();
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  describe('submitting', () => {
+    it('should refuse to save while nothing has been chosen', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.findComponent(BigDialogStub).props('action')).toMatchObject({ disabled: true });
+    });
+
+    it('should allow saving once a strategy is chosen', async () => {
+      const wrapper = createWrapper();
+
+      set(modelSolveAllUsing, 'local');
+      await nextTick();
+
+      expect(wrapper.findComponent(BigDialogStub).props('action')).toMatchObject({ disabled: false });
+    });
+
+    it('should submit the resolution on confirm', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+
+      expect(save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should close on cancel without submitting', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=stub-cancel]').trigger('click');
+
+      expect(wrapper.emitted('close')).toHaveLength(1);
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    it('should refresh the rules and close once every conflict is resolved', () => {
+      const wrapper = createWrapper();
+
+      onResolved.call();
+
+      expect(wrapper.emitted('refresh')).toHaveLength(1);
+      expect(wrapper.emitted('close')).toHaveLength(1);
+    });
+
+    /** Choices made one conflict at a time are lost on a stray click outside the dialog. */
+    it('should refuse to be dismissed by accident once choices have been made', async () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.findComponent(BigDialogStub).props('persistent')).toBe(false);
+
+      set(modelResolution, { 1: 'local' });
+      await nextTick();
+
+      expect(wrapper.findComponent(BigDialogStub).props('persistent')).toBe(true);
+    });
+  });
+
+  describe('resolving everything at once', () => {
+    it('should keep the local rules when the bulk choice is ticked', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.findComponent({ name: 'RuiCheckbox' }).vm.$emit('update:modelValue', true);
+
+      expect(get(modelSolveAllUsing)).toBe('local');
+    });
+
+    it('should return to per-conflict choices when it is unticked', async () => {
+      set(modelSolveAllUsing, 'remote');
+      const wrapper = createWrapper();
+
+      await wrapper.findComponent({ name: 'RuiCheckbox' }).vm.$emit('update:modelValue', false);
+
+      expect(get(modelSolveAllUsing)).toBeUndefined();
+    });
+
+    it('should count what is left to answer while choosing one at a time', () => {
+      set(collection, { data: [conflict()], found: 1, limit: 10, total: 3 });
+
+      const hint = createWrapper().find('.text-caption');
+
+      expect(hint.text()).toContain('conflict_dialog.hint');
+    });
+
+    it('should say which side it is taking once the bulk choice is made', () => {
+      set(modelSolveAllUsing, 'remote');
+
+      const hint = createWrapper().find('.text-caption');
+
+      expect(hint.text()).toContain('conflict_dialog.resolve_all_hint');
+    });
+  });
+
+  /**
+   * Each column is highlighted only where the two versions disagree, so the user can see what the
+   * update would change without reading every row.
+   */
+  describe('highlighting the differences', () => {
+    const highlight = 'bg-rui-error-lighter/[0.1]';
+
+    beforeEach(() => {
+      set(modelSolveAllUsing, 'local');
+    });
+
+    it('should highlight nothing when the two versions agree', () => {
+      set(collection, { data: [conflict()], found: 1, limit: 10, total: 1 });
+
+      const wrapper = createWrapper();
+
+      expect(cell(wrapper, 'taxable').classes()).not.toContain(highlight);
+      expect(cell(wrapper, 'countEntireAmountSpend').classes()).not.toContain(highlight);
+      expect(cell(wrapper, 'countCostBasisPnl').classes()).not.toContain(highlight);
+    });
+
+    it('should highlight the taxable column when only it differs', () => {
+      set(collection, { data: [conflict({ taxable: property(false) })], found: 1, limit: 10, total: 1 });
+
+      const wrapper = createWrapper();
+
+      expect(cell(wrapper, 'taxable').classes()).toContain(highlight);
+      expect(cell(wrapper, 'countEntireAmountSpend').classes()).not.toContain(highlight);
+    });
+
+    it('should highlight the spend column when only it differs', () => {
+      set(collection, {
+        data: [conflict({ countEntireAmountSpend: property(false) })],
+        found: 1,
+        limit: 10,
+        total: 1,
+      });
+
+      const wrapper = createWrapper();
+
+      expect(cell(wrapper, 'countEntireAmountSpend').classes()).toContain(highlight);
+      expect(cell(wrapper, 'taxable').classes()).not.toContain(highlight);
+    });
+
+    it('should highlight the cost basis column when only it differs', () => {
+      set(collection, { data: [conflict({ countCostBasisPnl: property(false) })], found: 1, limit: 10, total: 1 });
+
+      const wrapper = createWrapper();
+
+      expect(cell(wrapper, 'countCostBasisPnl').classes()).toContain(highlight);
+      expect(cell(wrapper, 'taxable').classes()).not.toContain(highlight);
+    });
+
+    it('should highlight the treatment column when only it differs', () => {
+      set(collection, { data: [conflict({ accountingTreatment: AccountingTreatment.SWAP })], found: 1, limit: 10, total: 1 });
+
+      const wrapper = createWrapper();
+
+      expect(cell(wrapper, 'accountingTreatment').classes()).toContain(highlight);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
@@ -301,7 +301,7 @@ const { total } = getCollectionData<AccountingRuleConflict>(collection);
         <template #item.countEntireAmountSpend="{ row }">
           <div
             class="w-full flex flex-col items-center justify-center p-4"
-            :class="diffClass(row.localData.taxable.value, row.remoteData.taxable.value)"
+            :class="diffClass(row.localData.countEntireAmountSpend.value, row.remoteData.countEntireAmountSpend.value)"
           >
             <AccountingRuleWithLinkedSettingDisplay
               :item="row.localData.countEntireAmountSpend"


### PR DESCRIPTION
Continues the SFC coverage work after #12964 / #13082, taking the four spec-less dialogs that hold
decisions. Two of them turned out to have real bugs, each isolated in its own `fix(` commit.

## Coverage

Measured on this branch against the same tree before the batch, summing lcov:

| | lines | pct |
|---|---|---|
| before | 35,155 / 49,253 | 71.38% |
| after | 35,360 / 49,252 | **71.79%** |

Suite 1052 → 1056 files, 11,373 → 11,443 tests. No new network calls.

All four targets were at **0 lines hit** beforehand. After:

| file | before | after |
|---|---|---|
| `AddressBookFormDialog.vue` | 0/60 | 56/59 |
| `ManualBalancesDialog.vue` | 0/59 | 55/59 |
| `AccountingRuleConflictsDialog.vue` | 0/59 | 50/59 |
| `CreateAccountWizard.vue` | 0/40 | logic moved to `use-create-account-wizard.ts`, 25/25 |

Children picked up along the way, without being targeted:
`AccountingRuleWithLinkedSettingDisplay.vue` 0/21 → 14/21, `HistoryEventTypeCombination.vue`
4/14 → 10/14.

## The two bugs

**The address book dialog could not be put into edit mode by handing it an entry.** `editMode` is
declared `boolean`, so Vue casts an absent prop to `false` rather than `undefined`, which makes
`editMode ?? !!editableItem` unreachable — it is always just `editMode`. Both call sites already
pass it explicitly, so nothing was broken in practice, but the fallback was dead code presented as
a default.

The visible half is that `dialogTitle` re-derived the same fact by the *other* route, reading
`editableItem`. `AppMessages` seeds the form with the address the backend has asked the user to
name and passes `:edit-mode="false"` on purpose, so that addition was announced as "Edit address
book entry". The title now follows `editMode`, like the save does, and the prop carries TSDoc
saying why it is not derived from `editableItem`.

**The conflicts table highlighted the wrong column.** The `countEntireAmountSpend` cell called
`diffClass` with the *taxable* values, so it lit up when taxable differed and stayed plain when the
spend setting itself did. A copy-paste from the cell above it.

Both were found by a spec failing for the right reason rather than by reading: the address-book one
surfaced as zero calls to `updateAddressBook` in a test that had handed the dialog an entry, and
the highlight one as two of the four `diffClass` assertions failing on first run.

## Notes on the specs

Each dialog is tested at its seam — what it renders for a given set of props, what it emits, and
what it calls on the composables it is wired to — with `BigDialog` and the forms stubbed as
pass-throughs, since the dialog reaches into the form through a template ref and an auto-stub would
leave that ref pointing at a component with no `validate()`.

`CreateAccountWizard` is the one that was extracted first rather than tested in place: its ~60 lines
of step-machine logic moved to `use-create-account-wizard.ts`, where the transitions can be tested
without mounting, and the SFC kept a smaller spec for the wiring the extraction left behind. The
returned refs are `model`-prefixed because they are `v-model`-bound and `readonly()` would break the
bindings.

Every claim was negative-controlled: inverting the step-1 reset, the error-routing branch, and the
back-button error clear each failed exactly the tests named after them and no others.

## Gates

`typecheck`, `knip`, `lint:style`, `check:linked-keys`, `test:proxy`, `lint:file:check` and the full
unit suite all pass, run one at a time.
