### PR TITLE
build(frontend): bump eslint config and write out reminder keys

### DIFF
--- a/frontend/app/src/modules/calendar/CalendarReminder.vue
+++ b/frontend/app/src/modules/calendar/CalendarReminder.vue
@@ -3,8 +3,9 @@ import type { ZodType } from 'zod';
 import type { CalendarReminderEntry as StoredEntry } from '@/modules/calendar/reminder';
 import type { CalendarEvent } from '@/modules/calendar/types';
 import { startPromise } from '@shared/utils';
+import { type MessageKey, msg } from '@/message-key';
 import CalendarReminderEntry from '@/modules/calendar/CalendarReminderEntry.vue';
-import { type ReminderRow, reminderRowsSchema, splitSeconds, toSeconds } from '@/modules/calendar/reminder-forms';
+import { type ReminderRow, reminderRowsSchema, splitSeconds, toSeconds, UNIT_LABELS } from '@/modules/calendar/reminder-forms';
 import { planReminderSync, type ReminderDraft } from '@/modules/calendar/reminder-sync';
 import { useCalendarReminderApi } from '@/modules/calendar/use-calendar-reminder-api';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
@@ -53,7 +54,7 @@ const schema = computed<ZodType>(() => reminderRowsSchema({
   amountMissing: t('calendar.reminder.validation.amount.non_empty'),
   amountTooLarge: (amount, unit) => t('calendar.reminder.validation.amount.max_value', {
     amount,
-    unit: t(`calendar.reminder.units.${unit}`),
+    unit: t(UNIT_LABELS[unit]),
   }),
   amountTooSmall: t('calendar.reminder.validation.amount.min_value'),
 }));
