### PR TITLE
test(frontend): cover the general settings components

### DIFF
--- a/frontend/app/src/modules/settings/general/InternalTxConflictRepullSettings.spec.ts
+++ b/frontend/app/src/modules/settings/general/InternalTxConflictRepullSettings.spec.ts
@@ -1,0 +1,213 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Defaults } from '@/modules/core/common/defaults';
+import InternalTxConflictRepullSettings from '@/modules/settings/general/InternalTxConflictRepullSettings.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const {
+  batchModel,
+  batchWriteError,
+  batchWriteSuccess,
+  flushBatch,
+  flushFrequency,
+  frequencyModel,
+  frequencyWriteError,
+  frequencyWriteSuccess,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    batchModel: ref<number>(20),
+    batchWriteError: ref<string>(''),
+    batchWriteSuccess: ref<boolean>(false),
+    flushBatch: vi.fn(async () => {}),
+    flushFrequency: vi.fn(async () => {}),
+    frequencyModel: ref<number>(3600),
+    frequencyWriteError: ref<string>(''),
+    frequencyWriteSuccess: ref<boolean>(false),
+  };
+});
+
+vi.mock('@/modules/settings/use-setting-model', () => ({
+  useSettingModel: (key: string): Record<string, unknown> =>
+    key === 'internalTxsToRepull'
+      ? { error: batchWriteError, flush: flushBatch, model: batchModel, success: batchWriteSuccess }
+      : { error: frequencyWriteError, flush: flushFrequency, model: frequencyModel, success: frequencyWriteSuccess },
+}));
+
+function createWrapper(): VueWrapper<any> {
+  return mount(InternalTxConflictRepullSettings, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        SettingResetConfirmButton: {
+          emits: ['confirm'],
+          name: 'SettingResetConfirmButton',
+          props: ['compact'],
+          template: '<button @click="$emit(\'confirm\')" />',
+        },
+        SettingsItem: { name: 'SettingsItem', template: '<div><slot /></div>' },
+      },
+    },
+  });
+}
+
+/**
+ * The two fields are the same component, so they are told apart by their test id.
+ *
+ * @remarks
+ * A string selector would resolve `findComponent` to its `WrapperLike` overload, which carries
+ * neither `props` nor `vm`.
+ */
+function field(wrapper: VueWrapper<any>, which: 'batch-size' | 'frequency'): VueWrapper<any> {
+  const found = wrapper
+    .findAllComponents({ name: 'RuiTextField' })
+    .find(component => component.attributes('data-testid') === `internal-tx-${which}`);
+  assert(found);
+  return found;
+}
+
+function resetButton(wrapper: VueWrapper<any>, which: 'batch-size' | 'frequency'): ReturnType<VueWrapper<any>['find']> {
+  return wrapper.find(`[data-testid=internal-tx-${which}-reset]`);
+}
+
+async function type(wrapper: VueWrapper<any>, which: 'batch-size' | 'frequency', value: string): Promise<void> {
+  await field(wrapper, which).vm.$emit('update:modelValue', value);
+  await nextTick();
+}
+
+describe('internalTxConflictRepullSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(batchModel, 20);
+    set(batchWriteError, '');
+    set(batchWriteSuccess, false);
+    set(frequencyModel, 3600);
+    set(frequencyWriteError, '');
+  });
+
+  /**
+   * The setting is stored in seconds and shown in minutes, so the conversion has to hold in both
+   * directions or the value drifts by a factor of sixty every round trip.
+   */
+  describe('the frequency, stored in seconds and shown in minutes', () => {
+    it('should show the stored seconds as minutes', () => {
+      set(frequencyModel, 3600);
+
+      expect(field(createWrapper(), 'frequency').props('modelValue')).toBe('60');
+    });
+
+    it('should store the entered minutes as seconds', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'frequency', '30');
+
+      expect(get(frequencyModel)).toBe(1800);
+    });
+
+    it('should keep a half minute rather than rounding it away', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'frequency', '0.5');
+
+      expect(get(frequencyModel)).toBe(30);
+    });
+
+    it('should follow the setting changing elsewhere', async () => {
+      const wrapper = createWrapper();
+
+      set(frequencyModel, 900);
+      await nextTick();
+
+      expect(field(wrapper, 'frequency').props('modelValue')).toBe('15');
+    });
+  });
+
+  describe('the batch size, which needs no conversion', () => {
+    it('should show the stored value', () => {
+      set(batchModel, 42);
+
+      expect(field(createWrapper(), 'batch-size').props('modelValue')).toBe('42');
+    });
+
+    it('should store what was entered', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'batch-size', '75');
+
+      expect(get(batchModel)).toBe(75);
+    });
+
+    it('should follow the setting changing elsewhere', async () => {
+      const wrapper = createWrapper();
+
+      set(batchModel, 5);
+      await nextTick();
+
+      expect(field(wrapper, 'batch-size').props('modelValue')).toBe('5');
+    });
+  });
+
+  /** An emptied field is the user mid-edit, not a request to store nothing. */
+  describe('while a field is empty', () => {
+    it('should leave the batch size alone', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'batch-size', '');
+
+      expect(get(batchModel)).toBe(20);
+    });
+
+    it('should leave the frequency alone', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'frequency', '');
+
+      expect(get(frequencyModel)).toBe(3600);
+    });
+  });
+
+  /** A reset is a deliberate act, so it is written immediately rather than on the debounce. */
+  describe('resetting to the default', () => {
+    it('should restore the default batch size and write it at once', async () => {
+      set(batchModel, 99);
+      const wrapper = createWrapper();
+
+      await resetButton(wrapper, 'batch-size').trigger('click');
+
+      expect(get(batchModel)).toBe(Defaults.DEFAULT_INTERNAL_TXS_TO_REPULL);
+      expect(flushBatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should restore the default frequency and write it at once', async () => {
+      set(frequencyModel, 60);
+      const wrapper = createWrapper();
+
+      await resetButton(wrapper, 'frequency').trigger('click');
+
+      expect(get(frequencyModel)).toBe(Defaults.DEFAULT_INTERNAL_TX_CONFLICT_REPULL_FREQUENCY);
+      expect(flushFrequency).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reporting a failed write', () => {
+    it('should name the field the batch size write failed on', async () => {
+      const wrapper = createWrapper();
+
+      set(batchWriteError, 'the backend said no');
+      await nextTick();
+
+      expect(field(wrapper, 'batch-size').props('errorMessages'))
+        .toContain('general_settings.history_event.internal_tx_conflicts.batch_size.error: the backend said no');
+    });
+
+    it('should name the field the frequency write failed on', async () => {
+      const wrapper = createWrapper();
+
+      set(frequencyWriteError, 'the backend said no');
+      await nextTick();
+
+      expect(field(wrapper, 'frequency').props('errorMessages'))
+        .toContain('general_settings.history_event.internal_tx_conflicts.frequency.error: the backend said no');
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/InternalTxConflictRepullSettings.vue
+++ b/frontend/app/src/modules/settings/general/InternalTxConflictRepullSettings.vue
@@ -101,10 +101,12 @@ watch(frequencyWriteError, (message) => {
           :min="1"
           :success-messages="batchSuccess"
           :error-messages="batchError"
+          data-testid="internal-tx-batch-size"
           @update:model-value="updateBatchSize($event)"
         />
         <SettingResetConfirmButton
           :compact="compact"
+          data-testid="internal-tx-batch-size-reset"
           @confirm="resetBatchSize()"
         />
       </div>
@@ -135,10 +137,12 @@ watch(frequencyWriteError, (message) => {
           :step="0.5"
           :success-messages="frequencySuccess"
           :error-messages="frequencyError"
+          data-testid="internal-tx-frequency"
           @update:model-value="updateFrequency($event)"
         />
         <SettingResetConfirmButton
           :compact="compact"
+          data-testid="internal-tx-frequency-reset"
           @confirm="resetFrequency()"
         />
       </div>

--- a/frontend/app/src/modules/settings/general/TimeFrameSettings.spec.ts
+++ b/frontend/app/src/modules/settings/general/TimeFrameSettings.spec.ts
@@ -1,0 +1,232 @@
+import { TimeFramePeriod, TimeFramePersist, type TimeFrameSetting } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import TimeFrameSettings from '@/modules/settings/general/TimeFrameSettings.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const { premium, updateFrontendSetting, updateSession } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    premium: ref<boolean>(true),
+    updateFrontendSetting: vi.fn(async () => ({ success: true })),
+    updateSession: vi.fn(),
+  };
+});
+
+vi.mock('@/modules/premium/use-premium', () => ({
+  usePremium: (): typeof premium => premium,
+}));
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): { updateFrontendSetting: Mock } => ({ updateFrontendSetting }),
+}));
+
+vi.mock('@/modules/settings/settings-repo', () => ({
+  useSettingsRepo: (): { updateSession: Mock } => ({ updateSession }),
+}));
+
+const ALL = Object.values(TimeFramePeriod);
+
+function createWrapper(props: Record<string, unknown> = {}): VueWrapper<any> {
+  return mount(TimeFrameSettings, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: { PremiumLock: true },
+    },
+    props: {
+      currentSessionTimeframe: TimeFramePeriod.WEEK,
+      message: { error: '', success: '' },
+      value: TimeFramePeriod.WEEK,
+      visibleTimeframes: [TimeFramePeriod.WEEK, TimeFramePeriod.MONTH, TimeFramePeriod.YEAR],
+      ...props,
+    },
+  });
+}
+
+/** The chips the user can pick from, in the order they render. */
+function chips(wrapper: VueWrapper<any>): VueWrapper<any>[] {
+  return wrapper.findAllComponents({ name: 'RuiChip' });
+}
+
+/**
+ * The chip's own label.
+ *
+ * @remarks
+ * `RuiIcon` is globally stubbed to render its name, so a closeable chip's text carries a trailing
+ * `lu-…` that is not part of the label.
+ */
+function label(chip: VueWrapper<any>): string {
+  return chip.text().replace(/lu-[\w-]+$/, '');
+}
+
+function chipFor(wrapper: VueWrapper<any>, timeframe: TimeFrameSetting): VueWrapper<any> | undefined {
+  return chips(wrapper).find(chip => label(chip) === timeframe);
+}
+
+function lastVisibleChange(wrapper: VueWrapper<any>): TimeFrameSetting[] | undefined {
+  return wrapper.emitted<[TimeFrameSetting[]]>('visible-timeframes-change')?.at(-1)?.[0];
+}
+
+describe('timeFrameSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(premium, true);
+  });
+
+  it('should offer remember alongside the visible timeframes', () => {
+    const wrapper = createWrapper();
+
+    expect(chips(wrapper)[0].text()).toBe(TimeFramePersist.REMEMBER);
+  });
+
+  it('should offer the rest as inactive', () => {
+    const wrapper = createWrapper({ visibleTimeframes: [TimeFramePeriod.WEEK] });
+
+    const shown = chips(wrapper).map(chip => label(chip));
+
+    for (const timeframe of ALL.filter(period => period !== TimeFramePeriod.WEEK))
+      expect(shown).toContain(timeframe);
+  });
+
+  /** The list is re-sorted into the period order, longest first, rather than order of adding. */
+  describe('adding a timeframe back', () => {
+    it('should put a longer period in front rather than appending it', async () => {
+      const wrapper = createWrapper({ visibleTimeframes: [TimeFramePeriod.WEEK] });
+
+      await chipFor(wrapper, TimeFramePeriod.YEAR)?.vm.$emit('click');
+
+      expect(lastVisibleChange(wrapper)).toEqual([TimeFramePeriod.YEAR, TimeFramePeriod.WEEK]);
+    });
+
+    it('should place a middle period between the two it belongs between', async () => {
+      const wrapper = createWrapper({ visibleTimeframes: [TimeFramePeriod.YEAR, TimeFramePeriod.WEEK] });
+
+      await chipFor(wrapper, TimeFramePeriod.MONTH)?.vm.$emit('click');
+
+      expect(lastVisibleChange(wrapper))
+        .toEqual([TimeFramePeriod.YEAR, TimeFramePeriod.MONTH, TimeFramePeriod.WEEK]);
+    });
+  });
+
+  describe('removing a timeframe', () => {
+    it('should drop it from the visible list', async () => {
+      const wrapper = createWrapper();
+
+      await chipFor(wrapper, TimeFramePeriod.MONTH)?.vm.$emit('click:close');
+
+      expect(lastVisibleChange(wrapper)).toEqual([TimeFramePeriod.YEAR, TimeFramePeriod.WEEK]);
+    });
+
+    /** The selected timeframe cannot stay selected once it is no longer on offer. */
+    it('should fall back to remember when the selected one is removed', async () => {
+      const wrapper = createWrapper({ value: TimeFramePeriod.MONTH });
+
+      await chipFor(wrapper, TimeFramePeriod.MONTH)?.vm.$emit('click:close');
+
+      expect(wrapper.emitted<[TimeFrameSetting]>('timeframe-change')?.at(-1)?.[0])
+        .toBe(TimeFramePersist.REMEMBER);
+    });
+
+    it('should leave the selection alone when another one is removed', async () => {
+      const wrapper = createWrapper({ value: TimeFramePeriod.WEEK });
+
+      await chipFor(wrapper, TimeFramePeriod.MONTH)?.vm.$emit('click:close');
+
+      expect(wrapper.emitted('timeframe-change')).toBeUndefined();
+    });
+
+    /**
+     * The session is showing that timeframe right now, so it is moved to the longest one still on
+     * offer and remembered, rather than left pointing at something that is gone.
+     */
+    it('should move the session on when its own timeframe is removed', async () => {
+      const wrapper = createWrapper({ currentSessionTimeframe: TimeFramePeriod.WEEK });
+
+      await chipFor(wrapper, TimeFramePeriod.WEEK)?.vm.$emit('click:close');
+      await flushPromises();
+
+      expect(updateSession).toHaveBeenCalledWith({ timeframe: TimeFramePeriod.YEAR });
+      expect(updateFrontendSetting).toHaveBeenCalledWith({ lastKnownTimeframe: TimeFramePeriod.YEAR });
+    });
+
+    it('should leave the session alone when another timeframe is removed', async () => {
+      const wrapper = createWrapper({ currentSessionTimeframe: TimeFramePeriod.WEEK });
+
+      await chipFor(wrapper, TimeFramePeriod.MONTH)?.vm.$emit('click:close');
+      await flushPromises();
+
+      expect(updateSession).not.toHaveBeenCalled();
+      expect(updateFrontendSetting).not.toHaveBeenCalled();
+    });
+
+    it('should refuse to remove the last one left', () => {
+      const wrapper = createWrapper({ visibleTimeframes: [TimeFramePeriod.WEEK] });
+
+      expect(chipFor(wrapper, TimeFramePeriod.WEEK)?.props('closeable')).toBe(false);
+    });
+
+    /** Remember is not a timeframe of its own, so it is never removable. */
+    it('should refuse to remove remember', () => {
+      const wrapper = createWrapper();
+
+      expect(chipFor(wrapper, TimeFramePersist.REMEMBER)?.props('closeable')).toBe(false);
+    });
+  });
+
+  /** The longer ranges are a premium feature, so a free account sees them but cannot pick them. */
+  describe('with premium', () => {
+    it('should leave the timeframes premium pays for usable', () => {
+      const wrapper = createWrapper({ visibleTimeframes: ALL });
+
+      expect(chipFor(wrapper, TimeFramePeriod.ALL)?.props('disabled')).toBe(false);
+    });
+  });
+
+  describe('without premium', () => {
+    beforeEach(() => {
+      set(premium, false);
+    });
+
+    it('should disable the timeframes premium pays for', () => {
+      const wrapper = createWrapper({ visibleTimeframes: ALL });
+
+      expect(chipFor(wrapper, TimeFramePeriod.ALL)?.props('disabled')).toBe(true);
+    });
+
+    it('should leave the short ranges usable', () => {
+      const wrapper = createWrapper({ visibleTimeframes: ALL });
+
+      expect(chipFor(wrapper, TimeFramePeriod.WEEK)?.props('disabled')).toBe(false);
+    });
+
+    it('should keep remember usable', () => {
+      const wrapper = createWrapper();
+
+      expect(chipFor(wrapper, TimeFramePersist.REMEMBER)?.props('disabled')).toBe(false);
+    });
+
+    it('should offer the upgrade prompt', () => {
+      expect(createWrapper().findComponent({ name: 'PremiumLock' }).exists()).toBe(true);
+    });
+
+    it('should not prompt a premium account', () => {
+      set(premium, true);
+
+      expect(createWrapper().findComponent({ name: 'PremiumLock' }).exists()).toBe(false);
+    });
+  });
+
+  describe('the status line', () => {
+    it('should show a success message', () => {
+      const wrapper = createWrapper({ message: { error: '', success: 'saved' } });
+
+      expect(wrapper.text()).toContain('saved');
+    });
+
+    it('should show an error message', () => {
+      const wrapper = createWrapper({ message: { error: 'nope', success: '' } });
+
+      expect(wrapper.text()).toContain('nope');
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/TimeFrameSettings.vue
+++ b/frontend/app/src/modules/settings/general/TimeFrameSettings.vue
@@ -21,6 +21,8 @@ const emit = defineEmits<{
 const timeframes = Object.values(TimeFramePeriod);
 const { t } = useI18n({ useScope: 'global' });
 const premium = usePremium();
+const { updateFrontendSetting } = useSettingsOperations();
+const { updateSession } = useSettingsRepo();
 
 const appendedVisibleTimeframes = computed(() => [TimeFramePersist.REMEMBER, ...visibleTimeframes]);
 
@@ -63,8 +65,6 @@ async function updateVisibleTimeframes(newTimeFrames: TimeFramePeriod[], replace
   newTimeFrames.sort((a: TimeFramePeriod, b: TimeFramePeriod) => timeframes.indexOf(a) - timeframes.indexOf(b));
 
   if (replaceCurrentSessionTimeframe) {
-    const { updateFrontendSetting } = useSettingsOperations();
-    const { updateSession } = useSettingsRepo();
     const value = newTimeFrames[0];
     updateSession({ timeframe: value });
     await updateFrontendSetting({ lastKnownTimeframe: value });

--- a/frontend/app/src/modules/settings/general/amount/AbbreviateNumberSetting.spec.ts
+++ b/frontend/app/src/modules/settings/general/amount/AbbreviateNumberSetting.spec.ts
@@ -1,0 +1,130 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import AbbreviateNumberSetting from '@/modules/settings/general/amount/AbbreviateNumberSetting.vue';
+
+const { abbreviate, model, writeError, writeSuccess } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    abbreviate: ref<boolean>(true),
+    model: ref<number>(4),
+    writeError: ref<string>(''),
+    writeSuccess: ref<boolean>(false),
+  };
+});
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (): typeof abbreviate => abbreviate,
+}));
+
+vi.mock('@/modules/settings/use-setting-model', () => ({
+  useSettingModel: (): Record<string, unknown> => ({ error: writeError, model, success: writeSuccess }),
+}));
+
+const RuiMenuSelectStub = defineComponent({
+  emits: ['update:modelValue'],
+  props: ['modelValue', 'options', 'successMessages', 'errorMessages', 'disabled'],
+  template: '<div />',
+});
+
+function createWrapper(): VueWrapper<any> {
+  return mount(AbbreviateNumberSetting, {
+    global: { stubs: { RuiMenuSelect: RuiMenuSelectStub, SettingSwitch: true } },
+  });
+}
+
+function select(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(RuiMenuSelectStub);
+}
+
+async function choose(wrapper: VueWrapper<any>, value: string): Promise<void> {
+  select(wrapper).vm.$emit('update:modelValue', value);
+  await nextTick();
+}
+
+describe('abbreviateNumberSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(abbreviate, true);
+    set(model, 4);
+    set(writeError, '');
+    set(writeSuccess, false);
+  });
+
+  /**
+   * The setting is stored as a number and the select binds strings, so the mapping has to hold in
+   * both directions or the stored value stops matching any offered option.
+   */
+  describe('the threshold, stored as a number and selected as a string', () => {
+    it('should show the stored number as a string', () => {
+      set(model, 7);
+
+      expect(select(createWrapper()).props('modelValue')).toBe('7');
+    });
+
+    it('should store the chosen string as a number', async () => {
+      const wrapper = createWrapper();
+
+      await choose(wrapper, '10');
+
+      expect(get(model)).toBe(10);
+    });
+
+    it('should follow the setting changing elsewhere', async () => {
+      const wrapper = createWrapper();
+
+      set(model, 13);
+      await nextTick();
+
+      expect(select(wrapper).props('modelValue')).toBe('13');
+    });
+  });
+
+  /**
+   * The threshold counts digits while an abbreviation is defined by its power of ten, so each
+   * option is the abbreviation's exponent plus one: a thousand abbreviates from four digits on.
+   */
+  it('should offer one option per abbreviation, at the digit count it starts', () => {
+    expect(select(createWrapper()).props('options')).toEqual([
+      { label: 'amount_display.abbreviation.k (k)', value: '4' },
+      { label: 'amount_display.abbreviation.m (M)', value: '7' },
+      { label: 'amount_display.abbreviation.b (B)', value: '10' },
+      { label: 'amount_display.abbreviation.t (T)', value: '13' },
+    ]);
+  });
+
+  /** The threshold means nothing while abbreviation is off. */
+  describe('the toggle', () => {
+    it('should disable the threshold while abbreviation is off', () => {
+      set(abbreviate, false);
+
+      expect(select(createWrapper()).props('disabled')).toBe(true);
+    });
+
+    it('should leave the threshold usable while abbreviation is on', () => {
+      expect(select(createWrapper()).props('disabled')).toBe(false);
+    });
+  });
+
+  describe('reporting the write', () => {
+    it('should report a failed write', async () => {
+      const wrapper = createWrapper();
+
+      set(writeError, 'the backend said no');
+      await nextTick();
+
+      expect(select(wrapper).props('errorMessages')).toContain('the backend said no');
+    });
+
+    it('should drop the message once the setting changes again', async () => {
+      const wrapper = createWrapper();
+      set(writeError, 'the backend said no');
+      await nextTick();
+
+      set(model, 7);
+      await nextTick();
+
+      expect(select(wrapper).props('errorMessages')).toBe('');
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/amount/MainCurrencySetting.spec.ts
+++ b/frontend/app/src/modules/settings/general/amount/MainCurrencySetting.spec.ts
@@ -1,0 +1,143 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { Currency } from '@/modules/assets/amount-display/currencies';
+import MainCurrencySetting from '@/modules/settings/general/amount/MainCurrencySetting.vue';
+
+const { model, writeError, writeSuccess } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  const { Currency: CurrencyClass } = await import('@/modules/assets/amount-display/currencies');
+  return {
+    model: ref(new CurrencyClass('US Dollar', 'USD', '$')),
+    writeError: ref<string>(''),
+    writeSuccess: ref<boolean>(false),
+  };
+});
+
+vi.mock('@/modules/settings/use-setting-model', () => ({
+  useSettingModel: (): Record<string, unknown> => ({ error: writeError, model, success: writeSuccess }),
+}));
+
+/** Renders the item slot for every option, so the per-item template is exercised. */
+const RuiMenuSelectStub = defineComponent({
+  emits: ['update:modelValue'],
+  props: ['modelValue', 'options', 'successMessages', 'errorMessages'],
+  template: `<div>
+    <span class="model">{{ modelValue }}</span>
+    <span class="success">{{ successMessages }}</span>
+    <span class="error">{{ errorMessages }}</span>
+    <template v-for="item in options" :key="item.tickerSymbol">
+      <slot name="item" :item="item" />
+    </template>
+  </div>`,
+});
+
+function createWrapper(): VueWrapper<any> {
+  return mount(MainCurrencySetting, {
+    global: { stubs: { RuiMenuSelect: RuiMenuSelectStub } },
+  });
+}
+
+function select(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(RuiMenuSelectStub);
+}
+
+async function choose(wrapper: VueWrapper<any>, ticker: string): Promise<void> {
+  select(wrapper).vm.$emit('update:modelValue', ticker);
+  await nextTick();
+}
+
+/** The font size the avatar of one currency renders at. */
+function avatarFontSize(wrapper: VueWrapper<any>, ticker: string): string | undefined {
+  return wrapper.find(`#currency__${ticker.toLocaleLowerCase()} .font-bold`).attributes('style');
+}
+
+describe('mainCurrencySetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(model, new Currency('US Dollar', 'USD', '$'));
+    set(writeError, '');
+    set(writeSuccess, false);
+  });
+
+  /**
+   * The setting holds a whole currency object while the select speaks ticker symbols, so the
+   * mapping has to hold in both directions or a change writes the wrong shape.
+   */
+  describe('the currency, stored as an object and selected by ticker', () => {
+    it('should show the stored currency by its ticker', () => {
+      set(model, new Currency('Euro', 'EUR', '€'));
+
+      expect(select(createWrapper()).props('modelValue')).toBe('EUR');
+    });
+
+    it('should store the whole currency the chosen ticker names', async () => {
+      const wrapper = createWrapper();
+
+      await choose(wrapper, 'JPY');
+
+      expect(get(model)).toMatchObject({ name: 'currencies.jpy', tickerSymbol: 'JPY', unicodeSymbol: '¥' });
+    });
+
+    it('should leave the setting alone when the ticker names no currency', async () => {
+      const wrapper = createWrapper();
+
+      await choose(wrapper, 'XXX');
+
+      expect(get(model).tickerSymbol).toBe('USD');
+    });
+
+    it('should follow the setting changing elsewhere', async () => {
+      const wrapper = createWrapper();
+
+      set(model, new Currency('Swiss Franc', 'CHF', 'CHF'));
+      await nextTick();
+
+      expect(select(wrapper).props('modelValue')).toBe('CHF');
+    });
+  });
+
+  describe('reporting the write', () => {
+    it('should name the currency it saved', async () => {
+      const wrapper = createWrapper();
+
+      set(writeSuccess, true);
+      await nextTick();
+
+      expect(select(wrapper).props('successMessages'))
+        .toContain('general_settings.validation.currency.success');
+    });
+
+    it('should report a failed write', async () => {
+      const wrapper = createWrapper();
+
+      set(writeError, 'the backend said no');
+      await nextTick();
+
+      expect(select(wrapper).props('errorMessages'))
+        .toContain('general_settings.validation.currency.error: the backend said no');
+    });
+
+    it('should drop the message once the setting changes again', async () => {
+      const wrapper = createWrapper();
+      set(writeError, 'the backend said no');
+      await nextTick();
+
+      set(model, new Currency('Euro', 'EUR', '€'));
+      await nextTick();
+
+      expect(select(wrapper).props('errorMessages')).toBe('');
+    });
+  });
+
+  /** A long symbol such as CHF has to shrink, or it overflows the avatar the short ones fill. */
+  describe('the avatar symbol', () => {
+    it('should render a one-character symbol at full size', () => {
+      expect(avatarFontSize(createWrapper(), 'USD')).toBe('font-size: 2em;');
+    });
+
+    it('should shrink a three-character symbol', () => {
+      expect(avatarFontSize(createWrapper(), 'CHF')).toBe('font-size: 1.2em;');
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/language/LanguageSetting.spec.ts
+++ b/frontend/app/src/modules/settings/general/language/LanguageSetting.spec.ts
@@ -1,0 +1,198 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import LanguageSetting from '@/modules/settings/general/language/LanguageSetting.vue';
+import { SupportedLanguage } from '@/modules/settings/types/frontend-settings';
+
+const { adaptiveLanguage, flush, forceUpdateMachineLanguage, lastLanguage, model, writeError, writeSuccess }
+  = await vi.hoisted(async () => {
+    const { ref } = await import('vue');
+    return {
+      adaptiveLanguage: ref<string>('en'),
+      flush: vi.fn(async () => {}),
+      forceUpdateMachineLanguage: ref<string>('true'),
+      lastLanguage: ref<string>('en'),
+      model: ref<string>('en'),
+      writeError: ref<string>(''),
+      writeSuccess: ref<boolean>(false),
+    };
+  });
+
+vi.mock('@/modules/session/use-locale', () => ({
+  useLocale: (): Record<string, unknown> => ({ adaptiveLanguage, forceUpdateMachineLanguage, lastLanguage }),
+}));
+
+vi.mock('@/modules/settings/use-setting-model', () => ({
+  useSettingModel: (): Record<string, unknown> => ({ error: writeError, flush, model, success: writeSuccess }),
+}));
+
+const RuiMenuSelectStub = defineComponent({
+  emits: ['update:modelValue'],
+  props: ['modelValue', 'options', 'successMessages', 'errorMessages'],
+  template: '<div />',
+});
+
+const RuiCheckboxStub = defineComponent({
+  emits: ['update:modelValue'],
+  props: ['modelValue'],
+  template: '<div />',
+});
+
+function createWrapper(props: Record<string, unknown> = {}): VueWrapper<any> {
+  return mount(LanguageSetting, {
+    global: {
+      stubs: {
+        ExternalLink: true,
+        LanguageSelectorItem: true,
+        RuiCheckbox: RuiCheckboxStub,
+        RuiMenuSelect: RuiMenuSelectStub,
+        SettingsItem: { name: 'SettingsItem', template: '<div><slot /></div>' },
+      },
+    },
+    props,
+  });
+}
+
+function select(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(RuiMenuSelectStub);
+}
+
+function checkbox(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(RuiCheckboxStub);
+}
+
+async function choose(wrapper: VueWrapper<any>, language: SupportedLanguage): Promise<void> {
+  select(wrapper).vm.$emit('update:modelValue', language);
+  await nextTick();
+}
+
+describe('languageSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(adaptiveLanguage, SupportedLanguage.EN);
+    set(forceUpdateMachineLanguage, 'true');
+    set(lastLanguage, SupportedLanguage.EN);
+    set(model, SupportedLanguage.EN);
+    set(writeError, '');
+    set(writeSuccess, false);
+  });
+
+  it('should start on the language the session resolved', async () => {
+    set(adaptiveLanguage, SupportedLanguage.GR);
+
+    const wrapper = createWrapper();
+    await nextTick();
+
+    expect(select(wrapper).props('modelValue')).toBe(SupportedLanguage.GR);
+  });
+
+  it('should offer every supported language', () => {
+    expect(select(createWrapper()).props('options')).toContainEqual({
+      countries: ['gb', 'us'],
+      identifier: SupportedLanguage.EN,
+      label: 'English',
+    });
+  });
+
+  /**
+   * The login screen picks a language before there is an account to store it against, so it keeps
+   * the choice locally instead of writing it to the user's settings.
+   */
+  describe('when it is the local setting', () => {
+    it('should remember the choice locally', async () => {
+      const wrapper = createWrapper({ useLocalSetting: true });
+
+      await choose(wrapper, SupportedLanguage.ES);
+
+      expect(get(lastLanguage)).toBe(SupportedLanguage.ES);
+    });
+
+    it('should not write it to the settings', async () => {
+      const wrapper = createWrapper({ useLocalSetting: true });
+
+      await choose(wrapper, SupportedLanguage.ES);
+
+      expect(get(model)).toBe(SupportedLanguage.EN);
+      expect(flush).not.toHaveBeenCalled();
+    });
+
+    it('should hide the machine language option', () => {
+      expect(checkbox(createWrapper({ useLocalSetting: true })).exists()).toBe(false);
+    });
+  });
+
+  /** A language change is a deliberate act, so it is written at once rather than on the debounce. */
+  describe('when it is the account setting', () => {
+    it('should write the choice immediately', async () => {
+      const wrapper = createWrapper();
+
+      await choose(wrapper, SupportedLanguage.ES);
+
+      expect(get(model)).toBe(SupportedLanguage.ES);
+      expect(flush).toHaveBeenCalledTimes(1);
+    });
+
+    it('should leave the local language alone', async () => {
+      const wrapper = createWrapper();
+
+      await choose(wrapper, SupportedLanguage.ES);
+
+      expect(get(lastLanguage)).toBe(SupportedLanguage.EN);
+    });
+  });
+
+  /** The preference is stored as a string, so the checkbox has to map both ways. */
+  describe('the machine language preference', () => {
+    it('should show it as checked while it is on', () => {
+      expect(checkbox(createWrapper()).props('modelValue')).toBe(true);
+    });
+
+    it('should show it as unchecked while it is off', () => {
+      set(forceUpdateMachineLanguage, 'false');
+
+      expect(checkbox(createWrapper()).props('modelValue')).toBe(false);
+    });
+
+    it('should store it as a string when turned off', async () => {
+      const wrapper = createWrapper();
+
+      checkbox(wrapper).vm.$emit('update:modelValue', false);
+      await nextTick();
+
+      expect(get(forceUpdateMachineLanguage)).toBe('false');
+    });
+
+    it('should store it as a string when turned back on', async () => {
+      set(forceUpdateMachineLanguage, 'false');
+      const wrapper = createWrapper();
+
+      checkbox(wrapper).vm.$emit('update:modelValue', true);
+      await nextTick();
+
+      expect(get(forceUpdateMachineLanguage)).toBe('true');
+    });
+  });
+
+  describe('reporting the write', () => {
+    it('should report a failed write', async () => {
+      const wrapper = createWrapper();
+
+      set(writeError, 'the backend said no');
+      await nextTick();
+
+      expect(select(wrapper).props('errorMessages'))
+        .toContain('general_settings.language.validation.error: the backend said no');
+    });
+
+    it('should drop the message once the setting changes again', async () => {
+      const wrapper = createWrapper();
+      set(writeError, 'the backend said no');
+      await nextTick();
+
+      set(model, SupportedLanguage.ES);
+      await nextTick();
+
+      expect(select(wrapper).props('errorMessages')).toBe('');
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/nft/NftImageRenderingSetting.spec.ts
+++ b/frontend/app/src/modules/settings/general/nft/NftImageRenderingSetting.spec.ts
@@ -1,0 +1,297 @@
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import NftImageRenderingSetting from '@/modules/settings/general/nft/NftImageRenderingSetting.vue';
+import { createRuiPlugin } from '@/plugins/rui';
+
+const {
+  confirm,
+  confirmVisible,
+  renderAllModel,
+  renderWriteError,
+  renderWriteSuccess,
+  whitelistModel,
+  whitelistWriteError,
+  whitelistWriteSuccess,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  /** Holds what the confirmation store was handed, so a test can accept or dismiss the prompt. */
+  const confirm: { accept?: () => void; reject?: () => void } = {};
+
+  return {
+    confirm,
+    confirmVisible: ref<boolean>(false),
+    renderAllModel: ref<boolean>(false),
+    renderWriteError: ref<string>(''),
+    renderWriteSuccess: ref<boolean>(false),
+    whitelistModel: ref<string[]>([]),
+    whitelistWriteError: ref<string>(''),
+    whitelistWriteSuccess: ref<boolean>(false),
+  };
+});
+
+vi.mock('@/modules/core/common/use-confirm-store', () => ({
+  useConfirmStore: (): Record<string, unknown> => ({
+    show: (_message: unknown, accept: () => void, reject?: () => void): void => {
+      confirm.accept = accept;
+      confirm.reject = reject;
+    },
+    visible: confirmVisible,
+  }),
+}));
+
+vi.mock('@/modules/settings/use-setting-model', () => ({
+  useSettingModel: (key: string): Record<string, unknown> =>
+    key === 'renderAllNftImages'
+      ? { error: renderWriteError, model: renderAllModel, success: renderWriteSuccess }
+      : { error: whitelistWriteError, model: whitelistModel, success: whitelistWriteSuccess },
+}));
+
+function createWrapper(): VueWrapper<any> {
+  return mount(NftImageRenderingSetting, {
+    global: {
+      plugins: [createRuiPlugin({})],
+      stubs: {
+        ConfirmDialog: {
+          emits: ['confirm', 'cancel'],
+          name: 'ConfirmDialog',
+          props: ['display', 'title', 'message', 'maxWidth'],
+          template: `<div>
+            <slot />
+            <button data-testid="stub-confirm" @click="$emit('confirm')" />
+            <button data-testid="stub-cancel" @click="$emit('cancel')" />
+          </div>`,
+        },
+      },
+    },
+  });
+}
+
+function radio(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent({ name: 'RuiRadioGroup' });
+}
+
+/** Picks a rendering mode the way the radio group reports it. */
+async function chooseMode(wrapper: VueWrapper<any>, mode: 'all' | 'whitelisted'): Promise<void> {
+  await radio(wrapper).vm.$emit('update:modelValue', mode);
+  await nextTick();
+}
+
+describe('nftImageRenderingSetting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    confirm.accept = undefined;
+    confirm.reject = undefined;
+    set(confirmVisible, false);
+    set(renderAllModel, false);
+    set(renderWriteError, '');
+    set(renderWriteSuccess, false);
+    set(whitelistModel, []);
+    set(whitelistWriteError, '');
+    set(whitelistWriteSuccess, false);
+  });
+
+  describe('the rendering mode', () => {
+    it('should open on the persisted setting', () => {
+      set(renderAllModel, true);
+
+      expect(radio(createWrapper()).props('modelValue')).toBe('all');
+    });
+
+    it('should follow the setting changing elsewhere', async () => {
+      const wrapper = createWrapper();
+
+      set(renderAllModel, true);
+      await nextTick();
+
+      expect(radio(wrapper).props('modelValue')).toBe('all');
+    });
+
+    it('should restrict to the whitelist without asking', async () => {
+      set(renderAllModel, true);
+      const wrapper = createWrapper();
+
+      await chooseMode(wrapper, 'whitelisted');
+
+      expect(get(renderAllModel)).toBe(false);
+      expect(confirm.accept).toBeUndefined();
+    });
+  });
+
+  /**
+   * Rendering every NFT image fetches from arbitrary domains, so it is confirmed rather than
+   * applied on the click.
+   */
+  describe('allowing every domain', () => {
+    it('should ask before applying it', async () => {
+      const wrapper = createWrapper();
+
+      await chooseMode(wrapper, 'all');
+
+      expect(get(renderAllModel)).toBe(false);
+      expect(confirm.accept).toBeDefined();
+    });
+
+    it('should apply it once confirmed', async () => {
+      const wrapper = createWrapper();
+      await chooseMode(wrapper, 'all');
+
+      confirm.accept?.();
+      await nextTick();
+
+      expect(get(renderAllModel)).toBe(true);
+    });
+
+    /** Leaving the radio on `all` after a refusal would misreport what is persisted. */
+    it('should put the control back when refused', async () => {
+      const wrapper = createWrapper();
+      await chooseMode(wrapper, 'all');
+
+      confirm.reject?.();
+      await nextTick();
+
+      expect(radio(wrapper).props('modelValue')).toBe('whitelisted');
+      expect(get(renderAllModel)).toBe(false);
+    });
+  });
+
+  describe('the whitelist', () => {
+    async function type(wrapper: VueWrapper<any>, value: string): Promise<void> {
+      await wrapper.findComponent({ name: 'RuiTextField' }).vm.$emit('update:modelValue', value);
+      await nextTick();
+    }
+
+    function saveButton(wrapper: VueWrapper<any>): ReturnType<VueWrapper<any>['find']> {
+      return wrapper.find('[data-testid=nft-whitelist-save]');
+    }
+
+    it('should refuse to save nothing', () => {
+      expect(saveButton(createWrapper()).attributes('disabled')).toBeDefined();
+    });
+
+    it('should offer to save once a domain is entered', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'rotki.com');
+
+      expect(saveButton(wrapper).attributes('disabled')).toBeUndefined();
+    });
+
+    it('should add the entered domains to the stored list', async () => {
+      set(whitelistModel, ['existing.com']);
+      const wrapper = createWrapper();
+      await type(wrapper, 'rotki.com');
+
+      await wrapper.find('[data-testid=stub-confirm]').trigger('click');
+
+      expect(get(whitelistModel)).toEqual(['existing.com', 'rotki.com']);
+    });
+
+    it('should keep the list untouched when the save is dismissed', async () => {
+      set(whitelistModel, ['existing.com']);
+      const wrapper = createWrapper();
+      await type(wrapper, 'rotki.com');
+
+      await wrapper.find('[data-testid=stub-cancel]').trigger('click');
+
+      expect(get(whitelistModel)).toEqual(['existing.com']);
+    });
+
+    it('should count what was entered', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'rotki.com,example.com');
+
+      expect(wrapper.text()).toContain('whitelisted_domain_entries::2');
+    });
+
+    it('should drop a domain the user removes', async () => {
+      set(whitelistModel, ['keep.com', 'drop.com']);
+      const wrapper = createWrapper();
+
+      await wrapper.findAllComponents({ name: 'RuiChip' })[1].vm.$emit('click:close');
+      await nextTick();
+
+      expect(get(whitelistModel)).toEqual(['keep.com']);
+    });
+
+    /** The whitelist has no effect while every domain is allowed, so it is not offered. */
+    it('should be closed for editing while every domain is allowed', async () => {
+      set(whitelistModel, ['keep.com']);
+      set(renderAllModel, true);
+      const wrapper = createWrapper();
+      await nextTick();
+
+      expect(wrapper.findComponent({ name: 'RuiTextField' }).props('disabled')).toBe(true);
+      expect(wrapper.findComponent({ name: 'RuiChip' }).props('closeable')).toBe(false);
+    });
+  });
+
+  /** The entered domains have moved into the stored list, so leaving them typed invites a re-add. */
+  describe('after the whitelist is written', () => {
+    async function typeAndSettle(wrapper: VueWrapper<any>, saved: boolean): Promise<void> {
+      await wrapper.findComponent({ name: 'RuiTextField' }).vm.$emit('update:modelValue', 'rotki.com');
+      await nextTick();
+      set(whitelistWriteSuccess, saved);
+      await nextTick();
+    }
+
+    it('should clear the input once the write lands', async () => {
+      const wrapper = createWrapper();
+
+      await typeAndSettle(wrapper, true);
+
+      expect(wrapper.findComponent({ name: 'RuiTextField' }).props('modelValue')).toBe('');
+    });
+
+    it('should leave what was typed while nothing has landed', async () => {
+      const wrapper = createWrapper();
+
+      await typeAndSettle(wrapper, false);
+
+      expect(wrapper.findComponent({ name: 'RuiTextField' }).props('modelValue')).toBe('rotki.com');
+    });
+
+    it('should surface what the write failed with', async () => {
+      const wrapper = createWrapper();
+
+      set(whitelistWriteError, 'the backend said no');
+      await nextTick();
+
+      expect(wrapper.findComponent({ name: 'RuiTextField' }).props('errorMessages'))
+        .toContain('general_settings.nft_setting.messages.error: the backend said no');
+    });
+  });
+
+  /** The page above dims while either prompt is up, so it needs telling. */
+  describe('telling the page a dialog is open', () => {
+    it('should report the save confirmation opening', async () => {
+      const wrapper = createWrapper();
+      await wrapper.findComponent({ name: 'RuiTextField' }).vm.$emit('update:modelValue', 'rotki.com');
+      await nextTick();
+
+      await wrapper.find('[data-testid=nft-whitelist-save]').trigger('click');
+
+      expect(wrapper.emitted<[boolean]>('dialog-open')?.at(-1)?.[0]).toBe(true);
+    });
+
+    it('should report the mode confirmation opening', async () => {
+      const wrapper = createWrapper();
+
+      set(confirmVisible, true);
+      await nextTick();
+
+      expect(wrapper.emitted<[boolean]>('dialog-open')?.at(-1)?.[0]).toBe(true);
+    });
+
+    it('should report both closing again', async () => {
+      const wrapper = createWrapper();
+      set(confirmVisible, true);
+      await nextTick();
+
+      set(confirmVisible, false);
+      await nextTick();
+
+      expect(wrapper.emitted<[boolean]>('dialog-open')?.at(-1)?.[0]).toBe(false);
+    });
+  });
+});

--- a/frontend/app/src/modules/settings/general/nft/NftImageRenderingSetting.vue
+++ b/frontend/app/src/modules/settings/general/nft/NftImageRenderingSetting.vue
@@ -107,6 +107,7 @@ watch(whitelistWriteError, (message) => {
       color="primary"
       :success-messages="renderSuccess"
       :error-messages="renderError"
+      data-testid="nft-render-mode"
       @update:model-value="updateRenderingSetting($event)"
     >
       <RuiRadio value="all">
@@ -131,6 +132,7 @@ watch(whitelistWriteError, (message) => {
         class="flex-1"
         variant="outlined"
         clearable
+        data-testid="nft-whitelist-input"
       />
       <RuiButton
         :disabled="!changed"
@@ -138,6 +140,7 @@ watch(whitelistWriteError, (message) => {
         variant="text"
         color="primary"
         icon
+        data-testid="nft-whitelist-save"
         @click="showUpdateWhitelistConfirmation = true"
       >
         <RuiIcon name="lu-save" />

--- a/frontend/app/src/modules/settings/general/rpc/RpcSettings.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/RpcSettings.spec.ts
@@ -1,0 +1,238 @@
+import { Blockchain } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type VNode } from 'vue';
+import RpcSettings from '@/modules/settings/general/rpc/RpcSettings.vue';
+import {
+  RpcSettingKey,
+  type RpcSettingTab,
+  type UseRpcSettingsTabsReturn,
+} from '@/modules/settings/general/rpc/use-rpc-settings-tabs';
+
+const {
+  addNewRpcNode,
+  canAddNode,
+  isMdAndUp,
+  loadNodes,
+  reload,
+  rpcSettingTabs,
+  selectedKey,
+  selectTab,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  const { Blockchain: Chain } = await import('@rotki/common');
+  return {
+    addNewRpcNode: vi.fn(),
+    canAddNode: ref<boolean>(true),
+    isMdAndUp: ref<boolean>(true),
+    loadNodes: vi.fn(async () => {}),
+    reload: vi.fn(async () => {}),
+    rpcSettingTabs: ref<RpcSettingTab[]>([]),
+    selectedKey: ref<string>(Chain.ETH),
+    selectTab: vi.fn(),
+  };
+});
+
+vi.mock('@/modules/settings/general/rpc/use-rpc-settings-tabs', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/settings/general/rpc/use-rpc-settings-tabs')>(),
+  useRpcSettingsTabs: (): UseRpcSettingsTabsReturn => ({
+    activeTab: computed(() => get(rpcSettingTabs)[0]),
+    allRailOptions: computed(() => []),
+    canAddNode: computed<boolean>(() => get(canAddNode)),
+    evmRailOptions: computed(() => []),
+    firstOtherKey: computed(() => undefined),
+    nodeChains: computed(() => [Blockchain.ETH]),
+    otherRailOptions: computed(() => []),
+    rpcSettingTabs: computed(() => get(rpcSettingTabs)),
+    selectedKey,
+    selectTab,
+  }),
+}));
+
+vi.mock('@rotki/ui-library', async importOriginal => ({
+  ...await importOriginal<typeof import('@rotki/ui-library')>(),
+  useBreakpoint: (): Record<string, unknown> => ({ isMdAndUp }),
+}));
+
+/**
+ * Stands in for the chain manager, which exposes both the add and the reload entry points.
+ *
+ * @remarks
+ * The managers are loaded through `defineAsyncComponent`, which only unwraps the `default` export
+ * of a module that says it is one. Without `__esModule` the mock namespace is taken for the
+ * component itself, and every property Vue reads off it fails as a missing export.
+ */
+vi.mock('@/modules/settings/general/rpc/BlockchainRpcNodeManager.vue', async () => {
+  const { defineComponent, h } = await import('vue');
+  return {
+    __esModule: true,
+    default: defineComponent({
+      name: 'BlockchainRpcNodeManager',
+      setup(_props, { expose }): () => VNode {
+        expose({ addNewRpcNode, loadNodes });
+        return () => h('div', { 'data-testid': 'chain-manager' });
+      },
+    }),
+  };
+});
+
+/** The simple manager has no node list to re-read, so it exposes only the add entry point. */
+vi.mock('@/modules/settings/general/rpc/simple/SimpleRpcNodeManager.vue', async () => {
+  const { defineComponent, h } = await import('vue');
+  return {
+    __esModule: true,
+    default: defineComponent({
+      name: 'SimpleRpcNodeManager',
+      setup(_props, { expose }): () => VNode {
+        expose({ addNewRpcNode });
+        return () => h('div', { 'data-testid': 'simple-manager' });
+      },
+    }),
+  };
+});
+
+vi.mock('@/modules/settings/general/rpc/providers/RpcProviderKeys.vue', async () => {
+  const { defineComponent, h } = await import('vue');
+  return {
+    default: defineComponent({
+      emits: ['removed'],
+      name: 'RpcProviderKeys',
+      setup(_props, { emit, expose }): () => VNode {
+        expose({ reload });
+        return () => h('button', { 'data-testid': 'provider-keys', 'onClick': () => emit('removed') });
+      },
+    }),
+  };
+});
+
+const RuiTabStub = defineComponent({
+  emits: ['click'],
+  props: ['active'],
+  template: '<button role="tab" :aria-selected="active" @click="$emit(\'click\')"><slot /></button>',
+});
+
+const CHAIN_TAB: RpcSettingTab = { chain: Blockchain.ETH };
+const SETTING_TAB: RpcSettingTab = { chain: Blockchain.KSM, setting: RpcSettingKey.KSM };
+
+async function createWrapper(): Promise<VueWrapper<any>> {
+  const wrapper = mount(RpcSettings, {
+    global: {
+      stubs: {
+        RpcSettingOption: true,
+        RuiMenuSelect: true,
+        RuiTab: RuiTabStub,
+        RuiTabs: { template: '<div><slot /></div>' },
+        SettingCategoryHeader: true,
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('rpcSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(canAddNode, true);
+    set(isMdAndUp, true);
+    set(rpcSettingTabs, [CHAIN_TAB]);
+    set(selectedKey, Blockchain.ETH);
+  });
+
+  describe('the manager on screen', () => {
+    it('should show the chain manager for a chain tab', async () => {
+      const wrapper = await createWrapper();
+
+      expect(wrapper.find('[data-testid=chain-manager]').exists()).toBe(true);
+    });
+
+    it('should show the simple manager for a tab backed by a single setting', async () => {
+      set(rpcSettingTabs, [SETTING_TAB]);
+      set(selectedKey, Blockchain.KSM);
+
+      const wrapper = await createWrapper();
+
+      expect(wrapper.find('[data-testid=simple-manager]').exists()).toBe(true);
+    });
+
+    it('should show only the selected tab', async () => {
+      set(rpcSettingTabs, [CHAIN_TAB, SETTING_TAB]);
+
+      const wrapper = await createWrapper();
+
+      expect(wrapper.find('[data-testid=chain-manager]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=simple-manager]').exists()).toBe(false);
+    });
+  });
+
+  /** The button belongs to the header, so it reaches the manager on screen through its ref. */
+  describe('adding a node', () => {
+    it('should ask the manager on screen to add one', async () => {
+      const wrapper = await createWrapper();
+
+      await wrapper.find('[data-testid=add-node]').trigger('click');
+
+      expect(addNewRpcNode).toHaveBeenCalledTimes(1);
+    });
+
+    it('should hide the button when the tab takes no new nodes', async () => {
+      set(canAddNode, false);
+
+      const wrapper = await createWrapper();
+
+      expect(wrapper.find('[data-testid=add-node]').exists()).toBe(false);
+    });
+  });
+
+  /**
+   * Removing a provider's keys deletes nodes, which may have emptied the chain on screen, so its
+   * list is re-read. Only the chain manager holds one.
+   */
+  describe('after a provider key is removed', () => {
+    it('should re-read the chain manager list', async () => {
+      const wrapper = await createWrapper();
+
+      await wrapper.find('[data-testid=provider-keys]').trigger('click');
+
+      expect(loadNodes).toHaveBeenCalledTimes(1);
+    });
+
+    it('should leave the simple manager alone, which has no list to re-read', async () => {
+      set(rpcSettingTabs, [SETTING_TAB]);
+      set(selectedKey, Blockchain.KSM);
+      const wrapper = await createWrapper();
+
+      await wrapper.find('[data-testid=provider-keys]').trigger('click');
+
+      expect(loadNodes).not.toHaveBeenCalled();
+    });
+  });
+
+  /** A fan-out adds nodes to chains the provider chips count, so the chips are re-read. */
+  it('should re-read the provider keys once the manager is done', async () => {
+    const wrapper = await createWrapper();
+
+    wrapper.findComponent({ name: 'BlockchainRpcNodeManager' }).vm.$emit('complete');
+    await nextTick();
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  describe('picking a tab', () => {
+    it('should show the rail on a wide screen', async () => {
+      const wrapper = await createWrapper();
+
+      expect(wrapper.find('[data-testid=rpc-settings-rail]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=rpc-settings-dropdowns]').exists()).toBe(false);
+    });
+
+    it('should fall back to a dropdown on a narrow one', async () => {
+      set(isMdAndUp, false);
+
+      const wrapper = await createWrapper();
+
+      expect(wrapper.find('[data-testid=rpc-settings-dropdowns]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid=rpc-settings-rail]').exists()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Continues the frontend coverage work on `#12964`'s remainder, taking the
`settings/general` cluster. Six units, one commit each.

## What is covered

| Component | Lines | What the spec pins |
|---|---|---|
| `NftImageRenderingSetting.vue` | 61/65 | render mode, the whitelist round trip, write messages |
| `InternalTxConflictRepullSettings.vue` | 43/51 | the seconds/minutes conversion both ways, the empty field, reset-writes-at-once |
| `TimeFrameSettings.vue` | 40/42 | canonical re-ordering on add and remove, the REMEMBER fallback, the session move, the close guards, the premium gate |
| `MainCurrencySetting.vue` | 23/23 | the currency-object/ticker mapping both ways, an unknown ticker, the avatar font size |
| `AbbreviateNumberSetting.vue` | 20/22 | the number/string mapping both ways, the option list derived from the abbreviation exponents, the disabled state |
| `LanguageSetting.vue` | 29/34 | the local vs account write paths, the string-mapped machine-language preference |
| `RpcSettings.vue` | 35/46 | the template-ref wiring: add-node reaching the active manager, the duck-typed reload guard, the provider-chip refresh, tab selection, rail vs dropdown |

Total line coverage 73.32% -> 73.79%.

## Source changes

Three, all needed by the components themselves rather than by the specs:

- `TimeFrameSettings.vue` acquired `useSettingsOperations()` and `useSettingsRepo()` from inside
  the removal handler. `useSettingsOperations` calls `useI18n`, which needs a current instance, so
  that path threw. They are now acquired in setup. Note the unit harness cannot catch this, since
  the shared setup mocks `vue-i18n` globally; it showed up while reading the component.
- `NftImageRenderingSetting.vue` and `InternalTxConflictRepullSettings.vue` gained `data-testid`
  attributes so the two same-component fields can be told apart.

`RpcSettings.vue` is unchanged: its tab logic already lives in `use-rpc-settings-tabs.ts` (40/41),
so the spec targets the orchestration the component adds on top.

## Verification

Every assertion has a negative control: the specific line was broken, the named tests were
confirmed to fail and only those, then it was restored. Two controls were findings rather than
confirmations and led to changed tests:

- dropping the premium gate in `TimeFrameSettings` broke nothing, because no test asserted that a
  premium account can actually use the long ranges. Added one.
- the first "canonical order" test survived removing the sort, since appending happened to produce
  the same array. Re-aimed at a case where the two differ.

Gates: `typecheck`, `knip`, `lint:file:check`, `lint:style`, `check:linked-keys`, `test:proxy` and
the full `test:unit` (1097 files, 11940 tests) all green.
