### PR TITLE
refactor(notifications): let priority own display

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
@@ -33,7 +33,6 @@ async function doImport() {
   set(loading, false);
   if (successEntries > 0) {
     notify({
-      display: true,
       message: t('address_book.import.import_success.message', {
         length: successEntries,
       }),

--- a/frontend/app/src/modules/accounts/use-account-migration.spec.ts
+++ b/frontend/app/src/modules/accounts/use-account-migration.spec.ts
@@ -1,15 +1,17 @@
+import type { Notification } from '@rotki/common';
 import type { MigratedAddresses } from '@/modules/core/messaging/types';
 import { flushPromises } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
+import { createNotification } from '@/modules/core/notifications/notification-utils';
 import '@test/i18n';
 
 const h = vi.hoisted(() => ({
   fetchAccounts: vi.fn(),
   isEvm: vi.fn((chain: string): boolean => chain === 'eth' || chain === 'optimism'),
-  notify: vi.fn(),
+  notify: vi.fn<(payload: Notification) => void>(),
   refreshBlockchainBalances: vi.fn(),
 }));
 
@@ -67,6 +69,7 @@ describe('useAccountMigration', () => {
 
     expect(h.fetchAccounts).toHaveBeenCalledWith({ blockchain: 'eth' });
     expect(h.notify).toHaveBeenCalledOnce();
+    expect(createNotification(1, h.notify.mock.calls[0][0])).toMatchObject({ display: true, duration: -1 });
     await flushPromises();
     expect(h.refreshBlockchainBalances).toHaveBeenCalledWith(
       { blockchain: 'eth' },

--- a/frontend/app/src/modules/accounts/use-account-migration.ts
+++ b/frontend/app/src/modules/accounts/use-account-migration.ts
@@ -76,7 +76,6 @@ export function useAccountMigration(): UseAccountMigrationReturn {
 
       notifications.push({
         category: NotificationCategory.ADDRESS_MIGRATION,
-        display: true,
         duration: -1,
         message: t(
           'notification_messages.address_migration.message',

--- a/frontend/app/src/modules/assets/admin/missing-mappings/exchange-unknown-asset-handler.ts
+++ b/frontend/app/src/modules/assets/admin/missing-mappings/exchange-unknown-asset-handler.ts
@@ -27,7 +27,6 @@ export function createExchangeUnknownAssetHandler(
         label: t('asset_management.cex_mapping.add_mapping'),
       },
       category: NotificationCategory.DEFAULT,
-      display: true,
       group: NotificationGroup.MISSING_EXCHANGE_MAPPING,
       groupCount,
       message: t('notification_messages.unknown_asset_mapping.message', { groupCount }),

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/solana-tokens-migration-handler.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/solana-tokens-migration-handler.ts
@@ -22,7 +22,6 @@ export function createSolanaTokensHandler(
         persist: true,
       },
       category: NotificationCategory.DEFAULT,
-      display: true,
       message: t('notification_messages.solana_tokens_migration.message', {
         tokens: data.identifiers.map(item => `- ${item}`).join('\n'),
       }),

--- a/frontend/app/src/modules/assets/admin/use-restore-asset-db.ts
+++ b/frontend/app/src/modules/assets/admin/use-restore-asset-db.ts
@@ -84,12 +84,7 @@ export function useRestoreAssetDb(): UseRestoreAssetDbReturn {
     if (message.includes(UNDELETABLE_ASSETS))
       showDoubleConfirmation(resetType);
 
-    notify({
-      display: true,
-      message,
-      severity: Severity.ERROR,
-      title: t('asset_update.restore.title'),
-    });
+    notify({ message, severity: Severity.ERROR, title: t('asset_update.restore.title') });
   }
 
   function showRestoreConfirmation(type: ResetType): void {

--- a/frontend/app/src/modules/assets/detection/new-token-detected-handler.ts
+++ b/frontend/app/src/modules/assets/detection/new-token-detected-handler.ts
@@ -31,7 +31,6 @@ export function createNewTokenDetectedHandler(
           label: t('notification_messages.new_detected_token.action'),
         },
         category: NotificationCategory.DEFAULT,
-        display: true,
         group: NotificationGroup.NEW_DETECTED_TOKENS,
         groupCount: count,
         message: t(

--- a/frontend/app/src/modules/assets/prices/components/oracle/OracleCacheContent.vue
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OracleCacheContent.vue
@@ -96,12 +96,7 @@ async function loadCaches(): Promise<void> {
     set(cacheEntries, await getPriceCache(get(cacheSource)));
   }
   catch (error: unknown) {
-    notify({
-      display: true,
-      message: getErrorMessage(error),
-      severity: Severity.ERROR,
-      title: t('oracle_prices.cache.notification.title'),
-    });
+    notify({ message: getErrorMessage(error), severity: Severity.ERROR, title: t('oracle_prices.cache.notification.title') });
     set(cacheEntries, []);
   }
   finally {
@@ -144,12 +139,7 @@ async function populateCache(): Promise<void> {
         toAsset: to,
       });
 
-  notify({
-    display: true,
-    message: message.toString(),
-    severity: status.success ? Severity.INFO : Severity.ERROR,
-    title: t('oracle_prices.cache.notification.title'),
-  });
+  notify({ message: message.toString(), severity: status.success ? Severity.INFO : Severity.ERROR, title: t('oracle_prices.cache.notification.title') });
 }
 
 async function clearCache(entry: OracleCacheMeta): Promise<void> {
@@ -160,7 +150,6 @@ async function clearCache(entry: OracleCacheMeta): Promise<void> {
   }
   catch (error: unknown) {
     notify({
-      display: true,
       message: t('oracle_prices.cache.delete.error', {
         error: getErrorMessage(error),
         fromAsset: getAssetField(entry.fromAsset, 'symbol'),

--- a/frontend/app/src/modules/assets/use-asset-info-retrieval.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-retrieval.ts
@@ -270,7 +270,6 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
         return [];
 
       notify({
-        display: true,
         group: NotificationGroup.ASSET_SEARCH_ERROR,
         message: t('asset_search.error.message', {
           message: getErrorMessage(error),

--- a/frontend/app/src/modules/calendar/CalendarReminder.vue
+++ b/frontend/app/src/modules/calendar/CalendarReminder.vue
@@ -76,11 +76,7 @@ const length = computed<number>(() => form.state.rows.length);
 
 function notifyFailure(key: 'add' | 'delete' | 'edit' | 'fetch', error: unknown): void {
   logger.error(error);
-  notify({
-    display: true,
-    message: t(`calendar.reminder.${key}_error.message`, { message: getErrorMessage(error) }),
-    title: t(`calendar.reminder.${key}_error.title`),
-  });
+  notify({ message: t(`calendar.reminder.${key}_error.message`, { message: getErrorMessage(error) }), title: t(`calendar.reminder.${key}_error.title`) });
 }
 
 async function loadStored(): Promise<void> {
@@ -148,11 +144,7 @@ async function addReminders(eventId: number, secsBefore: number[]): Promise<void
   try {
     const result = await addCalendarReminder(secsBefore.map(seconds => ({ eventId, secsBefore: seconds })));
     if (result.failed && result.failed.length > 0) {
-      notify({
-        display: true,
-        message: t('calendar.reminder.add_error.some_failed', { ids: result.failed.join(', ') }),
-        title: t('calendar.reminder.add_error.title'),
-      });
+      notify({ message: t('calendar.reminder.add_error.some_failed', { ids: result.failed.join(', ') }), title: t('calendar.reminder.add_error.title') });
     }
   }
   catch (error: unknown) {

--- a/frontend/app/src/modules/calendar/use-google-calendar-integration.ts
+++ b/frontend/app/src/modules/calendar/use-google-calendar-integration.ts
@@ -54,12 +54,7 @@ export function useGoogleCalendarIntegration(): UseGoogleCalendarIntegrationRetu
   const modelManualRefreshToken = shallowRef<string>('');
 
   function notifyMessage(message: string): void {
-    notify({
-      display: true,
-      message,
-      severity: Severity.ERROR,
-      title: t('external_services.google_calendar.error'),
-    });
+    notify({ message, severity: Severity.ERROR, title: t('external_services.google_calendar.error') });
   }
 
   function notifyError(error: unknown, fallback: string): void {
@@ -92,12 +87,7 @@ export function useGoogleCalendarIntegration(): UseGoogleCalendarIntegrationRetu
         set(showTokenInput, true);
       }
 
-      notify({
-        display: true,
-        message: t('external_services.google_calendar.opening_browser'),
-        severity: Severity.INFO,
-        title: t('external_services.google_calendar.authorizing'),
-      });
+      notify({ message: t('external_services.google_calendar.opening_browser'), severity: Severity.INFO, title: t('external_services.google_calendar.authorizing') });
     }
     catch (error: unknown) {
       notifyError(error, t('external_services.google_calendar.auth_failed'));
@@ -184,7 +174,6 @@ export function useGoogleCalendarIntegration(): UseGoogleCalendarIntegrationRetu
       const result = await syncCalendar();
 
       notify({
-        display: true,
         message: result.eventsProcessed === 0
           ? t('external_services.google_calendar.no_events_to_sync')
           : t('external_services.google_calendar.sync_complete', {

--- a/frontend/app/src/modules/core/messaging/handlers/accounting-rule-conflict.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/accounting-rule-conflict.ts
@@ -18,7 +18,6 @@ export function createAccountingRuleConflictHandler(t: ReturnType<typeof useI18n
         label: t('notification_messages.accounting_rule_conflict.action'),
       },
       category: NotificationCategory.DEFAULT,
-      display: true,
       message: t('notification_messages.accounting_rule_conflict.message', { conflicts: numOfConflicts }),
       priority: Priority.ACTION,
       severity: Severity.WARNING,

--- a/frontend/app/src/modules/core/messaging/handlers/binance-pairs-missing.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/binance-pairs-missing.ts
@@ -14,7 +14,6 @@ export function createBinancePairsMissingHandler(t: ReturnType<typeof useI18n>['
       persist: true,
     },
     category: NotificationCategory.DEFAULT,
-    display: true,
     message: t('notification_messages.binance_pairs_missing.message', { name }),
     priority: Priority.ACTION,
     severity: Severity.WARNING,

--- a/frontend/app/src/modules/core/messaging/handlers/calendar-reminder.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/calendar-reminder.ts
@@ -63,7 +63,6 @@ export function createCalendarReminderHandler(t: ReturnType<typeof useI18n>['t']
         label: t('notification_messages.reminder.open_calendar'),
       },
       category: NotificationCategory.CALENDAR_REMINDER,
-      display: true,
       extras: {
         eventId: identifier,
       },

--- a/frontend/app/src/modules/core/messaging/handlers/csv-import-result.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/csv-import-result.spec.ts
@@ -3,6 +3,7 @@ import { NotificationCategory, Priority, Severity } from '@rotki/common';
 import { mockT } from '@test/i18n';
 import { describe, expect, it } from 'vitest';
 import { createCsvImportResultHandler } from '@/modules/core/messaging/handlers/csv-import-result';
+import { createNotification } from '@/modules/core/notifications/notification-utils';
 
 function result(overrides: Partial<CsvImportResult> = {}): CsvImportResult {
   return {
@@ -22,7 +23,7 @@ describe('createCsvImportResultHandler', () => {
     expect(notification.severity).toBe(Severity.INFO);
     expect(notification.category).toBe(NotificationCategory.DEFAULT);
     expect(notification.priority).toBe(Priority.HIGH);
-    expect(notification.display).toBe(true);
+    expect(createNotification(1, notification).display).toBe(true);
   });
 
   it('should warn when only part of the rows were processed', async () => {

--- a/frontend/app/src/modules/core/messaging/handlers/csv-import-result.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/csv-import-result.ts
@@ -30,7 +30,6 @@ export function createCsvImportResultHandler(t: ReturnType<typeof useI18n>['t'])
       severity = Severity.INFO;
     return {
       category: NotificationCategory.DEFAULT,
-      display: true,
       message: messageBody,
       priority: Priority.HIGH,
       severity,

--- a/frontend/app/src/modules/core/messaging/handlers/gnosis-pay-session.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/gnosis-pay-session.ts
@@ -18,7 +18,6 @@ export function createGnosisPaySessionHandler(
       persist: true,
     },
     category: NotificationCategory.DEFAULT,
-    display: true,
     group: NotificationGroup.GNOSIS_PAY_SESSION_EXPIRED,
     message: data.error,
     severity: Severity.WARNING,

--- a/frontend/app/src/modules/core/messaging/handlers/legacy.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/legacy.ts
@@ -12,7 +12,7 @@ import { createNotificationHandler } from '../utils/handler-factories';
  * better. The bulk of the corpus is self-describing as ignorable ("Ignoring it", "Skipping
  * balance result", "Check logs for details and open a bug report"), and a condition that does
  * warrant an interrupt earns it by getting a structured `WSMessageType`, not by being a longer
- * string. Omitting `display` leaves `createNotification` to store it silently.
+ * string. `Priority.BULK` is what keeps the lane silent: raise it and all ~190 strings toast again.
  */
 export function createLegacyHandler(t: ReturnType<typeof useI18n>['t']): NotificationHandler<LegacyMessageData> {
   return createNotificationHandler<LegacyMessageData>(({ value, verbosity }) => ({

--- a/frontend/app/src/modules/core/messaging/handlers/missing-api-key.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/missing-api-key.spec.ts
@@ -6,6 +6,7 @@ import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { createMissingApiKeyHandler } from '@/modules/core/messaging/handlers/missing-api-key';
+import { createNotification } from '@/modules/core/notifications/notification-utils';
 
 const { mockOpenUrl, mockUpdate } = vi.hoisted(() => ({ mockOpenUrl: vi.fn(), mockUpdate: vi.fn() }));
 const mockSuppressList = ref<string[]>([]);
@@ -55,7 +56,7 @@ describe('createMissingApiKeyHandler', () => {
     assert(result);
     expect(result.category).toBe(NotificationCategory.ETHERSCAN);
     expect(result.severity).toBe(Severity.WARNING);
-    expect(result.display).toBe(true);
+    expect(createNotification(1, result).display).toBe(true);
   });
 
   it('should group per service so repeats collapse but different services stay separate', async () => {
@@ -120,7 +121,7 @@ describe('createMissingApiKeyHandler', () => {
     assert(result);
     expect(result.category).toBe(NotificationCategory.BEACONCHAIN);
     expect(result.severity).toBe(Severity.INFO);
-    expect(result.display).toBe(false);
+    expect(createNotification(1, result).display).toBe(false);
   });
 
   it('should include the docs url for thegraph', async () => {

--- a/frontend/app/src/modules/core/messaging/handlers/missing-api-key.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/missing-api-key.ts
@@ -151,7 +151,7 @@ export function createMissingApiKeyHandler(t: ReturnType<typeof useI18n>['t'], r
     return {
       action: actions,
       category,
-      display: !isBeaconchain,
+      display: isBeaconchain ? false : undefined,
       group: `${NotificationGroup.MISSING_API_KEY}:${service}`,
       i18nParam: {
         choice: 0,

--- a/frontend/app/src/modules/core/messaging/handlers/monerium-session.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/monerium-session.spec.ts
@@ -4,6 +4,7 @@ import { mockT } from '@test/i18n';
 import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMoneriumSessionHandler } from '@/modules/core/messaging/handlers/monerium-session';
+import { createNotification } from '@/modules/core/notifications/notification-utils';
 
 const mockRefreshStatus = vi.fn();
 const mockSetStatus = vi.fn();
@@ -32,7 +33,7 @@ describe('createMoneriumSessionHandler', () => {
     expect(result.category).toBe(NotificationCategory.DEFAULT);
     expect(result.severity).toBe(Severity.WARNING);
     expect(result.message).toBe('session expired');
-    expect(result.display).toBe(true);
+    expect(createNotification(1, result).display).toBe(true);
   });
 
   it('should share the group of the authentication flow, so a re-authentication replaces it', async () => {

--- a/frontend/app/src/modules/core/messaging/handlers/monerium-session.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/monerium-session.ts
@@ -33,7 +33,6 @@ export function createMoneriumSessionHandler(
         persist: true,
       },
       category: NotificationCategory.DEFAULT,
-      display: true,
       group: NotificationGroup.MONERIUM_AUTH,
       message: data.error,
       severity: Severity.WARNING,

--- a/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/no-available-indexers.ts
@@ -49,7 +49,6 @@ export function createNoAvailableIndexersHandler(t: ReturnType<typeof useI18n>['
     return {
       action: actions,
       category: NotificationCategory.DEFAULT,
-      display: true,
       group: `${NotificationGroup.NO_AVAILABLE_INDEXERS}:${chain}`,
       message: t('notification_messages.no_available_indexers.message', { chain: chainName }),
       priority: Priority.ACTION,

--- a/frontend/app/src/modules/core/messaging/handlers/premium-status.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/premium-status.ts
@@ -18,7 +18,6 @@ export function createPremiumStatusHandler(t: ReturnType<typeof useI18n>['t']): 
       if (isPremiumActive && !wasPremium) {
         return {
           category: NotificationCategory.DEFAULT,
-          display: true,
           message: t('notification_messages.premium.active.message'),
           severity: Severity.INFO,
           title: t('notification_messages.premium.active.title'),
@@ -27,7 +26,6 @@ export function createPremiumStatusHandler(t: ReturnType<typeof useI18n>['t']): 
       else if (!isPremiumActive && wasPremium) {
         return {
           category: NotificationCategory.DEFAULT,
-          display: true,
           message: reason ?? (expired
             ? t('notification_messages.premium.inactive.expired_message')
             : t('notification_messages.premium.inactive.network_problem_message')),

--- a/frontend/app/src/modules/core/messaging/handlers/snapshot-error.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/snapshot-error.ts
@@ -6,7 +6,6 @@ import { createNotificationHandler } from '@/modules/core/messaging/utils';
 export function createSnapshotErrorHandler(t: ReturnType<typeof useI18n>['t']): NotificationHandler<BalanceSnapshotError> {
   return createNotificationHandler<BalanceSnapshotError>(data => ({
     category: NotificationCategory.DEFAULT,
-    display: true,
     message: t('notification_messages.snapshot_failed.message', data),
     severity: Severity.ERROR,
     title: t('notification_messages.snapshot_failed.title'),

--- a/frontend/app/src/modules/core/messaging/index.ts
+++ b/frontend/app/src/modules/core/messaging/index.ts
@@ -109,11 +109,7 @@ export function useMessageHandling(): UseMessageHandling {
     }
     catch (error: unknown) {
       const message = handleMessageError(error, 'Message consumption failed');
-      notify({
-        display: true,
-        message,
-        title,
-      });
+      notify({ message, title });
     }
     finally {
       isRunning = false;

--- a/frontend/app/src/modules/core/notifications/notification-display-policy.spec.ts
+++ b/frontend/app/src/modules/core/notifications/notification-display-policy.spec.ts
@@ -1,0 +1,22 @@
+import { Priority } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_PRIORITY, displaysFor } from '@/modules/core/notifications/notification-display-policy';
+
+describe('displaysFor', () => {
+  it.each([
+    [Priority.ACTION, true],
+    [Priority.HIGH, true],
+    [Priority.NORMAL, false],
+    [Priority.BULK, false],
+  ])('should pop a %s notification: %s', (priority, expected) => {
+    expect(displaysFor(priority)).toBe(expected);
+  });
+
+  it('should classify an unclassified notification as the default priority', () => {
+    expect(displaysFor()).toBe(displaysFor(DEFAULT_PRIORITY));
+  });
+
+  it('should keep popping the unclassified, so deriving display changes no existing behaviour', () => {
+    expect(displaysFor(undefined)).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/core/notifications/notification-display-policy.ts
+++ b/frontend/app/src/modules/core/notifications/notification-display-policy.ts
@@ -1,0 +1,26 @@
+import { Priority } from '@rotki/common';
+
+/**
+ * The priority a notification lands on when its caller does not classify itself.
+ *
+ * @remarks
+ * `HIGH` preserves the behaviour the app shipped with, where anything reaching the dispatcher
+ * interrupted unless it opted out. The target model in rotki#12942 is `NORMAL`, so that an
+ * unclassified notification is stored rather than popped, but flipping this constant is a sweep
+ * of every call site's intent rather than a policy change, and it belongs with the classification
+ * work. It is a constant so that sweep is one edit.
+ */
+export const DEFAULT_PRIORITY = Priority.HIGH;
+
+/**
+ * Whether a notification of this priority interrupts the user with a popup.
+ *
+ * @remarks
+ * The single place the decision lives. `ACTION` is something only the user can resolve and `HIGH`
+ * is the outcome of something they just did, so both interrupt; `NORMAL` and `BULK` are recorded
+ * for the drawer and never pop. A caller may still suppress its own popup via `display: false`,
+ * which is why this answers the default rather than the final value.
+ */
+export function displaysFor(priority: Priority = DEFAULT_PRIORITY): boolean {
+  return priority >= Priority.HIGH;
+}

--- a/frontend/app/src/modules/core/notifications/notification-utils.spec.ts
+++ b/frontend/app/src/modules/core/notifications/notification-utils.spec.ts
@@ -1,0 +1,33 @@
+import { Priority, Severity } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { createNotification } from '@/modules/core/notifications/notification-utils';
+
+describe('createNotification', () => {
+  it('should build a silent placeholder when given no payload', () => {
+    expect(createNotification()).toMatchObject({ display: false, message: '', title: '' });
+  });
+
+  it('should derive display from the priority of a payload that does not ask', () => {
+    const popped = createNotification(1, { message: 'm', priority: Priority.ACTION, title: 't' });
+    const stored = createNotification(2, { message: 'm', priority: Priority.BULK, title: 't' });
+
+    expect(popped.display).toBe(true);
+    expect(stored.display).toBe(false);
+  });
+
+  it('should let a payload silence itself against its priority', () => {
+    const silenced = createNotification(1, {
+      display: false,
+      message: 'm',
+      priority: Priority.ACTION,
+      title: 't',
+    });
+
+    expect(silenced.display).toBe(false);
+  });
+
+  it('should record the priority it defaulted to, so the drawer sorts on the same value', () => {
+    expect(createNotification(1, { message: 'm', severity: Severity.ERROR, title: 't' }).priority)
+      .toBe(createNotification(2, { message: 'm', title: 't' }).priority);
+  });
+});

--- a/frontend/app/src/modules/core/notifications/notification-utils.ts
+++ b/frontend/app/src/modules/core/notifications/notification-utils.ts
@@ -5,7 +5,16 @@ import {
   type SemiPartial,
   Severity,
 } from '@rotki/common';
+import { DEFAULT_PRIORITY, displaysFor } from '@/modules/core/notifications/notification-display-policy';
 
+/**
+ * Builds the stored notification a payload becomes.
+ *
+ * @remarks
+ * Called with no payload it is the empty placeholder `NotificationPopup` holds while nothing is
+ * showing, which is why the default carries `display: false`. Without it the placeholder would
+ * inherit the default priority, pop as a blank toast, and block the queue it is supposed to drain.
+ */
 export function createNotification(
   id = 0,
   {
@@ -18,11 +27,12 @@ export function createNotification(
     groupCount,
     i18nParam,
     message = '',
-    priority,
+    priority = DEFAULT_PRIORITY,
     severity = Severity.INFO,
     title = '',
   }: SemiPartial<NotificationPayload, 'title' | 'message'> = {
     category: NotificationCategory.DEFAULT,
+    display: false,
     message: '',
     severity: Severity.INFO,
     title: '',
@@ -32,7 +42,7 @@ export function createNotification(
     action,
     category,
     date: new Date(),
-    display: display ?? false,
+    display: display ?? displaysFor(priority),
     duration: duration ?? 5000,
     extras,
     group,

--- a/frontend/app/src/modules/core/notifications/strategies/beaconchain-rate-limit.spec.ts
+++ b/frontend/app/src/modules/core/notifications/strategies/beaconchain-rate-limit.spec.ts
@@ -62,6 +62,27 @@ describe('createBeaconchainRateLimitStrategy', () => {
     });
   });
 
+  it('should pop again for a new endpoint after the row was already shown', () => {
+    const shown = createNotification(1, {
+      extras: { endpoints: ['Endpoint 1'], until: '2025-01-15T12:00:00Z' },
+      group: NotificationGroup.BEACONCHAIN_RATE_LIMITED,
+      groupCount: 1,
+      message: 'old message',
+      title: 'grouped',
+    });
+
+    const result = strategy.process(
+      {
+        message: 'Beaconcha.in is rate limited until 2025-01-15T12:00:00Z. Check logs',
+        severity: Severity.WARNING,
+        title: 'Endpoint 2',
+      },
+      { getNextId: vi.fn(), notifications: [{ ...shown, display: false }] },
+    );
+
+    expect(result!.notifications[0].display).toBe(true);
+  });
+
   it('should not add duplicate endpoints', () => {
     const existing = [
       createNotification(1, {

--- a/frontend/app/src/modules/core/notifications/strategies/beaconchain-rate-limit.ts
+++ b/frontend/app/src/modules/core/notifications/strategies/beaconchain-rate-limit.ts
@@ -1,5 +1,6 @@
 import type { NotificationStrategy } from './types';
 import { assert, NotificationGroup } from '@rotki/common';
+import { displaysFor } from '@/modules/core/notifications/notification-display-policy';
 import { createNotification } from '@/modules/core/notifications/notification-utils';
 
 const BEACONCHAIN_RATE_LIMITED_PREFIX = 'Beaconcha.in is rate limited';
@@ -58,7 +59,7 @@ export function createBeaconchainRateLimitStrategy(
         notifications[index] = {
           ...existing,
           date: new Date(),
-          display: true,
+          display: payload.display ?? displaysFor(payload.priority),
           extras: { endpoints, until },
           groupCount,
           message: t('notification_messages.beaconchain_rate_limited.message', {
@@ -74,7 +75,6 @@ export function createBeaconchainRateLimitStrategy(
 
         notifications.push(createNotification(context.getNextId(), {
           ...payload,
-          display: true,
           extras,
           group: NotificationGroup.BEACONCHAIN_RATE_LIMITED,
           groupCount: 1,

--- a/frontend/app/src/modules/core/notifications/strategies/group-update.spec.ts
+++ b/frontend/app/src/modules/core/notifications/strategies/group-update.spec.ts
@@ -1,6 +1,6 @@
 import type { UseNotificationCooldownReturn } from '../use-notification-cooldown';
 import type { NotificationStrategy, NotificationStrategyContext } from './types';
-import { NotificationGroup, Severity } from '@rotki/common';
+import { NotificationGroup, Priority, Severity } from '@rotki/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createNotification } from '@/modules/core/notifications/notification-utils';
 import { createGroupUpdateStrategy } from './group-update';
@@ -25,14 +25,14 @@ describe('createGroupUpdateStrategy', () => {
   }
 
   it('should skip a notification that belongs to no group', () => {
-    const result = strategy.process({ display: true, message: 'test', title: 'test' }, context());
+    const result = strategy.process({ message: 'test', title: 'test' }, context());
 
     expect(result).toBeUndefined();
     expect(cooldown.shouldSuppress).not.toHaveBeenCalled();
   });
 
   it('should show a new group notification that is not suppressed', () => {
-    const result = strategy.process({ display: true, group, message: 'no indexers', title: 'test' }, context());
+    const result = strategy.process({ group, message: 'no indexers', title: 'test' }, context());
 
     expect(result!.notifications).toHaveLength(1);
     expect(result!.notifications[0].display).toBe(true);
@@ -42,7 +42,7 @@ describe('createGroupUpdateStrategy', () => {
   it('should still create a suppressed group notification, without displaying it', () => {
     vi.mocked(cooldown.shouldSuppress).mockReturnValue(true);
 
-    const result = strategy.process({ display: true, group, message: 'no indexers', title: 'test' }, context());
+    const result = strategy.process({ group, message: 'no indexers', title: 'test' }, context());
 
     // Exhausted is not gone: the row stays in the sidebar, actionable, it just does not interrupt.
     expect(result!.notifications).toHaveLength(1);
@@ -54,23 +54,35 @@ describe('createGroupUpdateStrategy', () => {
   it('should not record a display for a notification that was never displayed', () => {
     vi.mocked(cooldown.shouldSuppress).mockReturnValue(true);
 
-    strategy.process({ display: true, group, message: 'no indexers', title: 'test' }, context());
+    strategy.process({ group, message: 'no indexers', title: 'test' }, context());
 
     expect(cooldown.recordDisplay).not.toHaveBeenCalled();
   });
 
-  it('should not record a display for a new notification that never asked to be displayed', () => {
-    const result = strategy.process({ group, message: 'no indexers', title: 'test' }, context());
+  it('should not record a display for a new notification whose priority does not pop', () => {
+    const result = strategy.process(
+      { group, message: 'no indexers', priority: Priority.NORMAL, title: 'test' },
+      context(),
+    );
 
     expect(result!.notifications[0].display).toBe(false);
     expect(cooldown.recordDisplay).not.toHaveBeenCalled();
   });
 
+  it('should store the same priority on update as it decided display from', () => {
+    const existing = [createNotification(2, { group, message: 'stale', title: 'test' })];
+
+    const result = strategy.process({ group, message: 'fresh', title: 'test' }, context(existing));
+
+    expect(result!.notifications[0].priority).toBe(existing[0].priority);
+    expect(result!.notifications[0].display).toBe(true);
+  });
+
   it('should keep separate subjects of the same group apart', () => {
     const other = `${NotificationGroup.NO_AVAILABLE_INDEXERS}:binance_sc`;
-    const existing = [createNotification(1, { display: true, group, message: 'optimism', title: 'test' })];
+    const existing = [createNotification(1, { group, message: 'optimism', title: 'test' })];
 
-    const result = strategy.process({ display: true, group: other, message: 'binance', title: 'test' }, context(existing));
+    const result = strategy.process({ group: other, message: 'binance', title: 'test' }, context(existing));
 
     expect(result!.notifications).toHaveLength(2);
     expect(result!.notifications.map(({ group }) => group)).toStrictEqual([group, other]);
@@ -79,11 +91,11 @@ describe('createGroupUpdateStrategy', () => {
   it('should refresh an existing notification and move it to the top', () => {
     const existing = [
       createNotification(1, { group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'other', title: 'other' }),
-      createNotification(2, { display: true, group, message: 'stale', title: 'test' }),
+      createNotification(2, { group, message: 'stale', title: 'test' }),
     ];
 
     const result = strategy.process(
-      { display: true, group, groupCount: 3, message: 'fresh', severity: Severity.WARNING, title: 'test' },
+      { group, groupCount: 3, message: 'fresh', severity: Severity.WARNING, title: 'test' },
       context(existing),
     );
 
@@ -99,11 +111,11 @@ describe('createGroupUpdateStrategy', () => {
 
   it('should update a suppressed existing notification without displaying it again', () => {
     vi.mocked(cooldown.shouldSuppress).mockReturnValue(true);
-    const existing = [createNotification(2, { display: true, group, groupCount: 1, message: 'stale', title: 'test' })];
+    const existing = [createNotification(2, { group, groupCount: 1, message: 'stale', title: 'test' })];
     const originalDate = existing[0].date;
 
     const result = strategy.process(
-      { display: true, group, groupCount: 5, message: 'fresh', title: 'test' },
+      { group, groupCount: 5, message: 'fresh', title: 'test' },
       context(existing),
     );
 
@@ -122,7 +134,7 @@ describe('createGroupUpdateStrategy', () => {
   });
 
   it('should consult the cooldown once per payload', () => {
-    strategy.process({ display: true, group, message: 'no indexers', title: 'test' }, context());
+    strategy.process({ group, message: 'no indexers', title: 'test' }, context());
 
     expect(cooldown.shouldSuppress).toHaveBeenCalledTimes(1);
   });

--- a/frontend/app/src/modules/core/notifications/strategies/group-update.ts
+++ b/frontend/app/src/modules/core/notifications/strategies/group-update.ts
@@ -1,5 +1,6 @@
 import type { UseNotificationCooldownReturn } from '../use-notification-cooldown';
 import type { NotificationStrategy } from './types';
+import { DEFAULT_PRIORITY, displaysFor } from '@/modules/core/notifications/notification-display-policy';
 import { createNotification } from '@/modules/core/notifications/notification-utils';
 
 /**
@@ -24,7 +25,7 @@ export function createGroupUpdateStrategy(cooldown: UseNotificationCooldownRetur
       if (existingIndex === -1) {
         const notification = createNotification(context.getNextId(), {
           ...payload,
-          display: (payload.display ?? false) && !suppressed,
+          ...(suppressed && { display: false }),
         });
 
         if (notification.display)
@@ -36,7 +37,7 @@ export function createGroupUpdateStrategy(cooldown: UseNotificationCooldownRetur
 
       const existing = notifications[existingIndex];
       let date = new Date();
-      let display = payload.display ?? false;
+      let display = payload.display ?? displaysFor(payload.priority);
 
       if (suppressed) {
         date = existing.date;
@@ -50,7 +51,7 @@ export function createGroupUpdateStrategy(cooldown: UseNotificationCooldownRetur
         display,
         groupCount: payload.groupCount,
         message: payload.message,
-        priority: payload.priority,
+        priority: payload.priority ?? DEFAULT_PRIORITY,
         severity: payload.severity ?? existing.severity,
         title: payload.title,
       };

--- a/frontend/app/src/modules/core/notifications/use-notification-dispatcher.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-notification-dispatcher.spec.ts
@@ -33,24 +33,13 @@ describe('useNotificationDispatcher', () => {
     const store = useNotificationsStore();
     const { data } = storeToRefs(store);
 
-    notify({
-      display: true,
-      group: NotificationGroup.NEW_DETECTED_TOKENS,
-      message: 'message-1',
-      title: 'title-1',
-    });
+    notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'message-1', title: 'title-1' });
 
     expect(get(data)[0]).toMatchObject({ display: true, group: NotificationGroup.NEW_DETECTED_TOKENS });
     const originalDate = get(data)[0].date;
 
     // Second notification within cooldown should suppress display
-    notify({
-      display: true,
-      group: NotificationGroup.NEW_DETECTED_TOKENS,
-      groupCount: 2,
-      message: 'message-2',
-      title: 'title-1',
-    });
+    notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, groupCount: 2, message: 'message-2', title: 'title-1' });
 
     expect(get(data)).toHaveLength(1);
     expect(get(data)[0]).toMatchObject({
@@ -62,13 +51,7 @@ describe('useNotificationDispatcher', () => {
 
     vi.advanceTimersByTime(NOTIFICATION_COOLDOWN_MS);
 
-    notify({
-      display: true,
-      group: NotificationGroup.NEW_DETECTED_TOKENS,
-      groupCount: 3,
-      message: 'message-3',
-      title: 'title-1',
-    });
+    notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, groupCount: 3, message: 'message-3', title: 'title-1' });
 
     expect(get(data)[0]).toMatchObject({ display: true, groupCount: 3, message: 'message-3' });
   });
@@ -205,8 +188,8 @@ describe('useNotificationDispatcher', () => {
     const store = useNotificationsStore();
     const { data } = storeToRefs(store);
 
-    notify({ display: true, message: 'msg-1', title: 'title-1' });
-    notify({ display: true, message: 'msg-2', title: 'title-2' });
+    notify({ message: 'msg-1', title: 'title-1' });
+    notify({ message: 'msg-2', title: 'title-2' });
 
     expect(get(data)).toHaveLength(2);
 
@@ -228,7 +211,7 @@ describe('useNotificationDispatcher', () => {
       const { notify } = useNotificationDispatcher();
       const { data, queue } = storeToRefs(useNotificationsStore());
 
-      notify({ display: true, message: 'msg', title: 'title' });
+      notify({ message: 'msg', title: 'title' });
 
       expect(get(queue)).toHaveLength(0);
       expect(get(data)[0]).toMatchObject({ display: false, message: 'msg' });
@@ -241,7 +224,6 @@ describe('useNotificationDispatcher', () => {
 
       notify({
         action: { action: vi.fn(), label: 'Configure' },
-        display: true,
         message: 'msg',
         priority: Priority.ACTION,
         title: 'title',
@@ -258,8 +240,8 @@ describe('useNotificationDispatcher', () => {
       const { notify } = useNotificationDispatcher();
       const { data } = storeToRefs(useNotificationsStore());
 
-      notify({ display: true, group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'first', title: 'title' });
-      notify({ display: true, group: NotificationGroup.NEW_DETECTED_TOKENS, groupCount: 2, message: 'second', title: 'title' });
+      notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'first', title: 'title' });
+      notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, groupCount: 2, message: 'second', title: 'title' });
 
       expect(get(data)).toHaveLength(1);
       expect(get(data)[0]).toMatchObject({ display: false, groupCount: 2, message: 'second' });
@@ -270,9 +252,9 @@ describe('useNotificationDispatcher', () => {
       const { notify } = useNotificationDispatcher();
       const { queue } = storeToRefs(useNotificationsStore());
 
-      notify({ display: true, message: 'quiet', title: 'title' });
+      notify({ message: 'quiet', title: 'title' });
       unsilence();
-      notify({ display: true, message: 'loud', title: 'title' });
+      notify({ message: 'loud', title: 'title' });
 
       expect(get(queue)).toHaveLength(1);
       expect(get(queue)[0]).toMatchObject({ message: 'loud' });

--- a/frontend/app/src/modules/core/notifications/use-notification-dispatcher.ts
+++ b/frontend/app/src/modules/core/notifications/use-notification-dispatcher.ts
@@ -27,7 +27,9 @@ export function useNotificationDispatcher(): UseNotificationDispatcherReturn {
   ];
 
   function notify(payload: SemiPartial<NotificationPayload, 'title' | 'message'>): void {
-    const incoming = get(silent) ? { ...payload, display: false } : payload;
+    const incoming: SemiPartial<NotificationPayload, 'title' | 'message'> = get(silent)
+      ? { ...payload, display: false }
+      : payload;
 
     const context: NotificationStrategyContext = {
       getNextId: store.getNextId,

--- a/frontend/app/src/modules/core/notifications/use-notifications-store.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-notifications-store.spec.ts
@@ -124,8 +124,8 @@ describe('useNotificationsStore', () => {
     const { queue } = storeToRefs(store);
 
     store.add([
-      createNotification(store.getNextId(), testPayload({ display: true, message: 'shown', title: 'shown' })),
-      createNotification(store.getNextId(), testPayload({ message: 'hidden', title: 'hidden' })),
+      createNotification(store.getNextId(), testPayload({ message: 'shown', title: 'shown' })),
+      createNotification(store.getNextId(), testPayload({ message: 'hidden', priority: Priority.NORMAL, title: 'hidden' })),
     ]);
 
     expect(get(queue)).toHaveLength(1);
@@ -137,7 +137,7 @@ describe('useNotificationsStore', () => {
     const { data } = storeToRefs(store);
 
     store.add([
-      createNotification(store.getNextId(), testPayload({ display: true, message: 'msg', title: 'title' })),
+      createNotification(store.getNextId(), testPayload({ message: 'msg', title: 'title' })),
     ]);
 
     const id = get(data)[0].id;
@@ -152,7 +152,7 @@ describe('useNotificationsStore', () => {
     const group = `${NotificationGroup.NO_AVAILABLE_INDEXERS}:optimism`;
 
     store.add([
-      createNotification(store.getNextId(), testPayload({ display: true, group, message: 'msg', title: 'title' })),
+      createNotification(store.getNextId(), testPayload({ group, message: 'msg', title: 'title' })),
     ]);
     store.displayed([get(data)[0].id]);
 
@@ -165,7 +165,7 @@ describe('useNotificationsStore', () => {
     const { data } = storeToRefs(store);
 
     store.add([
-      createNotification(store.getNextId(), testPayload({ display: true, message: 'msg', title: 'title' })),
+      createNotification(store.getNextId(), testPayload({ message: 'msg', title: 'title' })),
     ]);
     store.displayed([get(data)[0].id]);
 
@@ -177,12 +177,7 @@ describe('useNotificationsStore', () => {
     const { data } = storeToRefs(store);
 
     store.add([
-      createNotification(store.getNextId(), testPayload({
-        display: true,
-        group: NotificationGroup.NEW_DETECTED_TOKENS,
-        message: 'msg',
-        title: 'title',
-      })),
+      createNotification(store.getNextId(), testPayload({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'msg', title: 'title' })),
     ]);
     store.displayed([9999]);
 
@@ -195,12 +190,7 @@ describe('useNotificationsStore', () => {
     const { data } = storeToRefs(store);
 
     store.add([
-      createNotification(store.getNextId(), testPayload({
-        display: true,
-        group: NotificationGroup.NEW_DETECTED_TOKENS,
-        message: 'msg',
-        title: 'title',
-      })),
+      createNotification(store.getNextId(), testPayload({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'msg', title: 'title' })),
     ]);
     store.displayed([]);
 

--- a/frontend/app/src/modules/core/notifications/use-notifications.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-notifications.spec.ts
@@ -1,4 +1,4 @@
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 
@@ -34,7 +34,6 @@ describe('useNotifications', () => {
     notifyError('Error Title', 'Error message');
 
     expect(mockNotify).toHaveBeenCalledWith({
-      display: true,
       message: 'Error message',
       severity: Severity.ERROR,
       title: 'Error Title',
@@ -46,7 +45,6 @@ describe('useNotifications', () => {
     notifyWarning('Warn Title', 'Warn message');
 
     expect(mockNotify).toHaveBeenCalledWith({
-      display: true,
       message: 'Warn message',
       severity: Severity.WARNING,
       title: 'Warn Title',
@@ -58,28 +56,27 @@ describe('useNotifications', () => {
     notifyInfo('Info Title', 'Info message');
 
     expect(mockNotify).toHaveBeenCalledWith({
-      display: true,
       message: 'Info message',
       severity: Severity.INFO,
       title: 'Info Title',
     });
   });
 
-  it('should default display to true', () => {
+  it('should never decide display itself, leaving it to the dispatcher', () => {
     const { notifyError } = useNotifications();
     notifyError('Title', 'Message');
 
     expect(mockNotify).toHaveBeenCalledWith(
-      expect.objectContaining({ display: true }),
+      expect.not.objectContaining({ display: expect.anything() }),
     );
   });
 
-  it('should allow overriding display to false', () => {
+  it('should forward a classifying priority so the caller can opt out of a popup', () => {
     const { notifyError } = useNotifications();
-    notifyError('Title', 'Message', { display: false });
+    notifyError('Title', 'Message', { priority: Priority.NORMAL });
 
     expect(mockNotify).toHaveBeenCalledWith(
-      expect.objectContaining({ display: false }),
+      expect.objectContaining({ priority: Priority.NORMAL }),
     );
   });
 

--- a/frontend/app/src/modules/core/notifications/use-notifications.ts
+++ b/frontend/app/src/modules/core/notifications/use-notifications.ts
@@ -1,4 +1,4 @@
-import { type Notification, type NotificationData, Severity } from '@rotki/common';
+import { type Notification, type NotificationData, type Priority, Severity } from '@rotki/common';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
 import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
 import { useNotificationDispatcher } from './use-notification-dispatcher';
@@ -6,7 +6,15 @@ import { useNotificationDispatcher } from './use-notification-dispatcher';
 export { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 
 interface ToastOptions {
-  readonly display?: boolean;
+  /**
+   * Classifies the notification, which is what decides whether it interrupts.
+   *
+   * @remarks
+   * `NORMAL` or `BULK` records it in the drawer without a popup; the default pops. Callers say
+   * what the notification *is* and the dispatcher decides what to do with it, so there is no way
+   * to ask for a popup directly.
+   */
+  readonly priority?: Priority;
 }
 
 interface UseNotificationsReturn {
@@ -15,11 +23,11 @@ interface UseNotificationsReturn {
    * Use this for advanced patterns that the convenience methods don't cover.
    */
   notify: (notification: Notification) => void;
-  /** Show an error toast notification (displayed by default). */
+  /** Report an error, popped unless `options.priority` classifies it lower. */
   notifyError: (title: string, message: string, options?: ToastOptions) => void;
-  /** Show a warning toast notification (displayed by default). */
+  /** Report a warning, popped unless `options.priority` classifies it lower. */
   notifyWarning: (title: string, message: string, options?: ToastOptions) => void;
-  /** Show an info toast notification (displayed by default). */
+  /** Report an informational outcome, popped unless `options.priority` classifies it lower. */
   notifyInfo: (title: string, message: string, options?: ToastOptions) => void;
   /** Remove the first notification matching the predicate. */
   removeMatching: (predicate: (n: NotificationData) => boolean) => void;
@@ -44,8 +52,8 @@ export function useNotifications(): UseNotificationsReturn {
 
   function toast(severity: Severity, title: string, message: string, options?: ToastOptions): void {
     dispatchNotify({
-      display: options?.display ?? true,
       message,
+      priority: options?.priority,
       severity,
       title,
     });

--- a/frontend/app/src/modules/history/events/mapping/use-history-event-counterparty-mappings.ts
+++ b/frontend/app/src/modules/history/events/mapping/use-history-event-counterparty-mappings.ts
@@ -32,7 +32,6 @@ export const useHistoryEventCounterpartyMappings = createSharedComposable(() => 
             label: t('actions.fetch_counterparties.actions.fetch_again'),
           },
         ],
-        display: true,
         message: t('actions.fetch_counterparties.error.description', {
           message: getErrorMessage(error),
         }),

--- a/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.ts
+++ b/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.ts
@@ -242,7 +242,6 @@ export const useHistoryEventMappings = createSharedComposable(() => {
             label: t('actions.history_events.fetch_mapping.actions.fetch_again'),
           },
         ],
-        display: true,
         message: t('actions.history_events.fetch_mapping.error.description', {
           message: getErrorMessage(error),
         }),

--- a/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.spec.ts
+++ b/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.spec.ts
@@ -119,7 +119,6 @@ describe('useCustomizedEventDuplicatesDialog', () => {
 
       expect(notify).toHaveBeenCalledTimes(3);
       expect(notify).toHaveBeenCalledWith(expect.objectContaining({
-        display: true,
         severity: Severity.ERROR,
         title: 'actions.customized_event_duplicates.fetch_events_error.title',
       }));

--- a/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.ts
+++ b/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.ts
@@ -120,12 +120,7 @@ export function useCustomizedEventDuplicatesDialog(
     }
     catch (error: unknown) {
       logger.error('Failed to load duplicate event rows:', error);
-      notify({
-        display: true,
-        message: t('actions.customized_event_duplicates.fetch_events_error.description', { error: getErrorMessage(error) }),
-        severity: Severity.ERROR,
-        title: t('actions.customized_event_duplicates.fetch_events_error.title'),
-      });
+      notify({ message: t('actions.customized_event_duplicates.fetch_events_error.description', { error: getErrorMessage(error) }), severity: Severity.ERROR, title: t('actions.customized_event_duplicates.fetch_events_error.title') });
     }
     finally {
       set(group.loading, false);

--- a/frontend/app/src/modules/history/events/use-history-events-actions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-actions.spec.ts
@@ -168,7 +168,6 @@ describe('useHistoryEventsActions', () => {
 
       expect(mockNotify).toHaveBeenCalledWith({
         action: undefined,
-        display: true,
         message: 'actions.repulling_transaction.success.no_tx_description',
         severity: Severity.INFO,
         title: 'actions.repulling_transaction.task.title',
@@ -182,7 +181,6 @@ describe('useHistoryEventsActions', () => {
       await dialogHandlers.onRepullTransactions?.(createResult(5, { eth: ['0xhash1', '0xhash2'] }));
 
       expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({
-        display: true,
         severity: Severity.INFO,
         title: 'actions.repulling_transaction.task.title',
       }));

--- a/frontend/app/src/modules/history/events/use-history-events-dialog-handlers.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-dialog-handlers.ts
@@ -66,7 +66,6 @@ export function useHistoryEventsDialogHandlers(deps: UseHistoryEventsDialogHandl
 
       notify({
         action,
-        display: true,
         message: newTransactionsCount ? t('actions.repulling_transaction.success.description', { length: newTransactionsCount }) : t('actions.repulling_transaction.success.no_tx_description'),
         severity: Severity.INFO,
         title: t('actions.repulling_transaction.task.title'),

--- a/frontend/app/src/modules/history/events/use-history-events-export.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-export.ts
@@ -86,7 +86,6 @@ export function useHistoryEventsExport(
 
   function exportOutcomeMessage(succeeded: boolean, taskMessage?: string): ExportMessage {
     return {
-      display: true,
       message: succeeded
         ? t('actions.history_events_export.message.success')
         : t('actions.history_events_export.message.failure', { description: taskMessage }),
@@ -130,7 +129,6 @@ export function useHistoryEventsExport(
     }
     catch (error: unknown) {
       message = {
-        display: true,
         message: t('actions.history_events_export.message.failure', {
           description: getErrorMessage(error),
         }),

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.spec.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.spec.ts
@@ -1,3 +1,4 @@
+import { type Notification, Priority } from '@rotki/common';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { effectScope } from 'vue';
 import { type InternalTxConflict, InternalTxConflictActions } from './types';
@@ -6,6 +7,7 @@ import { type ResolutionCallbacks, useInternalTxConflictResolution } from './use
 const { spies } = vi.hoisted(() => ({
   spies: {
     cancelDecoding: vi.fn<() => Promise<void>>(),
+    notify: vi.fn<(payload: Notification) => void>(),
     pullAndDecodeTransactionsRaw: vi.fn<() => Promise<void>>(),
     removeKeys: vi.fn(),
   },
@@ -40,7 +42,7 @@ vi.mock('./use-internal-tx-conflict-selection', () => ({
 
 vi.mock('@/modules/core/notifications/use-notifications', () => ({
   useNotifications: (): object => ({
-    notify: vi.fn(),
+    notify: spies.notify,
     removeMatching: vi.fn(),
   }),
 }));
@@ -69,6 +71,7 @@ describe('use-internal-tx-conflict-resolution', () => {
     spies.pullAndDecodeTransactionsRaw.mockReset();
     spies.cancelDecoding.mockReset();
     spies.removeKeys.mockReset();
+    spies.notify.mockReset();
     spies.pullAndDecodeTransactionsRaw.mockResolvedValue(undefined);
     spies.cancelDecoding.mockResolvedValue(undefined);
     scope = effectScope();
@@ -144,6 +147,14 @@ describe('use-internal-tx-conflict-resolution', () => {
   });
 
   describe('resolveMany', () => {
+    it('should keep every progress notification below the popup threshold', async () => {
+      await composable.resolveMany([createMockConflict(), createMockConflict({ txHash: '0xdef' })], callbacks);
+
+      expect(spies.notify).toHaveBeenCalled();
+      for (const [payload] of spies.notify.mock.calls)
+        expect(payload.priority).toBe(Priority.NORMAL);
+    });
+
     it('processes each conflict individually', async () => {
       const conflicts = [
         createMockConflict({ chain: 'ethereum', txHash: '0x111' }),

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflict-resolution.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue';
 import type { InternalTxConflict } from './types';
-import { NotificationGroup, Severity } from '@rotki/common';
+import { NotificationGroup, Priority, Severity } from '@rotki/common';
 import { logger } from '@/modules/core/common/logging/logging';
 import { createPersistentSharedComposable } from '@/modules/core/common/use-persistent-shared-composable';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
@@ -114,6 +114,7 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
 
       notify({
         group: NotificationGroup.INTERNAL_TX_CONFLICT_RESOLUTION,
+        priority: Priority.NORMAL,
         message: t('internal_tx_conflicts.notifications.started', { total }),
         severity: Severity.INFO,
         title: t('internal_tx_conflicts.notifications.title'),
@@ -134,6 +135,7 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
           set(progress, { ...get(progress), completed });
           notify({
             group: NotificationGroup.INTERNAL_TX_CONFLICT_RESOLUTION,
+            priority: Priority.NORMAL,
             message: t('internal_tx_conflicts.notifications.progress', { completed, total }),
             severity: Severity.INFO,
             title: t('internal_tx_conflicts.notifications.title'),
@@ -163,6 +165,7 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
       if (cancelled) {
         notify({
           message: t('internal_tx_conflicts.notifications.cancelled', { completed, total }),
+          priority: Priority.NORMAL,
           severity: Severity.WARNING,
           title: t('internal_tx_conflicts.notifications.title'),
         });
@@ -170,6 +173,7 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
       else if (failed > 0) {
         notify({
           message: t('internal_tx_conflicts.notifications.completed_with_errors', { completed, failed, total }),
+          priority: Priority.NORMAL,
           severity: Severity.WARNING,
           title: t('internal_tx_conflicts.notifications.title'),
         });
@@ -177,6 +181,7 @@ export const useInternalTxConflictResolution = createPersistentSharedComposable(
       else {
         notify({
           message: t('internal_tx_conflicts.notifications.completed', { total }),
+          priority: Priority.NORMAL,
           severity: Severity.INFO,
           title: t('internal_tx_conflicts.notifications.title'),
         });

--- a/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.ts
+++ b/frontend/app/src/modules/integrations/gnosis-pay/use-gnosis-pay-safe-migration.ts
@@ -157,7 +157,6 @@ export const useGnosisPaySafeMigration = createSharedComposable((): UseGnosisPay
         },
       ],
       category: NotificationCategory.DEFAULT,
-      display: true,
       message: safe.type === 'new'
         ? t('notification_messages.gnosis_pay_safe_migration.message_new', { address: safe.address })
         : t('notification_messages.gnosis_pay_safe_migration.message_old', { address: safe.address }),

--- a/frontend/app/src/modules/integrations/monerium/MoneriumAuth.spec.ts
+++ b/frontend/app/src/modules/integrations/monerium/MoneriumAuth.spec.ts
@@ -87,7 +87,6 @@ describe('moneriumAuth', () => {
 
     expect(mockOpenUrl).toHaveBeenCalledWith('https://rotki.com/oauth/monerium?mode=app');
     expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({
-      display: true,
       group: NotificationGroup.MONERIUM_AUTH,
       severity: Severity.INFO,
     }));

--- a/frontend/app/src/modules/integrations/monerium/MoneriumAuth.vue
+++ b/frontend/app/src/modules/integrations/monerium/MoneriumAuth.vue
@@ -56,7 +56,6 @@ const cardAction = computed<ServiceKeyAction>(() => ({
 function notifyAuthStep(payload: Notification): void {
   notify({
     ...payload,
-    display: true,
     group: NotificationGroup.MONERIUM_AUTH,
   });
 }

--- a/frontend/app/src/modules/settings/api-keys/BinancePairsSelector.vue
+++ b/frontend/app/src/modules/settings/api-keys/BinancePairsSelector.vue
@@ -110,12 +110,7 @@ async function queryAllMarkets() {
     const description = t('binance_market_selector.query_all.error', {
       message: getErrorMessage(error),
     });
-    notify({
-      display: true,
-      message: description,
-      severity: Severity.ERROR,
-      title,
-    });
+    notify({ message: description, severity: Severity.ERROR, title });
   }
 }
 
@@ -131,12 +126,7 @@ async function loadUserMarkets() {
       const description = t('binance_market_selector.query_user.error', {
         message: getErrorMessage(error),
       });
-      notify({
-        display: true,
-        message: description,
-        severity: Severity.ERROR,
-        title,
-      });
+      notify({ message: description, severity: Severity.ERROR, title });
     }
   }
 }

--- a/frontend/app/src/modules/settings/data-security/ManageCustomAssets.vue
+++ b/frontend/app/src/modules/settings/data-security/ManageCustomAssets.vue
@@ -48,21 +48,11 @@ function exportNotification(result: Awaited<ReturnType<typeof exportCustomAssets
   const title = t('manage_user_assets.export.title');
 
   if ('success' in result && !result.success) {
-    return {
-      display: true,
-      message: t('manage_user_assets.export.error', { message: result.message }),
-      severity: Severity.ERROR,
-      title,
-    };
+    return { message: t('manage_user_assets.export.error', { message: result.message }), severity: Severity.ERROR, title };
   }
 
   if ('filePath' in result && result.directory) {
-    return {
-      display: true,
-      message: t('manage_user_assets.export.success', { filePath: result.filePath }),
-      severity: Severity.INFO,
-      title,
-    };
+    return { message: t('manage_user_assets.export.success', { filePath: result.filePath }), severity: Severity.INFO, title };
   }
 
   return undefined;

--- a/frontend/app/src/modules/settings/data-security/backups/use-database-backups.ts
+++ b/frontend/app/src/modules/settings/data-security/backups/use-database-backups.ts
@@ -101,11 +101,7 @@ export function useDatabaseBackups(): UseDatabaseBackupsReturn {
     }
     catch (error: unknown) {
       logger.error(error);
-      notify({
-        display: true,
-        message: t('database_backups.load_error.message', { message: getErrorMessage(error) }),
-        title: t('database_backups.load_error.title'),
-      });
+      notify({ message: t('database_backups.load_error.message', { message: getErrorMessage(error) }), title: t('database_backups.load_error.title') });
     }
     finally {
       set(loading, false);
@@ -122,11 +118,7 @@ export function useDatabaseBackups(): UseDatabaseBackupsReturn {
     }
     catch (error: unknown) {
       logger.error(error);
-      notify({
-        display: true,
-        message: t('database_backups.delete_error.mass_message', { message: getErrorMessage(error) }),
-        title: t('database_backups.delete_error.title'),
-      });
+      notify({ message: t('database_backups.delete_error.mass_message', { message: getErrorMessage(error) }), title: t('database_backups.delete_error.title') });
     }
   }
 
@@ -140,7 +132,6 @@ export function useDatabaseBackups(): UseDatabaseBackupsReturn {
     catch (error: unknown) {
       logger.error(error);
       notify({
-        display: true,
         message: t('database_backups.delete_error.message', {
           file: filepath,
           message: getErrorMessage(error),
@@ -154,22 +145,13 @@ export function useDatabaseBackups(): UseDatabaseBackupsReturn {
     try {
       set(saving, true);
       const filepath = await createBackup();
-      notify({
-        display: true,
-        message: t('database_backups.backup.message', { filepath }),
-        severity: Severity.INFO,
-        title: t('database_backups.backup.title'),
-      });
+      notify({ message: t('database_backups.backup.message', { filepath }), severity: Severity.INFO, title: t('database_backups.backup.title') });
 
       await loadInfo();
     }
     catch (error: unknown) {
       logger.error(error);
-      notify({
-        display: true,
-        message: t('database_backups.backup_error.message', { message: getErrorMessage(error) }),
-        title: t('database_backups.backup_error.title'),
-      });
+      notify({ message: t('database_backups.backup_error.message', { message: getErrorMessage(error) }), title: t('database_backups.backup_error.title') });
     }
     finally {
       set(saving, false);

--- a/frontend/app/src/modules/settings/database/DatabaseInformation.vue
+++ b/frontend/app/src/modules/settings/database/DatabaseInformation.vue
@@ -90,13 +90,9 @@ async function loadInfo() {
   }
   catch (error: unknown) {
     logger.error(error);
-    notify({
-      display: true,
-      message: t('database_backups.load_error.message', {
-        message: getErrorMessage(error),
-      }),
-      title: t('database_backups.load_error.title'),
-    });
+    notify({ message: t('database_backups.load_error.message', {
+      message: getErrorMessage(error),
+    }), title: t('database_backups.load_error.title') });
   }
   finally {
     set(loading, false);

--- a/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
@@ -1,5 +1,5 @@
-import type { Blockchain } from '@rotki/common';
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import { type Blockchain, Priority } from '@rotki/common';
 import { camelCase } from 'es-toolkit';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
@@ -111,6 +111,7 @@ export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>)
     catch (error: unknown) {
       notify({
         message: getErrorMessage(error),
+        priority: Priority.NORMAL,
         title: t('evm_rpc_node_manager.loading_error.title', {
           chain: toValue(chain),
         }),

--- a/frontend/app/src/modules/shell/app/use-backend-reload.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-reload.ts
@@ -43,12 +43,7 @@ export function useBackendReload(): UseBackendReloadReturn {
     const result = await restartBackend();
 
     if (result.status === BackendRestartStatus.failed) {
-      notify({
-        display: true,
-        message: t('backend_reload.failed.message', { message: result.message ?? '' }),
-        severity: Severity.ERROR,
-        title: t('backend_reload.failed.title'),
-      });
+      notify({ message: t('backend_reload.failed.message', { message: result.message ?? '' }), severity: Severity.ERROR, title: t('backend_reload.failed.title') });
       connect();
       return result;
     }

--- a/frontend/app/src/modules/shell/components/HelpSidebar.vue
+++ b/frontend/app/src/modules/shell/components/HelpSidebar.vue
@@ -70,11 +70,7 @@ async function downloadBrowserLog(): Promise<void> {
 
   await loggerDb.getAll((data: any) => {
     if (data?.length === 0) {
-      notify({
-        display: true,
-        message: t('help_sidebar.browser_log.error.empty.message'),
-        title: t('help_sidebar.browser_log.error.empty.title'),
-      });
+      notify({ message: t('help_sidebar.browser_log.error.empty.message'), title: t('help_sidebar.browser_log.error.empty.title') });
       return;
     }
     const messages = data.map((item: any) => item.message).join('\n');

--- a/frontend/app/src/modules/statistics/use-statistics-data-fetching.spec.ts
+++ b/frontend/app/src/modules/statistics/use-statistics-data-fetching.spec.ts
@@ -1,3 +1,4 @@
+import { Priority } from '@rotki/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useStatisticsDataFetching } from './use-statistics-data-fetching';
 import '@test/i18n';
@@ -36,7 +37,7 @@ describe('useStatisticsDataFetching', () => {
       expect(mockNotifyError).not.toHaveBeenCalled();
     });
 
-    it('should notify on error without displaying', async () => {
+    it('should classify the error below the popup threshold', async () => {
       mockQueryNetValueData.mockRejectedValue(new Error('Network error'));
 
       const { fetchNetValue } = useStatisticsDataFetching();
@@ -46,7 +47,7 @@ describe('useStatisticsDataFetching', () => {
       expect(mockNotifyError).toHaveBeenCalledWith(
         expect.any(String),
         expect.stringContaining('Network error'),
-        { display: false },
+        { priority: Priority.NORMAL },
       );
     });
   });

--- a/frontend/app/src/modules/statistics/use-statistics-data-fetching.ts
+++ b/frontend/app/src/modules/statistics/use-statistics-data-fetching.ts
@@ -1,3 +1,4 @@
+import { Priority } from '@rotki/common';
 import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { getErrorMessage, useNotifications } from '@/modules/core/notifications/use-notifications';
 import { useSetting } from '@/modules/settings/use-setting';
@@ -25,7 +26,7 @@ export function useStatisticsDataFetching(): UseStatisticsDataFetchingReturn {
 
       notifyError(t('actions.statistics.net_value.error.title'), t('actions.statistics.net_value.error.message', {
         message: getErrorMessage(error),
-      }), { display: false });
+      }), { priority: Priority.NORMAL });
     }
   }
 

--- a/frontend/app/src/pages/api-keys/exchanges/index.vue
+++ b/frontend/app/src/pages/api-keys/exchanges/index.vue
@@ -123,7 +123,6 @@ async function toggleSync(exchange: Exchange) {
 
   if (!status.success) {
     notify({
-      display: true,
       message: t('exchange_settings.sync.messages.description', {
         action: enable ? t('exchange_settings.sync.messages.enable') : t('exchange_settings.sync.messages.disable'),
         location: exchange.location,

--- a/frontend/app/src/pages/reports/use-reports-page-actions.ts
+++ b/frontend/app/src/pages/reports/use-reports-page-actions.ts
@@ -71,7 +71,6 @@ export function useReportsPageActions(options: UseReportsPageActionsOptions): Us
           action: () => onNavigateToReport(reportId),
           label: t('profit_loss_reports.notification.action'),
         },
-        display: true,
         message: t('profit_loss_reports.notification.message', {
           end: formatDate(period.end),
           start: formatDate(period.start),

--- a/frontend/common/src/messages/index.ts
+++ b/frontend/common/src/messages/index.ts
@@ -98,7 +98,16 @@ interface NotificationBase {
 }
 
 export interface NotificationPayload extends NotificationBase {
-  readonly display?: boolean;
+  /**
+   * Silences a notification whose priority would otherwise pop it.
+   *
+   * @remarks
+   * Suppression only, which is why the type is `false` rather than `boolean`. Whether a
+   * notification interrupts is the dispatcher's decision, derived from `priority`, so a caller
+   * cannot promote itself into a popup by asking. It can still opt out, because a condition that
+   * already has a home elsewhere in the UI should not also interrupt.
+   */
+  readonly display?: false;
   readonly duration?: number;
 }
 


### PR DESCRIPTION
Phase 1 of #12942, second of two PRs. #13083 stopped the legacy backend
lane from toasting; this one removes the per-call-site decision that
produced the noise in the first place.

## The problem

Whether a notification interrupts the user was delegated to every call
site, and the two doors disagreed on the default:

- `notifyError` / `notifyWarning` / `notifyInfo` passed `display: true`
- a raw `notify()` reached `createNotification`, which defaults it to `false`

So **50 call sites wrote `display: true` by hand** to get a popup out of
the second door, 7 wrote `display: false`, and the same field meant
opposite things depending on which function you called. Priority existed
but only 11 sites set it, so the "Needs action" tab was nearly empty and
the priority sort was a no-op.

## The change

Priority becomes the single input. `NotificationPayload` no longer
accepts `display: true`, and the new `notification-display-policy`
answers whether a priority pops:

```
ACTION, HIGH  -> interrupt
NORMAL, BULK  -> recorded for the drawer
```

The caller says what a notification *is*; the dispatcher decides what to
do with it. **The compiler now rejects a caller-supplied popup**, which
is why this needs no lint rule.

`display` survives as an opt-out, typed **`false`** rather than
`boolean`, so a caller may silence a notification its priority would
otherwise pop but never promote one. Three conditions need that: the
unmatched-movement and unmatched-bridge handlers, which are already
action-center rows and would otherwise announce the same thing twice, and
beaconchain, whose missing key is informational where every other
service's is not.

## Behaviour

`DEFAULT_PRIORITY` is `HIGH`, which is what the implicit `display: true`
meant, so the ~91 sites that classify nothing pop exactly as before.

Preserving that took more than deleting the field, because three paths
decide display without going through `createNotification`. Each is a bug
this PR would otherwise have shipped:

| Path | Would have happened |
|---|---|
| `NotificationPopup` holds `createNotification()` with no payload as its "nothing is showing" placeholder | it inherits the default priority and renders a **blank toast on every app start**, and `checkQueue` only drains while the placeholder is not displaying, so notifications arriving in that window are dropped |
| the beaconchain update branch spreads the existing row, which the store rewrites to `display: false` once shown | a second rate-limited endpoint updates the drawer row and **never pops again** |
| six sites set neither field, so never popped | the five internal-tx conflict-resolution progress notifications (a task-center activity in notification clothing) and the RPC node load error **start popping** |

All three are fixed and pinned by tests. `group-update` also wrote
`payload.priority` straight onto the updated row, so a grouped
notification created without one was stored as `HIGH` then rewritten to
`undefined` on its first update, which the drawer sorts as `NORMAL`; the
stored priority and the display decided from it now agree.

## What this defers

The target model wants `NORMAL` as the default, so anything unclassified
is recorded rather than popped. That is a judgement about each of the 148
call sites, not about the policy, so it stays a **one-line change to
`DEFAULT_PRIORITY`** for when the classification sweep lands.

## Tests

11,580 passing. `typecheck`, `knip`, `lint:style`, `check:linked-keys`
and `eslint` all green.

New specs for the policy and for `createNotification`, plus assertions
pinning the three paths above, which had no coverage — that is why the
suite stayed green while they were broken. Every one was controlled by
reverting its fix and confirming the intended test, and only that test,
went red; flipping `DEFAULT_PRIORITY` to `NORMAL` fails 9 tests across 5
files.