@@ -74,9 +75,27 @@ const form = useForm<{ rows: EditableRow[] }, { rows: EditableRow[] }>({
 
 const length = computed<number>(() => form.state.rows.length);
 
-function notifyFailure(key: 'add' | 'delete' | 'edit' | 'fetch', error: unknown): void {
+type ReminderAction = 'add' | 'delete' | 'edit' | 'fetch';
+
+/**
+ * The failure notification of each operation, written out one entry per action.
+ *
+ * @remarks
+ * Adding an action fails to typecheck until its pair of keys is added here, and branding with
+ * `msg.$t` keeps both keys visible to the i18n lint rules, which cannot read a key looked up by
+ * index.
+ */
+const NOTIFY_KEYS: Record<ReminderAction, { message: MessageKey; title: MessageKey }> = {
+  add: { message: msg.$t('calendar.reminder.add_error.message'), title: msg.$t('calendar.reminder.add_error.title') },
+  delete: { message: msg.$t('calendar.reminder.delete_error.message'), title: msg.$t('calendar.reminder.delete_error.title') },
+  edit: { message: msg.$t('calendar.reminder.edit_error.message'), title: msg.$t('calendar.reminder.edit_error.title') },
+  fetch: { message: msg.$t('calendar.reminder.fetch_error.message'), title: msg.$t('calendar.reminder.fetch_error.title') },
+};
+
+function notifyFailure(key: ReminderAction, error: unknown): void {
   logger.error(error);
-  notify({ message: t(`calendar.reminder.${key}_error.message`, { message: getErrorMessage(error) }), title: t(`calendar.reminder.${key}_error.title`) });
+  const keys = NOTIFY_KEYS[key];
+  notify({ message: t(keys.message, { message: getErrorMessage(error) }), title: t(keys.title) });
 }
 
 async function loadStored(): Promise<void> {

--- a/frontend/app/src/modules/calendar/CalendarReminderEntry.vue
+++ b/frontend/app/src/modules/calendar/CalendarReminderEntry.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { REMINDER_UNITS, ReminderUnit } from '@/modules/calendar/reminder-forms';
+import { REMINDER_UNITS, type ReminderUnit, UNIT_LABELS } from '@/modules/calendar/reminder-forms';
 import AmountInput from '@/modules/shell/components/inputs/AmountInput.vue';
 
 const amount = defineModel<string>('amount', { required: true });
@@ -17,13 +17,6 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
-
-const UNIT_LABELS: Record<ReminderUnit, string> = {
-  [ReminderUnit.DAYS]: 'calendar.reminder.units.days',
-  [ReminderUnit.HOURS]: 'calendar.reminder.units.hours',
-  [ReminderUnit.MINUTES]: 'calendar.reminder.units.minutes',
-  [ReminderUnit.WEEKS]: 'calendar.reminder.units.weeks',
-};
 
 const unitOptions = computed<{ key: ReminderUnit; label: string }[]>(() =>
   REMINDER_UNITS.map(unit => ({ key: unit, label: t(UNIT_LABELS[unit]) })),

--- a/frontend/app/src/modules/calendar/reminder-forms.ts
+++ b/frontend/app/src/modules/calendar/reminder-forms.ts
@@ -1,4 +1,5 @@
 import { z, type ZodType } from 'zod';
+import { type MessageKey, msg } from '@/message-key';
 
 export const ReminderUnit = {
   DAYS: 'days',
@@ -16,6 +17,21 @@ export const REMINDER_UNITS: readonly ReminderUnit[] = [
   ReminderUnit.DAYS,
   ReminderUnit.WEEKS,
 ];
+
+/**
+ * The label of each unit, written out one key per member rather than assembled from the unit name.
+ *
+ * @remarks
+ * Adding a unit fails to typecheck until its key is added here, and branding with `msg.$t` is what
+ * lets the i18n lint rules see these as real usages: they are resolved through `t(UNIT_LABELS[unit])`,
+ * an index expression the unused-key rule cannot read.
+ */
+export const UNIT_LABELS: Record<ReminderUnit, MessageKey> = {
+  [ReminderUnit.DAYS]: msg.$t('calendar.reminder.units.days'),
+  [ReminderUnit.HOURS]: msg.$t('calendar.reminder.units.hours'),
+  [ReminderUnit.MINUTES]: msg.$t('calendar.reminder.units.minutes'),
+  [ReminderUnit.WEEKS]: msg.$t('calendar.reminder.units.weeks'),
+};
 
 const SECONDS: Record<ReminderUnit, number> = {
   [ReminderUnit.MINUTES]: 60,

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -132,11 +132,11 @@ catalogs:
       specifier: 1.62.1
       version: 1.62.1
     '@rotki/eslint-config':
-      specifier: 8.2.0
-      version: 8.2.0
+      specifier: 8.3.0
+      version: 8.3.0
     '@rotki/eslint-plugin':
-      specifier: 1.7.0
-      version: 1.7.0
+      specifier: 1.8.0
+      version: 1.8.0
     '@rotki/ui-library':
       specifier: 2.24.0
       version: 2.24.0
@@ -392,10 +392,10 @@ importers:
         version: 4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0)
       '@rotki/eslint-config':
         specifier: 'catalog:'
-        version: 8.2.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.42)(eslint-plugin-tsdoc@0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)
+        version: 8.3.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.8.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.42)(eslint-plugin-tsdoc@0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)
       '@rotki/eslint-plugin':
         specifier: 'catalog:'
-        version: 1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+        version: 1.8.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       cac:
         specifier: 'catalog:'
         version: 7.0.0
@@ -2272,13 +2272,13 @@ packages:
       rollup:
         optional: true
 
-  '@rotki/eslint-config@8.2.0':
-    resolution: {integrity: sha512-4fcQZx1w5b3NsXGOCnnFV6vfcPp5oIUH1G5OG5vc1bmpAoISnHZDzyB7J+Ld1WixfJxIYkaNiF8+4nMxMqaO0w==}
+  '@rotki/eslint-config@8.3.0':
+    resolution: {integrity: sha512-JiXrzLAoXI8urTzWGFvUJ2E3d2nHr86/9c7b+zzvkEQDAOnkbnu4KWSjLUOdj7o3hq+7J6WCmpc92pKcxdaLCA==}
     engines: {node: '>=24 <25', pnpm: '>=11 <12'}
     peerDependencies:
       '@intlify/eslint-plugin-vue-i18n': ^4.2.0
       '@prettier/plugin-xml': ^3.4.1
-      '@rotki/eslint-plugin': '>=1.7.0'
+      '@rotki/eslint-plugin': '>=1.8.0'
       eslint: ^9.20.0 || ^10.0.0
       eslint-plugin-slop: '>=0.1.3'
       eslint-plugin-sonarjs: '>=4.0.0'
@@ -2300,8 +2300,8 @@ packages:
       eslint-plugin-tsdoc:
         optional: true
 
-  '@rotki/eslint-plugin@1.7.0':
-    resolution: {integrity: sha512-h+ts+/fBpZx8iPUUVHozQgqI1UA+KyhgAmHvwZu7NSLHfMsFytTIAJyJVd4bIfo920Yj4ewZTZ5ENQOrjgAPHQ==}
+  '@rotki/eslint-plugin@1.8.0':
+    resolution: {integrity: sha512-6o7A8VOKyadmOg+vGTK1IrZy27e3dN/QQbPeQDD8OOXFefO0tYT3HPQ1+lSB1nXxazLb676NjQQs1lelRKdwRQ==}
     engines: {node: '>=24 <25', pnpm: '>=10 <12'}
     peerDependencies:
       eslint: ^9.20.0 || ^10.0.0
@@ -8055,7 +8055,7 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.7
 
-  '@rotki/eslint-config@8.2.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.42)(eslint-plugin-tsdoc@0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)':
+  '@rotki/eslint-config@8.3.0(@intlify/eslint-plugin-vue-i18n@4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0))(@rotki/eslint-plugin@1.8.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(@vue/compiler-sfc@3.5.42)(eslint-plugin-tsdoc@0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)':
     dependencies:
       '@antfu/install-pkg': 2.0.1
       '@clack/prompts': 1.7.0
@@ -8096,7 +8096,7 @@ snapshots:
       yaml-eslint-parser: 2.1.0
     optionalDependencies:
       '@intlify/eslint-plugin-vue-i18n': 4.5.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(jsonc-eslint-parser@3.3.0)(supports-color@10.2.2)(vue-eslint-parser@10.4.1(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))(yaml-eslint-parser@2.1.0)
-      '@rotki/eslint-plugin': 1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@rotki/eslint-plugin': 1.8.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       eslint-plugin-tsdoc: 0.5.2(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@eslint/json'
@@ -8108,7 +8108,7 @@ snapshots:
       - typescript
       - vitest
 
-  '@rotki/eslint-plugin@1.7.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
+  '@rotki/eslint-plugin@1.8.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/parser': 8.68.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       '@typescript-eslint/utils': 8.68.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -59,8 +59,8 @@ catalog:
   '@intlify/unplugin-vue-i18n': 11.2.5
   '@pinia/testing': 2.0.1
   '@playwright/test': 1.62.1
-  '@rotki/eslint-config': 8.2.0
-  '@rotki/eslint-plugin': 1.7.0
+  '@rotki/eslint-config': 8.3.0
+  '@rotki/eslint-plugin': 1.8.0
   '@rotki/ui-library': 2.24.0
   '@tsconfig/node24': 24.0.5
   '@types/node': 24.13.3


### PR DESCRIPTION
Brings in `@rotki/eslint-config` 8.3.0, which turns on the new `@rotki/no-interpolated-i18n-key` rule, and writes out the one set of keys in `app/src` that the rule reports.

## Why the rule exists

`@rotki/no-unused-i18n-keys` reads the static prefix of an interpolated key as a usage of everything beneath it. So this line:

```ts
t(`calendar.reminder.units.${unit}`);
```

marked the whole `calendar.reminder` subtree as used. Nothing about that exemption appears in `eslint.config.ts`, so auditing the ignore list could not find it: a wildcard with no declaration site. The rule ([eslint-plugin #52](https://github.com/rotki/eslint-plugin/pull/52), released in 1.8.0) reports exactly the call shapes that create the wildcard. Identifiers, member and index expressions stay allowed, since those are the branded-key escape hatch.

## The fix in `modules/calendar`

Two key sets were addressed by interpolation, and both become exhaustive records of `msg.$t` keys, so adding a unit or an action fails `vue-tsc` until its key is written, and both the unused-key and missing-key rules can see every key:

- **Unit labels.** `CalendarReminderEntry.vue` already held a `Record<ReminderUnit, string>` of these keys, unbranded, while `CalendarReminder.vue` interpolated the same four. The record moves to `reminder-forms.ts` next to the `ReminderUnit` it is keyed by, branded with `msg.$t`, and both call sites share it.
- **Failure notifications.** `notifyFailure` built `calendar.reminder.${key}_error.message` / `.title` from its action argument. It now looks the pair up in a `Record<ReminderAction, { message, title }>`.

Worth stating, because it is the part that would bite anyone doing this piecemeal: the four unit keys were reachable *only* through that wildcard. `t(UNIT_LABELS[unit])` is an index expression the unused-key rule cannot read, so removing the interpolation without branding the record would have made those keys look unused and the autofix would delete them, translations included.

## Bumps

- `@rotki/eslint-config` 8.2.0 → **8.3.0**
- `@rotki/eslint-plugin` 1.7.0 → **1.8.0** — required by the config's peer range, and the catalog had been a minor behind since 1.7.1.

`pnpm-workspace.yaml` changed on those two lines only: both packages are already in `minimumReleaseAgeExclude`, so the install appended nothing.

## Verification

- `pnpm run lint`, `pnpm run typecheck`, `pnpm run lint:style`, `pnpm run knip` and `pnpm run check:linked-keys` (37 linked messages across 7 locales) all clean.
- `pnpm run test:unit src/modules/calendar/` — 12 files, 123 tests, green. That includes `CalendarReminderEntry`'s "should offer the units from smallest to largest", which is what covers the moved label record.
- Negative control, so the green lint means something: a throwaway file containing `t(\`calendar.reminder.units.${unit}\`)` was linted in this checkout and reported by `@rotki/no-interpolated-i18n-key` at the right column. The rule is live here, not merely installed.
