### PR TITLE
Cover the shell/components cluster, fixing the update check frequency

### DIFF
--- a/frontend/app/src/modules/shell/components/About.spec.ts
+++ b/frontend/app/src/modules/shell/components/About.spec.ts
@@ -1,0 +1,188 @@
+import type { SystemVersion } from '@shared/ipc';
+import type { WebVersion } from '@/types';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { nextTick, type Ref } from 'vue';
+import About from '@/modules/shell/components/About.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { copy, dataDirectory, getVersion, premium, version, versionSource } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    copy: vi.fn(),
+    dataDirectory: ref<string>('/home/user/.local/share/rotki/data'),
+    getVersion: vi.fn(),
+    premium: ref<boolean>(false),
+    version: ref<{ version: string }>({ version: '1.45.0' }),
+    versionSource: ref<string>(''),
+  };
+});
+
+vi.mock('@/modules/core/common/use-main-store', () => ({
+  useMainStore: (): { dataDirectory: Ref<string>; version: Ref<{ version: string }> } => ({
+    dataDirectory,
+    version,
+  }),
+}));
+
+vi.mock('@/modules/premium/use-premium', () => ({
+  usePremium: (): Ref<boolean> => premium,
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): Record<string, unknown> => ({
+    isPackaged: true,
+    openPath: vi.fn(),
+    version: getVersion,
+  }),
+}));
+
+vi.mock('@vueuse/core', async () => {
+  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+  return {
+    ...actual,
+    useClipboard: (options: { source: Ref<string> }): { copy: Mock } => {
+      set(versionSource, get(options.source));
+      return { copy };
+    },
+  };
+});
+
+const electron: SystemVersion = { arch: 'x64', electron: '43.5.0', os: 'Linux', osVersion: '6.1' };
+const web: WebVersion = { platform: 'Linux x86_64', userAgent: 'Mozilla/5.0 rotki' };
+
+function createWrapper(): VueWrapper<any> {
+  return mount(About, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        AboutDataDirectory: true,
+        AppUpdateIndicator: true,
+        DateDisplay: { name: 'DateDisplay', props: ['timestamp'], template: '<span />' },
+        ExternalLink: true,
+        RotkiLogo: true,
+      },
+    },
+  });
+}
+
+/** `asyncComputed` resolves after mount, so the platform rows need a tick to appear. */
+async function mountResolved(): Promise<VueWrapper<any>> {
+  const wrapper = createWrapper();
+  await nextTick();
+  await nextTick();
+  return wrapper;
+}
+
+describe('about', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(premium, false);
+    getVersion.mockResolvedValue(electron);
+    window.PremiumComponents = undefined;
+  });
+
+  afterEach(() => {
+    window.PremiumComponents = undefined;
+  });
+
+  /**
+   * The same endpoint answers with either shape, and only one of the two platform blocks belongs
+   * on screen: a browser has no electron build to report, and a desktop build has no user agent
+   * worth showing.
+   */
+  describe('which platform it reports', () => {
+    it('should show the electron build on the desktop app', async () => {
+      const wrapper = await mountResolved();
+
+      expect(wrapper.find('[data-testid=about-electron-version]').text()).toContain('43.5.0');
+      expect(wrapper.find('[data-testid=about-electron-platform]').text()).toContain('Linux x64 6.1');
+      expect(wrapper.find('[data-testid=about-user-agent]').exists()).toBe(false);
+    });
+
+    it('should show the user agent in a browser', async () => {
+      getVersion.mockResolvedValue(web);
+
+      const wrapper = await mountResolved();
+
+      expect(wrapper.find('[data-testid=about-user-agent]').text()).toContain('Mozilla/5.0 rotki');
+      expect(wrapper.find('[data-testid=about-web-platform]').text()).toContain('Linux x86_64');
+      expect(wrapper.find('[data-testid=about-electron-version]').exists()).toBe(false);
+    });
+
+    it('should show neither until the version resolves', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.find('[data-testid=about-electron-version]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid=about-user-agent]').exists()).toBe(false);
+    });
+  });
+
+  /**
+   * The premium components load into the page at runtime, so they are reported only when premium
+   * is active and the bundle actually arrived.
+   */
+  describe('the premium components', () => {
+    it('should be reported once premium loaded them', async () => {
+      set(premium, true);
+      window.PremiumComponents = { build: 1_700_000_000_000, version: '16.0.1' };
+
+      const wrapper = await mountResolved();
+
+      expect(wrapper.find('[data-testid=about-components-version]').text()).toContain('16.0.1');
+    });
+
+    it('should be left out for a non-premium account', async () => {
+      window.PremiumComponents = { build: 1_700_000_000_000, version: '16.0.1' };
+
+      const wrapper = await mountResolved();
+
+      expect(wrapper.find('[data-testid=about-components-version]').exists()).toBe(false);
+    });
+
+    it('should be left out when premium is on but the bundle never arrived', async () => {
+      set(premium, true);
+
+      const wrapper = await mountResolved();
+
+      expect(wrapper.find('[data-testid=about-components-version]').exists()).toBe(false);
+    });
+
+    it('should report the build as a date rather than a timestamp', async () => {
+      set(premium, true);
+      window.PremiumComponents = { build: 1_700_000_000_000, version: '16.0.1' };
+
+      const wrapper = await mountResolved();
+
+      expect(wrapper.findComponent({ name: 'DateDisplay' }).props('timestamp')).toBe(1_700_000_000);
+    });
+
+    /** A zero build time is the bundle saying it does not know, not midnight in 1970. */
+    it('should skip a build time the bundle could not report', async () => {
+      set(premium, true);
+      window.PremiumComponents = { build: 0, version: '16.0.1' };
+
+      const wrapper = await mountResolved();
+
+      expect(wrapper.find('[data-testid=about-components-build]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid=about-components-version]').exists()).toBe(true);
+    });
+  });
+
+  /** The whole point of the screen is pasting the versions into a bug report. */
+  describe('copying', () => {
+    it('should copy on request', async () => {
+      const wrapper = await mountResolved();
+
+      await wrapper.find('[data-testid=about-copy]').trigger('click');
+
+      expect(copy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should copy the assembled version text rather than the raw versions', async () => {
+      await mountResolved();
+
+      expect(get(versionSource)).toContain('1.45.0');
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/components/About.vue
+++ b/frontend/app/src/modules/shell/components/About.vue
@@ -108,7 +108,7 @@ const { copy } = useClipboard({ source: versionText });
             </td>
           </tr>
           <template v-if="webVersion">
-            <tr>
+            <tr data-testid="about-web-platform">
               <td class="font-medium py-0.5 min-w-[150px]">
                 {{ t('about.platform') }}
               </td>
@@ -116,7 +116,7 @@ const { copy } = useClipboard({ source: versionText });
                 {{ webVersion.platform }}
               </td>
             </tr>
-            <tr>
+            <tr data-testid="about-user-agent">
               <td class="font-medium py-0.5 min-w-[150px]">
                 {{ t('about.user_agent') }}
               </td>
@@ -126,7 +126,7 @@ const { copy } = useClipboard({ source: versionText });
             </tr>
           </template>
           <template v-if="electronVersion">
-            <tr>
+            <tr data-testid="about-electron-platform">
               <td class="font-medium py-0.5 min-w-[150px]">
                 {{ t('about.platform') }}
               </td>
@@ -135,7 +135,7 @@ const { copy } = useClipboard({ source: versionText });
                 {{ electronVersion.osVersion }}
               </td>
             </tr>
-            <tr>
+            <tr data-testid="about-electron-version">
               <td class="font-medium py-0.5 min-w-[150px]">
                 {{ t('about.electron') }}
               </td>
@@ -152,7 +152,10 @@ const { copy } = useClipboard({ source: versionText });
                 </div>
               </td>
             </tr>
-            <tr v-if="componentsVersion.version">
+            <tr
+              v-if="componentsVersion.version"
+              data-testid="about-components-version"
+            >
               <td class="font-medium py-0.5 min-w-[150px]">
                 {{ t('about.components.version') }}
               </td>
@@ -160,7 +163,10 @@ const { copy } = useClipboard({ source: versionText });
                 {{ componentsVersion.version }}
               </td>
             </tr>
-            <tr v-if="componentsVersion.build">
+            <tr
+              v-if="componentsVersion.build"
+              data-testid="about-components-build"
+            >
               <td class="font-medium py-0.5 min-w-[150px]">
                 {{ t('about.components.build') }}
               </td>
@@ -176,6 +182,7 @@ const { copy } = useClipboard({ source: versionText });
       <div class="flex justify-end w-full">
         <RuiButton
           color="primary"
+          data-testid="about-copy"
           @click="copy()"
         >
           <template #prepend>

--- a/frontend/app/src/modules/shell/components/AppUpdateIndicator.spec.ts
+++ b/frontend/app/src/modules/shell/components/AppUpdateIndicator.spec.ts
@@ -1,0 +1,151 @@
+import type { Ref } from 'vue';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import AppUpdateIndicator from '@/modules/shell/components/AppUpdateIndicator.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { checkFrequency, getVersion, interop, showUpdatePopup, updateNeeded, version } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    checkFrequency: ref<number>(24),
+    getVersion: vi.fn(),
+    interop: { isPackaged: false, openUrl: vi.fn() },
+    showUpdatePopup: ref<boolean>(false),
+    updateNeeded: ref<boolean>(true),
+    version: ref<{ downloadUrl: string; latestVersion: string }>({
+      downloadUrl: 'https://rotki.com/download',
+      latestVersion: '1.46.0',
+    }),
+  };
+});
+
+vi.mock('@/modules/core/common/use-main-store', () => ({
+  useMainStore: (): Record<string, unknown> => ({ updateNeeded, version }),
+}));
+
+vi.mock('@/modules/shell/app/use-backend-connection', () => ({
+  useBackendConnection: (): { getVersion: Mock } => ({ getVersion }),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): typeof interop => interop,
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (): Ref<number> => checkFrequency,
+}));
+
+vi.mock('@/modules/session/use-update-checker', () => ({
+  useUpdateChecker: (): { showUpdatePopup: Ref<boolean> } => ({ showUpdatePopup }),
+}));
+
+function createWrapper(): VueWrapper<any> {
+  return mount(AppUpdateIndicator, {
+    global: { plugins: [createRuiPlugin({})] },
+  });
+}
+
+const HOUR = 60 * 60 * 1000;
+
+describe('appUpdateIndicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    getVersion.mockResolvedValue(undefined);
+    interop.isPackaged = false;
+    set(checkFrequency, 24);
+    set(showUpdatePopup, false);
+    set(updateNeeded, true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should stay out of the way while the app is current', () => {
+    set(updateNeeded, false);
+
+    expect(createWrapper().find('[data-testid=app-update-indicator]').exists()).toBe(false);
+  });
+
+  /**
+   * A packaged build updates itself through its own popup, while a browser has nothing to install
+   * and is sent to the download page instead.
+   */
+  describe('acting on the update', () => {
+    it('should open the in-app popup in a packaged build', async () => {
+      interop.isPackaged = true;
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=app-update-indicator]').trigger('click');
+
+      expect(get(showUpdatePopup)).toBe(true);
+      expect(interop.openUrl).not.toHaveBeenCalled();
+    });
+
+    it('should send a browser to the download page', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=app-update-indicator]').trigger('click');
+
+      expect(interop.openUrl).toHaveBeenCalledWith('https://rotki.com/download');
+      expect(get(showUpdatePopup)).toBe(false);
+    });
+  });
+
+  describe('the version check interval', () => {
+    it('should check once the configured hours have passed', async () => {
+      set(checkFrequency, 1);
+      createWrapper();
+
+      await vi.advanceTimersByTimeAsync(HOUR);
+
+      expect(getVersion).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not check before then', async () => {
+      set(checkFrequency, 1);
+      createWrapper();
+
+      await vi.advanceTimersByTimeAsync(HOUR - 1000);
+
+      expect(getVersion).not.toHaveBeenCalled();
+    });
+
+    /** Zero is how the setting turns the check off, so no timer may keep running. */
+    it('should never check when the frequency is zero', async () => {
+      set(checkFrequency, 0);
+      createWrapper();
+
+      await vi.advanceTimersByTimeAsync(HOUR * 48);
+
+      expect(getVersion).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The interval has to follow the setting rather than the value it happened to hold at startup,
+     * or changing the frequency does nothing until the app is restarted.
+     */
+    it('should follow a frequency the user changes', async () => {
+      set(checkFrequency, 24);
+      createWrapper();
+
+      set(checkFrequency, 1);
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(HOUR);
+
+      expect(getVersion).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop checking once the frequency is set to zero', async () => {
+      set(checkFrequency, 1);
+      createWrapper();
+
+      set(checkFrequency, 0);
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(HOUR * 4);
+
+      expect(getVersion).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/components/AppUpdateIndicator.vue
+++ b/frontend/app/src/modules/shell/components/AppUpdateIndicator.vue
@@ -27,17 +27,18 @@ function update() {
   else openLink();
 }
 
-const period = get(versionUpdateCheckFrequency) * 60 * 60 * 1000;
+/** The configured hours as milliseconds; zero means the user turned the check off. */
+const period = computed<number>(() => get(versionUpdateCheckFrequency) * 60 * 60 * 1000);
 
 const { isActive, pause, resume } = useIntervalFn(() => {
   startPromise(getVersion());
 }, period, { immediate: false });
 
-function setVersionUpdateCheckInterval() {
-  if (isActive)
+function setVersionUpdateCheckInterval(): void {
+  if (get(isActive))
     pause();
 
-  if (period > 0)
+  if (get(period) > 0)
     resume();
 }
 
@@ -59,6 +60,7 @@ const { t } = useI18n({ useScope: 'global' });
       <RuiButton
         color="info"
         icon
+        data-testid="app-update-indicator"
         @click="update()"
       >
         <RuiIcon name="lu-circle-arrow-up" />

--- a/frontend/app/src/modules/shell/components/AssetIcon.vue
+++ b/frontend/app/src/modules/shell/components/AssetIcon.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { Blockchain, getAddressFromEvmIdentifier, getIdentifierFromSymbolMap, isEvmIdentifier } from '@rotki/common';
+import { getAddressFromEvmIdentifier, getIdentifierFromSymbolMap, isEvmIdentifier } from '@rotki/common';
 import { useBlockie } from '@/modules/accounts/use-blockie';
 import { useCurrencies } from '@/modules/assets/amount-display/currencies';
-import { HYPERLIQUID_TOKEN, SOLANA_CHAIN, SOLANA_TOKEN } from '@/modules/assets/types';
 import { useAssetIconCheck } from '@/modules/assets/use-asset-icon-check';
 import { type AssetResolutionOptions, useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { useAssetsStore } from '@/modules/assets/use-assets-store';
@@ -12,6 +11,14 @@ import { useCopy } from '@/modules/core/common/use-clipboard';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useSetting } from '@/modules/settings/use-setting';
 import AppImage from '@/modules/shell/components/AppImage.vue';
+import {
+  assetChain,
+  assetTooltip,
+  type AssetTooltip,
+  badgeSize,
+  displayAssetText,
+  visibleProtocol,
+} from '@/modules/shell/components/asset-icon-display';
 import CounterpartyDisplay from '@/modules/shell/components/display/CounterpartyDisplay.vue';
 import EvmChainIcon from '@/modules/shell/components/EvmChainIcon.vue';
 import GeneratedIcon from '@/modules/shell/components/GeneratedIcon.vue';
@@ -80,46 +87,14 @@ const url = reactify(getAssetIconUrl)(mappedIdentifier);
 
 const isCustomAsset = computed(() => get(asset)?.isCustomAsset ?? false);
 
-const chain = computed(() => {
-  if (forceChain) {
-    return forceChain;
-  }
-
-  const info = get(asset);
-  if (!info) {
-    return undefined;
-  }
-  if (info.evmChain) {
-    return info.evmChain;
-  }
-
-  if (info.assetType === SOLANA_TOKEN) {
-    return SOLANA_CHAIN;
-  }
-
-  if (info.assetType === HYPERLIQUID_TOKEN) {
-    return Blockchain.HYPERLIQUID;
-  }
-
-  return undefined;
-});
+const chain = computed<string | undefined>(() => assetChain(forceChain, get(asset)));
 const symbol = computed(() => get(asset)?.symbol);
 const name = computed(() => get(asset)?.name);
-const protocol = computed<string | undefined>(() => {
-  const protocol = get(asset)?.protocol;
-  if (!protocol || protocol === 'spam') {
-    return undefined;
-  }
-  return protocol;
-});
+const protocol = computed<string | undefined>(() => visibleProtocol(get(asset)?.protocol));
 
-const displayAsset = computed<string>(() => {
-  const currencySymbol = get(currency);
-  if (currencySymbol)
-    return currencySymbol;
-
-  return get(symbol) ?? get(name) ?? get(mappedIdentifier) ?? '';
-});
+const displayAsset = computed<string>(() =>
+  displayAssetText(get(currency), get(symbol), get(name), get(mappedIdentifier)),
+);
 
 /**
  * Whether the asset has anything to call itself by.
@@ -154,30 +129,7 @@ const blockie = computed<string | undefined>(() => {
  */
 const hasTooltipText = hasAssetText;
 
-const tooltip = computed(() => {
-  const assetName = get(name) ?? '';
-  const assetSymbol = get(symbol) ?? '';
-  const isCustom = get(isCustomAsset);
-
-  const emptyNameAsset = (symbol: string) => ({
-    name: '',
-    symbol,
-  });
-
-  if (isCustom) {
-    return emptyNameAsset(assetName);
-  }
-
-  const areSymbolAndNameEqual = assetName.toLowerCase() === assetSymbol.toLowerCase();
-  if (areSymbolAndNameEqual) {
-    return emptyNameAsset(assetSymbol);
-  }
-
-  return {
-    name: assetName,
-    symbol: assetSymbol,
-  };
-});
+const tooltip = computed<AssetTooltip>(() => assetTooltip(get(name), get(symbol), get(isCustomAsset)));
 
 const tooltipOptions = computed(() => ({
   autoUpdate: {
@@ -187,8 +139,8 @@ const tooltipOptions = computed(() => ({
   placement: 'top' as const,
 }));
 
-const usedChainIconSize = computed(() => chainIconSize || `${(Number.parseInt(size) * 50) / 100}px`);
-const usedProtocolIconSize = computed(() => chainIconSize || `${(Number.parseInt(size) * 40) / 100}px`);
+const usedChainIconSize = computed<string>(() => badgeSize(chainIconSize, size, 50));
+const usedProtocolIconSize = computed<string>(() => badgeSize(chainIconSize, size, 40));
 
 const chainIconMargin = computed(() => `-${get(usedChainIconSize)}`);
 
@@ -320,7 +272,7 @@ const { copied, copy } = useCopy(() => identifier);
     </template>
 
     <div v-if="hasTooltipText">
-      {{ t('asset_icon.tooltip', tooltip) }}
+      {{ t('asset_icon.tooltip', { ...tooltip }) }}
     </div>
 
     <!-- Chain and protocol otherwise live only in the corner badges, a few pixels across. For an

--- a/frontend/app/src/modules/shell/components/GlobalSearch.spec.ts
+++ b/frontend/app/src/modules/shell/components/GlobalSearch.spec.ts
@@ -1,0 +1,257 @@
+import type { SearchItem } from '@/modules/shell/layout/use-global-search';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import GlobalSearch from '@/modules/shell/components/GlobalSearch.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { currentPath, isMac, performSearch, push, resolve } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    currentPath: ref<string>('/dashboard'),
+    isMac: vi.fn(),
+    performSearch: vi.fn(),
+    push: vi.fn(),
+    resolve: vi.fn(),
+  };
+});
+
+vi.mock('vue-router', () => ({
+  useRouter: (): Record<string, unknown> => ({
+    currentRoute: computed(() => ({ fullPath: get(currentPath) })),
+    push,
+    resolve,
+  }),
+}));
+
+vi.mock('@/modules/shell/layout/use-global-search', () => ({
+  useGlobalSearch: (): { search: Mock } => ({ search: performSearch }),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): { isMac: Mock } => ({ isMac }),
+}));
+
+/** The shared stub carries neither of this component's two models, so it is replaced here. */
+const AutoCompleteStub = {
+  emits: ['update:modelValue', 'update:searchInput'],
+  name: 'RuiAutoComplete',
+  props: ['modelValue', 'searchInput', 'options', 'loading'],
+  template: '<div />',
+};
+
+const DialogStub = { name: 'RuiDialog', props: ['modelValue'], template: '<div><slot /></div>' };
+
+function item(overrides: Partial<SearchItem> = {}): SearchItem {
+  return { matchedPoints: 1, texts: ['Dashboard'], value: 1, ...overrides };
+}
+
+function createWrapper(): VueWrapper<any> {
+  return mount(GlobalSearch, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        AppImage: true,
+        AssetIcon: true,
+        FiatDisplay: true,
+        GlobalSearchItemTexts: true,
+        LocationIcon: true,
+        RuiAutoComplete: AutoCompleteStub,
+        RuiDialog: DialogStub,
+      },
+    },
+  });
+}
+
+function palette(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(DialogStub);
+}
+
+function isOpen(wrapper: VueWrapper<any>): boolean {
+  return palette(wrapper).props('modelValue');
+}
+
+/** Presses the palette shortcut, which is Command on macOS and Control everywhere else. */
+async function pressShortcut(modifier: 'meta' | 'ctrl', key = '/'): Promise<void> {
+  window.dispatchEvent(new KeyboardEvent('keydown', {
+    ctrlKey: modifier === 'ctrl',
+    key,
+    metaKey: modifier === 'meta',
+  }));
+  await nextTick();
+}
+
+/** Mounts and lets `onBeforeMount` settle, since the platform is resolved asynchronously. */
+async function mountReady(): Promise<VueWrapper<any>> {
+  const wrapper = createWrapper();
+  await flushPromises();
+  return wrapper;
+}
+
+/** Chooses the item at that index, the way the autocomplete reports a selection. */
+async function choose(wrapper: VueWrapper<any>, index: number): Promise<void> {
+  await wrapper.findComponent(AutoCompleteStub).vm.$emit('update:modelValue', index);
+  await nextTick();
+}
+
+describe('globalSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(currentPath, '/dashboard');
+    isMac.mockResolvedValue(false);
+    performSearch.mockResolvedValue([]);
+    push.mockResolvedValue(undefined);
+    resolve.mockImplementation((route: string) => ({ fullPath: route }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * The modifier check is one way round rather than accepting either, so the wrong modifier does
+   * not open the palette on the platform it does not belong to.
+   */
+  describe('the keyboard shortcut', () => {
+    it('should open on control off macOS', async () => {
+      const wrapper = await mountReady();
+
+      await pressShortcut('ctrl');
+
+      expect(isOpen(wrapper)).toBe(true);
+    });
+
+    it('should ignore command off macOS', async () => {
+      const wrapper = await mountReady();
+
+      await pressShortcut('meta');
+
+      expect(isOpen(wrapper)).toBe(false);
+    });
+
+    it('should open on command on macOS', async () => {
+      isMac.mockResolvedValue(true);
+      const wrapper = await mountReady();
+
+      await pressShortcut('meta');
+
+      expect(isOpen(wrapper)).toBe(true);
+    });
+
+    it('should ignore control on macOS', async () => {
+      isMac.mockResolvedValue(true);
+      const wrapper = await mountReady();
+
+      await pressShortcut('ctrl');
+
+      expect(isOpen(wrapper)).toBe(false);
+    });
+
+    it('should ignore the modifier on its own', async () => {
+      const wrapper = await mountReady();
+
+      await pressShortcut('ctrl', 'k');
+
+      expect(isOpen(wrapper)).toBe(false);
+    });
+  });
+
+  describe('choosing a result', () => {
+    it('should navigate to the route it carries', async () => {
+      performSearch.mockResolvedValue([item({ route: '/settings/general' })]);
+      const wrapper = await mountReady();
+      await search(wrapper, 'settings');
+
+      await choose(wrapper, 0);
+
+      expect(push).toHaveBeenCalledWith('/settings/general');
+    });
+
+    /** Pushing the route the user is already on would stack a pointless history entry. */
+    it('should not navigate when it leads where the user already is', async () => {
+      performSearch.mockResolvedValue([item({ route: '/dashboard' })]);
+      const wrapper = await mountReady();
+      await search(wrapper, 'dash');
+
+      await choose(wrapper, 0);
+
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it('should run an item that acts instead of navigating', async () => {
+      const action = vi.fn();
+      performSearch.mockResolvedValue([item({ action })]);
+      const wrapper = await mountReady();
+      await search(wrapper, 'privacy');
+
+      await choose(wrapper, 0);
+
+      expect(action).toHaveBeenCalledTimes(1);
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it('should close the palette', async () => {
+      performSearch.mockResolvedValue([item({ route: '/settings/general' })]);
+      const wrapper = await mountReady();
+      await pressShortcut('ctrl');
+      await search(wrapper, 'settings');
+
+      await choose(wrapper, 0);
+
+      expect(isOpen(wrapper)).toBe(false);
+    });
+
+    it('should do nothing for an index no result sits at', async () => {
+      const wrapper = await mountReady();
+
+      await choose(wrapper, 3);
+
+      expect(push).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('searching', () => {
+    it('should report itself busy as soon as something is typed', async () => {
+      const wrapper = await mountReady();
+
+      await wrapper.findComponent(AutoCompleteStub).vm.$emit('update:searchInput', 'set');
+      await nextTick();
+
+      expect(wrapper.findComponent(AutoCompleteStub).props('loading')).toBe(true);
+    });
+
+    /** The search is debounced, so a keystroke must not reach it until the typing settles. */
+    it('should wait for the typing to settle before searching', async () => {
+      vi.useFakeTimers();
+      const wrapper = createWrapper();
+      await vi.advanceTimersByTimeAsync(0);
+
+      await wrapper.findComponent(AutoCompleteStub).vm.$emit('update:searchInput', 'set');
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(performSearch).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(performSearch).toHaveBeenCalledWith('set');
+    });
+
+    it('should offer what came back and stop reporting itself busy', async () => {
+      performSearch.mockResolvedValue([item(), item({ value: 2 })]);
+      const wrapper = await mountReady();
+
+      await search(wrapper, 'set');
+
+      expect(wrapper.findComponent(AutoCompleteStub).props('options')).toHaveLength(2);
+      expect(wrapper.findComponent(AutoCompleteStub).props('loading')).toBe(false);
+    });
+  });
+});
+
+/** Types into the palette and lets the debounce elapse. */
+async function search(wrapper: VueWrapper<any>, keyword: string): Promise<void> {
+  vi.useFakeTimers();
+  await wrapper.findComponent(AutoCompleteStub).vm.$emit('update:searchInput', keyword);
+  await vi.advanceTimersByTimeAsync(900);
+  vi.useRealTimers();
+  await flushPromises();
+}

--- a/frontend/app/src/modules/shell/components/HelpSidebar.spec.ts
+++ b/frontend/app/src/modules/shell/components/HelpSidebar.spec.ts
@@ -1,0 +1,150 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import HelpSidebar from '@/modules/shell/components/HelpSidebar.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { downloadFileByTextContent, getAll, interop, notify, showReportIssue } = vi.hoisted(() => ({
+  downloadFileByTextContent: vi.fn(),
+  getAll: vi.fn(),
+  interop: { isPackaged: false, openUrl: vi.fn() },
+  notify: vi.fn(),
+  showReportIssue: vi.fn(),
+}));
+
+vi.mock('@/modules/core/common/file/download', () => ({
+  downloadFileByTextContent,
+}));
+
+vi.mock('@/modules/core/common/helpers/indexed-db', () => ({
+  IndexedDb: class {
+    getAll = getAll;
+  },
+}));
+
+vi.mock('@/modules/core/common/use-report-issue', () => ({
+  useReportIssue: (): { show: Mock } => ({ show: showReportIssue }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): { notify: Mock } => ({ notify }),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): typeof interop => interop,
+}));
+
+/** The drawer teleports, so a pass-through keeps its contents inside the wrapper. */
+const DrawerStub = {
+  name: 'RuiNavigationDrawer',
+  props: ['modelValue', 'width', 'temporary', 'position'],
+  template: '<div><slot /></div>',
+};
+
+function createWrapper(): VueWrapper<any> {
+  return mount(HelpSidebar, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: { RuiNavigationDrawer: DrawerStub },
+    },
+    props: { modelValue: true },
+  });
+}
+
+/** Runs the log download, invoking whatever the store handed back to its callback. */
+async function downloadLog(wrapper: VueWrapper<any>, entries: unknown[]): Promise<void> {
+  getAll.mockImplementation(async (callback: (data: unknown[]) => void) => {
+    callback(entries);
+  });
+  await wrapper.find('[data-testid=help-download-log]').trigger('click');
+}
+
+describe('helpSidebar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    interop.isPackaged = false;
+  });
+
+  it('should open the report issue dialog', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=help-report-issue]').trigger('click');
+
+    expect(showReportIssue).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close on request', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=help-close]').trigger('click');
+
+    expect(wrapper.emitted<[boolean]>('update:modelValue')?.at(-1)?.[0]).toBe(false);
+  });
+
+  /** The about screen replaces the sidebar rather than opening behind it. */
+  it('should close itself when opening the about screen', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=help-about]').trigger('click');
+
+    expect(wrapper.emitted('about')).toHaveLength(1);
+    expect(wrapper.emitted<[boolean]>('update:modelValue')?.at(-1)?.[0]).toBe(false);
+  });
+
+  /**
+   * A packaged build has no browser to open a link in and no browser log to download, so it hands
+   * the link to the desktop shell and drops the two browser-only rows.
+   */
+  describe('in a packaged build', () => {
+    it('should open a link through the desktop shell rather than as an href', async () => {
+      interop.isPackaged = true;
+      const wrapper = createWrapper();
+
+      const link = wrapper.findAll('[data-testid=help-link]')[0];
+      await link.trigger('click');
+
+      expect(interop.openUrl).toHaveBeenCalledTimes(1);
+      expect(link.attributes('href')).toBeUndefined();
+    });
+
+    it('should leave the link to the browser otherwise', async () => {
+      const wrapper = createWrapper();
+
+      const link = wrapper.findAll('[data-testid=help-link]')[0];
+      await link.trigger('click');
+
+      expect(interop.openUrl).not.toHaveBeenCalled();
+      expect(link.attributes('href')).toBeTruthy();
+    });
+
+    it('should withhold the about and log rows', () => {
+      interop.isPackaged = true;
+
+      const wrapper = createWrapper();
+
+      expect(wrapper.find('[data-testid=help-about]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid=help-download-log]').exists()).toBe(false);
+    });
+  });
+
+  describe('downloading the browser log', () => {
+    it('should download what the log holds', async () => {
+      const wrapper = createWrapper();
+
+      await downloadLog(wrapper, [{ message: 'first' }, { message: 'second' }]);
+
+      expect(downloadFileByTextContent).toHaveBeenCalledWith('first\nsecond', 'frontend_log.txt');
+    });
+
+    /** An empty file would look like a successful download of nothing. */
+    it('should say so rather than download an empty log', async () => {
+      const wrapper = createWrapper();
+
+      await downloadLog(wrapper, []);
+
+      expect(downloadFileByTextContent).not.toHaveBeenCalled();
+      expect(notify).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'help_sidebar.browser_log.error.empty.message',
+      }));
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/components/HelpSidebar.vue
+++ b/frontend/app/src/modules/shell/components/HelpSidebar.vue
@@ -93,6 +93,7 @@ async function downloadBrowserLog(): Promise<void> {
       <RuiButton
         variant="text"
         icon
+        data-testid="help-close"
         @click="display = false"
       >
         <RuiIcon name="lu-x" />
@@ -101,6 +102,7 @@ async function downloadBrowserLog(): Promise<void> {
     <div class="py-0">
       <div
         class="flex items-center gap-6 py-4 px-6 hover:!bg-rui-grey-100 hover:dark:!bg-rui-grey-800 border-y border-default cursor-pointer"
+        data-testid="help-report-issue"
         @click="showReportIssue()"
       >
         <RuiIcon
@@ -124,6 +126,7 @@ async function downloadBrowserLog(): Promise<void> {
         target="_blank"
         class="flex items-center gap-6 py-4 px-6 hover:!bg-rui-grey-100 hover:dark:!bg-rui-grey-800 cursor-pointer"
         :class="{ 'border-t border-default': index > 0 }"
+        data-testid="help-link"
         @click="interop.isPackaged ? interop.openUrl(item.link) : null"
       >
         <RuiIcon
@@ -143,6 +146,7 @@ async function downloadBrowserLog(): Promise<void> {
       <template v-if="!interop.isPackaged">
         <div
           class="flex items-center gap-6 py-4 px-6 hover:!bg-rui-grey-100 hover:dark:!bg-rui-grey-800 border-t border-default cursor-pointer"
+          data-testid="help-about"
           @click="openAbout()"
         >
           <RuiIcon
@@ -162,6 +166,7 @@ async function downloadBrowserLog(): Promise<void> {
 
         <div
           class="flex items-center gap-6 py-4 px-6 hover:!bg-rui-grey-100 hover:dark:!bg-rui-grey-800 border-t border-default cursor-pointer"
+          data-testid="help-download-log"
           @click="downloadBrowserLog()"
         >
           <RuiIcon

--- a/frontend/app/src/modules/shell/components/ReportIssueDialog.spec.ts
+++ b/frontend/app/src/modules/shell/components/ReportIssueDialog.spec.ts
@@ -1,0 +1,263 @@
+import { SUPPORT_EMAIL } from '@shared/external-links';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { nextTick, type Ref } from 'vue';
+import ReportIssueDialog from '@/modules/shell/components/ReportIssueDialog.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { close, copy, initialDescription, initialTitle, openUrl, privacyMode, scrambleEnabled, showPrivacyModeMenu, visible } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    close: vi.fn(),
+    copy: vi.fn(),
+    initialDescription: ref<string>(''),
+    initialTitle: ref<string>(''),
+    openUrl: vi.fn(),
+    privacyMode: ref<number>(0),
+    scrambleEnabled: ref<boolean>(false),
+    showPrivacyModeMenu: ref<boolean>(false),
+    visible: ref<boolean>(true),
+  };
+});
+
+vi.mock('@/modules/core/common/use-report-issue', () => ({
+  useReportIssue: (): Record<string, unknown> => ({
+    close,
+    initialDescription,
+    initialTitle,
+    visible,
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-area-visibility-store', () => ({
+  useAreaVisibilityStore: (): { showPrivacyModeMenu: Ref<boolean> } => ({ showPrivacyModeMenu }),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): { openUrl: Mock } => ({ openUrl }),
+}));
+
+vi.mock('@/modules/settings/use-scramble-settings', () => ({
+  useScrambleSetting: (): { enabled: Ref<boolean> } => ({ enabled: scrambleEnabled }),
+}));
+
+vi.mock('@/modules/settings/use-privacy', () => ({
+  usePrivacyMode: (): { privacyMode: Ref<number> } => ({ privacyMode }),
+}));
+
+vi.mock('@vueuse/core', async () => {
+  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+  return { ...actual, useClipboard: (): { copy: Mock } => ({ copy }) };
+});
+
+const EmailButtonStub = {
+  emits: ['submit-email', 'copy-email', 'open-gmail'],
+  name: 'ReportIssueEmailButton',
+  props: ['email', 'isFormValid'],
+  template: `<div>
+    <button data-testid="stub-mailto" @click="$emit('submit-email')" />
+    <button data-testid="stub-copy" @click="$emit('copy-email')" />
+    <button data-testid="stub-gmail" @click="$emit('open-gmail')" />
+  </div>`,
+};
+
+/** `RuiDialog` teleports, so a pass-through keeps the card inside the wrapper. */
+const DialogStub = { name: 'RuiDialog', props: ['modelValue'], template: '<div><slot /></div>' };
+
+function createWrapper(): VueWrapper<any> {
+  return mount(ReportIssueDialog, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        ReportIssueDiscordTip: { emits: ['open-discord'], name: 'ReportIssueDiscordTip', template: '<button data-testid="stub-discord" @click="$emit(\'open-discord\')" />' },
+        ReportIssueEmailButton: EmailButtonStub,
+        RuiDialog: DialogStub,
+      },
+    },
+  });
+}
+
+/** Fills the form the way the user does, through the two fields the dialog binds. */
+async function fillDraft(wrapper: VueWrapper<any>, title = 'a title', description = 'a description'): Promise<void> {
+  await wrapper.findComponent({ name: 'RuiTextField' }).vm.$emit('update:modelValue', title);
+  await wrapper.findComponent({ name: 'RuiTextArea' }).vm.$emit('update:modelValue', description);
+}
+
+describe('reportIssueDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(initialTitle, '');
+    set(initialDescription, '');
+    set(privacyMode, 0);
+    set(scrambleEnabled, false);
+    set(showPrivacyModeMenu, false);
+  });
+
+  /** The dialog can be opened with a subject already chosen, from wherever asked for it. */
+  it('should open on the draft the caller asked for', async () => {
+    set(initialTitle, 'a crash on login');
+    set(initialDescription, 'it happened twice');
+
+    const wrapper = createWrapper();
+    await nextTick();
+
+    expect(wrapper.findComponent({ name: 'RuiTextField' }).props('modelValue')).toBe('a crash on login');
+    expect(wrapper.findComponent({ name: 'RuiTextArea' }).props('modelValue')).toBe('it happened twice');
+  });
+
+  describe('submitting', () => {
+    it('should refuse every route until the form is filled', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.find('[data-testid=report-issue-github]').attributes('disabled')).toBeDefined();
+      expect(wrapper.find('[data-testid=report-issue-google-form]').attributes('disabled')).toBeDefined();
+      expect(wrapper.findComponent(EmailButtonStub).props('isFormValid')).toBe(false);
+    });
+
+    it('should offer every route once it is', async () => {
+      const wrapper = createWrapper();
+
+      await fillDraft(wrapper);
+
+      expect(wrapper.find('[data-testid=report-issue-github]').attributes('disabled')).toBeUndefined();
+      expect(wrapper.findComponent(EmailButtonStub).props('isFormValid')).toBe(true);
+    });
+
+    it('should carry the draft to github', async () => {
+      const wrapper = createWrapper();
+      await fillDraft(wrapper, 'a crash', 'it happened twice');
+
+      await wrapper.find('[data-testid=report-issue-github]').trigger('click');
+
+      expect(openUrl).toHaveBeenCalledWith(expect.stringContaining('a%20crash'));
+      expect(openUrl).toHaveBeenCalledWith(expect.stringContaining('github.com'));
+    });
+
+    it('should carry the draft to the google form', async () => {
+      const wrapper = createWrapper();
+      await fillDraft(wrapper, 'a crash');
+
+      await wrapper.find('[data-testid=report-issue-google-form]').trigger('click');
+
+      expect(openUrl).toHaveBeenCalledWith(expect.stringContaining('a%20crash'));
+    });
+
+    it('should carry the draft to a mail client', async () => {
+      const wrapper = createWrapper();
+      await fillDraft(wrapper, 'a crash');
+
+      await wrapper.find('[data-testid=stub-mailto]').trigger('click');
+
+      expect(openUrl).toHaveBeenCalledWith(expect.stringContaining('mailto:'));
+    });
+
+    it('should carry the draft to gmail', async () => {
+      const wrapper = createWrapper();
+      await fillDraft(wrapper, 'a crash');
+
+      await wrapper.find('[data-testid=stub-gmail]').trigger('click');
+
+      expect(openUrl).toHaveBeenCalledWith(expect.stringContaining('mail.google.com'));
+    });
+
+    /** The report continues in the browser, so the dialog has nothing left to do. */
+    it('should close once a route was taken', async () => {
+      const wrapper = createWrapper();
+      await fillDraft(wrapper);
+
+      await wrapper.find('[data-testid=report-issue-github]').trigger('click');
+
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    /** Reopening starts a fresh report rather than the last one the user walked away from. */
+    it('should forget the draft on close', async () => {
+      const wrapper = createWrapper();
+      await fillDraft(wrapper, 'a crash');
+
+      await wrapper.find('[data-testid=report-issue-close]').trigger('click');
+
+      expect(wrapper.findComponent({ name: 'RuiTextField' }).props('modelValue')).toBe('');
+      expect(wrapper.findComponent({ name: 'RuiTextArea' }).props('modelValue')).toBe('');
+    });
+  });
+
+  describe('the support address', () => {
+    it('should be offered for copying', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=stub-copy]').trigger('click');
+
+      expect(copy).toHaveBeenCalledWith(SUPPORT_EMAIL);
+    });
+
+    it('should be handed to the button as the address to show', () => {
+      expect(createWrapper().findComponent(EmailButtonStub).props('email')).toBe(SUPPORT_EMAIL);
+    });
+  });
+
+  /** Discord is a conversation rather than a filed report, so the dialog stays up behind it. */
+  it('should stay open when discord is opened', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=stub-discord]').trigger('click');
+
+    expect(openUrl).toHaveBeenCalledTimes(1);
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The tip exists to stop a screenshot leaking balances, so it offers the privacy menu only while
+   * nothing is masking them yet, and otherwise reports what is already on.
+   */
+  describe('the screenshot privacy tip', () => {
+    it('should offer the privacy menu while nothing is masked', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=report-issue-enable-privacy]').trigger('click');
+
+      expect(get(showPrivacyModeMenu)).toBe(true);
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stop offering it once privacy mode is on', () => {
+      set(privacyMode, 1);
+
+      const wrapper = createWrapper();
+
+      expect(wrapper.find('[data-testid=report-issue-enable-privacy]').exists()).toBe(false);
+    });
+
+    it('should stop offering it once scrambling is on', () => {
+      set(scrambleEnabled, true);
+
+      const wrapper = createWrapper();
+
+      expect(wrapper.find('[data-testid=report-issue-enable-privacy]').exists()).toBe(false);
+    });
+
+    it('should name semi-private mode', () => {
+      set(privacyMode, 1);
+
+      expect(createWrapper().find('[data-testid=report-issue-privacy-status]').text())
+        .toContain('semi_private');
+    });
+
+    it('should name private mode', () => {
+      set(privacyMode, 2);
+
+      expect(createWrapper().find('[data-testid=report-issue-privacy-status]').text())
+        .toContain('tips.screenshot.private');
+    });
+
+    it('should name both when scrambling joins a privacy mode', () => {
+      set(privacyMode, 2);
+      set(scrambleEnabled, true);
+
+      const status = createWrapper().find('[data-testid=report-issue-privacy-status]').text();
+
+      expect(status).toContain('tips.screenshot.private');
+      expect(status).toContain('scramble');
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
+++ b/frontend/app/src/modules/shell/components/ReportIssueDialog.vue
@@ -161,6 +161,7 @@ onMounted(() => {
               variant="outlined"
               color="primary"
               :disabled="!isFormValid"
+              data-testid="report-issue-github"
               @click="submitViaGithub()"
             >
               <template #prepend>
@@ -172,6 +173,7 @@ onMounted(() => {
               variant="outlined"
               color="primary"
               :disabled="!isFormValid"
+              data-testid="report-issue-google-form"
               @click="submitViaGoogleForm()"
             >
               <template #prepend>
@@ -227,6 +229,7 @@ onMounted(() => {
                 color="primary"
                 size="sm"
                 class="self-start -ml-1.5 !py-0"
+                data-testid="report-issue-enable-privacy"
                 @click="openPrivacyModeMenu()"
               >
                 {{ t('help_sidebar.report_issue.dialog.tips.screenshot.action') }}
@@ -234,6 +237,7 @@ onMounted(() => {
               <span
                 v-else
                 class="text-xs text-rui-success flex items-center gap-1 py-1"
+                data-testid="report-issue-privacy-status"
               >
                 <RuiIcon
                   name="lu-check"
@@ -251,6 +255,7 @@ onMounted(() => {
         <RuiButton
           variant="text"
           color="primary"
+          data-testid="report-issue-close"
           @click="closeDialog()"
         >
           {{ t('common.actions.close') }}

--- a/frontend/app/src/modules/shell/components/UserDropdown.spec.ts
+++ b/frontend/app/src/modules/shell/components/UserDropdown.spec.ts
@@ -1,0 +1,170 @@
+import type { Ref } from 'vue';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import UserDropdown from '@/modules/shell/components/UserDropdown.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { confirm, currentTier, interop, logout, premium, privacyModeIcon, savedRememberPassword, username } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  /** Holds the callback the confirmation store was handed, so a test can accept the prompt. */
+  const confirm: { run?: () => Promise<void> } = {};
+
+  return {
+    confirm,
+    currentTier: ref<string>(''),
+    interop: { clearPassword: vi.fn(), isPackaged: false },
+    logout: vi.fn(),
+    premium: ref<boolean>(false),
+    privacyModeIcon: ref<string>('lu-eye'),
+    savedRememberPassword: ref<boolean>(false),
+    username: ref<string>('alice'),
+  };
+});
+
+vi.mock('@/modules/auth/use-logout', () => ({
+  useLogout: (): { logout: Mock } => ({ logout }),
+}));
+
+vi.mock('@/modules/auth/use-remember-settings', () => ({
+  useRememberSettings: (): { savedRememberPassword: Ref<boolean> } => ({ savedRememberPassword }),
+}));
+
+vi.mock('@/modules/auth/use-session-auth-store', () => ({
+  useSessionAuthStore: (): { username: Ref<string> } => ({ username }),
+}));
+
+vi.mock('@/modules/shell/app/use-electron-interop', () => ({
+  useInterop: (): typeof interop => interop,
+}));
+
+vi.mock('@/modules/premium/use-premium-helper', () => ({
+  usePremiumHelper: (): { currentTier: Ref<string>; premium: Ref<boolean> } => ({ currentTier, premium }),
+}));
+
+vi.mock('@/modules/settings/use-privacy', () => ({
+  usePrivacyMode: (): Record<string, unknown> => ({
+    privacyModeIcon,
+    togglePrivacyMode: vi.fn(),
+  }),
+}));
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): { show: (message: unknown, run: () => Promise<void>) => void } => ({
+    show: (_message, run): void => {
+      confirm.run = run;
+    },
+  }),
+}));
+
+function createWrapper(): VueWrapper<any> {
+  return mount(UserDropdown, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        // An auto-stub renders no default slot, which would hide the tier label it wraps.
+        ExternalLink: { name: 'ExternalLink', props: ['url', 'custom'], template: '<div><slot /></div>' },
+        MenuTooltipButton: { name: 'MenuTooltipButton', template: '<button><slot /></button>' },
+        // Both slots are scoped, so the stubs have to hand back what the template destructures.
+        RouterLink: { name: 'RouterLink', template: '<div><slot :navigate="() => {}" /></div>' },
+        RuiMenu: {
+          name: 'RuiMenu',
+          template: '<div><slot name="activator" :attrs="{}" /><slot /></div>',
+        },
+        ThemeControl: true,
+      },
+    },
+  });
+}
+
+/** Presses log out and accepts the confirmation. */
+async function logOut(wrapper: VueWrapper<any>): Promise<void> {
+  await wrapper.find('[data-testid=logout-button]').trigger('click');
+  await confirm.run?.();
+}
+
+describe('userDropdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    confirm.run = undefined;
+    interop.isPackaged = false;
+    set(currentTier, '');
+    set(premium, false);
+    set(savedRememberPassword, false);
+    set(username, 'alice');
+  });
+
+  it('should name the signed in account', () => {
+    expect(createWrapper().find('[data-testid=username]').text()).toContain('alice');
+  });
+
+  describe('the premium tier', () => {
+    it('should be named for a premium account', () => {
+      set(premium, true);
+      set(currentTier, 'Pro');
+
+      expect(createWrapper().text()).toContain('premium_placeholder.current_plan::Pro');
+    });
+
+    it('should be left out for a non-premium account', () => {
+      set(currentTier, 'Pro');
+
+      expect(createWrapper().text()).not.toContain('premium_placeholder.current_plan');
+    });
+
+    it('should be left out when premium reports no tier', () => {
+      set(premium, true);
+
+      expect(createWrapper().text()).not.toContain('premium_placeholder.current_plan');
+    });
+  });
+
+  describe('logging out', () => {
+    it('should ask before doing it', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=logout-button]').trigger('click');
+
+      expect(logout).not.toHaveBeenCalled();
+    });
+
+    it('should log out once confirmed', async () => {
+      const wrapper = createWrapper();
+
+      await logOut(wrapper);
+
+      expect(logout).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * Only the packaged build stores the password, and only when the user asked it to. Clearing it
+     * on log out is what stops the next person on the machine signing straight back in.
+     */
+    it('should clear a password the desktop build remembered', async () => {
+      interop.isPackaged = true;
+      set(savedRememberPassword, true);
+
+      await logOut(createWrapper());
+
+      expect(interop.clearPassword).toHaveBeenCalledTimes(1);
+      expect(logout).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear nothing when the password was never remembered', async () => {
+      interop.isPackaged = true;
+
+      await logOut(createWrapper());
+
+      expect(interop.clearPassword).not.toHaveBeenCalled();
+      expect(logout).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear nothing in a browser, which stores no password', async () => {
+      set(savedRememberPassword, true);
+
+      await logOut(createWrapper());
+
+      expect(interop.clearPassword).not.toHaveBeenCalled();
+      expect(logout).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/components/asset-icon-display.spec.ts
+++ b/frontend/app/src/modules/shell/components/asset-icon-display.spec.ts
@@ -1,0 +1,136 @@
+import { type AssetInfoWithId, Blockchain } from '@rotki/common';
+import { describe, expect, it } from 'vitest';
+import { HYPERLIQUID_TOKEN, SOLANA_CHAIN, SOLANA_TOKEN } from '@/modules/assets/types';
+import {
+  assetChain,
+  assetTooltip,
+  badgeSize,
+  displayAssetText,
+  visibleProtocol,
+} from '@/modules/shell/components/asset-icon-display';
+
+function asset(overrides: Partial<AssetInfoWithId> = {}): AssetInfoWithId {
+  return { identifier: 'ETH', isCustomAsset: false, name: 'Ethereum', symbol: 'ETH', ...overrides };
+}
+
+describe('assetChain', () => {
+  it('should take an evm asset chain from the asset', () => {
+    expect(assetChain(undefined, asset({ evmChain: 'optimism' }))).toBe('optimism');
+  });
+
+  /** Solana and hyperliquid tokens carry no chain, and are recognised by their type instead. */
+  it('should recognise a solana token by its type', () => {
+    expect(assetChain(undefined, asset({ assetType: SOLANA_TOKEN }))).toBe(SOLANA_CHAIN);
+  });
+
+  it('should recognise a hyperliquid token by its type', () => {
+    expect(assetChain(undefined, asset({ assetType: HYPERLIQUID_TOKEN }))).toBe(Blockchain.HYPERLIQUID);
+  });
+
+  it('should badge nothing for an asset with no chain', () => {
+    expect(assetChain(undefined, asset())).toBeUndefined();
+  });
+
+  it('should badge nothing while the asset is still resolving', () => {
+    expect(assetChain(undefined, null)).toBeUndefined();
+  });
+
+  describe('a chain the caller forces', () => {
+    it('should win over the asset own chain', () => {
+      expect(assetChain('base', asset({ evmChain: 'optimism' }))).toBe('base');
+    });
+
+    it('should show even before the asset resolves', () => {
+      expect(assetChain('base', null)).toBe('base');
+    });
+  });
+});
+
+describe('visibleProtocol', () => {
+  it('should badge a real protocol', () => {
+    expect(visibleProtocol('aave')).toBe('aave');
+  });
+
+  /** Spam is a classification, and badging it would dress a spam token as a real one. */
+  it('should not badge spam as a protocol', () => {
+    expect(visibleProtocol('spam')).toBeUndefined();
+  });
+
+  it('should badge nothing when the asset has no protocol', () => {
+    expect(visibleProtocol(undefined)).toBeUndefined();
+  });
+
+  it('should badge nothing for an empty protocol', () => {
+    expect(visibleProtocol('')).toBeUndefined();
+  });
+});
+
+describe('displayAssetText', () => {
+  /** A fiat currency shows its own symbol, which is why it outranks the asset's names. */
+  it('should prefer the currency symbol', () => {
+    expect(displayAssetText('$', 'USD', 'US Dollar', 'USD')).toBe('$');
+  });
+
+  it('should fall back to the symbol', () => {
+    expect(displayAssetText(undefined, 'ETH', 'Ethereum', 'eip155:1/erc20:0x0')).toBe('ETH');
+  });
+
+  it('should fall back to the name when there is no symbol', () => {
+    expect(displayAssetText(undefined, undefined, 'Ethereum', 'eip155:1/erc20:0x0')).toBe('Ethereum');
+  });
+
+  it('should fall back to the identifier when the asset has neither', () => {
+    expect(displayAssetText(undefined, undefined, undefined, 'eip155:1/erc20:0x0')).toBe('eip155:1/erc20:0x0');
+  });
+
+  it('should never be undefined', () => {
+    expect(displayAssetText(undefined, undefined, undefined, undefined)).toBe('');
+  });
+});
+
+describe('assetTooltip', () => {
+  it('should show both when they differ', () => {
+    expect(assetTooltip('Ethereum', 'ETH', false)).toEqual({ name: 'Ethereum', symbol: 'ETH' });
+  });
+
+  /** Repeating the symbol as a name would render `[ETH] ETH`. */
+  it('should drop a name that only repeats the symbol', () => {
+    expect(assetTooltip('ETH', 'ETH', false)).toEqual({ name: '', symbol: 'ETH' });
+  });
+
+  it('should treat a case difference as a repeat', () => {
+    expect(assetTooltip('eth', 'ETH', false)).toEqual({ name: '', symbol: 'ETH' });
+  });
+
+  /** A custom asset has no symbol of its own, so its name is what the tooltip shows as one. */
+  it('should show a custom asset name as the symbol', () => {
+    expect(assetTooltip('My holdings', '', true)).toEqual({ name: '', symbol: 'My holdings' });
+  });
+
+  it('should show a custom asset name even when a symbol exists', () => {
+    expect(assetTooltip('My holdings', 'MINE', true)).toEqual({ name: '', symbol: 'My holdings' });
+  });
+
+  it('should render an unresolved asset as two empty strings', () => {
+    expect(assetTooltip(undefined, undefined, false)).toEqual({ name: '', symbol: '' });
+  });
+});
+
+describe('badgeSize', () => {
+  it('should take half the icon for a chain badge', () => {
+    expect(badgeSize(undefined, '24px', 50)).toBe('12px');
+  });
+
+  it('should take two fifths for a protocol badge', () => {
+    expect(badgeSize(undefined, '40px', 40)).toBe('16px');
+  });
+
+  it('should read the size from a css length', () => {
+    expect(badgeSize(undefined, '24', 50)).toBe('12px');
+  });
+
+  /** An explicit size is the caller overriding the scale deliberately. */
+  it('should let the caller override it', () => {
+    expect(badgeSize('9px', '24px', 50)).toBe('9px');
+  });
+});

--- a/frontend/app/src/modules/shell/components/asset-icon-display.ts
+++ b/frontend/app/src/modules/shell/components/asset-icon-display.ts
@@ -1,0 +1,127 @@
+import { type AssetInfoWithId, Blockchain } from '@rotki/common';
+import { HYPERLIQUID_TOKEN, SOLANA_CHAIN, SOLANA_TOKEN } from '@/modules/assets/types';
+
+/** What the tooltip's first line shows; an empty name collapses it to the symbol alone. */
+export interface AssetTooltip {
+  name: string;
+  symbol: string;
+}
+
+/**
+ * The chain badge to overlay on the icon.
+ *
+ * @remarks
+ * An EVM asset carries its chain directly. Solana and Hyperliquid tokens do not, and are
+ * recognised by their asset type instead. Anything else has no chain to show.
+ *
+ * @param forceChain - a chain the caller insists on, which wins over the asset's own
+ * @param asset - the resolved asset, absent while it is still resolving
+ * @returns the chain to badge, or undefined when there is none
+ */
+export function assetChain(
+  forceChain: string | undefined,
+  asset: AssetInfoWithId | null | undefined,
+): string | undefined {
+  if (forceChain)
+    return forceChain;
+
+  if (!asset)
+    return undefined;
+
+  if (asset.evmChain)
+    return asset.evmChain;
+
+  if (asset.assetType === SOLANA_TOKEN)
+    return SOLANA_CHAIN;
+
+  if (asset.assetType === HYPERLIQUID_TOKEN)
+    return Blockchain.HYPERLIQUID;
+
+  return undefined;
+}
+
+/**
+ * The protocol badge, if the asset has one worth showing.
+ *
+ * @remarks
+ * `spam` is a classification rather than a protocol, and badging it would give a spam token the
+ * same treatment as a real one.
+ *
+ * @param protocol - the asset's protocol as resolved
+ * @returns the protocol to badge, or undefined
+ */
+export function visibleProtocol(protocol: string | undefined): string | undefined {
+  if (!protocol || protocol === 'spam')
+    return undefined;
+
+  return protocol;
+}
+
+/**
+ * The text the icon falls back to when there is no image.
+ *
+ * @remarks
+ * A fiat currency shows its unicode symbol, which is why the currency wins over the asset's own
+ * names. The identifier is the last resort and is never empty, so the final `''` is unreachable
+ * in practice and exists to keep the type a plain string.
+ *
+ * @returns whatever the icon can call the asset
+ */
+export function displayAssetText(
+  currency: string | undefined,
+  symbol: string | undefined,
+  name: string | undefined,
+  identifier: string | undefined,
+): string {
+  return currency ?? symbol ?? name ?? identifier ?? '';
+}
+
+/**
+ * The two lines the tooltip shows for an asset.
+ *
+ * @remarks
+ * The name is dropped when it would only repeat the symbol, which is the common case for a custom
+ * asset (it has no symbol of its own, so its name is shown as one) and for assets whose symbol and
+ * name match apart from case.
+ *
+ * @returns the name and symbol to render, either of which may be empty
+ */
+export function assetTooltip(
+  name: string | undefined,
+  symbol: string | undefined,
+  isCustomAsset: boolean,
+): AssetTooltip {
+  const assetName = name ?? '';
+  const assetSymbol = symbol ?? '';
+
+  if (isCustomAsset)
+    return { name: '', symbol: assetName };
+
+  if (assetName.toLowerCase() === assetSymbol.toLowerCase())
+    return { name: '', symbol: assetSymbol };
+
+  return { name: assetName, symbol: assetSymbol };
+}
+
+/**
+ * A badge size derived from the icon's own.
+ *
+ * @remarks
+ * The caller's explicit size wins. Otherwise the badge is a percentage of the icon, so the two
+ * scale together wherever the icon is used.
+ *
+ * @param override - a size the caller set, which wins outright
+ * @param iconSize - the icon's size, as a css length whose leading number is used
+ * @param percentage - how much of the icon the badge takes
+ * @returns the badge size as a css length
+ */
+export function badgeSize(
+  override: string | undefined,
+  iconSize: string,
+  percentage: number,
+): string {
+  if (override)
+    return override;
+
+  return `${(Number.parseInt(iconSize) * percentage) / 100}px`;
+}

--- a/frontend/app/src/modules/shell/components/display/LabeledAddressDisplay.spec.ts
+++ b/frontend/app/src/modules/shell/components/display/LabeledAddressDisplay.spec.ts
@@ -1,0 +1,197 @@
+import type { Ref } from 'vue';
+import type { BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import LabeledAddressDisplay from '@/modules/shell/components/display/LabeledAddressDisplay.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { getAddressName, getEnsName, labelWidth, SCRAMBLED_ADDRESS, scrambleData, shouldShowAmount } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    getAddressName: vi.fn(),
+    getEnsName: vi.fn(),
+    SCRAMBLED_ADDRESS: '0x1111111111111111111111111111111111111111',
+    /** happy-dom measures every element as zero-wide, so the width is supplied here instead. */
+    labelWidth: ref<number>(1000),
+    scrambleData: ref<boolean>(false),
+    shouldShowAmount: ref<boolean>(true),
+  };
+});
+
+vi.mock('@/modules/settings/use-scramble', () => ({
+  useScramble: (): Record<string, unknown> => ({
+    scrambleAddress: (address: string) => (get(scrambleData) ? SCRAMBLED_ADDRESS : address),
+    scrambleData,
+    scrambleIdentifier: (id: string) => `scrambled-${id}`,
+    shouldShowAmount,
+  }),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-address-name-resolution', () => ({
+  useAddressNameResolution: (): { getAddressName: Mock; getEnsName: Mock } => ({
+    getAddressName,
+    getEnsName,
+  }),
+}));
+
+vi.mock('@vueuse/core', async () => {
+  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core');
+  return { ...actual, useElementSize: (): { width: Ref<number> } => ({ width: labelWidth }) };
+});
+
+const ADDRESS = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+
+function account(overrides: Partial<BlockchainAccount> = {}): BlockchainAccount {
+  return {
+    chain: 'eth',
+    data: { address: ADDRESS, type: 'address' },
+    label: 'my wallet',
+    nativeAsset: 'ETH',
+    tags: undefined,
+    ...overrides,
+  };
+}
+
+function xpubAccount(): BlockchainAccount {
+  return account({
+    chain: 'btc',
+    data: { derivationPath: 'm/84/0/0', type: 'xpub', xpub: 'xpub6C...' },
+    label: 'cold storage',
+  });
+}
+
+function createWrapper(acc: BlockchainAccount = account()): VueWrapper<any> {
+  return mount(LabeledAddressDisplay, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        EnsAvatar: { name: 'EnsAvatar', props: ['address', 'avatar'], template: '<div />' },
+        HashLink: { name: 'HashLink', props: ['text', 'displayMode', 'location'], template: '<div />' },
+        RuiDivider: true,
+      },
+    },
+    props: { account: acc },
+  });
+}
+
+function shown(wrapper: VueWrapper<any>): string {
+  return wrapper.find('[data-testid=labeled-address-display]').text();
+}
+
+/**
+ * The full detail lives in a tooltip, which renders only while hovered.
+ *
+ * @param wrapper - the mounted display
+ * @returns everything the tooltip reveals
+ */
+async function tooltip(wrapper: VueWrapper<any>): Promise<string> {
+  await wrapper.find('[data-testid=labeled-address-display]').trigger('mouseover');
+  return wrapper.text();
+}
+
+describe('labeledAddressDisplay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(scrambleData, false);
+    set(shouldShowAmount, true);
+    set(labelWidth, 1000);
+    getAddressName.mockReturnValue(undefined);
+    getEnsName.mockReturnValue(null);
+  });
+
+  /** The account's own label is a fallback; a name resolved for the address is the better one. */
+  describe('which name it shows', () => {
+    it('should show the account label when the address resolves to nothing', () => {
+      expect(shown(createWrapper())).toContain('my wallet');
+    });
+
+    it('should prefer a resolved address book name', () => {
+      getAddressName.mockReturnValue('Exchange deposit');
+
+      expect(shown(createWrapper())).toContain('Exchange deposit');
+    });
+
+    it('should keep the label for an xpub rather than resolving its address', () => {
+      getAddressName.mockReturnValue('Exchange deposit');
+
+      expect(shown(createWrapper(xpubAccount()))).toContain('cold storage');
+    });
+
+    it('should fall back to the address when there is no label at all', () => {
+      expect(shown(createWrapper(account({ label: '' })))).toContain('0x9531');
+    });
+  });
+
+  /**
+   * A numeric label is an account identifier rather than a name the user chose, so it is scrambled
+   * with the same treatment identifiers get elsewhere.
+   */
+  describe('a numeric label', () => {
+    it('should be scrambled as an identifier', () => {
+      expect(shown(createWrapper(account({ label: '12345' })))).toContain('scrambled-12345');
+    });
+
+    it('should leave a label that only starts with digits alone', () => {
+      expect(shown(createWrapper(account({ label: '1st wallet' })))).toContain('1st wallet');
+    });
+  });
+
+  /** Scrambling exists so a screenshot leaks nothing, so no resolved name may survive it. */
+  describe('while scrambling', () => {
+    it('should withhold a resolved address book name', () => {
+      getAddressName.mockReturnValue('Exchange deposit');
+      set(scrambleData, true);
+
+      expect(shown(createWrapper())).not.toContain('Exchange deposit');
+    });
+
+    it('should withhold the ens name', async () => {
+      getEnsName.mockReturnValue('rotki.eth');
+      set(scrambleData, true);
+
+      expect(await tooltip(createWrapper())).not.toContain('rotki.eth');
+    });
+
+    it('should show a scrambled address rather than the real one', () => {
+      set(scrambleData, true);
+
+      const label = shown(createWrapper(account({ label: '' })));
+
+      expect(label).not.toContain('0x9531');
+      expect(label).toContain('0x1111');
+    });
+  });
+
+  describe('an xpub account', () => {
+    it('should be marked as one', () => {
+      expect(shown(createWrapper(xpubAccount()))).toContain('common.xpub');
+    });
+
+    it('should show its derivation path', async () => {
+      expect(await tooltip(createWrapper(xpubAccount()))).toContain('m/84/0/0');
+    });
+
+    /** An xpub has no address to open on a block explorer, so the link only offers a copy. */
+    it('should offer only copying rather than a block explorer link', () => {
+      const link = createWrapper(xpubAccount()).findComponent({ name: 'HashLink' });
+
+      expect(link.props('displayMode')).toBe('copy');
+    });
+
+    it('should link a plain address to its explorer', () => {
+      expect(createWrapper().findComponent({ name: 'HashLink' }).props('displayMode')).toBe('default');
+    });
+  });
+
+  it('should shorten the label to the space it has', () => {
+    set(labelWidth, 120);
+
+    expect(shown(createWrapper(account({ label: '' })))).toContain('...');
+  });
+
+  it('should blur the label when amounts are hidden', () => {
+    set(shouldShowAmount, false);
+
+    expect(createWrapper().find('.blur').exists()).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/shell/components/display/LabeledAddressDisplay.vue
+++ b/frontend/app/src/modules/shell/components/display/LabeledAddressDisplay.vue
@@ -6,9 +6,9 @@ import type {
 import { consistOfNumbers } from '@rotki/common';
 import { getAccountAddress, getAccountLabel, getChain, isXpubAccount } from '@/modules/accounts/account-utils';
 import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
-import { findAddressKnownPrefix, truncateAddress } from '@/modules/core/common/display/truncate';
 import { useScramble } from '@/modules/settings/use-scramble';
 import EnsAvatar from '@/modules/shell/components/display/EnsAvatar.vue';
+import { truncateToWidth } from '@/modules/shell/components/display/truncate-to-width';
 import HashLink from '@/modules/shell/components/HashLink.vue';
 
 const { account } = defineProps<{
@@ -75,21 +75,9 @@ const labelDisplayed = computed(() => {
   return get(address);
 });
 
-const CH = 7.21;
-const truncatedLabelDisplayed = computed(() => {
-  const label = get(labelDisplayed);
-  const characterLength = label.length;
-  const displayedWidth = get(displayedLabelWidth);
-  const charDisplayLimit = Math.floor(displayedWidth / CH);
-
-  if (charDisplayLimit >= characterLength)
-    return label;
-
-  const knownPrefix = findAddressKnownPrefix(label);
-
-  const charactersWithinSpace = Math.floor((charDisplayLimit - knownPrefix.length - 3) / 2);
-  return truncateAddress(label, charactersWithinSpace);
-});
+const truncatedLabelDisplayed = computed<string>(() =>
+  truncateToWidth(get(labelDisplayed), get(displayedLabelWidth)),
+);
 </script>
 
 <template>

--- a/frontend/app/src/modules/shell/components/display/truncate-to-width.spec.ts
+++ b/frontend/app/src/modules/shell/components/display/truncate-to-width.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { truncateToWidth } from '@/modules/shell/components/display/truncate-to-width';
+
+/** Wide enough for `characters` glyphs at the label font's 7.21px per character. */
+function widthFor(characters: number): number {
+  return characters * 7.21;
+}
+
+const address = '0x9531C059098e3d194fF87FebB587aB07B30B1306';
+
+describe('truncateToWidth', () => {
+  it('should leave a label that fits alone', () => {
+    expect(truncateToWidth(address, widthFor(address.length))).toBe(address);
+  });
+
+  it('should leave a label alone when there is room to spare', () => {
+    expect(truncateToWidth('vault', widthFor(40))).toBe('vault');
+  });
+
+  it('should truncate a label that does not fit', () => {
+    const truncated = truncateToWidth(address, widthFor(20));
+
+    expect(truncated).not.toBe(address);
+    expect(truncated).toContain('...');
+  });
+
+  /** The prefix is what makes an address recognisable, so it is kept rather than split through. */
+  it('should keep the address prefix whole', () => {
+    expect(truncateToWidth(address, widthFor(20)).startsWith('0x')).toBe(true);
+  });
+
+  it('should keep an xpub prefix whole', () => {
+    const xpub = 'xpub68V4ZQSmhTHUAAmVPzDwSQpTX8FZLrNMFbfj9uMFyEsvvo1qC1x3W8Xy4mM8j2B';
+
+    expect(truncateToWidth(xpub, widthFor(24)).startsWith('xpub')).toBe(true);
+  });
+
+  it('should keep the end of the label, which is what distinguishes two similar ones', () => {
+    expect(truncateToWidth(address, widthFor(20)).endsWith('1306')).toBe(true);
+  });
+
+  it('should give a wider space more of the label', () => {
+    const narrow = truncateToWidth(address, widthFor(16));
+    const wide = truncateToWidth(address, widthFor(28));
+
+    expect(wide.length).toBeGreaterThan(narrow.length);
+  });
+
+  /**
+   * Zero is what an element reports before it has been measured. There is no budget to truncate
+   * against, and the container hides the overflow, so the label is left for CSS to clip.
+   */
+  it('should leave the label alone while the space is unmeasured', () => {
+    expect(truncateToWidth(address, 0)).toBe(address);
+  });
+
+  it('should leave a short label alone while unmeasured', () => {
+    expect(truncateToWidth('bank', 0)).toBe('bank');
+  });
+
+  /** Truncating on a budget this small asks for a negative length and grows the label instead. */
+  it('should never return more than it was given', () => {
+    for (const width of [0, 1, 10, 20, 30, 40, 50]) {
+      expect(truncateToWidth(address, width).length).toBeLessThanOrEqual(address.length);
+    }
+  });
+});

--- a/frontend/app/src/modules/shell/components/display/truncate-to-width.ts
+++ b/frontend/app/src/modules/shell/components/display/truncate-to-width.ts
@@ -1,0 +1,42 @@
+import { findAddressKnownPrefix, truncateAddress } from '@/modules/core/common/display/truncate';
+
+/**
+ * The width one character takes in the label's font, in pixels.
+ *
+ * @remarks
+ * Measured rather than derived. The label renders in a monospaced face, so one constant stands for
+ * every character; a proportional font would need the text measured instead.
+ */
+const CHARACTER_WIDTH = 7.21;
+
+/**
+ * The label shortened to whatever fits the space it has.
+ *
+ * @remarks
+ * The ellipsis and the address prefix (`0x`, an xpub prefix) are kept whole and charged against the
+ * budget, so what remains is split evenly between the head and the tail. A width that fits the
+ * whole label leaves it alone.
+ *
+ * A width too small to hold even the prefix and the ellipsis leaves the label alone, which covers
+ * the element not having been measured yet: its container hides the overflow, so an unshortened
+ * label is clipped rather than wrong. Truncating on that budget would ask for a negative number of
+ * characters, which returns a string *longer* than the label it was given.
+ *
+ * @param label - the address or name to show
+ * @param availableWidth - the space the label has, in pixels; zero means not yet measured
+ * @returns the label, truncated only when it does not fit and there is room to say so
+ */
+export function truncateToWidth(label: string, availableWidth: number): string {
+  const charDisplayLimit = Math.floor(availableWidth / CHARACTER_WIDTH);
+
+  if (charDisplayLimit >= label.length)
+    return label;
+
+  const knownPrefix = findAddressKnownPrefix(label);
+  const charactersWithinSpace = Math.floor((charDisplayLimit - knownPrefix.length - 3) / 2);
+
+  if (charactersWithinSpace < 1)
+    return label;
+
+  return truncateAddress(label, charactersWithinSpace);
+}

--- a/frontend/app/src/modules/shell/components/navigation/NavigationMenuItem.spec.ts
+++ b/frontend/app/src/modules/shell/components/navigation/NavigationMenuItem.spec.ts
@@ -1,0 +1,122 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import NavigationMenuItem from '@/modules/shell/components/navigation/NavigationMenuItem.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { push } = vi.hoisted(() => ({ push: vi.fn() }));
+
+vi.mock('vue-router', () => ({
+  useRouter: (): { push: Mock } => ({ push }),
+}));
+
+function createWrapper(props: Record<string, unknown> = {}): VueWrapper<any> {
+  return mount(NavigationMenuItem, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: { AppImage: true },
+    },
+    props: { text: 'Balances', ...props },
+    slots: { default: '<div data-testid="child">child</div>' },
+  });
+}
+
+function isExpanded(wrapper: VueWrapper<any>): boolean {
+  return wrapper.find('[data-testid=submenu-wrapper]').attributes('data-expanded') === 'true';
+}
+
+describe('navigationMenuItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /** A leaf is a plain link handled by the router-link around it; only a parent expands. */
+  describe('a leaf item', () => {
+    it('should carry no submenu at all', () => {
+      expect(createWrapper().find('[data-testid=submenu-wrapper]').exists()).toBe(false);
+    });
+
+    it('should not navigate on its own', async () => {
+      const wrapper = createWrapper({ to: '/balances' });
+
+      await wrapper.find('[data-testid=navigation-item-body]').trigger('click');
+
+      expect(push).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('a parent item', () => {
+    it('should start collapsed', () => {
+      expect(isExpanded(createWrapper({ parent: true }))).toBe(false);
+    });
+
+    /** Landing on a page inside the group should show the user where they are. */
+    it('should start expanded when the group holds the active page', async () => {
+      const wrapper = createWrapper({ active: true, parent: true });
+      await nextTick();
+
+      expect(isExpanded(wrapper)).toBe(true);
+    });
+
+    it('should not start expanded when only active and not a parent', () => {
+      expect(createWrapper({ active: true }).find('[data-testid=submenu-wrapper]').exists()).toBe(false);
+    });
+
+    it('should expand when its body is pressed', async () => {
+      const wrapper = createWrapper({ parent: true });
+
+      await wrapper.find('[data-testid=navigation-item-body]').trigger('click');
+
+      expect(isExpanded(wrapper)).toBe(true);
+    });
+
+    it('should collapse again when pressed a second time', async () => {
+      const wrapper = createWrapper({ parent: true });
+
+      await wrapper.find('[data-testid=navigation-item-body]').trigger('click');
+      await wrapper.find('[data-testid=navigation-item-body]').trigger('click');
+
+      expect(isExpanded(wrapper)).toBe(false);
+    });
+
+    /**
+     * A parent that is itself a page opens that page as it expands, so pressing it once both shows
+     * the group and goes where the user asked.
+     */
+    it('should open its own page as it expands', async () => {
+      const wrapper = createWrapper({ parent: true, to: '/balances' });
+
+      await wrapper.find('[data-testid=navigation-item-body]').trigger('click');
+
+      expect(push).toHaveBeenCalledWith('/balances');
+      expect(isExpanded(wrapper)).toBe(true);
+    });
+
+    /** Collapsing is not a navigation, so pressing an open group only closes it. */
+    it('should not navigate again when collapsing', async () => {
+      const wrapper = createWrapper({ parent: true, to: '/balances' });
+      await wrapper.find('[data-testid=navigation-item-body]').trigger('click');
+      push.mockClear();
+
+      await wrapper.find('[data-testid=navigation-item-body]').trigger('click');
+
+      expect(push).not.toHaveBeenCalled();
+      expect(isExpanded(wrapper)).toBe(false);
+    });
+
+    it('should expand from the chevron without navigating', async () => {
+      const wrapper = createWrapper({ parent: true, to: '/balances' });
+
+      await wrapper.find('[data-testid=navigation-item-chevron]').trigger('click');
+
+      expect(isExpanded(wrapper)).toBe(true);
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    /** The collapsed rail has no room for a chevron, and nothing to expand into. */
+    it('should offer no chevron while the menu is collapsed to icons', () => {
+      const wrapper = createWrapper({ mini: true, parent: true });
+
+      expect(wrapper.find('[data-testid=navigation-item-chevron]').exists()).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/shell/components/navigation/NavigationMenuItem.vue
+++ b/frontend/app/src/modules/shell/components/navigation/NavigationMenuItem.vue
@@ -72,6 +72,7 @@ onMounted(() => {
         'px-0 justify-center': mini,
         'pl-3': mini && subMenu,
       }"
+      data-testid="navigation-item-body"
       @click="onBodyClick()"
     >
       <DefineImage>
@@ -120,6 +121,7 @@ onMounted(() => {
         v-if="parent && !mini"
         class="p-1 -mr-1 rounded-full hover:bg-black/10 dark:hover:bg-white/10"
         :class="active ? 'text-rui-primary' : 'text-rui-grey-500'"
+        data-testid="navigation-item-chevron"
         @click.stop="toggleExpand()"
       >
         <RuiIcon


### PR DESCRIPTION
Continues the SFC coverage work after #13086, taking the `shell/components` cluster: the eight
spec-less components in it that hold a decision, plus the two whose logic was already extracted on
09-08 and only needed their wiring covered.

## Coverage

| | lines | pct |
|---|---|---|
| before | 35,593 / 49,249 | 72.27% |
| after | 36,424 / 49,678 | **73.32%** |

Suite 1066 → 1090 files, 11,567 → 11,849 tests. No new network calls. (The line total grew because
develop moved underneath; the branch itself adds 282 tests.)

| file | before | after |
|---|---|---|
| `ReportIssueDialog.vue` | 0/76 | 75/76 |
| `About.vue` | 0/56 | 59/60 |
| `GlobalSearch.vue` | 0/54 | 47/54 |
| `LabeledAddressDisplay.vue` | 3/54 | 45/45 |
| `HelpSidebar.vue` | 0/41 | 40/41 |
| `UserDropdown.vue` | 0/36 | 31/36 |
| `AssetIcon.vue` | 67/100 | 58/71 |
| `NavigationMenuItem.vue` | 0/29 | 27/29 |
| `AppUpdateIndicator.vue` | 0/28 | 27/28 |

The three extracted modules (`asset-icon-display`, `truncate-to-width`) are at 100%.

## One real bug

**The version check frequency setting never took effect.** `AppUpdateIndicator` built its interval
from the setting read once at setup, so the watcher that reacted to a change paused and resumed a
timer whose period never moved: changing the frequency from 24 hours to 1 kept checking every 24
until the app restarted. Reverting the fix fails exactly the two frequency-change tests.

Alongside it, `if (isActive)` tested the ref object rather than its value, so it was always truthy.
Pausing an idle timer is a no-op, so nothing behaved differently, but the check did not say what it
meant.

## A defect the extraction surfaced

`LabeledAddressDisplay`'s width-based truncation returned a string **longer** than the label it was
given. Once the budget falls below one character the arithmetic asks `truncateAddress` for a
negative length, so `slice(0, -1)` keeps all but the last character and still appends the ellipsis:
a 42-character address came back as 44, and `bank` as `ba...`.

Measured in a browser, that window is **0px to 7px** of container width — in practice the paint
before `useElementSize` has measured the element, since zero is what it reports until then. Above
8px the old code degraded sanely. The container hides its overflow, so the label is now left for
CSS to clip instead.

This was untestable in place: `useElementSize` reports zero outside a browser, so every
in-component test would have exercised the one broken width and agreed with it. Making the width a
parameter is what exposed it.

The same browser check confirmed the `7.21px` per character the truncation is built on: Roboto Mono
at `text-xs` measures 7.20125px, nothing overflows between 60px and 340px, and the unused space is
at most two characters — the expected loss from halving the budget with a `floor` on each side.

## Notes for review

Three components had no `data-testid` at all (`ReportIssueDialog`, `About`, `HelpSidebar`), and
`AssetIcon`/`NavigationMenuItem` needed one or two more. Those are added here, since the repo asks
for them in components and queries alike.

`AssetIcon`'s tooltip values are now spread at the call site: `t()`'s named-interpolation overload
needs an implicit index signature, which the inferred object literal had and the extracted
`interface` does not. A `type` alias would also satisfy it but `consistent-type-definitions` rejects
one, so the spread is the way both gates agree.

Every claim is negative-controlled. Two of the specs were caught passing **vacuously** by those
controls before they went in: an auto-stubbed `ExternalLink` renders no default slot, so the premium
tier label was never in the DOM, and the shared `RuiTooltip` stub only renders on hover, so an ens
name assertion was checking text that never rendered.

`JsonInput` is left alone deliberately: the shared setup stubs it globally because it lazy-loads
`vanilla-jsoneditor` on mount, so covering it means fighting the harness for little return.

## Gates

Rebased on current develop. `typecheck`, `knip`, `lint:style`, `check:linked-keys`, `test:proxy`,
`lint:file:check` over every changed file, and the full unit suite all pass, run one at a time.

