### PR TITLE
Cover the history/events cluster, dropping three dead branches

### DIFF
--- a/frontend/app/src/modules/history/events/HistoryEventFormDialog.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventFormDialog.spec.ts
@@ -1,0 +1,170 @@
+import type { EvmSwapEvent, StandaloneEditableEvents } from '@/modules/history/events/schemas';
+import type { GroupEventData, StandaloneEventData } from '@/modules/history/management/forms/form-types';
+import { createMock } from '@test/utils/create-mock';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, ref, type VNode } from 'vue';
+import HistoryEventFormDialog from '@/modules/history/events/HistoryEventFormDialog.vue';
+
+const save = vi.fn(async () => true);
+const errorCount = ref<number>(0);
+
+/**
+ * The dialog reads the error count and saves through a template ref, so the stub exposes both. An
+ * auto-stub would leave the ref pointing at a component with neither.
+ */
+const FormStub = defineComponent({
+  name: 'HistoryEventForm',
+  props: ['data', 'stateUpdated'],
+  setup(_, { expose }): () => VNode {
+    expose({ errorCount, save });
+    return () => h('div');
+  },
+});
+
+/** `BigDialog` teleports and owns the footer buttons; the two here stand for confirm and cancel. */
+const BigDialogStub = {
+  emits: ['confirm', 'cancel'],
+  name: 'BigDialog',
+  props: ['title', 'display', 'action', 'errors', 'loading', 'promptOnClose'],
+  template: `<div>
+    <slot />
+    <button data-testid="stub-confirm" @click="$emit('confirm')" />
+    <button data-testid="stub-cancel" @click="$emit('cancel')" />
+  </div>`,
+};
+
+const addData: StandaloneEventData = { nextSequenceId: '1', type: 'add' };
+const editData: StandaloneEventData = {
+  event: createMock<StandaloneEditableEvents>({ identifier: 1 }),
+  nextSequenceId: '2',
+  type: 'edit',
+};
+const groupAddData: GroupEventData = {
+  group: createMock<EvmSwapEvent>(),
+  nextSequenceId: '1',
+  type: 'group-add',
+};
+
+function createWrapper(modelValue: GroupEventData | StandaloneEventData | undefined): VueWrapper<any> {
+  return mount(HistoryEventFormDialog, {
+    global: {
+      stubs: {
+        BigDialog: BigDialogStub,
+        HistoryEventForm: FormStub,
+      },
+    },
+    props: { modelValue },
+  });
+}
+
+async function confirm(wrapper: VueWrapper<any>): Promise<void> {
+  await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+  await flushPromises();
+}
+
+function dialog(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent({ name: 'BigDialog' });
+}
+
+describe('historyEventFormDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    save.mockResolvedValue(true);
+    set(errorCount, 0);
+  });
+
+  describe('the heading', () => {
+    it('should announce an addition', () => {
+      expect(dialog(createWrapper(addData)).props('title')).toBe('transactions.events.dialog.add.title');
+    });
+
+    it('should announce adding into an existing group', () => {
+      expect(dialog(createWrapper(groupAddData)).props('title')).toBe('transactions.events.dialog.add.title');
+    });
+
+    it('should announce an edit', () => {
+      expect(dialog(createWrapper(editData)).props('title')).toBe('transactions.events.dialog.edit.title');
+    });
+  });
+
+  describe('saving', () => {
+    it('should close and ask for a refresh when the form saved', async () => {
+      const wrapper = createWrapper(addData);
+
+      await confirm(wrapper);
+
+      expect(save).toHaveBeenCalledTimes(1);
+      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([undefined]);
+      expect(wrapper.emitted('refresh')).toHaveLength(1);
+    });
+
+    it('should stay open when the form refused', async () => {
+      save.mockResolvedValue(false);
+      const wrapper = createWrapper(addData);
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+      expect(wrapper.emitted('refresh')).toBeUndefined();
+    });
+
+    /** A second press while the first save is in flight would submit the same event twice. */
+    it('should ignore a second confirm while the first is still saving', async () => {
+      let release: (value: boolean) => void = () => {};
+      save.mockReturnValue(new Promise<boolean>((resolve) => {
+        release = resolve;
+      }));
+      const wrapper = createWrapper(addData);
+
+      await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+      await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+      release(true);
+      await flushPromises();
+
+      expect(save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should discard the event when dismissed', async () => {
+      const wrapper = createWrapper(addData);
+
+      await wrapper.find('[data-testid=stub-cancel]').trigger('click');
+
+      expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual([undefined]);
+      expect(save).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * The count drives the dialog's scroll-to-first-error, so it stays at zero until a save has
+   * actually been refused: a form the user has not submitted yet should not be scrolled.
+   */
+  describe('the error count', () => {
+    it('should report none before the first save', () => {
+      set(errorCount, 3);
+
+      expect(dialog(createWrapper(addData)).props('errors')).toMatchObject({ count: 0 });
+    });
+
+    it('should report the form errors once a save was refused', async () => {
+      save.mockResolvedValue(false);
+      set(errorCount, 3);
+      const wrapper = createWrapper(addData);
+
+      await confirm(wrapper);
+
+      expect(dialog(wrapper).props('errors')).toMatchObject({ count: 3 });
+    });
+
+    it('should go quiet again once the dialog is closed', async () => {
+      save.mockResolvedValue(false);
+      set(errorCount, 3);
+      const wrapper = createWrapper(addData);
+      await confirm(wrapper);
+
+      await wrapper.setProps({ modelValue: undefined });
+
+      expect(dialog(wrapper).props('errors')).toMatchObject({ count: 0 });
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/HistoryEventsExport.vue
+++ b/frontend/app/src/modules/history/events/HistoryEventsExport.vue
@@ -1,18 +1,6 @@
 <script setup lang="ts">
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
-import { type NotificationPayload, type SemiPartial, Severity } from '@rotki/common';
-import { omit } from 'es-toolkit';
-import { isErr, map as mapResult, type Result } from 'plainfp/result';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
-import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
-import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
-import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
-import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
-import { useInterop } from '@/modules/shell/app/use-electron-interop';
-import { activityLabel } from '@/modules/task-center/activity-labels';
-import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
-import { useNativeTask } from '@/modules/task-center/use-native-task';
-import { useTaskCenter } from '@/modules/task-center/use-task-center';
+import { useHistoryEventsExport } from '@/modules/history/events/use-history-events-export';
 
 const { filters, matchExactEvents } = defineProps<{
   matchExactEvents: boolean;
@@ -21,119 +9,10 @@ const { filters, matchExactEvents } = defineProps<{
 
 const { t } = useI18n({ useScope: 'global' });
 
-const { appSession, openDirectory } = useInterop();
-
-const { downloadHistoryEventsCSV, exportHistoryEventsCSV } = useHistoryEventsApi();
-
-const { submitTask } = useNativeTask();
-const { useIsActive } = useTaskCenter();
-const { notify } = useNotificationDispatcher();
-
-async function createCsv(directoryPath?: string): Promise<{ result: boolean | { filePath: string }; message?: string } | null> {
-  const outcome = await submitTask<boolean | { filePath: string }>({
-    id: makeActivityId(ActivityKind.HISTORY_EVENTS, ActivityPart.EXPORT),
-    kind: ActivityKind.HISTORY_EVENTS,
-    rerunnable: false,
-    run: async ({ runTask }): Promise<Result<boolean | { filePath: string }, TaskError>> => mapResult(
-      await runTask<boolean | { filePath: string }>(
-        () => exportHistoryEventsCSV({
-          ...omit(filters, ['limit', 'offset', 'aggregateByGroupIds']),
-          matchExactEvents,
-        }, directoryPath),
-      ),
-      value => value,
-    ),
-    subtitle: activityLabel(ActivityKind.HISTORY_EVENTS, ActivityPart.EXPORT),
-    title: t('task_center.group.history_events'),
-  });
-
-  if (!isErr(outcome))
-    return { result: outcome.value };
-
-  if (!isActionable(outcome.error))
-    return null;
-
-  return {
-    message: outcome.error.message,
-    result: false,
-  };
-}
-
-type ExportMessage = SemiPartial<NotificationPayload, 'title' | 'message'>;
-
-function exportOutcomeMessage(succeeded: boolean, taskMessage?: string): ExportMessage {
-  return {
-    display: true,
-    message: succeeded
-      ? t('actions.history_events_export.message.success')
-      : t('actions.history_events_export.message.failure', { description: taskMessage }),
-    severity: succeeded ? Severity.INFO : Severity.ERROR,
-    title: t('actions.history_events_export.title'),
-  };
-}
-
-/**
- * In an app session the file was written where the user chose, so the outcome is only reported. A
- * browser session instead gets the generated file streamed back, and only a failure is reported.
- */
-async function reportExport(response: Awaited<ReturnType<typeof createCsv>> & object): Promise<ExportMessage | null> {
-  const { message: taskMessage, result } = response;
-
-  if (appSession || !result)
-    return exportOutcomeMessage(!!result, taskMessage);
-
-  if (result !== true && 'filePath' in result)
-    await downloadHistoryEventsCSV(result.filePath);
-
-  return null;
-}
-
-async function exportCSV(): Promise<void> {
-  let message: ExportMessage | null = null;
-
-  try {
-    let directoryPath;
-    if (appSession) {
-      directoryPath = await openDirectory(t('common.select_directory'));
-      if (!directoryPath)
-        return;
-    }
-
-    const response = await createCsv(directoryPath);
-    if (response === null)
-      return;
-
-    message = await reportExport(response);
-  }
-  catch (error: unknown) {
-    message = {
-      display: true,
-      message: t('actions.history_events_export.message.failure', {
-        description: getErrorMessage(error),
-      }),
-      severity: Severity.ERROR,
-      title: t('actions.history_events_export.title'),
-    };
-  }
-
-  if (message)
-    notify(message);
-}
-
-const { show } = useConfirmStore();
-
-function showConfirmation() {
-  show(
-    {
-      message: t('transactions.events.export.confirmation_message'),
-      title: t('common.actions.export_csv'),
-      type: 'info',
-    },
-    exportCSV,
-  );
-}
-
-const taskRunning = useIsActive(ActivityKind.HISTORY_EVENTS, ActivityPart.EXPORT);
+const { showConfirmation, taskRunning } = useHistoryEventsExport(
+  () => filters,
+  () => matchExactEvents,
+);
 </script>
 
 <template>

--- a/frontend/app/src/modules/history/events/PotentialMatchesList.spec.ts
+++ b/frontend/app/src/modules/history/events/PotentialMatchesList.spec.ts
@@ -1,0 +1,141 @@
+import type { PotentialMatchRow, UnmatchedEventGroup } from '@/modules/history/events/matching/types';
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import { createMock } from '@test/utils/create-mock';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PotentialMatchesList from '@/modules/history/events/PotentialMatchesList.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const entry = createMock<HistoryEventEntry>({ eventSubtype: 'deposit', identifier: 1 });
+
+vi.mock('@/modules/history/event-utils', () => ({
+  getEventEntryFromCollection: (): { entry: HistoryEventEntry } => ({ entry }),
+}));
+
+vi.mock('@/modules/history/management/forms/utils', () => ({
+  getAssetMovementsType: (): string => 'deposit-label',
+}));
+
+const SubjectTableStub = {
+  name: 'PotentialMatchSubjectTable',
+  props: ['entry', 'typeLabel', 'locationHeader'],
+  template: '<div />',
+};
+
+const EmptyStub = {
+  emits: ['widen'],
+  name: 'PotentialMatchesEmpty',
+  props: ['hours', 'tolerance', 'canWiden', 'explanation'],
+  template: '<button data-testid="stub-widen" @click="$emit(\'widen\')" />',
+};
+
+const movement = createMock<UnmatchedEventGroup>({ asset: 'ETH', groupIdentifier: '0xabc' });
+
+const noMatches: PotentialMatchRow[] = [];
+
+function createWrapper(props: Record<string, unknown> = {}): VueWrapper<any> {
+  return mount(PotentialMatchesList, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        AmountInput: { name: 'AmountInput', props: ['modelValue'], template: '<div />' },
+        PotentialMatchesCards: true,
+        PotentialMatchesEmpty: EmptyStub,
+        PotentialMatchesTable: true,
+        PotentialMatchSubjectCard: true,
+        PotentialMatchSubjectTable: SubjectTableStub,
+      },
+    },
+    props: {
+      loading: false,
+      matches: noMatches,
+      movement,
+      onlyExpectedAssets: false,
+      searchTimeRange: '24',
+      selectedMatchIds: [],
+      tolerancePercentage: '5',
+      ...props,
+    },
+  });
+}
+
+function subject(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(SubjectTableStub);
+}
+
+describe('potentialMatchesList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * Flows that are not asset movements relabel the type badge and the location column together, so
+   * a caller that supplies neither gets the asset-movement wording for both.
+   */
+  describe('describing the unmatched entry', () => {
+    it('should fall back to the asset movement type and the exchange header', () => {
+      const wrapper = createWrapper();
+
+      expect(subject(wrapper).props('typeLabel')).toBe('deposit-label');
+      expect(subject(wrapper).props('locationHeader')).toBe('common.exchange');
+    });
+
+    it('should use the labels the caller supplied', () => {
+      const wrapper = createWrapper({
+        entryLabels: { locationHeader: 'Chain', type: 'Bridge out' },
+      });
+
+      expect(subject(wrapper).props('typeLabel')).toBe('Bridge out');
+      expect(subject(wrapper).props('locationHeader')).toBe('Chain');
+    });
+  });
+
+  describe('widening the search', () => {
+    it('should double both criteria and search again', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=stub-widen]').trigger('click');
+
+      expect(wrapper.emitted<[string]>('update:searchTimeRange')?.at(-1)?.[0]).toBe('48');
+      expect(wrapper.emitted<[string]>('update:tolerancePercentage')?.at(-1)?.[0]).toBe('10');
+      expect(wrapper.emitted('search')).toHaveLength(1);
+    });
+
+    it('should offer widening while a criterion has room', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.findComponent(EmptyStub).props('canWiden')).toBe(true);
+    });
+
+    it('should stop offering it once both criteria are at their max', () => {
+      const wrapper = createWrapper({ searchTimeRange: '168', tolerancePercentage: '100' });
+
+      expect(wrapper.findComponent(EmptyStub).props('canWiden')).toBe(false);
+    });
+  });
+
+  describe('the results', () => {
+    it('should explain an empty result rather than showing a table', () => {
+      const wrapper = createWrapper({ emptyExplanation: 'nothing within range' });
+
+      expect(wrapper.findComponent(EmptyStub).exists()).toBe(true);
+      expect(wrapper.findComponent(EmptyStub).props('explanation')).toBe('nothing within range');
+    });
+
+    it('should stop explaining while a search is still running', () => {
+      const wrapper = createWrapper({ loading: true });
+
+      expect(wrapper.findComponent(EmptyStub).exists()).toBe(false);
+    });
+
+    it('should show what the last search failed with', () => {
+      const wrapper = createWrapper({ searchError: 'the backend said no' });
+
+      expect(wrapper.text()).toContain('the backend said no');
+    });
+
+    it('should say nothing about a search that did not fail', () => {
+      expect(createWrapper().text()).not.toContain('the backend said no');
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/PotentialMatchesList.vue
+++ b/frontend/app/src/modules/history/events/PotentialMatchesList.vue
@@ -2,6 +2,7 @@
 import type { PotentialMatchRow, UnmatchedEventGroup } from '@/modules/history/events/matching/types';
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import { getEventEntryFromCollection } from '@/modules/history/event-utils';
+import { canWidenSearch, type SearchCriteria, widenedSearch } from '@/modules/history/events/matching/search-widening';
 import PotentialMatchesCards from '@/modules/history/events/PotentialMatchesCards.vue';
 import PotentialMatchesEmpty from '@/modules/history/events/PotentialMatchesEmpty.vue';
 import PotentialMatchesTable from '@/modules/history/events/PotentialMatchesTable.vue';
@@ -61,25 +62,17 @@ const tableMaxHeight = computed<string>(() =>
     : 'calc(100vh - 33rem)',
 );
 
-/** Seven days, matching the time field's own max. */
-const MAX_SEARCH_HOURS = 168;
+const searchCriteria = computed<SearchCriteria>(() => ({
+  hours: get(searchTimeRange),
+  tolerance: get(tolerancePercentage),
+}));
 
-/** Raising this past 100 changes nothing: a full 100% either side already excludes no candidate. */
-const MAX_TOLERANCE_PERCENTAGE = 100;
+const canWiden = computed<boolean>(() => canWidenSearch(get(searchCriteria)));
 
-const canWiden = computed<boolean>(() =>
-  Number(get(searchTimeRange)) < MAX_SEARCH_HOURS || Number(get(tolerancePercentage)) < MAX_TOLERANCE_PERCENTAGE);
-
-/** Doubles both criteria, capped at each field's max. */
 function widenSearch(): void {
-  const hours = Number(get(searchTimeRange));
-  if (!Number.isNaN(hours))
-    set(searchTimeRange, Math.min(hours * 2, MAX_SEARCH_HOURS).toString());
-
-  const tolerance = Number(get(tolerancePercentage));
-  if (!Number.isNaN(tolerance))
-    set(tolerancePercentage, Math.min(tolerance * 2, MAX_TOLERANCE_PERCENTAGE).toString());
-
+  const { hours, tolerance } = widenedSearch(get(searchCriteria));
+  set(searchTimeRange, hours);
+  set(tolerancePercentage, tolerance);
   emit('search');
 }
 

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.spec.ts
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.spec.ts
@@ -1,0 +1,144 @@
+import type { DataTableSortData, TablePaginationData } from '@rotki/ui-library';
+import type { Ref } from 'vue';
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import HistoryEventsVirtualHeader from '@/modules/history/events/components/HistoryEventsVirtualHeader.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { globalItemsPerPage } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return { globalItemsPerPage: ref<number>(10) };
+});
+
+vi.mock('@/modules/session/use-items-per-page', () => ({
+  useItemsPerPage: (): Ref<number> => globalItemsPerPage,
+}));
+
+const MenuSelectStub = {
+  name: 'RuiMenuSelect',
+  props: ['modelValue', 'options', 'dense', 'hideDetails', 'classNames'],
+  template: '<div />',
+};
+
+function createWrapper(
+  pagination: TablePaginationData,
+  sort: DataTableSortData<HistoryEventEntry> = [],
+): VueWrapper<any> {
+  return mount(HistoryEventsVirtualHeader, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: { RuiMenuSelect: MenuSelectStub },
+    },
+    props: { pagination, sort },
+  });
+}
+
+function page(pagination: Partial<TablePaginationData> = {}): TablePaginationData {
+  return { limit: 10, page: 1, total: 100, ...pagination };
+}
+
+function lastPagination(wrapper: VueWrapper<any>): TablePaginationData | undefined {
+  return wrapper.emitted<[TablePaginationData]>('update:pagination')?.at(-1)?.[0];
+}
+
+describe('historyEventsVirtualHeader', () => {
+  beforeEach(() => {
+    set(globalItemsPerPage, 10);
+  });
+
+  describe('sorting', () => {
+    it('should start the sort descending when the control is first pressed', async () => {
+      const wrapper = createWrapper(page());
+
+      await wrapper.find('[data-testid=events-sort-date]').trigger('click');
+
+      expect(wrapper.emitted<[unknown]>('update:sort')?.at(-1)?.[0])
+        .toEqual([{ column: 'timestamp', direction: 'desc' }]);
+    });
+
+    it('should reverse a sort already in force', async () => {
+      const wrapper = createWrapper(page(), [{ column: 'timestamp', direction: 'desc' }]);
+
+      await wrapper.find('[data-testid=events-sort-date]').trigger('click');
+
+      expect(wrapper.emitted<[unknown]>('update:sort')?.at(-1)?.[0])
+        .toEqual([{ column: 'timestamp', direction: 'asc' }]);
+    });
+  });
+
+  describe('paging', () => {
+    it('should move to the next page', async () => {
+      const wrapper = createWrapper(page({ page: 2 }));
+
+      await wrapper.find('[data-testid=events-page-next]').trigger('click');
+
+      expect(lastPagination(wrapper)).toMatchObject({ page: 3 });
+    });
+
+    it('should jump back to the first page', async () => {
+      const wrapper = createWrapper(page({ page: 5 }));
+
+      await wrapper.find('[data-testid=events-page-first]').trigger('click');
+
+      expect(lastPagination(wrapper)).toMatchObject({ page: 1 });
+    });
+
+    it('should not offer the first page while already on it', () => {
+      const wrapper = createWrapper(page({ page: 1 }));
+
+      expect(wrapper.find('[data-testid=events-page-first]').attributes('disabled')).toBeDefined();
+    });
+
+    it('should not offer a next page from the last one', () => {
+      const wrapper = createWrapper(page({ limit: 10, page: 10, total: 100 }));
+
+      expect(wrapper.find('[data-testid=events-page-next]').attributes('disabled')).toBeDefined();
+    });
+
+    it('should offer a next page while rows remain', () => {
+      const wrapper = createWrapper(page({ limit: 10, page: 9, total: 100 }));
+
+      expect(wrapper.find('[data-testid=events-page-next]').attributes('disabled')).toBeUndefined();
+    });
+  });
+
+  describe('the page size', () => {
+    it('should return to the first page when it changes', async () => {
+      const wrapper = createWrapper(page({ page: 7 }));
+
+      await wrapper.findComponent(MenuSelectStub).vm.$emit('update:modelValue', 50);
+
+      expect(lastPagination(wrapper)).toMatchObject({ limit: 50, page: 1 });
+    });
+
+    /** The size is a preference, so choosing it here is choosing it for every table. */
+    it('should become the account-wide preference', async () => {
+      const wrapper = createWrapper(page());
+
+      await wrapper.findComponent(MenuSelectStub).vm.$emit('update:modelValue', 50);
+
+      expect(get(globalItemsPerPage)).toBe(50);
+    });
+
+    it('should show the size the table is currently paging by', () => {
+      const wrapper = createWrapper(page({ limit: 25 }));
+
+      expect(wrapper.findComponent(MenuSelectStub).props('modelValue')).toBe(25);
+    });
+  });
+
+  describe('the range on show', () => {
+    it('should count from one on the first page', () => {
+      const wrapper = createWrapper(page({ limit: 10, page: 1, total: 100 }));
+
+      expect(wrapper.find('[data-testid=events-page-range]').text()).toContain('1-10');
+    });
+
+    it('should stop at the last row rather than the page size', () => {
+      const wrapper = createWrapper(page({ limit: 10, page: 3, total: 25 }));
+
+      expect(wrapper.find('[data-testid=events-page-range]').text()).toContain('21-25');
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
+++ b/frontend/app/src/modules/history/events/components/HistoryEventsVirtualHeader.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import type { HistoryEventEntry } from '@/modules/history/events/schemas';
 import { type DataTableSortData, type TablePaginationData, useBreakpoint } from '@rotki/ui-library';
+import {
+  leadingSortColumn,
+  pageCount,
+  sortDirection as sortDirectionOf,
+  toggledSort,
+} from '@/modules/history/events/components/history-events-table-header';
 import { useItemsPerPage } from '@/modules/session/use-items-per-page';
 
 const sort = defineModel<DataTableSortData<HistoryEventEntry>>('sort', { required: true });
@@ -15,41 +21,12 @@ const { t } = useI18n({ useScope: 'global' });
 const globalItemsPerPage = useItemsPerPage();
 const { isSmAndDown } = useBreakpoint();
 
-function getSortArray() {
-  const sortData = get(sort);
-  if (Array.isArray(sortData))
-    return sortData;
-  return sortData ? [sortData] : [];
-}
+const sortColumn = computed<'timestamp' | undefined>(() => leadingSortColumn(get(sort), 'timestamp'));
 
-const sortColumn = computed<'timestamp' | undefined>({
-  get() {
-    const sortArray = getSortArray();
-    if (sortArray.length === 0)
-      return undefined;
-    return sortArray[0]?.column === 'timestamp' ? 'timestamp' : undefined;
-  },
-  set(column: 'timestamp' | undefined) {
-    if (!column) {
-      set(sort, []);
-      return;
-    }
-    const sortArray = getSortArray();
-    const currentDirection = sortArray[0]?.direction ?? 'desc';
-    let newDirection: 'asc' | 'desc' = 'desc';
-    if (sortArray[0]?.column === column)
-      newDirection = currentDirection === 'asc' ? 'desc' : 'asc';
-    set(sort, [{ column, direction: newDirection }]);
-  },
-});
-
-const sortDirection = computed<'asc' | 'desc'>(() => {
-  const sortArray = getSortArray();
-  return sortArray[0]?.direction ?? 'desc';
-});
+const sortDirection = computed<'asc' | 'desc'>(() => sortDirectionOf(get(sort)));
 
 function toggleSort(): void {
-  set(sortColumn, 'timestamp');
+  set(sort, toggledSort(get(sort), 'timestamp'));
 }
 
 const currentPage = computed<number>({
@@ -68,15 +45,11 @@ const itemsPerPage = computed<number>({
   set(limit: number) {
     set(pagination, { ...get(pagination), limit, page: 1 });
 
-    if (limit !== get(globalItemsPerPage))
-      set(globalItemsPerPage, limit);
+    set(globalItemsPerPage, limit);
   },
 });
 
-const totalPages = computed<number>(() => {
-  const perPage = get(itemsPerPage);
-  return Math.ceil(get(pagination).total / perPage);
-});
+const totalPages = computed<number>(() => pageCount(get(pagination).total, get(itemsPerPage)));
 
 const limits = [10, 25, 50, 100];
 </script>

--- a/frontend/app/src/modules/history/events/components/RedecodeConfirmationDialog.spec.ts
+++ b/frontend/app/src/modules/history/events/components/RedecodeConfirmationDialog.spec.ts
@@ -1,0 +1,202 @@
+import type { Ref } from 'vue';
+import type { PullEventPayload } from '@/modules/history/events/event-payloads';
+import type { PrioritizedListId } from '@/modules/settings/types/prioritized-list-id';
+import { HistoryEventEntryType } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import RedecodeConfirmationDialog from '@/modules/history/events/components/RedecodeConfirmationDialog.vue';
+import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { defaultEvmIndexerOrder, evmIndexersOrder } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    defaultEvmIndexerOrder: ref<string[]>([]),
+    evmIndexersOrder: ref<Record<string, string[]>>({}),
+  };
+});
+
+vi.mock('@/modules/settings/use-evm-indexer-settings', () => ({
+  useEvmIndexerSettings: (): { defaultEvmIndexerOrder: Ref<string[]>; evmIndexersOrder: Ref<Record<string, string[]>> } => ({
+    defaultEvmIndexerOrder,
+    evmIndexersOrder,
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): { getEvmChainName: (location: string) => string } => ({
+    getEvmChainName: (location: string) => location,
+  }),
+}));
+
+const evmEvent: PullEventPayload = {
+  data: { location: 'optimism', txRef: '0xabc' },
+  type: HistoryEventEntryType.EVM_EVENT,
+};
+
+const blockEvent: PullEventPayload = { data: [42], type: HistoryEventEntryType.ETH_BLOCK_EVENT };
+
+/** `RuiDialog` teleports, so a pass-through keeps the card inside the wrapper. */
+const DialogStub = { name: 'RuiDialog', props: ['modelValue', 'maxWidth'], template: '<div><slot /></div>' };
+
+function createWrapper(props: Record<string, unknown> = {}): VueWrapper<any> {
+  return mount(RedecodeConfirmationDialog, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        PrioritizedList: {
+          name: 'PrioritizedList',
+          props: ['modelValue', 'allItems', 'itemDataName', 'disableDelete', 'dense', 'variant'],
+          template: '<div />',
+        },
+        RuiDialog: DialogStub,
+        SettingsItem: { name: 'SettingsItem', template: '<div><slot name="title" /><slot /></div>' },
+      },
+    },
+    props: { payload: evmEvent, show: true, ...props },
+  });
+}
+
+function order(wrapper: VueWrapper<any>): PrioritizedListId[] {
+  return wrapper.findComponent({ name: 'PrioritizedList' }).props('modelValue');
+}
+
+interface ConfirmEvent { payload: PullEventPayload; deleteCustom: boolean; customIndexersOrder?: string[] }
+
+async function proceed(wrapper: VueWrapper<any>): Promise<ConfirmEvent | undefined> {
+  await wrapper.findComponent({ name: 'RuiButton' }).trigger('click');
+  return wrapper.emitted<[ConfirmEvent]>('confirm')?.[0]?.[0];
+}
+
+describe('redecodeConfirmationDialog', () => {
+  beforeEach(() => {
+    set(defaultEvmIndexerOrder, []);
+    set(evmIndexersOrder, {});
+  });
+
+  describe('the indexer order', () => {
+    it('should open on the order stored for the event chain', () => {
+      set(evmIndexersOrder, { optimism: [EvmIndexer.BLOCKSCOUT] });
+
+      expect(order(createWrapper({ showIndexerOptions: true }))).toEqual([EvmIndexer.BLOCKSCOUT]);
+    });
+
+    it('should be offered only for an EVM event', () => {
+      const wrapper = createWrapper({ payload: blockEvent, showIndexerOptions: true });
+
+      expect(wrapper.findComponent({ name: 'PrioritizedList' }).exists()).toBe(false);
+    });
+
+    it('should be withheld when the caller did not ask for it', () => {
+      const wrapper = createWrapper({ showIndexerOptions: false });
+
+      expect(wrapper.findComponent({ name: 'PrioritizedList' }).exists()).toBe(false);
+    });
+
+    /** Removing the last indexer would leave the redecode nothing to ask. */
+    it('should refuse to delete the only indexer left', () => {
+      set(evmIndexersOrder, { optimism: [EvmIndexer.BLOCKSCOUT] });
+
+      const list = createWrapper({ showIndexerOptions: true }).findComponent({ name: 'PrioritizedList' });
+
+      expect(list.props('disableDelete')).toBe(true);
+    });
+
+    it('should allow deleting while more than one remains', () => {
+      set(evmIndexersOrder, { optimism: [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN] });
+
+      const list = createWrapper({ showIndexerOptions: true }).findComponent({ name: 'PrioritizedList' });
+
+      expect(list.props('disableDelete')).toBe(false);
+    });
+
+    it('should warn when the stored order left no indexer at all', () => {
+      set(evmIndexersOrder, { optimism: [] });
+
+      const wrapper = createWrapper({ showIndexerOptions: true });
+
+      expect(wrapper.text()).toContain('evm_settings.indexer.no_indexers_warning');
+    });
+  });
+
+  describe('proceeding', () => {
+    it('should hand back the payload it was given', async () => {
+      expect((await proceed(createWrapper()))?.payload).toEqual(evmEvent);
+    });
+
+    it('should send the chosen indexer order for an EVM event', async () => {
+      set(evmIndexersOrder, { optimism: [EvmIndexer.BLOCKSCOUT] });
+
+      const event = await proceed(createWrapper({ showIndexerOptions: true }));
+
+      expect(event?.customIndexersOrder).toEqual([EvmIndexer.BLOCKSCOUT]);
+    });
+
+    /** A non-EVM redecode has no indexer to pick, so the order is left out rather than sent empty. */
+    it('should send no indexer order for a block event', async () => {
+      set(defaultEvmIndexerOrder, [EvmIndexer.ETHERSCAN]);
+
+      const event = await proceed(createWrapper({ payload: blockEvent }));
+
+      expect(event?.customIndexersOrder).toBeUndefined();
+    });
+
+    it('should send no indexer order when none is left', async () => {
+      set(evmIndexersOrder, { optimism: [] });
+
+      const event = await proceed(createWrapper({ showIndexerOptions: true }));
+
+      expect(event?.customIndexersOrder).toBeUndefined();
+    });
+
+    it('should close the dialog', async () => {
+      const wrapper = createWrapper();
+
+      await proceed(wrapper);
+
+      expect(wrapper.emitted<[boolean]>('update:show')?.at(-1)?.[0]).toBe(false);
+    });
+
+    it('should stay silent when it was opened without a payload', async () => {
+      const wrapper = createWrapper({ payload: undefined });
+
+      await proceed(wrapper);
+
+      expect(wrapper.emitted('confirm')).toBeUndefined();
+      expect(wrapper.emitted<[boolean]>('update:show')?.at(-1)?.[0]).toBe(false);
+    });
+  });
+
+  describe('custom events', () => {
+    it('should warn that redecoding discards them', () => {
+      expect(createWrapper({ hasCustomEvents: true }).text())
+        .toContain('transactions.events.confirmation.reset.custom_events_warning');
+    });
+
+    it('should not warn when the group holds none', () => {
+      expect(createWrapper().text())
+        .not
+        .toContain('transactions.events.confirmation.reset.custom_events_warning');
+    });
+
+    it('should tell the caller to delete them', async () => {
+      expect((await proceed(createWrapper({ hasCustomEvents: true })))?.deleteCustom).toBe(true);
+    });
+
+    it('should leave them alone when the group holds none', async () => {
+      expect((await proceed(createWrapper()))?.deleteCustom).toBe(false);
+    });
+  });
+
+  /** The dialog is reused across groups, so what the previous one chose must not leak into the next. */
+  it('should reseed the order each time it is reopened', async () => {
+    set(evmIndexersOrder, { optimism: [EvmIndexer.BLOCKSCOUT] });
+    const wrapper = createWrapper({ showIndexerOptions: true });
+
+    set(evmIndexersOrder, { optimism: [EvmIndexer.ROUTESCAN] });
+    await wrapper.setProps({ show: false });
+    await wrapper.setProps({ show: true });
+
+    expect(order(wrapper)).toEqual([EvmIndexer.ROUTESCAN]);
+  });
+});

--- a/frontend/app/src/modules/history/events/components/RedecodeConfirmationDialog.vue
+++ b/frontend/app/src/modules/history/events/components/RedecodeConfirmationDialog.vue
@@ -2,8 +2,8 @@
 import type { PullEventPayload } from '@/modules/history/events/event-payloads';
 import { HistoryEventEntryType } from '@rotki/common';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { initialIndexerOrder } from '@/modules/history/events/components/redecode-indexer-order';
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
-import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
 import { PrioritizedListData } from '@/modules/settings/types/prioritized-list-data';
 import {
   BLOCKSCOUT_PRIO_LIST_ITEM,
@@ -61,33 +61,13 @@ const evmChainName = computed<string | undefined>(() => {
   return undefined;
 });
 
-/**
- * The indexer order this dialog opens with: the chain's own order, else the default one, else
- * every indexer.
- *
- * @remarks
- * The final fallback is listed here rather than read from a setting, so the dialog still offers a
- * choice on an account that has never configured one.
- */
-function getInitialIndexerOrder(): PrioritizedListId[] {
-  const chainName = get(evmChainName);
-  const chainOrders = get(evmIndexersOrder);
-
-  if (chainName && chainOrders && chainOrders[chainName]) {
-    return [...chainOrders[chainName]];
-  }
-
-  const defaultOrder = get(defaultEvmIndexerOrder);
-  if (defaultOrder && defaultOrder.length > 0) {
-    return [...defaultOrder];
-  }
-
-  return [EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT, EvmIndexer.ROUTESCAN];
-}
-
 function resetState(): void {
   set(deleteCustom, get(forceDeleteCustom));
-  set(localIndexerOrder, getInitialIndexerOrder());
+  set(localIndexerOrder, initialIndexerOrder(
+    get(evmChainName),
+    get(evmIndexersOrder),
+    get(defaultEvmIndexerOrder),
+  ));
 }
 
 function confirmRedecode(): void {
@@ -103,7 +83,7 @@ function confirmRedecode(): void {
   resetState();
 }
 
-watch(show, (value) => {
+watchImmediate(show, (value) => {
   if (value) {
     resetState();
   }

--- a/frontend/app/src/modules/history/events/components/history-events-table-header.spec.ts
+++ b/frontend/app/src/modules/history/events/components/history-events-table-header.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  leadingSortColumn,
+  pageCount,
+  sortDirection,
+  toggledSort,
+  toSortArray,
+} from '@/modules/history/events/components/history-events-table-header';
+
+describe('toSortArray', () => {
+  it('should wrap a single entry', () => {
+    expect(toSortArray({ column: 'timestamp', direction: 'asc' }))
+      .toEqual([{ column: 'timestamp', direction: 'asc' }]);
+  });
+
+  it('should pass a list through', () => {
+    const sort = [{ column: 'timestamp', direction: 'asc' }] as const;
+
+    expect(toSortArray([...sort])).toEqual(sort);
+  });
+
+  it('should read an unsorted table as empty', () => {
+    expect(toSortArray(undefined)).toEqual([]);
+  });
+
+  it('should read an empty list as empty', () => {
+    expect(toSortArray([])).toEqual([]);
+  });
+});
+
+describe('leadingSortColumn', () => {
+  it('should report the column when it leads the sort', () => {
+    expect(leadingSortColumn({ column: 'timestamp', direction: 'asc' }, 'timestamp')).toBe('timestamp');
+  });
+
+  it('should report nothing when another column leads', () => {
+    expect(leadingSortColumn({ column: 'location', direction: 'asc' }, 'timestamp')).toBeUndefined();
+  });
+
+  /** The header offers one control, so a column further down the sort is not the one it shows. */
+  it('should report nothing when the column only follows another', () => {
+    const sort = [
+      { column: 'location', direction: 'asc' },
+      { column: 'timestamp', direction: 'asc' },
+    ] as const;
+
+    expect(leadingSortColumn([...sort], 'timestamp')).toBeUndefined();
+  });
+
+  it('should report nothing for an unsorted table', () => {
+    expect(leadingSortColumn(undefined, 'timestamp')).toBeUndefined();
+  });
+});
+
+describe('sortDirection', () => {
+  it('should report the direction in force', () => {
+    expect(sortDirection({ column: 'timestamp', direction: 'asc' })).toBe('asc');
+  });
+
+  it('should default an unsorted table to descending', () => {
+    expect(sortDirection(undefined)).toBe('desc');
+  });
+});
+
+describe('toggledSort', () => {
+  it('should reverse a column already sorted ascending', () => {
+    expect(toggledSort({ column: 'timestamp', direction: 'asc' }, 'timestamp'))
+      .toEqual([{ column: 'timestamp', direction: 'desc' }]);
+  });
+
+  it('should reverse a column already sorted descending', () => {
+    expect(toggledSort({ column: 'timestamp', direction: 'desc' }, 'timestamp'))
+      .toEqual([{ column: 'timestamp', direction: 'asc' }]);
+  });
+
+  /** Newest first is what a table of events is expected to open on. */
+  it('should start an unsorted table descending', () => {
+    expect(toggledSort(undefined, 'timestamp')).toEqual([{ column: 'timestamp', direction: 'desc' }]);
+  });
+
+  it('should start descending when another column held the sort', () => {
+    expect(toggledSort({ column: 'location', direction: 'asc' }, 'timestamp'))
+      .toEqual([{ column: 'timestamp', direction: 'desc' }]);
+  });
+
+  it('should replace a multi-column sort rather than add to it', () => {
+    const sort = [
+      { column: 'timestamp', direction: 'asc' },
+      { column: 'location', direction: 'asc' },
+    ] as const;
+
+    expect(toggledSort([...sort], 'timestamp')).toHaveLength(1);
+  });
+
+  it('should leave the sort it was handed unchanged', () => {
+    const sort = [{ column: 'timestamp' as const, direction: 'asc' as const }];
+
+    toggledSort(sort, 'timestamp');
+
+    expect(sort).toEqual([{ column: 'timestamp', direction: 'asc' }]);
+  });
+});
+
+describe('pageCount', () => {
+  it('should count the pages the rows fill', () => {
+    expect(pageCount(25, 10)).toBe(3);
+  });
+
+  it('should count an exactly filled last page once', () => {
+    expect(pageCount(20, 10)).toBe(2);
+  });
+
+  it('should report no pages for no rows', () => {
+    expect(pageCount(0, 10)).toBe(0);
+  });
+
+  /** Dividing by a zero page size would otherwise make the last-page control unreachable. */
+  it('should report no pages rather than infinity for a zero page size', () => {
+    expect(pageCount(25, 0)).toBe(0);
+  });
+});

--- a/frontend/app/src/modules/history/events/components/history-events-table-header.ts
+++ b/frontend/app/src/modules/history/events/components/history-events-table-header.ts
@@ -1,0 +1,88 @@
+import type { DataTableSortData } from '@rotki/ui-library';
+import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+
+type SortEntry = Exclude<DataTableSortData<HistoryEventEntry>, undefined | unknown[]>;
+
+/** The columns the events table can be sorted by. */
+type SortColumn = NonNullable<SortEntry['column']>;
+
+/** The direction a column falls back to when it has not been sorted yet. */
+const DEFAULT_SORT_DIRECTION = 'desc';
+
+/**
+ * The sort as an array, whatever shape the table handed over.
+ *
+ * @remarks
+ * `DataTableSortData` is one entry, a list of them, or nothing, and every caller here wants the
+ * list form.
+ *
+ * @param sort - the table's current sort
+ * @returns the sort entries, empty when the table is unsorted
+ */
+export function toSortArray(sort: DataTableSortData<HistoryEventEntry>): SortEntry[] {
+  if (Array.isArray(sort))
+    return sort;
+
+  return sort ? [sort] : [];
+}
+
+/**
+ * Whether the table is currently sorted by the given column.
+ *
+ * @remarks
+ * Only the first entry counts: the header offers one sort control, so a multi-column sort set
+ * elsewhere reads as sorted by whichever column leads it.
+ *
+ * @param sort - the table's current sort
+ * @param column - the column the header controls
+ * @returns the column when it leads the sort, otherwise undefined
+ */
+export function leadingSortColumn<T extends SortColumn>(
+  sort: DataTableSortData<HistoryEventEntry>,
+  column: T,
+): T | undefined {
+  const [first] = toSortArray(sort);
+  return first?.column === column ? column : undefined;
+}
+
+/** The direction the sort currently runs in, defaulting to descending. */
+export function sortDirection(sort: DataTableSortData<HistoryEventEntry>): 'asc' | 'desc' {
+  return toSortArray(sort)[0]?.direction ?? DEFAULT_SORT_DIRECTION;
+}
+
+/**
+ * The sort after the header's control is pressed.
+ *
+ * @remarks
+ * Pressing the column already leading the sort reverses it; pressing any other column starts it
+ * descending, which is what a table of events ordered by time is expected to open on.
+ *
+ * @param sort - the table's current sort
+ * @param column - the column that was pressed
+ * @returns the replacement sort, as a single-entry array
+ */
+export function toggledSort(
+  sort: DataTableSortData<HistoryEventEntry>,
+  column: SortColumn,
+): SortEntry[] {
+  const [first] = toSortArray(sort);
+
+  if (first?.column !== column)
+    return [{ column, direction: DEFAULT_SORT_DIRECTION }];
+
+  return [{ column, direction: first.direction === 'asc' ? 'desc' : 'asc' }];
+}
+
+/**
+ * How many pages the rows fill.
+ *
+ * @param total - how many rows there are in all
+ * @param perPage - the page size; zero or less yields no pages rather than infinity
+ * @returns the page count, never negative or fractional
+ */
+export function pageCount(total: number, perPage: number): number {
+  if (perPage <= 0)
+    return 0;
+
+  return Math.ceil(total / perPage);
+}

--- a/frontend/app/src/modules/history/events/components/redecode-indexer-order.spec.ts
+++ b/frontend/app/src/modules/history/events/components/redecode-indexer-order.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { FALLBACK_INDEXER_ORDER, initialIndexerOrder } from '@/modules/history/events/components/redecode-indexer-order';
+import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
+
+describe('initialIndexerOrder', () => {
+  it('should prefer the order stored for the chain being redecoded', () => {
+    const chainOrders = { ethereum: [EvmIndexer.ROUTESCAN], optimism: [EvmIndexer.BLOCKSCOUT] };
+
+    expect(initialIndexerOrder('optimism', chainOrders, [EvmIndexer.ETHERSCAN])).toEqual([EvmIndexer.BLOCKSCOUT]);
+  });
+
+  it('should fall back to the account default when the chain has no order', () => {
+    const chainOrders = { ethereum: [EvmIndexer.ROUTESCAN] };
+
+    expect(initialIndexerOrder('optimism', chainOrders, [EvmIndexer.ETHERSCAN])).toEqual([EvmIndexer.ETHERSCAN]);
+  });
+
+  it('should fall back to the account default for an event with no chain', () => {
+    const chainOrders = { ethereum: [EvmIndexer.ROUTESCAN] };
+
+    expect(initialIndexerOrder(undefined, chainOrders, [EvmIndexer.ETHERSCAN])).toEqual([EvmIndexer.ETHERSCAN]);
+  });
+
+  it('should offer every indexer when nothing has been configured', () => {
+    expect(initialIndexerOrder(undefined, undefined, undefined)).toEqual([...FALLBACK_INDEXER_ORDER]);
+  });
+
+  /** An empty default would leave the redecode no indexer to ask, so it is treated as unset. */
+  it('should offer every indexer when the stored default is empty', () => {
+    expect(initialIndexerOrder('optimism', {}, [])).toEqual([...FALLBACK_INDEXER_ORDER]);
+  });
+
+  /** A chain order is taken as given: that one was chosen for this chain deliberately. */
+  it('should honour an empty order stored for the chain', () => {
+    expect(initialIndexerOrder('optimism', { optimism: [] }, [EvmIndexer.ETHERSCAN])).toEqual([]);
+  });
+
+  it('should copy the stored order rather than hand back the setting', () => {
+    const chainOrders = { optimism: [EvmIndexer.BLOCKSCOUT] };
+
+    const order = initialIndexerOrder('optimism', chainOrders, undefined);
+    order.push(EvmIndexer.ETHERSCAN);
+
+    expect(chainOrders.optimism).toEqual([EvmIndexer.BLOCKSCOUT]);
+  });
+
+  it('should copy the default order rather than hand back the setting', () => {
+    const defaultOrder = [EvmIndexer.BLOCKSCOUT];
+
+    const order = initialIndexerOrder(undefined, undefined, defaultOrder);
+    order.push(EvmIndexer.ETHERSCAN);
+
+    expect(defaultOrder).toEqual([EvmIndexer.BLOCKSCOUT]);
+  });
+
+  it('should copy the fallback rather than hand back the shared constant', () => {
+    const order = initialIndexerOrder(undefined, undefined, undefined);
+    order.push(EvmIndexer.ETHERSCAN);
+
+    expect(FALLBACK_INDEXER_ORDER).toHaveLength(3);
+  });
+});

--- a/frontend/app/src/modules/history/events/components/redecode-indexer-order.ts
+++ b/frontend/app/src/modules/history/events/components/redecode-indexer-order.ts
@@ -1,0 +1,44 @@
+import type { PrioritizedListId } from '@/modules/settings/types/prioritized-list-id';
+import type { SettingValue } from '@/modules/settings/use-setting';
+import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
+
+/**
+ * Every indexer the dialog can offer, in the order it falls back to.
+ *
+ * @remarks
+ * Listed here rather than read from a setting so the dialog still offers a choice on an account
+ * that has never configured one.
+ */
+export const FALLBACK_INDEXER_ORDER: readonly PrioritizedListId[] = [
+  EvmIndexer.ETHERSCAN,
+  EvmIndexer.BLOCKSCOUT,
+  EvmIndexer.ROUTESCAN,
+];
+
+/**
+ * The indexer order the redecode dialog opens with: the chain's own order, else the account-wide
+ * default, else every indexer.
+ *
+ * @remarks
+ * An empty stored default is treated as unset, because an order with nothing in it would leave the
+ * redecode no indexer to ask. A chain order is taken as given, empty or not: that one was chosen
+ * for this chain deliberately.
+ *
+ * @param chainName - the EVM chain being redecoded, absent for a non-EVM event
+ * @param chainOrders - the per-chain orders, as stored in settings
+ * @param defaultOrder - the account-wide order, as stored in settings
+ * @returns a fresh array the caller may reorder in place
+ */
+export function initialIndexerOrder(
+  chainName: string | undefined,
+  chainOrders: SettingValue<'evmIndexersOrder'> | undefined,
+  defaultOrder: SettingValue<'defaultEvmIndexerOrder'> | undefined,
+): PrioritizedListId[] {
+  if (chainName && chainOrders?.[chainName])
+    return [...chainOrders[chainName]];
+
+  if (defaultOrder && defaultOrder.length > 0)
+    return [...defaultOrder];
+
+  return [...FALLBACK_INDEXER_ORDER];
+}

--- a/frontend/app/src/modules/history/events/matching/search-widening.spec.ts
+++ b/frontend/app/src/modules/history/events/matching/search-widening.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canWidenSearch,
+  MAX_SEARCH_HOURS,
+  MAX_TOLERANCE_PERCENTAGE,
+  widenedSearch,
+} from '@/modules/history/events/matching/search-widening';
+
+describe('canWidenSearch', () => {
+  it('should offer to widen while both criteria have room', () => {
+    expect(canWidenSearch({ hours: '24', tolerance: '5' })).toBe(true);
+  });
+
+  it('should offer to widen while only the time range has room', () => {
+    expect(canWidenSearch({ hours: '24', tolerance: '100' })).toBe(true);
+  });
+
+  it('should offer to widen while only the tolerance has room', () => {
+    expect(canWidenSearch({ hours: '168', tolerance: '5' })).toBe(true);
+  });
+
+  it('should stop offering once both criteria are at their max', () => {
+    expect(canWidenSearch({ hours: '168', tolerance: '100' })).toBe(false);
+  });
+
+  it('should stop offering once both criteria are past their max', () => {
+    expect(canWidenSearch({ hours: '500', tolerance: '400' })).toBe(false);
+  });
+
+  it('should stop offering when neither criterion is a number', () => {
+    expect(canWidenSearch({ hours: 'abc', tolerance: 'abc' })).toBe(false);
+  });
+
+  /** An empty field is zero, not unparsable, so the control stays offered. */
+  it('should keep offering while a criterion is empty', () => {
+    expect(canWidenSearch({ hours: '', tolerance: 'abc' })).toBe(true);
+  });
+});
+
+describe('widenedSearch', () => {
+  it('should double both criteria', () => {
+    expect(widenedSearch({ hours: '12', tolerance: '5' })).toEqual({ hours: '24', tolerance: '10' });
+  });
+
+  it('should cap the time range at its max', () => {
+    expect(widenedSearch({ hours: '120', tolerance: '5' }).hours).toBe(String(MAX_SEARCH_HOURS));
+  });
+
+  it('should cap the tolerance at its max', () => {
+    expect(widenedSearch({ hours: '12', tolerance: '80' }).tolerance).toBe(String(MAX_TOLERANCE_PERCENTAGE));
+  });
+
+  it('should leave a criterion already at its max alone', () => {
+    expect(widenedSearch({ hours: '168', tolerance: '100' })).toEqual({ hours: '168', tolerance: '100' });
+  });
+
+  /** Widening must not throw away what the user was in the middle of entering. */
+  it('should leave a criterion that does not parse exactly as typed', () => {
+    expect(widenedSearch({ hours: '1e', tolerance: '5' })).toEqual({ hours: '1e', tolerance: '10' });
+  });
+
+  /** Doubling zero is zero, so an emptied field stays put while the other one grows. */
+  it('should leave a zero criterion at zero', () => {
+    expect(widenedSearch({ hours: '0', tolerance: '5' })).toEqual({ hours: '0', tolerance: '10' });
+  });
+
+  it('should read an empty criterion as zero', () => {
+    expect(widenedSearch({ hours: '', tolerance: '5' }).hours).toBe('0');
+  });
+});

--- a/frontend/app/src/modules/history/events/matching/search-widening.ts
+++ b/frontend/app/src/modules/history/events/matching/search-widening.ts
@@ -1,0 +1,52 @@
+/** Seven days, matching the time field's own max. */
+export const MAX_SEARCH_HOURS = 168;
+
+/** Raising this past 100 changes nothing: a full 100% either side already excludes no candidate. */
+export const MAX_TOLERANCE_PERCENTAGE = 100;
+
+export interface SearchCriteria {
+  /** How far either side of the unmatched entry to look, in hours. */
+  hours: string;
+  /** How far the amounts may differ, as a percentage. */
+  tolerance: string;
+}
+
+/**
+ * Whether either criterion still has room to grow.
+ *
+ * @remarks
+ * A criterion that is not a number at all compares false either way, so it counts as having no
+ * room. An empty field is not that case: it reads as zero, which does have room, though doubling
+ * it leaves it at zero.
+ *
+ * @param criteria - the search as the fields currently hold it
+ * @returns whether widening would change either criterion
+ */
+export function canWidenSearch({ hours, tolerance }: SearchCriteria): boolean {
+  return Number(hours) < MAX_SEARCH_HOURS || Number(tolerance) < MAX_TOLERANCE_PERCENTAGE;
+}
+
+/**
+ * The search after the user asks to widen it: both criteria doubled, each capped at its own max.
+ *
+ * @remarks
+ * A criterion that does not parse is left exactly as typed rather than reset, so widening never
+ * throws away what the user was in the middle of entering.
+ *
+ * @param criteria - the search as the fields currently hold it
+ * @returns the replacement values, as the strings the fields hold
+ */
+export function widenedSearch({ hours, tolerance }: SearchCriteria): SearchCriteria {
+  return {
+    hours: doubleUpTo(hours, MAX_SEARCH_HOURS),
+    tolerance: doubleUpTo(tolerance, MAX_TOLERANCE_PERCENTAGE),
+  };
+}
+
+function doubleUpTo(value: string, max: number): string {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed))
+    return value;
+
+  return Math.min(parsed * 2, max).toString();
+}

--- a/frontend/app/src/modules/history/events/use-history-events-export.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-export.spec.ts
@@ -1,0 +1,239 @@
+import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
+import { Severity } from '@rotki/common';
+import { err, ok, type Result } from 'plainfp/result';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { computed, type ComputedRef } from 'vue';
+import { Cancelled, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { useHistoryEventsExport } from '@/modules/history/events/use-history-events-export';
+
+const { confirm, downloadHistoryEventsCSV, exportHistoryEventsCSV, interop, notify, submitTask } = vi.hoisted(() => {
+  /** Holds the callback the confirmation store was handed, so a test can accept the prompt. */
+  const confirm: { run?: () => Promise<void> } = {};
+
+  return {
+    confirm,
+    downloadHistoryEventsCSV: vi.fn(async () => {}),
+    exportHistoryEventsCSV: vi.fn(),
+    interop: { appSession: false, openDirectory: vi.fn() },
+    notify: vi.fn(),
+    submitTask: vi.fn(),
+  };
+});
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): typeof interop => interop,
+}));
+
+vi.mock('@/modules/history/api/events/use-history-events-api', () => ({
+  useHistoryEventsApi: (): Record<string, Mock> => ({ downloadHistoryEventsCSV, exportHistoryEventsCSV }),
+}));
+
+vi.mock('@/modules/task-center/use-native-task', () => ({
+  useNativeTask: (): { submitTask: Mock } => ({ submitTask }),
+}));
+
+vi.mock('@/modules/task-center/use-task-center', () => ({
+  useTaskCenter: (): { useIsActive: () => ComputedRef<boolean> } => ({
+    useIsActive: () => computed(() => true),
+  }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): { notify: Mock } => ({ notify }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): { show: (message: unknown, run: () => Promise<void>) => void } => ({
+    show: (_message, run): void => {
+      confirm.run = run;
+    },
+  }),
+}));
+
+const filters: HistoryEventRequestPayload = {
+  aggregateByGroupIds: true,
+  limit: 10,
+  location: 'ethereum',
+  offset: 20,
+};
+
+function taskFailed(message: string): TaskError {
+  return TaskFailed({ message });
+}
+
+/** Runs the export the way the user does: press the control, then accept the confirmation. */
+async function exportAfterConfirming(matchExactEvents = false): Promise<void> {
+  const { showConfirmation } = useHistoryEventsExport(() => filters, () => matchExactEvents);
+  showConfirmation();
+  await confirm.run?.();
+}
+
+/** Invokes the task body the export handed the task centre, with a stand-in `runTask`. */
+async function runSubmittedTask(result: Result<boolean | { filePath: string }, TaskError>): Promise<void> {
+  const spec = submitTask.mock.calls[0][0];
+  await spec.run({ runTask: async (fn: () => Promise<unknown>) => {
+    await fn();
+    return result;
+  } });
+}
+
+describe('useHistoryEventsExport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    confirm.run = undefined;
+    interop.appSession = false;
+    interop.openDirectory.mockResolvedValue('/tmp/export');
+    exportHistoryEventsCSV.mockResolvedValue(true);
+    submitTask.mockResolvedValue(ok(true));
+  });
+
+  it('should report the export as running while the task centre says so', () => {
+    const { taskRunning } = useHistoryEventsExport(() => filters, () => false);
+
+    expect(get(taskRunning)).toBe(true);
+  });
+
+  it('should not export until the confirmation is accepted', () => {
+    const { showConfirmation } = useHistoryEventsExport(() => filters, () => false);
+
+    showConfirmation();
+
+    expect(submitTask).not.toHaveBeenCalled();
+  });
+
+  describe('choosing where the file goes', () => {
+    it('should ask the app session for a directory', async () => {
+      interop.appSession = true;
+
+      await exportAfterConfirming();
+
+      expect(interop.openDirectory).toHaveBeenCalledTimes(1);
+      expect(submitTask).toHaveBeenCalledTimes(1);
+    });
+
+    it('should abandon the export when the directory picker is dismissed', async () => {
+      interop.appSession = true;
+      interop.openDirectory.mockResolvedValue(undefined);
+
+      await exportAfterConfirming();
+
+      expect(submitTask).not.toHaveBeenCalled();
+      expect(notify).not.toHaveBeenCalled();
+    });
+
+    it('should not ask a browser session where to put it', async () => {
+      await exportAfterConfirming();
+
+      expect(interop.openDirectory).not.toHaveBeenCalled();
+      expect(submitTask).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /** The export covers everything the filters match, so the table's paging must not narrow it. */
+  describe('what the backend is asked for', () => {
+    it('should drop the paging and grouping the table was using', async () => {
+      await exportAfterConfirming();
+      await runSubmittedTask(ok(true));
+
+      expect(exportHistoryEventsCSV).toHaveBeenCalledWith({
+        location: 'ethereum',
+        matchExactEvents: false,
+      }, undefined);
+    });
+
+    it('should pass on whether the matched events were asked for', async () => {
+      await exportAfterConfirming(true);
+      await runSubmittedTask(ok(true));
+
+      expect(exportHistoryEventsCSV).toHaveBeenCalledWith(
+        expect.objectContaining({ matchExactEvents: true }),
+        undefined,
+      );
+    });
+
+    it('should send the directory the app session chose', async () => {
+      interop.appSession = true;
+
+      await exportAfterConfirming();
+      await runSubmittedTask(ok(true));
+
+      expect(exportHistoryEventsCSV).toHaveBeenCalledWith(expect.anything(), '/tmp/export');
+    });
+  });
+
+  describe('reporting the outcome in an app session', () => {
+    beforeEach(() => {
+      interop.appSession = true;
+    });
+
+    it('should confirm the file was written', async () => {
+      await exportAfterConfirming();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'actions.history_events_export.message.success',
+        severity: Severity.INFO,
+      }));
+    });
+
+    it('should report a backend that declined to write one', async () => {
+      submitTask.mockResolvedValue(ok(false));
+
+      await exportAfterConfirming();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ severity: Severity.ERROR }));
+    });
+  });
+
+  describe('reporting the outcome in a browser session', () => {
+    it('should stream the generated file back instead of announcing it', async () => {
+      submitTask.mockResolvedValue(ok({ filePath: '/tmp/events.csv' }));
+
+      await exportAfterConfirming();
+
+      expect(downloadHistoryEventsCSV).toHaveBeenCalledWith('/tmp/events.csv');
+      expect(notify).not.toHaveBeenCalled();
+    });
+
+    it('should still report a failure', async () => {
+      submitTask.mockResolvedValue(ok(false));
+
+      await exportAfterConfirming();
+
+      expect(downloadHistoryEventsCSV).not.toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({ severity: Severity.ERROR }));
+    });
+  });
+
+  describe('when the task fails', () => {
+    it('should surface an actionable failure with what the task said', async () => {
+      submitTask.mockResolvedValue(err(taskFailed('disk full')));
+
+      await exportAfterConfirming();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'actions.history_events_export.message.failure::disk full',
+        severity: Severity.ERROR,
+      }));
+    });
+
+    /** A cancellation is the user's own doing and the task centre already shows it. */
+    it('should stay quiet when the task was cancelled', async () => {
+      submitTask.mockResolvedValue(err(Cancelled({ message: 'cancelled' })));
+
+      await exportAfterConfirming();
+
+      expect(notify).not.toHaveBeenCalled();
+    });
+
+    it('should report an error thrown on the way', async () => {
+      submitTask.mockRejectedValue(new Error('boom'));
+
+      await exportAfterConfirming();
+
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'actions.history_events_export.message.failure::boom',
+        severity: Severity.ERROR,
+      }));
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-history-events-export.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-export.ts
@@ -1,0 +1,161 @@
+import type { MaybeRefOrGetter, Ref } from 'vue';
+import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
+import { type NotificationPayload, type SemiPartial, Severity } from '@rotki/common';
+import { omit } from 'es-toolkit';
+import { isErr, map as mapResult, type Result } from 'plainfp/result';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
+import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
+import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { useInterop } from '@/modules/shell/app/use-electron-interop';
+import { activityLabel } from '@/modules/task-center/activity-labels';
+import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { useNativeTask } from '@/modules/task-center/use-native-task';
+import { useTaskCenter } from '@/modules/task-center/use-task-center';
+
+/** What the backend reports: `true` for a file it wrote itself, a path for one to stream back. */
+type ExportResult = boolean | { filePath: string };
+
+interface ExportOutcome {
+  result: ExportResult;
+  message?: string;
+}
+
+type ExportMessage = SemiPartial<NotificationPayload, 'title' | 'message'>;
+
+interface UseHistoryEventsExportReturn {
+  /** Whether an export is already running, so the caller can disable its control. */
+  taskRunning: Ref<boolean>;
+  /** Asks the user to confirm, then exports. */
+  showConfirmation: () => void;
+}
+
+/**
+ * Exports the events matching the current filters to CSV.
+ *
+ * @param filters - the table's filters; paging and grouping are dropped, since the export is whole
+ * @param matchExactEvents - whether to export the matched events rather than their groups
+ * @returns the running flag and the confirm-then-export entry point
+ */
+export function useHistoryEventsExport(
+  filters: MaybeRefOrGetter<HistoryEventRequestPayload>,
+  matchExactEvents: MaybeRefOrGetter<boolean>,
+): UseHistoryEventsExportReturn {
+  const { t } = useI18n({ useScope: 'global' });
+
+  const { appSession, openDirectory } = useInterop();
+  const { downloadHistoryEventsCSV, exportHistoryEventsCSV } = useHistoryEventsApi();
+  const { submitTask } = useNativeTask();
+  const { useIsActive } = useTaskCenter();
+  const { notify } = useNotificationDispatcher();
+  const { show } = useConfirmStore();
+
+  /**
+   * @returns the outcome, or `null` when the failure was already reported by the task centre
+   */
+  async function createCsv(directoryPath?: string): Promise<ExportOutcome | null> {
+    const outcome = await submitTask<ExportResult>({
+      id: makeActivityId(ActivityKind.HISTORY_EVENTS, ActivityPart.EXPORT),
+      kind: ActivityKind.HISTORY_EVENTS,
+      rerunnable: false,
+      run: async ({ runTask }): Promise<Result<ExportResult, TaskError>> => mapResult(
+        await runTask<ExportResult>(
+          async () => exportHistoryEventsCSV({
+            ...omit(toValue(filters), ['limit', 'offset', 'aggregateByGroupIds']),
+            matchExactEvents: toValue(matchExactEvents),
+          }, directoryPath),
+        ),
+        value => value,
+      ),
+      subtitle: activityLabel(ActivityKind.HISTORY_EVENTS, ActivityPart.EXPORT),
+      title: t('task_center.group.history_events'),
+    });
+
+    if (!isErr(outcome))
+      return { result: outcome.value };
+
+    if (!isActionable(outcome.error))
+      return null;
+
+    return {
+      message: outcome.error.message,
+      result: false,
+    };
+  }
+
+  function exportOutcomeMessage(succeeded: boolean, taskMessage?: string): ExportMessage {
+    return {
+      display: true,
+      message: succeeded
+        ? t('actions.history_events_export.message.success')
+        : t('actions.history_events_export.message.failure', { description: taskMessage }),
+      severity: succeeded ? Severity.INFO : Severity.ERROR,
+      title: t('actions.history_events_export.title'),
+    };
+  }
+
+  /**
+   * In an app session the file was written where the user chose, so the outcome is only reported. A
+   * browser session instead gets the generated file streamed back, and only a failure is reported.
+   */
+  async function reportExport(outcome: ExportOutcome): Promise<ExportMessage | null> {
+    const { message: taskMessage, result } = outcome;
+
+    if (appSession || !result)
+      return exportOutcomeMessage(!!result, taskMessage);
+
+    if (result !== true && 'filePath' in result)
+      await downloadHistoryEventsCSV(result.filePath);
+
+    return null;
+  }
+
+  async function exportCSV(): Promise<void> {
+    let message: ExportMessage | null = null;
+
+    try {
+      let directoryPath;
+      if (appSession) {
+        directoryPath = await openDirectory(t('common.select_directory'));
+        if (!directoryPath)
+          return;
+      }
+
+      const outcome = await createCsv(directoryPath);
+      if (outcome === null)
+        return;
+
+      message = await reportExport(outcome);
+    }
+    catch (error: unknown) {
+      message = {
+        display: true,
+        message: t('actions.history_events_export.message.failure', {
+          description: getErrorMessage(error),
+        }),
+        severity: Severity.ERROR,
+        title: t('actions.history_events_export.title'),
+      };
+    }
+
+    if (message)
+      notify(message);
+  }
+
+  function showConfirmation(): void {
+    show(
+      {
+        message: t('transactions.events.export.confirmation_message'),
+        title: t('common.actions.export_csv'),
+        type: 'info',
+      },
+      exportCSV,
+    );
+  }
+
+  return {
+    showConfirmation,
+    taskRunning: useIsActive(ActivityKind.HISTORY_EVENTS, ActivityPart.EXPORT),
+  };
+}


### PR DESCRIPTION
Continues the SFC coverage work after #13084, taking the `history/events` cluster: the five
spec-less components in it that hold a decision. Four had logic worth lifting out of the template
first; one is inherently component-bound and is tested in place.

## Coverage

Measured on this branch against the same tree before the batch, summing lcov:

| | lines | pct |
|---|---|---|
| before | 35,402 / 49,252 | 71.88% |
| after | 35,593 / 49,249 | **72.27%** |

Suite 1058 → 1066 files, 11,461 → 11,567 tests. No new network calls.

| file | before | after |
|---|---|---|
| `RedecodeConfirmationDialog.vue` | 0/51 | 39/43 |
| `HistoryEventsVirtualHeader.vue` | 7/57 | 33/35 |
| `PotentialMatchesList.vue` | 6/49 | 33/44 |
| `HistoryEventFormDialog.vue` | 0/34 | 33/34 |
| `HistoryEventsExport.vue` | 0/43 | 0/9, its logic now in a 38/38 composable |

The extracted modules (`redecode-indexer-order`, `use-history-events-export`,
`history-events-table-header`, `search-widening`) are at 100%.

## What the specs found

**The redecode dialog seeded its state only on a `show` transition.** Mounted already open it
offered no indexers at all, and reported `deleteCustom: false` while displaying the warning that it
*will* delete custom events. The parent always mounts it closed, so this was latent rather than
live, but the correctness rested on mount order; it now seeds immediately.

**Three pieces of dead code, each found by a test that could not be made to fail.**
- `sortColumn`'s setter had a clear-the-sort branch nothing could reach: the template only reads it
  and `toggleSort` only ever writes the column.
- The page-size setter guarded against writing an unchanged value to a ref, which a ref already
  ignores. The test pinning it agreed with both the guarded and unguarded code, so the guard went
  and the test was re-aimed.
- `DEFAULT_SORT_DIRECTION` was exported with no importer outside its own file, which only `knip`
  catches.

**One test asserted behaviour the code does not have.** It claimed an unparsable search criterion
blocks the widen control; `Number('')` is `0`, not `NaN`, so an empty field reads as zero and does
still offer widening, which then leaves it at zero. The documentation and the tests were corrected
to the real behaviour rather than the code changed to match the assumption.

## Notes

`HistoryEventsExport.vue` reads 0/9 after the extraction. Those nine lines are the button wiring
around a fully covered composable; a mount-only test there would move the number and prove nothing.

Every claim is negative-controlled: the reseed on reopen, the dismissed directory picker, the
cancelled-task silence, the descending sort toggle, the widening caps, the double-save guard and
the loading gate each failed exactly the tests named after them, and no others.

## Gates

`typecheck`, `knip`, `lint:style`, `check:linked-keys`, `test:proxy`, `lint:file:check` and the
full unit suite all pass, run one at a time.
