### PR TITLE
test(frontend): extract and cover the accounts module

### DIFF
--- a/frontend/app/src/modules/accounts/AccountBalancesExportImport.spec.ts
+++ b/frontend/app/src/modules/accounts/AccountBalancesExportImport.spec.ts
@@ -1,0 +1,164 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type VNode } from 'vue';
+import AccountBalancesExportImport from '@/modules/accounts/AccountBalancesExportImport.vue';
+
+const { exportAccounts, importAccounts, removeFile } = vi.hoisted(() => ({
+  exportAccounts: vi.fn(),
+  importAccounts: vi.fn(async () => {}),
+  /** Only stands in for the uploader's own reset; whether it is reached depends on the dialog. */
+  removeFile: vi.fn(),
+}));
+
+vi.mock('@/modules/accounts/import-export/use-account-import-export', () => ({
+  useAccountImportExport: (): Record<string, unknown> => ({ exportAccounts, importAccounts }),
+}));
+
+/** Exposes `removeFile` under the name the component calls on its uploader ref. */
+vi.mock('@/modules/user-data/FileUpload.vue', async () => {
+  const { defineComponent, h } = await import('vue');
+  return {
+    __esModule: true,
+    default: defineComponent({
+      emits: ['update:modelValue'],
+      name: 'FileUpload',
+      props: { modelValue: { default: undefined, type: Object } },
+      setup(_props, { expose }): () => VNode {
+        expose({ removeFile });
+        return () => h('div');
+      },
+    }),
+  };
+});
+
+const MenuStub = defineComponent({
+  template: '<div><slot name="activator" :attrs="{}" /><slot /></div>',
+});
+
+function createWrapper(): VueWrapper<any> {
+  return mount(AccountBalancesExportImport, {
+    global: {
+      stubs: {
+        ExternalLink: true,
+        RuiCard: { template: '<div><slot name="header" /><slot /><slot name="footer" /></div>' },
+        RuiDialog: { props: ['modelValue'], template: '<div v-if="modelValue"><slot /></div>' },
+        RuiMenu: MenuStub,
+      },
+    },
+  });
+}
+
+function button(wrapper: VueWrapper<any>, id: string): VueWrapper<any> {
+  const found = wrapper
+    .findAllComponents({ name: 'RuiButton' })
+    .find(item => item.attributes('data-testid') === id);
+  assert(found);
+  return found;
+}
+
+function uploader(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent({ name: 'FileUpload' });
+}
+
+const CSV = new File(['address,chain'], 'accounts.csv', { type: 'text/csv' });
+
+async function openImport(wrapper: VueWrapper<any>): Promise<void> {
+  await button(wrapper, 'accounts-import').trigger('click');
+}
+
+async function choose(wrapper: VueWrapper<any>, file: File): Promise<void> {
+  uploader(wrapper).vm.$emit('update:modelValue', file);
+  await nextTick();
+}
+
+describe('accountBalancesExportImport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should export on request', async () => {
+    const wrapper = createWrapper();
+
+    await button(wrapper, 'accounts-export').trigger('click');
+
+    expect(exportAccounts).toHaveBeenCalledTimes(1);
+  });
+
+  describe('importing', () => {
+    it('should stay closed until it is asked for', () => {
+      expect(createWrapper().findComponent({ name: 'FileUpload' }).exists()).toBe(false);
+    });
+
+    it('should open on request', async () => {
+      const wrapper = createWrapper();
+
+      await openImport(wrapper);
+
+      expect(uploader(wrapper).exists()).toBe(true);
+    });
+
+    /** There is nothing to import until a file has been chosen. */
+    it('should refuse to import while no file is chosen', async () => {
+      const wrapper = createWrapper();
+      await openImport(wrapper);
+
+      expect(button(wrapper, 'accounts-import-confirm').props('disabled')).toBe(true);
+    });
+
+    it('should offer the import once a file is chosen', async () => {
+      const wrapper = createWrapper();
+      await openImport(wrapper);
+
+      await choose(wrapper, CSV);
+
+      expect(button(wrapper, 'accounts-import-confirm').props('disabled')).toBe(false);
+    });
+
+    it('should import the chosen file', async () => {
+      const wrapper = createWrapper();
+      await openImport(wrapper);
+      await choose(wrapper, CSV);
+
+      await button(wrapper, 'accounts-import-confirm').trigger('click');
+      await flushPromises();
+
+      expect(importAccounts).toHaveBeenCalledWith(CSV);
+    });
+
+    /** The dialog closes on the way in, so the import runs against the page rather than over it. */
+    it('should close before the import runs', async () => {
+      const wrapper = createWrapper();
+      await openImport(wrapper);
+      await choose(wrapper, CSV);
+
+      await button(wrapper, 'accounts-import-confirm').trigger('click');
+      await flushPromises();
+
+      expect(uploader(wrapper).exists()).toBe(false);
+    });
+
+    /** Reopening the dialog after an import must not offer the file that was already imported. */
+    it('should forget the file once the import is done', async () => {
+      const wrapper = createWrapper();
+      await openImport(wrapper);
+      await choose(wrapper, CSV);
+      await button(wrapper, 'accounts-import-confirm').trigger('click');
+      await flushPromises();
+
+      await openImport(wrapper);
+
+      expect(uploader(wrapper).props('modelValue')).toBeUndefined();
+      expect(button(wrapper, 'accounts-import-confirm').props('disabled')).toBe(true);
+    });
+
+    it('should leave the dialog alone on cancel', async () => {
+      const wrapper = createWrapper();
+      await openImport(wrapper);
+
+      await button(wrapper, 'accounts-import-cancel').trigger('click');
+
+      expect(uploader(wrapper).exists()).toBe(false);
+      expect(importAccounts).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
+++ b/frontend/app/src/modules/accounts/AccountBalancesExportImport.vue
@@ -46,6 +46,7 @@ async function doImport() {
       </template>
       <RuiButton
         variant="list"
+        data-testid="accounts-export"
         @click="exportAccounts()"
       >
         <template #prepend>
@@ -55,6 +56,7 @@ async function doImport() {
       </RuiButton>
       <RuiButton
         variant="list"
+        data-testid="accounts-import"
         @click="importDialogOpen = true;"
       >
         <template #prepend>
@@ -97,6 +99,7 @@ async function doImport() {
           <RuiButton
             variant="text"
             color="primary"
+            data-testid="accounts-import-cancel"
             @click="importDialogOpen = false"
           >
             {{ t('common.actions.cancel') }}
@@ -105,6 +108,7 @@ async function doImport() {
             color="primary"
             :disabled="!importFile"
             :loading="loading"
+            data-testid="accounts-import-confirm"
             @click="doImport()"
           >
             {{ t('common.actions.import') }}

--- a/frontend/app/src/modules/accounts/EthStakingValidators.spec.ts
+++ b/frontend/app/src/modules/accounts/EthStakingValidators.spec.ts
@@ -1,0 +1,244 @@
+import type { EthereumValidator } from '@/modules/accounts/blockchain-accounts';
+import { bigNumberify, Blockchain } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import EthStakingValidators from '@/modules/accounts/EthStakingValidators.vue';
+
+const {
+  accountOperation,
+  confirmDelete,
+  deleteSelected,
+  editValidator,
+  filters,
+  modelSelected,
+  refresh,
+  rows,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    accountOperation: ref<boolean>(false),
+    confirmDelete: vi.fn(),
+    deleteSelected: vi.fn(),
+    editValidator: vi.fn(),
+    filters: ref<Record<string, unknown>>({}),
+    modelSelected: ref<string[]>([]),
+    refresh: vi.fn(),
+    rows: ref<{ data: EthereumValidator[]; found: number; limit: number; total: number }>({
+      data: [],
+      found: 0,
+      limit: 10,
+      total: 0,
+    }),
+  };
+});
+
+vi.mock('@/modules/staking/eth/use-eth-validator-data', async () => {
+  const { computed, ref } = await import('vue');
+  return {
+    useEthValidatorData: (): Record<string, unknown> => ({
+      cols: computed(() => []),
+      ethStakingValidators: computed(() => []),
+      fields: computed(() => []),
+      filters,
+      modelSelected,
+      pagination: ref({ limit: 10, page: 1, total: 0 }),
+      rows: computed(() => rows.value),
+      sort: ref([]),
+    }),
+  };
+});
+
+vi.mock('@/modules/staking/eth/use-eth-validator-operations', () => ({
+  useEthValidatorOperations: (): Record<string, unknown> => ({
+    accountOperation,
+    confirmDelete,
+    deleteSelected,
+    edit: editValidator,
+    refresh,
+  }),
+}));
+
+vi.mock('@/modules/staking/eth/use-eth-validator-utils', async () => {
+  const { computed } = await import('vue');
+  return {
+    useEthValidatorUtils: (): Record<string, unknown> => ({
+      getOwnershipPercentage: (): string => '100',
+      useTotal: () => computed(() => bigNumberify(0)),
+      useTotalAmount: () => computed(() => bigNumberify(0)),
+    }),
+  };
+});
+
+vi.mock('@/modules/core/table/pill/composables/use-pill-bar-labels', () => ({
+  usePillBarLabels: (): Record<string, unknown> => ({}),
+}));
+
+const ViewsMenuStub = defineComponent({
+  emits: ['apply'],
+  props: ['fields', 'location', 'state', 'disabled'],
+  template: '<div />',
+});
+
+/** Renders the row actions, which is where a validator's edit and delete are wired. */
+const TableStub = defineComponent({
+  props: ['cols', 'rows', 'loading', 'sort', 'pagination', 'modelValue'],
+  template: `<div>
+    <template v-for="row in rows" :key="row.index">
+      <slot name="item.actions" :row="row" />
+    </template>
+  </div>`,
+});
+
+const RowActionsStub = defineComponent({
+  emits: ['edit-click', 'delete-click'],
+  props: ['disabled', 'editTooltip'],
+  template: '<div />',
+});
+
+function validator(index: number): EthereumValidator {
+  return {
+    amount: bigNumberify(32),
+    index,
+    ownershipPercentage: '100',
+    publicKey: `0xabc${index}`,
+    status: 'active',
+    type: 'validator',
+    value: bigNumberify(32),
+  };
+}
+
+function createWrapper(): VueWrapper<any> {
+  return mount(EthStakingValidators, {
+    global: {
+      stubs: {
+        Eth2ValidatorLimitRow: true,
+        PillFilterBar: { props: ['matches', 'fields', 'labels'], template: '<div><slot name="views" :disabled="false" /></div>' },
+        PillViewsMenu: ViewsMenuStub,
+        RowActions: RowActionsStub,
+        RowAppend: true,
+        RuiDataTable: TableStub,
+      },
+    },
+  });
+}
+
+function deleteButton(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findAllComponents({ name: 'RuiButton' })[0];
+}
+
+describe('ethStakingValidators', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    set(accountOperation, false);
+    set(filters, {});
+    set(modelSelected, []);
+    set(rows, { data: [validator(1), validator(2)], found: 2, limit: 10, total: 2 });
+  });
+
+  describe('deleting the selection', () => {
+    it('should offer no delete while nothing is selected', () => {
+      expect(deleteButton(createWrapper()).props('disabled')).toBe(true);
+    });
+
+    it('should offer it once validators are picked', async () => {
+      const wrapper = createWrapper();
+
+      set(modelSelected, ['1']);
+      await nextTick();
+
+      expect(deleteButton(wrapper).props('disabled')).toBe(false);
+    });
+
+    /** The selection is a list of keys, so the rows on screen are what resolves it. */
+    it('should delete the picked validators out of the rows in view', async () => {
+      const wrapper = createWrapper();
+      set(modelSelected, ['1']);
+      await nextTick();
+
+      await deleteButton(wrapper).trigger('click');
+
+      expect(deleteSelected).toHaveBeenCalledWith(get(rows).data, ['1']);
+    });
+
+    it('should let the selection be cleared', async () => {
+      const wrapper = createWrapper();
+      set(modelSelected, ['1']);
+      await nextTick();
+
+      const clear = wrapper.findAllComponents({ name: 'RuiButton' })[1];
+      await clear.trigger('click');
+
+      expect(get(modelSelected)).toEqual([]);
+    });
+  });
+
+  /**
+   * Every pill on this bar is filter-bound, so a saved view is its matches alone and the params
+   * side stays empty rather than carrying a shape this table never reads.
+   */
+  describe('saved views', () => {
+    it('should offer the current filters as the view to save', async () => {
+      const wrapper = createWrapper();
+
+      set(filters, { status: 'active' });
+      await nextTick();
+
+      expect(wrapper.findComponent(ViewsMenuStub).props('state')).toEqual({
+        matches: { status: 'active' },
+        params: {},
+      });
+    });
+
+    it('should apply a saved view to the filters', async () => {
+      const wrapper = createWrapper();
+
+      wrapper.findComponent(ViewsMenuStub).vm.$emit('apply', { matches: { status: 'exited' }, params: {} });
+      await nextTick();
+
+      expect(get(filters)).toEqual({ status: 'exited' });
+    });
+  });
+
+  describe('a validator row', () => {
+    /** The parent opens the dialog, so the row has to hand it a state it can edit. */
+    it('should hand the parent an edit state for the validator', async () => {
+      editValidator.mockReturnValue({ chain: Blockchain.ETH2, data: {}, mode: 'edit', type: 'validator' });
+      const wrapper = createWrapper();
+
+      wrapper.findComponent(RowActionsStub).vm.$emit('edit-click');
+      await nextTick();
+
+      expect(editValidator).toHaveBeenCalledWith(validator(1));
+      expect(wrapper.emitted('edit')?.at(-1)?.[0]).toEqual({
+        chain: Blockchain.ETH2,
+        data: {},
+        mode: 'edit',
+        type: 'validator',
+      });
+    });
+
+    it('should confirm before deleting one', async () => {
+      const wrapper = createWrapper();
+
+      wrapper.findComponent(RowActionsStub).vm.$emit('delete-click');
+      await nextTick();
+
+      expect(confirmDelete).toHaveBeenCalledWith(validator(1));
+    });
+
+    /** A row cannot be acted on while another account operation is still running. */
+    it('should close off the row while an operation is running', async () => {
+      set(accountOperation, true);
+
+      expect(createWrapper().findComponent(RowActionsStub).props('disabled')).toBe(true);
+    });
+  });
+
+  it('should expose the refresh its parent drives', () => {
+    createWrapper().vm.refresh();
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/app/src/modules/accounts/QueriedAddressDialog.spec.ts
+++ b/frontend/app/src/modules/accounts/QueriedAddressDialog.spec.ts
@@ -1,0 +1,194 @@
+import type { AddressData, BlockchainAccount } from '@/modules/accounts/blockchain-accounts';
+import { Blockchain } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import QueriedAddressDialog from '@/modules/accounts/QueriedAddressDialog.vue';
+import { Module } from '@/modules/core/common/modules';
+import { useSessionMetadataStore } from '@/modules/session/use-session-metadata-store';
+
+const { addQueriedAddress, deleteQueriedAddress, getAccounts, getAddresses } = vi.hoisted(() => ({
+  addQueriedAddress: vi.fn(async () => {}),
+  deleteQueriedAddress: vi.fn(async () => {}),
+  getAccounts: vi.fn<(chain: string) => BlockchainAccount[]>(() => []),
+  getAddresses: vi.fn<(chain: string) => string[]>(() => []),
+}));
+
+vi.mock('@/modules/accounts/use-queried-address-operations', () => ({
+  useQueriedAddressOperations: (): Record<string, unknown> => ({ addQueriedAddress, deleteQueriedAddress }),
+}));
+
+vi.mock('@/modules/accounts/use-blockchain-accounts-store', () => ({
+  useBlockchainAccountsStore: (): Record<string, unknown> => ({ getAccounts }),
+}));
+
+vi.mock('@/modules/balances/blockchain/use-account-addresses', () => ({
+  useAccountAddresses: (): Record<string, unknown> => ({ getAddresses }),
+}));
+
+const ADDRESSES = [
+  '0x9531C059098e3d194fF87FebB587aB07B30B1306',
+  '0xc37b40ABdB939635068d3c5f13E7faF686F03B65',
+];
+
+/** Stands in for the account picker, exposing what it was offered and letting a test pick one. */
+const AccountSelectorStub = defineComponent({
+  emits: ['update:modelValue'],
+  props: ['modelValue', 'source', 'field'],
+  template: '<div />',
+});
+
+function account(address: string): BlockchainAccount<AddressData> {
+  return {
+    chain: Blockchain.ETH,
+    data: { address, type: 'address' },
+    nativeAsset: 'ETH',
+    tags: ['mine'],
+  };
+}
+
+function createWrapper(module: Module = Module.ETH2): VueWrapper<any> {
+  return mount(QueriedAddressDialog, {
+    global: {
+      stubs: {
+        AppImage: true,
+        BlockchainAccountSelector: AccountSelectorStub,
+        LabeledAddressDisplay: { props: ['account'], template: '<div class="address">{{ account.data.address }}</div>' },
+        RuiDialog: { template: '<div><slot /></div>' },
+        RuiTooltip: { template: '<div><slot name="activator" /></div>' },
+        TagDisplay: true,
+      },
+    },
+    props: { module },
+  });
+}
+
+function selector(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(AccountSelectorStub);
+}
+
+/** The addresses already queried for this module, as the list renders them. */
+function listed(wrapper: VueWrapper<any>): string[] {
+  return wrapper.findAll('.address').map(node => node.text());
+}
+
+/** The add button, told apart from the close and remove buttons by its own id. */
+function addButton(wrapper: VueWrapper<any>): VueWrapper<any> {
+  const found = wrapper
+    .findAllComponents({ name: 'RuiButton' })
+    .find(button => button.attributes('data-testid') === 'queried-address-add');
+  assert(found);
+  return found;
+}
+
+async function pick(wrapper: VueWrapper<any>, address: string): Promise<void> {
+  selector(wrapper).vm.$emit('update:modelValue', [account(address)]);
+  await nextTick();
+}
+
+describe('queriedAddressDialog', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    getAccounts.mockImplementation(() => ADDRESSES.map(address => account(address)));
+    getAddresses.mockImplementation(() => ADDRESSES);
+    set(storeToRefs(useSessionMetadataStore()).queriedAddresses, {});
+  });
+
+  function queried(addresses: Record<string, string[]>): void {
+    set(storeToRefs(useSessionMetadataStore()).queriedAddresses, addresses);
+  }
+
+  /**
+   * The module identifier is snake_case while the map is keyed in camelCase, so the lookup has to
+   * transform it or every module reads as having no addresses at all.
+   */
+  describe('the addresses already queried', () => {
+    it('should list the ones stored under the module', () => {
+      queried({ eth2: [ADDRESSES[0]] });
+
+      expect(listed(createWrapper(Module.ETH2))).toEqual([ADDRESSES[0]]);
+    });
+
+    it('should find a multi-word module under its camelCase key', () => {
+      queried({ makerdaoVaults: [ADDRESSES[0]] });
+
+      expect(listed(createWrapper(Module.MAKERDAO_VAULTS))).toEqual([ADDRESSES[0]]);
+    });
+
+    it('should list none for a module with no addresses of its own', () => {
+      queried({ eth2: [ADDRESSES[0]] });
+
+      expect(listed(createWrapper(Module.NFTS))).toEqual([]);
+    });
+
+    it('should say so when the module queries every address', () => {
+      const wrapper = createWrapper();
+
+      expect(wrapper.text()).toContain('queried_address_dialog.all_address_queried');
+    });
+  });
+
+  /** Offering an address that is already queried would only produce a duplicate. */
+  describe('the addresses on offer', () => {
+    it('should leave out the ones already queried', () => {
+      queried({ eth2: [ADDRESSES[0]] });
+
+      expect(selector(createWrapper()).props('source').usableAddresses).toEqual([ADDRESSES[1]]);
+    });
+
+    it('should offer every address while none are queried', () => {
+      expect(selector(createWrapper()).props('source').usableAddresses).toEqual(ADDRESSES);
+    });
+  });
+
+  describe('adding an address', () => {
+    it('should refuse to add while nothing is picked', () => {
+      expect(addButton(createWrapper()).props('disabled')).toBe(true);
+    });
+
+    it('should offer the add once an account is picked', async () => {
+      const wrapper = createWrapper();
+
+      await pick(wrapper, ADDRESSES[0]);
+
+      expect(addButton(wrapper).props('disabled')).toBe(false);
+    });
+
+    it('should add the picked address for this module', async () => {
+      const wrapper = createWrapper(Module.NFTS);
+      await pick(wrapper, ADDRESSES[0]);
+
+      await addButton(wrapper).trigger('click');
+
+      expect(addQueriedAddress).toHaveBeenCalledWith({ address: ADDRESSES[0], module: Module.NFTS });
+    });
+
+    it('should clear the picker once it has been added', async () => {
+      const wrapper = createWrapper();
+      await pick(wrapper, ADDRESSES[0]);
+
+      await addButton(wrapper).trigger('click');
+      await flushPromises();
+
+      expect(selector(wrapper).props('modelValue')).toEqual([]);
+    });
+  });
+
+  it('should remove an address from the module', async () => {
+    queried({ eth2: [ADDRESSES[0]] });
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=queried-address-remove]').trigger('click');
+
+    expect(deleteQueriedAddress).toHaveBeenCalledWith({ address: ADDRESSES[0], module: Module.ETH2 });
+  });
+
+  it('should report being closed', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=queried-address-close]').trigger('click');
+
+    expect(wrapper.emitted('close')).toHaveLength(1);
+  });
+});

--- a/frontend/app/src/modules/accounts/QueriedAddressDialog.vue
+++ b/frontend/app/src/modules/accounts/QueriedAddressDialog.vue
@@ -103,6 +103,7 @@ function close() {
             class="shrink-0"
             variant="text"
             icon
+            data-testid="queried-address-close"
             @click="close()"
           >
             <RuiIcon name="lu-x" />
@@ -120,6 +121,7 @@ function close() {
           :disabled="selectedAccounts.length === 0"
           variant="text"
           icon
+          data-testid="queried-address-add"
           @click="addAddress()"
         >
           <RuiIcon name="lu-plus" />
@@ -133,6 +135,7 @@ function close() {
           v-for="address in addresses"
           :key="address"
           class="flex items-start gap-4 py-2 border-t border-default"
+          data-testid="queried-address-row"
         >
           <div class="flex-1">
             <LabeledAddressDisplay :account="getAccount(address)" />
@@ -151,6 +154,7 @@ function close() {
                 icon
                 color="primary"
                 class="!p-2 mt-0.5"
+                data-testid="queried-address-remove"
                 @click="
                   deleteQueriedAddress({
                     module,

--- a/frontend/app/src/modules/accounts/account-helpers.spec.ts
+++ b/frontend/app/src/modules/accounts/account-helpers.spec.ts
@@ -156,6 +156,157 @@ describe('sortAndFilterAccounts', () => {
   });
 });
 
+/**
+ * A group stands for its member accounts, so a filter that can match on different members, or an
+ * exclusion that drops some of them, has to be resolved against the members rather than the group.
+ */
+describe('sortAndFilterAccounts, over groups', () => {
+  function group(overrides: Partial<BlockchainAccountGroupWithBalance> = {}): BlockchainAccountGroupWithBalance {
+    return {
+      amount: bigNumberify(3),
+      chains: ['eth', 'optimism'],
+      data: { address: '0xaaa', type: 'address' },
+      tags: ['hot'],
+      type: 'group',
+      value: bigNumberify(300),
+      ...overrides,
+    };
+  }
+
+  function member(chain: string, value: number, tags: string[]): BlockchainAccountWithBalance {
+    return account({ chain, data: { address: '0xaaa', type: 'address' }, tags, value: bigNumberify(value) });
+  }
+
+  const members = (): BlockchainAccountWithBalance[] => [
+    member('eth', 200, ['hot']),
+    member('optimism', 100, ['cold']),
+  ];
+
+  /** The excluded chains are still part of the group, they just stop counting towards its value. */
+  describe('an excluded chain', () => {
+    it('should leave the group holding only what is still included', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ excluded: { '0xaaa': ['optimism'] } }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data[0].includedValue?.toNumber()).toBe(200);
+    });
+
+    it('should leave a group with nothing excluded alone', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ excluded: { '0xbbb': ['optimism'] } }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data[0].includedValue).toBeUndefined();
+    });
+
+    /** A group on one chain cannot have that chain excluded and still be a group worth showing. */
+    it('should leave a single-chain group alone', () => {
+      const result = sortAndFilterAccounts(
+        [group({ chains: ['eth'] })],
+        payload({ excluded: { '0xaaa': ['eth'] } }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data[0].includedValue).toBeUndefined();
+    });
+  });
+
+  /**
+   * A tag or chain filter matching different members would otherwise show the whole group, which
+   * says the group matched when no single account in it did.
+   */
+  describe('a filter that can match different members', () => {
+    it('should narrow the group to the members that match the chain', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ chain: ['eth'] }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data[0].chains).toEqual(['eth']);
+      expect(result.data[0].value.toNumber()).toBe(200);
+    });
+
+    it('should keep the chains the group spans, so what was narrowed away is still known', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ chain: ['eth'] }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data[0].allChains).toEqual(['eth', 'optimism']);
+    });
+
+    it('should carry only the tags of the members that survived', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ chain: ['optimism'] }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data[0].tags).toEqual(['cold']);
+    });
+
+    /** One surviving member is no longer a group of alternatives, so it expands as that account. */
+    it('should expand a single survivor as itself', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ chain: ['eth'] }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data[0].expansion).toBeUndefined();
+    });
+
+    it('should expand several survivors as accounts', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ chain: ['eth', 'optimism'] }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data[0].expansion).toBe('accounts');
+    });
+
+    /** Tag and chain have to hold on the same member, not on two different ones. */
+    it('should drop a group whose members match the tag and the chain separately', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ chain: ['optimism'], tags: ['hot'] }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data).toHaveLength(0);
+    });
+
+    it('should keep a group whose member matches both', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ chain: ['eth'], tags: ['hot'] }),
+        { getAccounts: () => members(), getLabel: noLabel },
+      );
+
+      expect(result.data).toHaveLength(1);
+    });
+
+    /** Without a resolver there are no members to refine against, so the group stands as it is. */
+    it('should leave the group alone when its members cannot be read', () => {
+      const result = sortAndFilterAccounts(
+        [group()],
+        payload({ chain: ['eth'] }),
+        { getLabel: noLabel },
+      );
+
+      expect(result.data[0].chains).toEqual(['eth', 'optimism']);
+    });
+  });
+});
+
 describe('convertBtcAccounts', () => {
   const accounts: BitcoinAccounts = {
     standalone: [{ address: 'bc1standalone', label: 'Standalone', tags: null }],

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagement.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagement.spec.ts
@@ -1,0 +1,215 @@
+import type { AddressBookEntry } from '@/modules/accounts/address-book/eth-names';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import AddressBookManagement from '@/modules/accounts/address-book/AddressBookManagement.vue';
+
+const { fetch, getAddressBook, refetch } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    fetch: ref<((filter: unknown) => unknown) | undefined>(undefined),
+    getAddressBook: vi.fn(async () => ({ data: [], found: 0, limit: 0, total: 0 })),
+    refetch: vi.fn(async () => {}),
+  };
+});
+
+vi.mock('@/modules/accounts/address-book/use-address-book-operations', () => ({
+  useAddressBookOperations: (): Record<string, unknown> => ({ getAddressBook }),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-address-book-fields', () => ({
+  useAddressBookFields: (): unknown[] => [],
+}));
+
+vi.mock('@/modules/core/table/pill/composables/use-pill-bar-labels', () => ({
+  usePillBarLabels: (): Record<string, unknown> => ({}),
+}));
+
+/**
+ * Captures the fetch the table was configured with, which is where the location reaches the query,
+ * and stands in for the table's own state.
+ */
+vi.mock('@/modules/core/table/use-server-table', async () => {
+  const { computed, ref } = await import('vue');
+  return {
+    useServerTable: (options: { fetch: (filter: unknown) => unknown }): Record<string, unknown> => {
+      fetch.value = options.fetch;
+      return {
+        collection: computed(() => ({ data: [], found: 0, limit: 0, total: 0 })),
+        filter: ref({}),
+        isLoading: ref(false),
+        pagination: ref({ limit: 10, page: 1, total: 0 }),
+        refetch,
+        sort: ref([]),
+      };
+    },
+  };
+});
+
+const TableStub = defineComponent({
+  emits: ['edit', 'refresh'],
+  props: ['collection', 'location', 'loading', 'blockchain', 'sort', 'pagination'],
+  template: '<div />',
+});
+
+const DialogStub = defineComponent({
+  emits: ['update:open', 'update-tab', 'refresh'],
+  props: ['open', 'editableItem', 'editMode', 'selectedChain', 'location'],
+  template: '<div />',
+});
+
+const TabsStub = defineComponent({
+  emits: ['update:modelValue'],
+  props: ['modelValue'],
+  template: '<div><slot /></div>',
+});
+
+function createWrapper(): VueWrapper<any> {
+  return mount(AddressBookManagement, {
+    global: {
+      stubs: {
+        AddressBookFormDialog: DialogStub,
+        AddressBookManagementMore: true,
+        AddressBookTable: TableStub,
+        EthNamesHint: true,
+        PillFilterBar: true,
+        RuiTab: true,
+        RuiTabItem: { template: '<div><slot /></div>' },
+        RuiTabItems: { template: '<div><slot /></div>' },
+        RuiTabs: TabsStub,
+        TablePageLayout: { template: '<div><slot name="buttons" /><slot /></div>' },
+      },
+    },
+  });
+}
+
+function dialog(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(DialogStub);
+}
+
+function entry(): AddressBookEntry {
+  return { address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', blockchain: 'eth', name: 'mine' };
+}
+
+async function switchToPrivate(wrapper: VueWrapper<any>): Promise<void> {
+  wrapper.findComponent(TabsStub).vm.$emit('update:modelValue', 1);
+  await nextTick();
+}
+
+describe('addressBookManagement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setActivePinia(createPinia());
+  });
+
+  /** The tab strip is the scope of everything below it, so the tab index picks the address book. */
+  describe('the scope tabs', () => {
+    it('should start on the global address book', () => {
+      expect(dialog(createWrapper()).props('location')).toBe('global');
+    });
+
+    it('should switch to the private one', async () => {
+      const wrapper = createWrapper();
+
+      await switchToPrivate(wrapper);
+
+      expect(dialog(wrapper).props('location')).toBe('private');
+    });
+
+    it('should query the address book of the tab in view', async () => {
+      const wrapper = createWrapper();
+      await switchToPrivate(wrapper);
+
+      const query = get(fetch);
+      assert(query);
+      await query({});
+
+      expect(getAddressBook).toHaveBeenCalledWith('private', {});
+    });
+
+    /** Each book holds its own entries, so switching tabs has to go back to the backend. */
+    it('should refetch when the tab changes', async () => {
+      const wrapper = createWrapper();
+      refetch.mockClear();
+
+      await switchToPrivate(wrapper);
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fetch once on arrival, before any tab is touched', () => {
+      createWrapper();
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /** The dialog both adds and edits, and what it does is decided by what it was seeded with. */
+  describe('the form dialog', () => {
+    it('should stay closed until it is asked for', () => {
+      expect(dialog(createWrapper()).props('open')).toBe(false);
+    });
+
+    it('should open empty for an addition', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.find('[data-testid=address-book-add]').trigger('click');
+
+      expect(dialog(wrapper).props('open')).toBe(true);
+      expect(dialog(wrapper).props('editableItem')).toBeNull();
+      expect(dialog(wrapper).props('editMode')).toBe(false);
+    });
+
+    /** The dialog is reused, so an addition after an edit must not reopen on the edited entry. */
+    it('should open empty for an addition following an edit', async () => {
+      const wrapper = createWrapper();
+      wrapper.findComponent(TableStub).vm.$emit('edit', entry());
+      await nextTick();
+
+      await wrapper.find('[data-testid=address-book-add]').trigger('click');
+
+      expect(dialog(wrapper).props('editableItem')).toBeNull();
+      expect(dialog(wrapper).props('editMode')).toBe(false);
+    });
+
+    it('should open on the entry being edited', async () => {
+      const wrapper = createWrapper();
+
+      wrapper.findComponent(TableStub).vm.$emit('edit', entry());
+      await nextTick();
+
+      expect(dialog(wrapper).props('open')).toBe(true);
+      expect(dialog(wrapper).props('editMode')).toBe(true);
+    });
+
+    /** An entry carries no book of its own, so the one in view is what it is saved back into. */
+    it('should edit the entry into the book in view', async () => {
+      const wrapper = createWrapper();
+      await switchToPrivate(wrapper);
+
+      wrapper.findComponent(TableStub).vm.$emit('edit', entry());
+      await nextTick();
+
+      expect(dialog(wrapper).props('editableItem')).toEqual({ ...entry(), location: 'private' });
+    });
+
+    it('should follow the dialog moving to another tab', async () => {
+      const wrapper = createWrapper();
+
+      dialog(wrapper).vm.$emit('update-tab', 1);
+      await nextTick();
+
+      expect(dialog(wrapper).props('location')).toBe('private');
+    });
+
+    it('should reload the table once an entry is saved', async () => {
+      const wrapper = createWrapper();
+      refetch.mockClear();
+
+      dialog(wrapper).vm.$emit('refresh');
+      await nextTick();
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.spec.ts
@@ -1,0 +1,155 @@
+import { Severity } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type VNode } from 'vue';
+import AddressBookManagementMore from '@/modules/accounts/address-book/AddressBookManagementMore.vue';
+
+const { importAddressBook, notify, removeFile } = vi.hoisted(() => ({
+  importAddressBook: vi.fn<(file: File) => Promise<number>>(async () => 0),
+  notify: vi.fn(),
+  removeFile: vi.fn(),
+}));
+
+vi.mock('@/modules/accounts/address-book/use-address-book-import', () => ({
+  useAddressBookImport: (): Record<string, unknown> => ({ importAddressBook }),
+}));
+
+vi.mock('@/modules/core/notifications/use-notification-dispatcher', () => ({
+  useNotificationDispatcher: (): Record<string, unknown> => ({ notify }),
+}));
+
+vi.mock('@/modules/user-data/FileUpload.vue', async () => {
+  const { defineComponent, h } = await import('vue');
+  return {
+    __esModule: true,
+    default: defineComponent({
+      emits: ['update:modelValue'],
+      name: 'FileUpload',
+      props: { modelValue: { default: undefined, type: Object } },
+      setup(_props, { expose }): () => VNode {
+        expose({ removeFile });
+        return () => h('div');
+      },
+    }),
+  };
+});
+
+const MenuStub = defineComponent({
+  template: '<div><slot name="activator" :attrs="{}" /><slot /></div>',
+});
+
+function createWrapper(): VueWrapper<any> {
+  return mount(AddressBookManagementMore, {
+    global: {
+      stubs: {
+        ExternalLink: true,
+        RuiCard: { template: '<div><slot name="header" /><slot /><slot name="footer" /></div>' },
+        RuiDialog: { props: ['modelValue'], template: '<div v-if="modelValue"><slot /></div>' },
+        RuiMenu: MenuStub,
+      },
+    },
+  });
+}
+
+function button(wrapper: VueWrapper<any>, id: string): VueWrapper<any> {
+  const found = wrapper
+    .findAllComponents({ name: 'RuiButton' })
+    .find(item => item.attributes('data-testid') === id);
+  assert(found);
+  return found;
+}
+
+const CSV = new File(['address,name'], 'address-book.csv', { type: 'text/csv' });
+
+async function importFile(wrapper: VueWrapper<any>): Promise<void> {
+  await button(wrapper, 'address-book-import').trigger('click');
+  wrapper.findComponent({ name: 'FileUpload' }).vm.$emit('update:modelValue', CSV);
+  await nextTick();
+  await button(wrapper, 'address-book-import-confirm').trigger('click');
+  await flushPromises();
+}
+
+describe('addressBookManagementMore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    importAddressBook.mockResolvedValue(0);
+  });
+
+  it('should refuse to import while no file is chosen', async () => {
+    const wrapper = createWrapper();
+
+    await button(wrapper, 'address-book-import').trigger('click');
+
+    expect(button(wrapper, 'address-book-import-confirm').props('disabled')).toBe(true);
+  });
+
+  it('should import the chosen file', async () => {
+    importAddressBook.mockResolvedValue(3);
+    const wrapper = createWrapper();
+
+    await importFile(wrapper);
+
+    expect(importAddressBook).toHaveBeenCalledWith(CSV);
+  });
+
+  /** The table behind the dialog is now stale whatever the import did, so it is always reloaded. */
+  describe('once the import is done', () => {
+    it('should ask for a reload after entries were added', async () => {
+      importAddressBook.mockResolvedValue(3);
+      const wrapper = createWrapper();
+
+      await importFile(wrapper);
+
+      expect(wrapper.emitted('refresh')).toHaveLength(1);
+    });
+
+    it('should ask for a reload even when nothing was added', async () => {
+      const wrapper = createWrapper();
+
+      await importFile(wrapper);
+
+      expect(wrapper.emitted('refresh')).toHaveLength(1);
+    });
+
+    /** An import that added nothing has nothing to announce. */
+    it('should say how many entries were added', async () => {
+      importAddressBook.mockResolvedValue(3);
+      const wrapper = createWrapper();
+
+      await importFile(wrapper);
+
+      expect(notify).toHaveBeenCalledWith({
+        message: 'address_book.import.import_success.message::3',
+        severity: Severity.INFO,
+        title: 'address_book.import.title',
+      });
+    });
+
+    it('should stay quiet when nothing was added', async () => {
+      const wrapper = createWrapper();
+
+      await importFile(wrapper);
+
+      expect(notify).not.toHaveBeenCalled();
+    });
+
+    it('should forget the file so it is not offered again', async () => {
+      const wrapper = createWrapper();
+      await importFile(wrapper);
+
+      await button(wrapper, 'address-book-import').trigger('click');
+
+      expect(button(wrapper, 'address-book-import-confirm').props('disabled')).toBe(true);
+    });
+  });
+
+  it('should import nothing on cancel', async () => {
+    const wrapper = createWrapper();
+    await button(wrapper, 'address-book-import').trigger('click');
+
+    await button(wrapper, 'address-book-import-cancel').trigger('click');
+
+    expect(importAddressBook).not.toHaveBeenCalled();
+    expect(wrapper.emitted('refresh')).toBeUndefined();
+  });
+});

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
@@ -63,6 +63,7 @@ async function doImport() {
       </template>
       <RuiButton
         variant="list"
+        data-testid="address-book-import"
         @click="importDialogOpen = true;"
       >
         <template #prepend>
@@ -105,6 +106,7 @@ async function doImport() {
           <RuiButton
             variant="text"
             color="primary"
+            data-testid="address-book-import-cancel"
             @click="importDialogOpen = false"
           >
             {{ t('common.actions.cancel') }}
@@ -113,6 +115,7 @@ async function doImport() {
             color="primary"
             :disabled="!importFile"
             :loading="loading"
+            data-testid="address-book-import-confirm"
             @click="doImport()"
           >
             {{ t('common.actions.import') }}

--- a/frontend/app/src/modules/accounts/blockchain/use-account-manage.spec.ts
+++ b/frontend/app/src/modules/accounts/blockchain/use-account-manage.spec.ts
@@ -1,4 +1,4 @@
-import type { AccountManage, StakingValidatorManage } from './use-account-manage';
+import type { AccountAgnosticManage, AccountManage, StakingValidatorManage, XpubManage } from './use-account-manage';
 import type { ActionStatus } from '@/modules/core/common/action';
 import { Blockchain, Zero } from '@rotki/common';
 import { type Pinia, setActivePinia } from 'pinia';
@@ -10,12 +10,17 @@ import { TaskFailed } from '@/modules/core/tasks/task-result';
 const mockAddAccounts = vi.fn();
 const mockAddEvmAccounts = vi.fn();
 const mockShowErrorMessage = vi.fn();
+const mockFetchAccounts = vi.fn().mockResolvedValue(undefined);
+const mockEditAccount = vi.fn();
+const mockEditAgnosticAccount = vi.fn();
+const mockUpdateAccountData = vi.fn();
+const mockUpdateAccounts = vi.fn();
 
 vi.mock('@/modules/accounts/use-blockchain-account-management', () => ({
   useBlockchainAccountManagement: vi.fn(() => ({
     addAccounts: mockAddAccounts,
     addEvmAccounts: mockAddEvmAccounts,
-    fetchAccounts: vi.fn().mockResolvedValue(undefined),
+    fetchAccounts: mockFetchAccounts,
     refreshAccounts: vi.fn().mockResolvedValue(undefined),
   })),
 }));
@@ -33,15 +38,15 @@ vi.mock('@/modules/core/notifications/use-notifications', async () => ({
 
 vi.mock('@/modules/accounts/use-account-edits', () => ({
   useAccountEdits: vi.fn(() => ({
-    editAccount: vi.fn(),
-    editAgnosticAccount: vi.fn(),
+    editAccount: mockEditAccount,
+    editAgnosticAccount: mockEditAgnosticAccount,
   })),
 }));
 
 vi.mock('@/modules/accounts/use-blockchain-accounts-store', () => ({
   useBlockchainAccountsStore: vi.fn(() => ({
-    updateAccountData: vi.fn(),
-    updateAccounts: vi.fn(),
+    updateAccountData: mockUpdateAccountData,
+    updateAccounts: mockUpdateAccounts,
   })),
 }));
 
@@ -349,6 +354,105 @@ describe('composables/accounts/blockchain/use-account-manage', () => {
       expect(result).toBe(false);
       expect(get(modelErrorMessages)).toEqual({ address: ['already typed'] });
       expect(mockShowErrorMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveXpub', () => {
+    function xpubState(mode: 'add' | 'edit'): XpubManage {
+      return {
+        chain: Blockchain.BTC,
+        data: {
+          tags: null,
+          xpub: { derivationPath: 'm/0', xpub: 'zpub6r', xpubType: XpubKeyType.ZPUB },
+        },
+        mode,
+        type: 'xpub',
+      };
+    }
+
+    it('should add the xpub and report it saved', async () => {
+      mockAddAccounts.mockResolvedValue({ added: [{ address: 'zpub6r' }], failed: [], noActivity: [] });
+
+      const { save } = useAccountManage();
+
+      expect(await save(xpubState('add'))).toBe(true);
+      expect(mockAddAccounts).toHaveBeenCalledWith(Blockchain.BTC, xpubState('add').data, { wait: true });
+    });
+
+    /** An edit does not go through the addition summary, so the list is re-read instead. */
+    it('should edit the xpub and re-read the chain', async () => {
+      const { save } = useAccountManage();
+
+      expect(await save(xpubState('edit'))).toBe(true);
+      expect(mockEditAccount).toHaveBeenCalledWith(xpubState('edit').data, Blockchain.BTC);
+      expect(mockFetchAccounts).toHaveBeenCalledWith({ blockchain: Blockchain.BTC });
+    });
+
+    /**
+     * The xpub errors are reported against the two fields of the xpub form rather than an address,
+     * which is what the empty props name.
+     */
+    it('should report a failed addition against the xpub fields', async () => {
+      mockAddAccounts.mockResolvedValue({
+        added: [],
+        failed: [{ address: 'zpub6r', error: new Error('{"xpub":["not a valid xpub"]}') }],
+        noActivity: [],
+      });
+
+      const { modelErrorMessages, save } = useAccountManage();
+
+      expect(await save(xpubState('add'))).toBe(false);
+      expect(get(modelErrorMessages)).toEqual({ xpub: ['not a valid xpub'] });
+    });
+
+    it('should report a rejected edit rather than closing the dialog', async () => {
+      mockEditAccount.mockRejectedValue(new Error('the backend said no'));
+
+      const { save } = useAccountManage();
+
+      expect(await save(xpubState('edit'))).toBe(false);
+      expect(mockShowErrorMessage).toHaveBeenCalled();
+    });
+
+    /** Cancelling the addition is not a failure, but nothing was added, so the dialog stays open. */
+    it('should not report a fully cancelled addition as saved', async () => {
+      mockAddAccounts.mockResolvedValue({ added: [], cancelled: true, failed: [] });
+
+      const { modelErrorMessages, save } = useAccountManage();
+
+      expect(await save(xpubState('add'))).toBe(false);
+      expect(get(modelErrorMessages)).toEqual({});
+      expect(mockShowErrorMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveAgnosticAccount', () => {
+    function groupState(): AccountAgnosticManage {
+      return {
+        category: 'evm',
+        chain: undefined,
+        data: { address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', tags: null },
+        mode: 'edit',
+        type: 'group',
+      };
+    }
+
+    /** A group spans chains, so the edit is written once and mirrored into every account. */
+    it('should edit the group and carry the change into the accounts', async () => {
+      const { save } = useAccountManage();
+
+      expect(await save(groupState())).toBe(true);
+      expect(mockEditAgnosticAccount).toHaveBeenCalledWith('evm', groupState().data);
+      expect(mockUpdateAccountData).toHaveBeenCalledWith(groupState().data);
+    });
+
+    it('should not touch the accounts when the edit is rejected', async () => {
+      mockEditAgnosticAccount.mockRejectedValue(new Error('the backend said no'));
+
+      const { save } = useAccountManage();
+
+      expect(await save(groupState())).toBe(false);
+      expect(mockUpdateAccountData).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/app/src/modules/accounts/management/AccountDialog.spec.ts
+++ b/frontend/app/src/modules/accounts/management/AccountDialog.spec.ts
@@ -1,0 +1,334 @@
+import { Blockchain } from '@rotki/common';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type VNode } from 'vue';
+import { type AccountManageState, createNewBlockchainAccount } from '@/modules/accounts/blockchain/use-account-manage';
+import AccountDialog from '@/modules/accounts/management/AccountDialog.vue';
+
+const {
+  currentTier,
+  ethStakedLimit,
+  loading,
+  modelErrorMessages,
+  pending,
+  premium,
+  resetSaveError,
+  save,
+  saveError,
+  saveErrorIsPremium,
+  validate,
+  validatorsLimitInfo,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    currentTier: ref<string>('free'),
+    ethStakedLimit: ref<number>(0),
+    loading: ref<boolean>(false),
+    modelErrorMessages: ref<Record<string, string[]>>({}),
+    pending: ref<boolean>(false),
+    premium: ref<boolean>(false),
+    resetSaveError: vi.fn(),
+    save: vi.fn<(state: AccountManageState) => Promise<boolean>>(async () => true),
+    saveError: ref<string>(''),
+    saveErrorIsPremium: ref<boolean>(false),
+    validate: vi.fn<() => Promise<boolean>>(async () => true),
+    validatorsLimitInfo: ref<{ limit: number; showWarning: boolean; total: number }>({
+      limit: 4,
+      showWarning: false,
+      total: 0,
+    }),
+  };
+});
+
+vi.mock('@/modules/accounts/blockchain/use-account-manage', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/accounts/blockchain/use-account-manage')>(),
+  useAccountManage: (): Record<string, unknown> => ({
+    modelErrorMessages,
+    pending,
+    resetSaveError,
+    save,
+    saveError,
+    saveErrorIsPremium,
+  }),
+}));
+
+vi.mock('@/modules/accounts/use-account-loading', () => ({
+  useAccountLoading: (): Record<string, unknown> => ({ loading }),
+}));
+
+vi.mock('@/modules/accounts/use-eth-staking', () => ({
+  useEthStaking: (): Record<string, unknown> => ({ validatorsLimitInfo }),
+}));
+
+vi.mock('@/modules/premium/use-premium-helper', () => ({
+  usePremiumHelper: (): Record<string, unknown> => ({ currentTier, ethStakedLimit, premium }),
+}));
+
+/** Exposes `validate` under the name the dialog calls on its form ref. */
+vi.mock('@/modules/accounts/management/AccountForm.vue', async () => {
+  const { defineComponent, h } = await import('vue');
+  return {
+    __esModule: true,
+    default: defineComponent({
+      name: 'AccountForm',
+      setup(_props, { expose }): () => VNode {
+        expose({ validate });
+        return () => h('div', { 'data-testid': 'account-form' });
+      },
+    }),
+  };
+});
+
+/** Renders the dialog body and surfaces the action bar the spec drives. */
+const BigDialogStub = defineComponent({
+  emits: ['confirm', 'cancel'],
+  props: ['display', 'title', 'subtitle', 'action', 'loading', 'promptOnClose'],
+  template: `<div v-if="display">
+    <span class="title">{{ title }}</span>
+    <span class="subtitle">{{ subtitle }}</span>
+    <button data-testid="confirm" :disabled="action.disabled" @click="$emit('confirm')" />
+    <button data-testid="cancel" @click="$emit('cancel')" />
+    <slot />
+  </div>`,
+});
+
+function createWrapper(modelValue: AccountManageState | undefined = createNewBlockchainAccount()): VueWrapper<any> {
+  return mount(AccountDialog, {
+    global: {
+      stubs: {
+        'BigDialog': BigDialogStub,
+        'ExternalLink': true,
+        'I18nT': { props: ['keypath'], template: '<span>{{ keypath }}</span>' },
+        'i18n-t': { props: ['keypath'], template: '<span>{{ keypath }}</span>' },
+        'RuiAlert': { template: '<div><slot /></div>' },
+      },
+    },
+    props: { chainIds: [], modelValue },
+  });
+}
+
+/** The same account with an address typed into it, which is an edit rather than a new target. */
+function edited(): AccountManageState {
+  return {
+    ...createNewBlockchainAccount(),
+    data: [{ address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', tags: null }],
+  };
+}
+
+function dialog(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(BigDialogStub);
+}
+
+function lastModel(wrapper: VueWrapper<any>): AccountManageState | undefined {
+  return wrapper.emitted<[AccountManageState | undefined]>('update:modelValue')?.at(-1)?.[0];
+}
+
+async function confirm(wrapper: VueWrapper<any>): Promise<void> {
+  await wrapper.find('[data-testid=confirm]').trigger('click');
+  await flushPromises();
+}
+
+describe('accountDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(currentTier, 'free');
+    set(ethStakedLimit, 0);
+    set(loading, false);
+    set(modelErrorMessages, {});
+    set(pending, false);
+    set(premium, false);
+    set(saveError, '');
+    set(saveErrorIsPremium, false);
+    set(validatorsLimitInfo, { limit: 4, showWarning: false, total: 0 });
+    save.mockResolvedValue(true);
+    validate.mockResolvedValue(true);
+  });
+
+  describe('the heading', () => {
+    it('should say it is adding when the account is new', () => {
+      const wrapper = createWrapper();
+
+      expect(dialog(wrapper).props('title')).toBe('blockchain_balances.form_dialog.add_title');
+      expect(dialog(wrapper).props('subtitle')).toBe('');
+    });
+
+    it('should say it is editing an existing account', () => {
+      const wrapper = createWrapper({ chain: Blockchain.ETH2, data: {}, mode: 'edit', type: 'validator' });
+
+      expect(dialog(wrapper).props('title')).toBe('blockchain_balances.form_dialog.edit_title');
+      expect(dialog(wrapper).props('subtitle')).toBe('blockchain_balances.form_dialog.edit_subtitle');
+    });
+  });
+
+  /** Saving an invalid form would send it to the backend to be rejected there instead. */
+  describe('confirming', () => {
+    it('should save a valid account', async () => {
+      const wrapper = createWrapper();
+
+      await confirm(wrapper);
+
+      expect(save).toHaveBeenCalledWith(createNewBlockchainAccount());
+    });
+
+    it('should not save while the form rejects it', async () => {
+      validate.mockResolvedValue(false);
+      const wrapper = createWrapper();
+
+      await confirm(wrapper);
+
+      expect(save).not.toHaveBeenCalled();
+    });
+
+    it('should clear the previous errors before trying again', async () => {
+      set(modelErrorMessages, { address: ['nope'] });
+      const wrapper = createWrapper();
+
+      await confirm(wrapper);
+
+      expect(get(modelErrorMessages)).toEqual({});
+      expect(resetSaveError).toHaveBeenCalled();
+    });
+
+    it('should close and report a saved account', async () => {
+      const wrapper = createWrapper();
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('complete')).toHaveLength(1);
+      expect(lastModel(wrapper)).toBeUndefined();
+    });
+
+    /** A rejected save leaves the dialog open, so the user can correct what the backend refused. */
+    it('should stay open when the save is refused', async () => {
+      save.mockResolvedValue(false);
+      const wrapper = createWrapper();
+
+      await confirm(wrapper);
+
+      expect(wrapper.emitted('complete')).toBeUndefined();
+      expect(lastModel(wrapper)).toBeUndefined();
+    });
+  });
+
+  it('should drop the account and its error on cancel', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('[data-testid=cancel]').trigger('click');
+
+    expect(lastModel(wrapper)).toBeUndefined();
+    expect(resetSaveError).toHaveBeenCalled();
+  });
+
+  /** The close prompt exists to stop typed-in work being lost, so it follows real edits only. */
+  describe('prompting before an unsaved close', () => {
+    it('should not prompt on a freshly opened dialog', () => {
+      expect(dialog(createWrapper()).props('promptOnClose')).toBe(false);
+    });
+
+    it('should prompt once the account has been edited', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.setProps({ modelValue: edited() });
+
+      expect(dialog(wrapper).props('promptOnClose')).toBe(true);
+    });
+
+    /**
+     * A different chain means the dialog was pointed at another account, not that this one was
+     * edited, so there is nothing typed in to lose.
+     */
+    it('should not prompt when the dialog is pointed at another chain', async () => {
+      const wrapper = createWrapper();
+
+      await wrapper.setProps({ modelValue: { ...createNewBlockchainAccount(), chain: Blockchain.BTC } });
+
+      expect(dialog(wrapper).props('promptOnClose')).toBe(false);
+    });
+
+    it('should stop prompting once the dialog is closed', async () => {
+      const wrapper = createWrapper();
+      await wrapper.setProps({ modelValue: edited() });
+
+      await wrapper.setProps({ modelValue: undefined });
+
+      expect(dialog(wrapper).props('promptOnClose')).toBe(false);
+    });
+
+    /** A refused save is the one case where nothing changed but the work is still unsaved. */
+    it('should prompt after a save the backend refused', async () => {
+      save.mockResolvedValue(false);
+      const wrapper = createWrapper();
+
+      await confirm(wrapper);
+
+      expect(dialog(wrapper).props('promptOnClose')).toBe(true);
+    });
+  });
+
+  /** Past the validator limit the account cannot be saved, so the action is closed off. */
+  describe('the validator limit', () => {
+    it('should refuse to save another validator once it is reached', () => {
+      set(validatorsLimitInfo, { limit: 4, showWarning: true, total: 4 });
+
+      const wrapper = createWrapper({ chain: Blockchain.ETH2, data: {}, mode: 'add', type: 'validator' });
+
+      expect(dialog(wrapper).props('action').disabled).toBe(true);
+    });
+
+    it('should not stand in the way of editing an existing validator', () => {
+      set(validatorsLimitInfo, { limit: 4, showWarning: true, total: 4 });
+
+      const wrapper = createWrapper({ chain: Blockchain.ETH2, data: {}, mode: 'edit', type: 'validator' });
+
+      expect(dialog(wrapper).props('action').disabled).toBe(false);
+    });
+
+    it('should not stand in the way of an ordinary account', () => {
+      set(validatorsLimitInfo, { limit: 4, showWarning: true, total: 4 });
+
+      const wrapper = createWrapper();
+
+      expect(dialog(wrapper).props('action').disabled).toBe(false);
+    });
+  });
+
+  describe('reporting a refused save', () => {
+    it('should show what the backend said', async () => {
+      const wrapper = createWrapper();
+
+      set(saveError, 'the backend said no');
+      await nextTick();
+
+      expect(wrapper.text()).toContain('the backend said no');
+    });
+
+    /** A premium refusal is explained with an upgrade route rather than the raw message. */
+    it('should explain a staking limit rather than repeating the error', async () => {
+      set(ethStakedLimit, 4);
+      const wrapper = createWrapper();
+
+      set(saveError, 'limit reached');
+      set(saveErrorIsPremium, true);
+      await nextTick();
+
+      expect(wrapper.text()).toContain('blockchain_balances.eth_staking_limit_error');
+      expect(wrapper.text()).not.toContain('limit reached');
+    });
+
+    it('should explain having no access at all when there is no limit to name', async () => {
+      const wrapper = createWrapper();
+
+      set(saveError, 'no access');
+      set(saveErrorIsPremium, true);
+      await nextTick();
+
+      expect(wrapper.text()).toContain('blockchain_balances.eth_staking_no_access');
+    });
+  });
+
+  it('should keep the dialog busy while an account is being saved', () => {
+    set(pending, true);
+
+    expect(dialog(createWrapper()).props('loading')).toBe(true);
+  });
+});

--- a/frontend/app/src/modules/accounts/management/AccountForm.vue
+++ b/frontend/app/src/modules/accounts/management/AccountForm.vue
@@ -1,28 +1,18 @@
 <script setup lang="ts">
+import type { AccountManageState } from '@/modules/accounts/blockchain/use-account-manage';
 import type { ValidationErrors } from '@/modules/core/api/types/errors';
-import { assert, Blockchain } from '@rotki/common';
+import { assert } from '@rotki/common';
 import { startPromise } from '@shared/utils';
-import { camelCase } from 'es-toolkit';
-import { XpubKeyType } from '@/modules/accounts/blockchain-accounts';
-import {
-  type AccountManageState,
-  createNewBlockchainAccount,
-  type StakingValidatorManage,
-  type XpubManage,
-} from '@/modules/accounts/blockchain/use-account-manage';
 import AccountFormApiKeyAlertContent from '@/modules/accounts/management/AccountFormApiKeyAlertContent.vue';
 import AccountSelector from '@/modules/accounts/management/inputs/AccountSelector.vue';
 import AddressAccountForm from '@/modules/accounts/management/types/AddressAccountForm.vue';
 import AgnosticAddressAccountForm from '@/modules/accounts/management/types/AgnosticAddressAccountForm.vue';
 import BtcAccountForm from '@/modules/accounts/management/types/BtcAccountForm.vue';
 import ValidatorAccountForm from '@/modules/accounts/management/types/ValidatorAccountForm.vue';
-import { isBtcChain } from '@/modules/core/common/chains';
-import { InputMode } from '@/modules/core/common/input-mode';
+import { useAccountFormState } from '@/modules/accounts/management/use-account-form-state';
+import { useAccountFormWarnings } from '@/modules/accounts/management/use-account-form-warnings';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
-import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
-import { useSetting } from '@/modules/settings/use-setting';
 
 const modelValue = defineModel<AccountManageState>({ required: true });
 
@@ -33,7 +23,7 @@ defineProps<{
   chainIds: string[];
 }>();
 
-const inputMode = ref<InputMode>(InputMode.MANUAL_ADD);
+const { t } = useI18n({ useScope: 'global' });
 
 const form = useTemplateRef<
   | InstanceType<typeof AddressAccountForm>
@@ -41,165 +31,21 @@ const form = useTemplateRef<
   | InstanceType<typeof BtcAccountForm>
 >('form');
 
+const { getChainName } = useSupportedChains();
+
+const { handleDetectedAddress, handleDetectedXpub, selectChain, setValidator } = useAccountFormState(modelValue);
+
+const {
+  beaconchainInfo,
+  hasMultipleWarnings,
+  hiddenWarningCount,
+  toggleWarningExpanded,
+  visibleWarnings,
+  warningExpanded,
+  warnings,
+} = useAccountFormWarnings(modelValue);
+
 const chain = computed<string | undefined>(() => get(modelValue).chain);
-
-/**
- * A validator edit only ever reaches a state that holds a validator, which is what the guard says.
- * Narrowing first is what lets the rest of the state be carried over as itself, rather than a field
- * being written onto whichever variant happens to be there.
- */
-function setValidator(data: StakingValidatorManage['data']): void {
-  const state = get(modelValue);
-  if (state.type !== 'validator')
-    return;
-
-  set(modelValue, { ...state, data });
-}
-
-const { getChainName, isEarlyIntegrationChain, isEvm, isSolanaChains, txEvmChains } = useSupportedChains();
-const { t } = useI18n({ useScope: 'global' });
-const { getApiKey } = useExternalApiKeys();
-
-const beaconRpcEndpoint = useSetting('beaconRpcEndpoint');
-const defaultEvmIndexerOrder = useSetting('defaultEvmIndexerOrder');
-const evmIndexersOrder = useSetting('evmIndexersOrder');
-
-/**
- * Checks if etherscan is the top priority indexer for a given chain.
- */
-function isEtherscanTopPriority(chainId: string): boolean {
-  const chainOrders = get(evmIndexersOrder);
-  const evmChainName = camelCase(get(txEvmChains).find(c => c.id === chainId)?.evmChainName || '');
-  const indexerOrder = evmChainName && chainOrders[evmChainName]
-    ? chainOrders[evmChainName]
-    : get(defaultEvmIndexerOrder);
-
-  return indexerOrder[0] === EvmIndexer.ETHERSCAN;
-}
-
-/**
- * Checks if etherscan is the top priority for the selected chain(s).
- * For 'all', returns true if etherscan is top priority for any EVM chain.
- */
-function shouldShowEtherscanWarning(selectedChain: string): boolean {
-  if (selectedChain === 'all') {
-    return get(txEvmChains).some(chain => isEtherscanTopPriority(chain.id));
-  }
-
-  if (!isEvm(selectedChain))
-    return false;
-
-  return isEtherscanTopPriority(selectedChain);
-}
-
-/** Without a beaconchain key, validators fall back to a consensus RPC, which needs its own endpoint. */
-function validatorKeyService(): 'beaconchain' | 'consensusRpc' | undefined {
-  if (getApiKey('beaconchain'))
-    return undefined;
-
-  return get(beaconRpcEndpoint) ? 'beaconchain' : 'consensusRpc';
-}
-
-/** Both indexers are only worth warning about on chains that actually use them. */
-function indexerKeyService(chain: string): 'etherscan' | 'blockscout' | undefined {
-  if (!shouldShowEtherscanWarning(chain))
-    return undefined;
-
-  if (!getApiKey('etherscan'))
-    return 'etherscan';
-
-  return getApiKey('blockscout') ? undefined : 'blockscout';
-}
-
-const missingApiKeyService = computed<'etherscan' | 'helius' | 'beaconchain' | 'consensusRpc' | 'blockscout' | undefined>(() => {
-  const selectedChain = get(chain);
-  const currentModelValue = get(modelValue);
-
-  if (currentModelValue.mode !== 'add' || !selectedChain)
-    return undefined;
-
-  if (currentModelValue.type === 'validator')
-    return validatorKeyService();
-
-  if (isSolanaChains(selectedChain))
-    return getApiKey('helius') ? undefined : 'helius';
-
-  return indexerKeyService(selectedChain);
-});
-
-const showSolanaInitialAlert = computed<boolean>(() => {
-  const selectedChain = get(chain);
-  const currentModelValue = get(modelValue);
-
-  return currentModelValue.mode === 'add' && !!selectedChain && isSolanaChains(selectedChain);
-});
-
-const earlyIntegrationChain = computed<string | undefined>(() => {
-  const selectedChain = get(chain);
-  const currentModelValue = get(modelValue);
-
-  if (currentModelValue.mode === 'add' && selectedChain && isEarlyIntegrationChain(selectedChain))
-    return selectedChain;
-  return undefined;
-});
-
-const showBinanceEtherscanWarning = computed<boolean>(() => {
-  const selectedChain = get(chain);
-  const currentModelValue = get(modelValue);
-
-  return currentModelValue.mode === 'add' && selectedChain === 'all';
-});
-
-const warningExpanded = ref<boolean>(false);
-
-type WarningType = 'solana' | 'apiKey' | 'binance' | 'earlyChain';
-
-interface WarningItem {
-  type: WarningType;
-  service?: 'etherscan' | 'helius' | 'beaconchain' | 'consensusRpc' | 'blockscout';
-  chain?: string;
-}
-
-function isBeaconchainService(service: WarningItem['service']): boolean {
-  return service === 'beaconchain' || service === 'consensusRpc';
-}
-
-const beaconchainInfo = computed<WarningItem | undefined>(() => {
-  const service = get(missingApiKeyService);
-  if (!service || !isBeaconchainService(service))
-    return undefined;
-  return { service, type: 'apiKey' };
-});
-
-const warnings = computed<WarningItem[]>(() => {
-  const result: WarningItem[] = [];
-  const service = get(missingApiKeyService);
-  if (service && !isBeaconchainService(service))
-    result.push({ service, type: 'apiKey' });
-  if (get(showSolanaInitialAlert))
-    result.push({ type: 'solana' });
-  const earlyChain = get(earlyIntegrationChain);
-  if (earlyChain)
-    result.push({ chain: earlyChain, type: 'earlyChain' });
-  if (get(showBinanceEtherscanWarning))
-    result.push({ type: 'binance' });
-  return result;
-});
-
-const hasMultipleWarnings = computed<boolean>(() => get(warnings).length > 1);
-
-const visibleWarnings = computed<WarningItem[]>(() => {
-  const all = get(warnings);
-  if (all.length <= 1 || get(warningExpanded))
-    return all;
-  return all.slice(0, 1);
-});
-
-const hiddenWarningCount = computed<number>(() => get(warnings).length - get(visibleWarnings).length);
-
-function toggleWarningExpanded(): void {
-  set(warningExpanded, !get(warningExpanded));
-}
 
 async function validate(): Promise<boolean> {
   const selectedForm = get(form);
@@ -210,121 +56,6 @@ async function validate(): Promise<boolean> {
   logger.debug('selected form does not implement validate default to true');
   return true;
 }
-
-async function handleDetectedXpub(key: string): Promise<void> {
-  const selectedChain = get(chain);
-  if (!selectedChain || !isBtcChain(selectedChain))
-    return;
-
-  set(inputMode, InputMode.XPUB_ADD);
-  await nextTick();
-
-  const current = get(modelValue);
-  if (current.type !== 'xpub')
-    return;
-
-  set(modelValue, {
-    ...current,
-    data: {
-      ...current.data,
-      xpub: {
-        ...current.data.xpub,
-        xpub: key,
-      },
-    },
-  });
-}
-
-async function handleDetectedAddress(address: string): Promise<void> {
-  let targetChain = get(chain);
-  if (!targetChain)
-    return;
-
-  if (targetChain === Blockchain.BTC && address.startsWith('bitcoincash:'))
-    targetChain = Blockchain.BCH;
-
-  set(inputMode, InputMode.MANUAL_ADD);
-  await nextTick();
-  set(modelValue, {
-    chain: targetChain,
-    data: [{ address, tags: null }],
-    mode: 'add',
-    type: 'account',
-  });
-}
-
-watch(modelValue, (modelValue) => {
-  if ('xpub' in modelValue.data && modelValue.mode === 'edit')
-    set(inputMode, InputMode.XPUB_ADD);
-}, {
-  immediate: true,
-});
-
-/**
- * Answers a chosen chain with a whole state.
- *
- * Each chain implies a kind of account: eth2 a validator, anything else an address account, each
- * with a different shape of `data` and a different form below to edit it in. So this replaces the
- * state rather than writing a field into it — writing the chain alone would leave it paired with
- * the previous kind, which is a state the union does not admit and nothing downstream expects.
- *
- * An account being edited already exists on its chain, so there is nothing to choose.
- */
-function selectChain(next: string | undefined): void {
-  if (!next || get(modelValue).mode === 'edit')
-    return;
-
-  if (get(inputMode) === InputMode.XPUB_ADD)
-    set(inputMode, InputMode.MANUAL_ADD);
-
-  if (next === Blockchain.ETH2) {
-    set(modelValue, {
-      chain: Blockchain.ETH2,
-      data: {},
-      mode: 'add',
-      type: 'validator',
-    } satisfies StakingValidatorManage);
-    return;
-  }
-
-  const addressesTypedForTheOldChain = get(modelValue).data;
-  set(modelValue, {
-    ...createNewBlockchainAccount(),
-    chain: next,
-    ...(Array.isArray(addressesTypedForTheOldChain) ? { data: addressesTypedForTheOldChain } : {}),
-  });
-}
-
-watch(inputMode, (mode) => {
-  const selectedChain = get(chain);
-  if (get(modelValue).mode === 'edit' || !selectedChain)
-    return;
-
-  if (mode === InputMode.XPUB_ADD) {
-    assert(isBtcChain(selectedChain));
-    set(modelValue, {
-      chain: selectedChain,
-      data: {
-        tags: null,
-        xpub: {
-          derivationPath: '',
-          xpub: '',
-          xpubType: selectedChain === Blockchain.BCH ? XpubKeyType.XPUB : XpubKeyType.ZPUB,
-        },
-      },
-      mode: 'add',
-      type: 'xpub',
-    } satisfies XpubManage);
-  }
-  else {
-    const account = createNewBlockchainAccount();
-
-    set(modelValue, {
-      ...account,
-      chain: selectedChain,
-    });
-  }
-});
 
 defineExpose({
   validate,

--- a/frontend/app/src/modules/accounts/management/use-account-form-state.spec.ts
+++ b/frontend/app/src/modules/accounts/management/use-account-form-state.spec.ts
@@ -1,0 +1,247 @@
+import { Blockchain } from '@rotki/common';
+import { assert, beforeEach, describe, expect, it } from 'vitest';
+import { type Ref, ref } from 'vue';
+import { XpubKeyType } from '@/modules/accounts/blockchain-accounts';
+import {
+  type AccountManageState,
+  createNewBlockchainAccount,
+  type XpubManage,
+} from '@/modules/accounts/blockchain/use-account-manage';
+import { useAccountFormState } from '@/modules/accounts/management/use-account-form-state';
+
+function xpub(mode: 'add' | 'edit', chain: Blockchain.BTC | Blockchain.BCH = Blockchain.BTC): XpubManage {
+  return {
+    chain,
+    data: {
+      tags: null,
+      xpub: { derivationPath: '', xpub: '', xpubType: XpubKeyType.ZPUB },
+    },
+    mode,
+    type: 'xpub',
+  };
+}
+
+/** An account group has no chain of its own, which is the only state that reaches the no-chain guards. */
+function groupAccount(): AccountManageState {
+  return {
+    category: 'evm',
+    chain: undefined,
+    data: { address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', tags: null },
+    mode: 'edit',
+    type: 'group',
+  };
+}
+
+function validator(mode: 'add' | 'edit' = 'edit'): AccountManageState {
+  return { chain: Blockchain.ETH2, data: {}, mode, type: 'validator' };
+}
+
+function accountOn(chain: string): AccountManageState {
+  return { ...createNewBlockchainAccount(), chain };
+}
+
+describe('useAccountFormState', () => {
+  let modelValue: Ref<AccountManageState>;
+
+  beforeEach(() => {
+    modelValue = ref<AccountManageState>(createNewBlockchainAccount());
+  });
+
+  /**
+   * The chain implies the kind of account, so a choice replaces the whole state. Writing the chain
+   * alone would leave it paired with the previous kind, which the union does not admit.
+   */
+  describe('choosing a chain', () => {
+    it('should answer eth2 with a validator', () => {
+      const { selectChain } = useAccountFormState(modelValue);
+
+      selectChain(Blockchain.ETH2);
+
+      expect(get(modelValue)).toStrictEqual({
+        chain: Blockchain.ETH2,
+        data: {},
+        mode: 'add',
+        type: 'validator',
+      });
+    });
+
+    it('should answer any other chain with an address account', () => {
+      set(modelValue, validator('add'));
+      const { selectChain } = useAccountFormState(modelValue);
+
+      selectChain(Blockchain.BTC);
+
+      expect(get(modelValue).type).toBe('account');
+      expect(get(modelValue).chain).toBe(Blockchain.BTC);
+    });
+
+    /** Only the chain was answered, so what the user already typed is not thrown away. */
+    it('should carry already typed addresses across the change', () => {
+      const typed = [{ address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', tags: null }];
+      set(modelValue, { ...createNewBlockchainAccount(), data: typed });
+      const { selectChain } = useAccountFormState(modelValue);
+
+      selectChain(Blockchain.BTC);
+
+      expect(get(modelValue).data).toStrictEqual(typed);
+    });
+
+    /** An xpub's data is not a list of addresses, so there is nothing to carry over. */
+    it('should not carry xpub data across the change', () => {
+      set(modelValue, xpub('add'));
+      const { selectChain } = useAccountFormState(modelValue);
+
+      selectChain(Blockchain.ETH);
+
+      expect(get(modelValue).data).toStrictEqual(createNewBlockchainAccount().data);
+    });
+
+    it('should leave an account being edited on its chain', () => {
+      set(modelValue, xpub('edit'));
+      const before = get(modelValue);
+      const { selectChain } = useAccountFormState(modelValue);
+
+      selectChain(Blockchain.ETH2);
+
+      expect(get(modelValue)).toBe(before);
+    });
+
+    it('should ignore a cleared chain', () => {
+      const before = get(modelValue);
+      const { selectChain } = useAccountFormState(modelValue);
+
+      selectChain(undefined);
+
+      expect(get(modelValue)).toBe(before);
+    });
+  });
+
+  describe('editing a validator', () => {
+    it('should keep the rest of the state around the new validator', () => {
+      set(modelValue, validator());
+      const { setValidator } = useAccountFormState(modelValue);
+
+      setValidator({ publicKey: '0xabc' });
+
+      expect(get(modelValue)).toStrictEqual({
+        chain: Blockchain.ETH2,
+        data: { publicKey: '0xabc' },
+        mode: 'edit',
+        type: 'validator',
+      });
+    });
+
+    /** Writing validator data onto an address account would produce a state nothing expects. */
+    it('should refuse to write validator data onto another kind of account', () => {
+      const before = get(modelValue);
+      const { setValidator } = useAccountFormState(modelValue);
+
+      setValidator({ publicKey: '0xabc' });
+
+      expect(get(modelValue)).toBe(before);
+    });
+  });
+
+  /** An xpub pasted into the address field is a request to switch the form over to xpub entry. */
+  describe('detecting a pasted xpub', () => {
+    it('should turn the state into an xpub carrying the key', async () => {
+      set(modelValue, accountOn(Blockchain.BTC));
+      const { handleDetectedXpub } = useAccountFormState(modelValue);
+
+      await handleDetectedXpub('zpub6r');
+
+      const state = get(modelValue);
+      assert(state.type === 'xpub');
+      expect(state.data.xpub.xpub).toBe('zpub6r');
+      expect(state.chain).toBe(Blockchain.BTC);
+    });
+
+    it('should default a bitcoin cash xpub to its own key type', async () => {
+      set(modelValue, accountOn(Blockchain.BCH));
+      const { handleDetectedXpub } = useAccountFormState(modelValue);
+
+      await handleDetectedXpub('xpub6r');
+
+      const state = get(modelValue);
+      assert(state.type === 'xpub');
+      expect(state.data.xpub.xpubType).toBe(XpubKeyType.XPUB);
+    });
+
+    it('should default a bitcoin xpub to zpub', async () => {
+      set(modelValue, accountOn(Blockchain.BTC));
+      const { handleDetectedXpub } = useAccountFormState(modelValue);
+
+      await handleDetectedXpub('zpub6r');
+
+      const state = get(modelValue);
+      assert(state.type === 'xpub');
+      expect(state.data.xpub.xpubType).toBe(XpubKeyType.ZPUB);
+    });
+
+    /** Only bitcoin chains have xpubs, so on anything else the paste is not one. */
+    it('should ignore it on a chain that has no xpubs', async () => {
+      set(modelValue, accountOn(Blockchain.ETH));
+      const before = get(modelValue);
+      const { handleDetectedXpub } = useAccountFormState(modelValue);
+
+      await handleDetectedXpub('zpub6r');
+
+      expect(get(modelValue)).toBe(before);
+    });
+  });
+
+  describe('detecting a pasted address', () => {
+    it('should put the address into the state', async () => {
+      set(modelValue, accountOn(Blockchain.ETH));
+      const { handleDetectedAddress } = useAccountFormState(modelValue);
+
+      await handleDetectedAddress('0x9531C059098e3d194fF87FebB587aB07B30B1306');
+
+      expect(get(modelValue)).toStrictEqual({
+        chain: Blockchain.ETH,
+        data: [{ address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', tags: null }],
+        mode: 'add',
+        type: 'account',
+      });
+    });
+
+    /** A `bitcoincash:` address names its own chain, so the form follows it off bitcoin. */
+    it('should move a bitcoin cash address off bitcoin', async () => {
+      set(modelValue, accountOn(Blockchain.BTC));
+      const { handleDetectedAddress } = useAccountFormState(modelValue);
+
+      await handleDetectedAddress('bitcoincash:qpm2');
+
+      expect(get(modelValue).chain).toBe(Blockchain.BCH);
+    });
+
+    it('should leave a plain address on bitcoin', async () => {
+      set(modelValue, accountOn(Blockchain.BTC));
+      const { handleDetectedAddress } = useAccountFormState(modelValue);
+
+      await handleDetectedAddress('1A1zP1eP5Q');
+
+      expect(get(modelValue).chain).toBe(Blockchain.BTC);
+    });
+
+    it('should ignore it on an account group, which has no chain', async () => {
+      set(modelValue, groupAccount());
+      const before = get(modelValue);
+      const { handleDetectedAddress } = useAccountFormState(modelValue);
+
+      await handleDetectedAddress('0x9531C059098e3d194fF87FebB587aB07B30B1306');
+
+      expect(get(modelValue)).toBe(before);
+    });
+
+    /** Coming back from xpub entry has to leave an address account behind, not an empty xpub. */
+    it('should turn an xpub state back into an address account', async () => {
+      set(modelValue, xpub('add'));
+      const { handleDetectedAddress } = useAccountFormState(modelValue);
+
+      await handleDetectedAddress('1A1zP1eP5Q');
+
+      expect(get(modelValue).type).toBe('account');
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/management/use-account-form-state.ts
+++ b/frontend/app/src/modules/accounts/management/use-account-form-state.ts
@@ -1,0 +1,167 @@
+import type { Ref } from 'vue';
+import { assert, Blockchain } from '@rotki/common';
+import { XpubKeyType } from '@/modules/accounts/blockchain-accounts';
+import {
+  type AccountManageState,
+  createNewBlockchainAccount,
+  type StakingValidatorManage,
+  type XpubManage,
+} from '@/modules/accounts/blockchain/use-account-manage';
+import { isBtcChain } from '@/modules/core/common/chains';
+import { InputMode } from '@/modules/core/common/input-mode';
+
+export interface UseAccountFormStateReturn {
+  setValidator: (data: StakingValidatorManage['data']) => void;
+  selectChain: (next: string | undefined) => void;
+  handleDetectedXpub: (key: string) => Promise<void>;
+  handleDetectedAddress: (address: string) => Promise<void>;
+}
+
+/**
+ * Owns the account form's state transitions, each of which replaces the whole state rather than
+ * writing a field into it.
+ *
+ * @remarks
+ * `AccountManageState` is a discriminated union in which the chain implies the kind of account and
+ * so the shape of `data`. Writing one field therefore type-checks while producing a state the union
+ * does not admit, which is why every transition here builds a complete state.
+ */
+export function useAccountFormState(modelValue: Ref<AccountManageState>): UseAccountFormStateReturn {
+  const inputMode = ref<InputMode>(InputMode.MANUAL_ADD);
+
+  const chain = computed<string | undefined>(() => get(modelValue).chain);
+
+  /**
+   * A validator edit only ever reaches a state that holds a validator, which is what the guard says.
+   * Narrowing first is what lets the rest of the state be carried over as itself, rather than a
+   * field being written onto whichever variant happens to be there.
+   */
+  function setValidator(data: StakingValidatorManage['data']): void {
+    const state = get(modelValue);
+    if (state.type !== 'validator')
+      return;
+
+    set(modelValue, { ...state, data });
+  }
+
+  /**
+   * Answers a chosen chain with a whole state.
+   *
+   * @remarks
+   * An account being edited already exists on its chain, so there is nothing to choose. Addresses
+   * already typed survive the change, since only the chain was answered.
+   */
+  function selectChain(next: string | undefined): void {
+    if (!next || get(modelValue).mode === 'edit')
+      return;
+
+    if (get(inputMode) === InputMode.XPUB_ADD)
+      set(inputMode, InputMode.MANUAL_ADD);
+
+    if (next === Blockchain.ETH2) {
+      set(modelValue, {
+        chain: Blockchain.ETH2,
+        data: {},
+        mode: 'add',
+        type: 'validator',
+      } satisfies StakingValidatorManage);
+      return;
+    }
+
+    const addressesTypedForTheOldChain = get(modelValue).data;
+    set(modelValue, {
+      ...createNewBlockchainAccount(),
+      chain: next,
+      ...(Array.isArray(addressesTypedForTheOldChain) ? { data: addressesTypedForTheOldChain } : {}),
+    });
+  }
+
+  /** An xpub pasted into the address field is a request to switch the form over to xpub entry. */
+  async function handleDetectedXpub(key: string): Promise<void> {
+    const selectedChain = get(chain);
+    if (!selectedChain || !isBtcChain(selectedChain))
+      return;
+
+    set(inputMode, InputMode.XPUB_ADD);
+    await nextTick();
+
+    const current = get(modelValue);
+    if (current.type !== 'xpub')
+      return;
+
+    set(modelValue, {
+      ...current,
+      data: {
+        ...current.data,
+        xpub: {
+          ...current.data.xpub,
+          xpub: key,
+        },
+      },
+    });
+  }
+
+  /** A `bitcoincash:` address pasted while on BTC names its own chain, so the form follows it. */
+  async function handleDetectedAddress(address: string): Promise<void> {
+    let targetChain = get(chain);
+    if (!targetChain)
+      return;
+
+    if (targetChain === Blockchain.BTC && address.startsWith('bitcoincash:'))
+      targetChain = Blockchain.BCH;
+
+    set(inputMode, InputMode.MANUAL_ADD);
+    await nextTick();
+    set(modelValue, {
+      chain: targetChain,
+      data: [{ address, tags: null }],
+      mode: 'add',
+      type: 'account',
+    });
+  }
+
+  /** An xpub being edited opens in xpub entry, since that is the account it is. */
+  watch(modelValue, (state) => {
+    if ('xpub' in state.data && state.mode === 'edit')
+      set(inputMode, InputMode.XPUB_ADD);
+  }, {
+    immediate: true,
+  });
+
+  /** Switching entry mode re-shapes the account, since the two modes hold different data. */
+  watch(inputMode, (mode) => {
+    const selectedChain = get(chain);
+    if (get(modelValue).mode === 'edit' || !selectedChain)
+      return;
+
+    if (mode === InputMode.XPUB_ADD) {
+      assert(isBtcChain(selectedChain));
+      set(modelValue, {
+        chain: selectedChain,
+        data: {
+          tags: null,
+          xpub: {
+            derivationPath: '',
+            xpub: '',
+            xpubType: selectedChain === Blockchain.BCH ? XpubKeyType.XPUB : XpubKeyType.ZPUB,
+          },
+        },
+        mode: 'add',
+        type: 'xpub',
+      } satisfies XpubManage);
+    }
+    else {
+      set(modelValue, {
+        ...createNewBlockchainAccount(),
+        chain: selectedChain,
+      });
+    }
+  });
+
+  return {
+    handleDetectedAddress,
+    handleDetectedXpub,
+    selectChain,
+    setValidator,
+  };
+}

--- a/frontend/app/src/modules/accounts/management/use-account-form-warnings.spec.ts
+++ b/frontend/app/src/modules/accounts/management/use-account-form-warnings.spec.ts
@@ -1,0 +1,286 @@
+import { Blockchain } from '@rotki/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type AccountManageState, createNewBlockchainAccount } from '@/modules/accounts/blockchain/use-account-manage';
+import { useAccountFormWarnings } from '@/modules/accounts/management/use-account-form-warnings';
+import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
+
+const {
+  apiKeys,
+  beaconRpcEndpoint,
+  defaultEvmIndexerOrder,
+  evmIndexersOrder,
+  isEarlyIntegrationChain,
+  isEvm,
+  isSolanaChains,
+  txEvmChains,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    apiKeys: ref<Record<string, string>>({}),
+    beaconRpcEndpoint: ref<string>(''),
+    defaultEvmIndexerOrder: ref<string[]>([]),
+    evmIndexersOrder: ref<Record<string, string[]>>({}),
+    isEarlyIntegrationChain: vi.fn<(chain: string) => boolean>(() => false),
+    isEvm: vi.fn<(chain: string) => boolean>(() => false),
+    isSolanaChains: vi.fn<(chain: string) => boolean>(() => false),
+    txEvmChains: ref<{ evmChainName: string; id: string }[]>([]),
+  };
+});
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: (): Record<string, unknown> => ({
+    isEarlyIntegrationChain,
+    isEvm,
+    isSolanaChains,
+    txEvmChains,
+  }),
+}));
+
+vi.mock('@/modules/settings/api-keys/external/use-external-api-keys', () => ({
+  useExternalApiKeys: (): Record<string, unknown> => ({
+    getApiKey: (name: string): string => get(apiKeys)[name] ?? '',
+  }),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (key: string): unknown => {
+    if (key === 'evmIndexersOrder')
+      return evmIndexersOrder;
+    if (key === 'defaultEvmIndexerOrder')
+      return defaultEvmIndexerOrder;
+    return beaconRpcEndpoint;
+  },
+}));
+
+function adding(chain: string): AccountManageState {
+  return { ...createNewBlockchainAccount(), chain };
+}
+
+function addingValidator(): AccountManageState {
+  return { chain: Blockchain.ETH2, data: {}, mode: 'add', type: 'validator' };
+}
+
+function editing(chain: string): AccountManageState {
+  return { chain, data: { address: '0x9531C059098e3d194fF87FebB587aB07B30B1306', tags: null }, mode: 'edit', type: 'account' };
+}
+
+describe('useAccountFormWarnings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    set(apiKeys, {});
+    set(beaconRpcEndpoint, '');
+    set(defaultEvmIndexerOrder, [EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT]);
+    set(evmIndexersOrder, {});
+    set(txEvmChains, [{ evmChainName: 'ethereum', id: Blockchain.ETH }]);
+    isEarlyIntegrationChain.mockReturnValue(false);
+    isEvm.mockReturnValue(false);
+    isSolanaChains.mockReturnValue(false);
+  });
+
+  /** An account being edited already exists, so there is no key the user is about to walk into. */
+  it('should warn about nothing while editing', () => {
+    isEvm.mockReturnValue(true);
+    isEarlyIntegrationChain.mockReturnValue(true);
+
+    const { beaconchainInfo, warnings } = useAccountFormWarnings(editing(Blockchain.ETH));
+
+    expect(get(warnings)).toEqual([]);
+    expect(get(beaconchainInfo)).toBeUndefined();
+  });
+
+  describe('the indexer key on an evm chain', () => {
+    beforeEach(() => {
+      isEvm.mockReturnValue(true);
+    });
+
+    it('should name etherscan when it leads and has no key', () => {
+      const { warnings } = useAccountFormWarnings(adding(Blockchain.ETH));
+
+      expect(get(warnings)).toEqual([{ service: 'etherscan', type: 'apiKey' }]);
+    });
+
+    /** With etherscan keyed, the fallback indexer is the one that would be queried keyless. */
+    it('should name blockscout once etherscan is keyed', () => {
+      set(apiKeys, { etherscan: 'key' });
+
+      const { warnings } = useAccountFormWarnings(adding(Blockchain.ETH));
+
+      expect(get(warnings)).toEqual([{ service: 'blockscout', type: 'apiKey' }]);
+    });
+
+    it('should stay quiet once both are keyed', () => {
+      set(apiKeys, { blockscout: 'key', etherscan: 'key' });
+
+      const { warnings } = useAccountFormWarnings(adding(Blockchain.ETH));
+
+      expect(get(warnings)).toEqual([]);
+    });
+
+    /** A chain that does not put etherscan first never queries it, so a missing key costs nothing. */
+    it('should stay quiet when etherscan does not lead for that chain', () => {
+      set(evmIndexersOrder, { ethereum: [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN] });
+
+      const { warnings } = useAccountFormWarnings(adding(Blockchain.ETH));
+
+      expect(get(warnings)).toEqual([]);
+    });
+
+    it('should fall back to the default order for a chain with no order of its own', () => {
+      set(defaultEvmIndexerOrder, [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
+
+      const { warnings } = useAccountFormWarnings(adding(Blockchain.ETH));
+
+      expect(get(warnings)).toEqual([]);
+    });
+
+    it('should stay quiet on a chain that is not evm', () => {
+      isEvm.mockReturnValue(false);
+
+      const { warnings } = useAccountFormWarnings(adding(Blockchain.BTC));
+
+      expect(get(warnings)).toEqual([]);
+    });
+  });
+
+  /** Adding to every chain at once queries whichever of them leads with etherscan. */
+  describe('adding to all chains', () => {
+    it('should warn when any evm chain leads with etherscan', () => {
+      set(txEvmChains, [
+        { evmChainName: 'ethereum', id: Blockchain.ETH },
+        { evmChainName: 'optimism', id: 'optimism' },
+      ]);
+      set(evmIndexersOrder, { ethereum: [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN] });
+
+      const { warnings } = useAccountFormWarnings(adding('all'));
+
+      expect(get(warnings)).toContainEqual({ service: 'etherscan', type: 'apiKey' });
+    });
+
+    it('should stay quiet about keys when none of them do', () => {
+      set(evmIndexersOrder, { ethereum: [EvmIndexer.BLOCKSCOUT] });
+
+      const { warnings } = useAccountFormWarnings(adding('all'));
+
+      expect(get(warnings)).not.toContainEqual({ service: 'etherscan', type: 'apiKey' });
+    });
+
+    it('should warn that binance chain is queried through etherscan', () => {
+      const { warnings } = useAccountFormWarnings(adding('all'));
+
+      expect(get(warnings)).toContainEqual({ type: 'binance' });
+    });
+  });
+
+  describe('a solana chain', () => {
+    beforeEach(() => {
+      isSolanaChains.mockReturnValue(true);
+    });
+
+    it('should ask for a helius key when there is none', () => {
+      const { warnings } = useAccountFormWarnings(adding('solana'));
+
+      expect(get(warnings)).toContainEqual({ service: 'helius', type: 'apiKey' });
+    });
+
+    it('should stop asking once helius is keyed', () => {
+      set(apiKeys, { helius: 'key' });
+
+      const { warnings } = useAccountFormWarnings(adding('solana'));
+
+      expect(get(warnings)).not.toContainEqual({ service: 'helius', type: 'apiKey' });
+    });
+
+    it('should still explain what adding a solana account does', () => {
+      set(apiKeys, { helius: 'key' });
+
+      const { warnings } = useAccountFormWarnings(adding('solana'));
+
+      expect(get(warnings)).toEqual([{ type: 'solana' }]);
+    });
+  });
+
+  /**
+   * The beaconchain notice is informational rather than a warning, so it renders on its own and is
+   * kept out of the warning list.
+   */
+  describe('a validator', () => {
+    it('should name the consensus rpc when neither a key nor an endpoint is set', () => {
+      const { beaconchainInfo, warnings } = useAccountFormWarnings(addingValidator());
+
+      expect(get(beaconchainInfo)).toEqual({ service: 'consensusRpc', type: 'apiKey' });
+      expect(get(warnings)).toEqual([]);
+    });
+
+    it('should name beaconchain once an endpoint is configured', () => {
+      set(beaconRpcEndpoint, 'https://example.invalid');
+
+      const { beaconchainInfo } = useAccountFormWarnings(addingValidator());
+
+      expect(get(beaconchainInfo)).toEqual({ service: 'beaconchain', type: 'apiKey' });
+    });
+
+    it('should say nothing once beaconchain is keyed', () => {
+      set(apiKeys, { beaconchain: 'key' });
+
+      const { beaconchainInfo } = useAccountFormWarnings(addingValidator());
+
+      expect(get(beaconchainInfo)).toBeUndefined();
+    });
+  });
+
+  it('should warn that a chain is an early integration', () => {
+    isEarlyIntegrationChain.mockReturnValue(true);
+
+    const { warnings } = useAccountFormWarnings(adding('scroll'));
+
+    expect(get(warnings)).toContainEqual({ chain: 'scroll', type: 'earlyChain' });
+  });
+
+  /** Several warnings at once are collapsed to the first, so the form is not buried in alerts. */
+  describe('collapsing several warnings', () => {
+    function several(): ReturnType<typeof useAccountFormWarnings> {
+      isEvm.mockReturnValue(true);
+      isEarlyIntegrationChain.mockReturnValue(true);
+      return useAccountFormWarnings(adding(Blockchain.ETH));
+    }
+
+    it('should show a lone warning in full', () => {
+      isEarlyIntegrationChain.mockReturnValue(true);
+
+      const { hasMultipleWarnings, hiddenWarningCount, visibleWarnings, warnings } = useAccountFormWarnings(adding('scroll'));
+
+      expect(get(warnings)).toHaveLength(1);
+      expect(get(hasMultipleWarnings)).toBe(false);
+      expect(get(visibleWarnings)).toEqual(get(warnings));
+      expect(get(hiddenWarningCount)).toBe(0);
+    });
+
+    it('should show only the first of several', () => {
+      const { hasMultipleWarnings, hiddenWarningCount, visibleWarnings, warnings } = several();
+
+      expect(get(warnings)).toHaveLength(2);
+      expect(get(hasMultipleWarnings)).toBe(true);
+      expect(get(visibleWarnings)).toEqual([get(warnings)[0]]);
+      expect(get(hiddenWarningCount)).toBe(1);
+    });
+
+    it('should show the rest once expanded', () => {
+      const { hiddenWarningCount, toggleWarningExpanded, visibleWarnings, warnings } = several();
+
+      toggleWarningExpanded();
+
+      expect(get(visibleWarnings)).toEqual(get(warnings));
+      expect(get(hiddenWarningCount)).toBe(0);
+    });
+
+    it('should collapse again on a second toggle', () => {
+      const { toggleWarningExpanded, visibleWarnings, warningExpanded } = several();
+
+      toggleWarningExpanded();
+      toggleWarningExpanded();
+
+      expect(get(warningExpanded)).toBe(false);
+      expect(get(visibleWarnings)).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/app/src/modules/accounts/management/use-account-form-warnings.ts
+++ b/frontend/app/src/modules/accounts/management/use-account-form-warnings.ts
@@ -1,0 +1,176 @@
+import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
+import type { AccountManageState } from '@/modules/accounts/blockchain/use-account-manage';
+import { camelCase } from 'es-toolkit';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
+import { EvmIndexer } from '@/modules/settings/types/evm-indexer';
+import { useSetting } from '@/modules/settings/use-setting';
+
+/** The services worth warning about when the account being added would query them without a key. */
+type MissingKeyService = 'etherscan' | 'helius' | 'beaconchain' | 'consensusRpc' | 'blockscout';
+
+type WarningType = 'apiKey' | 'binance' | 'earlyChain' | 'solana';
+
+interface WarningItem {
+  type: WarningType;
+  service?: MissingKeyService;
+  chain?: string;
+}
+
+export interface UseAccountFormWarningsReturn {
+  /**
+   * The beaconchain key notice, which is informational rather than a warning and so renders on its
+   * own; it is therefore kept out of `warnings`.
+   */
+  beaconchainInfo: ComputedRef<WarningItem | undefined>;
+  warnings: ComputedRef<WarningItem[]>;
+  hasMultipleWarnings: ComputedRef<boolean>;
+  /** The warnings to render: all of them once expanded, otherwise the first alone. */
+  visibleWarnings: ComputedRef<WarningItem[]>;
+  hiddenWarningCount: ComputedRef<number>;
+  warningExpanded: Readonly<Ref<boolean>>;
+  toggleWarningExpanded: () => void;
+}
+
+function isBeaconchainService(service: MissingKeyService | undefined): boolean {
+  return service === 'beaconchain' || service === 'consensusRpc';
+}
+
+/**
+ * Derives what the account form warns about before an account is added.
+ *
+ * @remarks
+ * Nothing is warned about while editing: the account already exists, so a missing key is not
+ * something the user is about to walk into.
+ */
+export function useAccountFormWarnings(state: MaybeRefOrGetter<AccountManageState>): UseAccountFormWarningsReturn {
+  const { isEarlyIntegrationChain, isEvm, isSolanaChains, txEvmChains } = useSupportedChains();
+  const { getApiKey } = useExternalApiKeys();
+
+  const beaconRpcEndpoint = useSetting('beaconRpcEndpoint');
+  const defaultEvmIndexerOrder = useSetting('defaultEvmIndexerOrder');
+  const evmIndexersOrder = useSetting('evmIndexersOrder');
+
+  const warningExpanded = shallowRef<boolean>(false);
+
+  const chain = computed<string | undefined>(() => toValue(state).chain);
+  const isAdding = computed<boolean>(() => toValue(state).mode === 'add');
+
+  function isEtherscanTopPriority(chainId: string): boolean {
+    const chainOrders = get(evmIndexersOrder);
+    const evmChainName = camelCase(get(txEvmChains).find(c => c.id === chainId)?.evmChainName ?? '');
+    const indexerOrder = evmChainName && chainOrders[evmChainName]
+      ? chainOrders[evmChainName]
+      : get(defaultEvmIndexerOrder);
+
+    return indexerOrder[0] === EvmIndexer.ETHERSCAN;
+  }
+
+  /** For 'all', any EVM chain putting etherscan first is enough to warn. */
+  function shouldShowEtherscanWarning(selectedChain: string): boolean {
+    if (selectedChain === 'all')
+      return get(txEvmChains).some(chain => isEtherscanTopPriority(chain.id));
+
+    if (!isEvm(selectedChain))
+      return false;
+
+    return isEtherscanTopPriority(selectedChain);
+  }
+
+  /** Without a beaconchain key, validators fall back to a consensus RPC, which needs its own endpoint. */
+  function validatorKeyService(): MissingKeyService | undefined {
+    if (getApiKey('beaconchain'))
+      return undefined;
+
+    return get(beaconRpcEndpoint) ? 'beaconchain' : 'consensusRpc';
+  }
+
+  /** Both indexers are only worth warning about on chains that actually use them. */
+  function indexerKeyService(chain: string): MissingKeyService | undefined {
+    if (!shouldShowEtherscanWarning(chain))
+      return undefined;
+
+    if (!getApiKey('etherscan'))
+      return 'etherscan';
+
+    return getApiKey('blockscout') ? undefined : 'blockscout';
+  }
+
+  const missingApiKeyService = computed<MissingKeyService | undefined>(() => {
+    const selectedChain = get(chain);
+    const currentState = toValue(state);
+
+    if (!get(isAdding) || !selectedChain)
+      return undefined;
+
+    if (currentState.type === 'validator')
+      return validatorKeyService();
+
+    if (isSolanaChains(selectedChain))
+      return getApiKey('helius') ? undefined : 'helius';
+
+    return indexerKeyService(selectedChain);
+  });
+
+  const showSolanaInitialAlert = computed<boolean>(() => {
+    const selectedChain = get(chain);
+    return get(isAdding) && !!selectedChain && isSolanaChains(selectedChain);
+  });
+
+  const earlyIntegrationChain = computed<string | undefined>(() => {
+    const selectedChain = get(chain);
+
+    if (get(isAdding) && selectedChain && isEarlyIntegrationChain(selectedChain))
+      return selectedChain;
+    return undefined;
+  });
+
+  const showBinanceEtherscanWarning = computed<boolean>(() => get(isAdding) && get(chain) === 'all');
+
+  const beaconchainInfo = computed<WarningItem | undefined>(() => {
+    const service = get(missingApiKeyService);
+    if (!service || !isBeaconchainService(service))
+      return undefined;
+    return { service, type: 'apiKey' };
+  });
+
+  const warnings = computed<WarningItem[]>(() => {
+    const result: WarningItem[] = [];
+    const service = get(missingApiKeyService);
+    if (service && !isBeaconchainService(service))
+      result.push({ service, type: 'apiKey' });
+    if (get(showSolanaInitialAlert))
+      result.push({ type: 'solana' });
+    const earlyChain = get(earlyIntegrationChain);
+    if (earlyChain)
+      result.push({ chain: earlyChain, type: 'earlyChain' });
+    if (get(showBinanceEtherscanWarning))
+      result.push({ type: 'binance' });
+    return result;
+  });
+
+  const hasMultipleWarnings = computed<boolean>(() => get(warnings).length > 1);
+
+  const visibleWarnings = computed<WarningItem[]>(() => {
+    const all = get(warnings);
+    if (all.length <= 1 || get(warningExpanded))
+      return all;
+    return all.slice(0, 1);
+  });
+
+  const hiddenWarningCount = computed<number>(() => get(warnings).length - get(visibleWarnings).length);
+
+  function toggleWarningExpanded(): void {
+    set(warningExpanded, !get(warningExpanded));
+  }
+
+  return {
+    beaconchainInfo,
+    hasMultipleWarnings,
+    hiddenWarningCount,
+    toggleWarningExpanded,
+    visibleWarnings,
+    warningExpanded: readonly(warningExpanded),
+    warnings,
+  };
+}

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.spec.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.spec.ts
@@ -1,0 +1,232 @@
+import type { ManualBalanceWithPrice } from '@/modules/balances/types/manual-balances';
+import { bigNumberify } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import ManualBalanceTable from '@/modules/accounts/manual-balances/ManualBalanceTable.vue';
+import { BalanceType } from '@/modules/balances/types/balances';
+
+const {
+  dataSource,
+  fetch,
+  prepareForEdit,
+  pricesLoading,
+  refetch,
+  refresh,
+  refreshing,
+  rows,
+  showDeleteConfirmation,
+} = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    dataSource: ref<unknown[]>([]),
+    fetch: vi.fn(async () => ({ data: [], found: 0, limit: 0, total: 0 })),
+    prepareForEdit: vi.fn((balance: unknown) => balance),
+    pricesLoading: ref<boolean>(false),
+    refetch: vi.fn(async () => {}),
+    refresh: vi.fn(),
+    refreshing: ref<boolean>(false),
+    rows: ref<unknown[]>([]),
+    showDeleteConfirmation: vi.fn(),
+  };
+});
+
+vi.mock('@/modules/balances/manual/use-manual-balances-or-liabilities', async () => {
+  const { computed } = await import('vue');
+  return {
+    useManualBalancesOrLiabilities: (): Record<string, unknown> => ({
+      dataSource,
+      fetch,
+      locations: computed(() => []),
+    }),
+  };
+});
+
+vi.mock('@/modules/accounts/manual-balances/use-manual-balance-table-actions', () => ({
+  useManualBalanceTableActions: (): Record<string, unknown> => ({
+    prepareForEdit,
+    pricesLoading,
+    refresh,
+    refreshing,
+    showDeleteConfirmation,
+  }),
+}));
+
+vi.mock('@/modules/accounts/manual-balances/use-manual-balance-fields', () => ({
+  useManualBalanceFields: (): unknown[] => [],
+}));
+
+vi.mock('@/modules/core/table/pill/composables/use-pill-bar-labels', () => ({
+  usePillBarLabels: (): Record<string, unknown> => ({}),
+}));
+
+vi.mock('@/modules/core/table/use-remember-table-sorting', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/table/use-remember-table-sorting')>(),
+  useRememberTableSorting: (): void => {},
+}));
+
+vi.mock('@/modules/core/table/use-server-table', async () => {
+  const { computed, ref } = await import('vue');
+  return {
+    useServerTable: (): Record<string, unknown> => ({
+      collection: computed(() => ({ data: rows.value, found: rows.value.length, limit: 10, total: rows.value.length })),
+      filter: ref({}),
+      isLoading: ref(false),
+      pagination: ref({ limit: 10, page: 1, total: 0 }),
+      refetch,
+      sort: ref([]),
+    }),
+  };
+});
+
+/** Renders the row actions, which is where the edit and delete of a row are wired. */
+const TableStub = defineComponent({
+  props: ['cols', 'rows', 'loading', 'sort', 'pagination'],
+  template: `<div>
+    <template v-for="row in rows" :key="row.identifier">
+      <slot name="item.actions" :row="row" />
+    </template>
+  </div>`,
+});
+
+const RowActionsStub = defineComponent({
+  emits: ['edit-click', 'delete-click'],
+  template: '<div />',
+});
+
+function balance(): ManualBalanceWithPrice {
+  return {
+    amount: bigNumberify(1),
+    asset: 'ETH',
+    assetIsMissing: false,
+    balanceType: BalanceType.ASSET,
+    identifier: 1,
+    label: 'savings',
+    location: 'external',
+    price: bigNumberify(2),
+    tags: null,
+    value: bigNumberify(2),
+  };
+}
+
+function createWrapper(type: 'balances' | 'liabilities' = 'balances'): VueWrapper<any> {
+  return mount(ManualBalanceTable, {
+    global: {
+      stubs: {
+        PillFilterBar: true,
+        RefreshButton: { emits: ['refresh'], props: ['loading', 'tooltip'], template: '<button @click="$emit(\'refresh\')" />' },
+        RowActions: RowActionsStub,
+        RuiCard: { template: '<div><slot name="custom-header" /><slot /></div>' },
+        RuiDataTable: TableStub,
+      },
+    },
+    props: { type },
+  });
+}
+
+function actions(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(RowActionsStub);
+}
+
+describe('manualBalanceTable', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    set(dataSource, []);
+    set(pricesLoading, false);
+    set(refreshing, false);
+    set(rows, [balance()]);
+    prepareForEdit.mockImplementation((value: unknown) => value);
+  });
+
+  describe('a row', () => {
+    /** The edit dialog takes a plain balance, not the priced row the table holds. */
+    it('should hand the parent the balance behind the row', async () => {
+      const wrapper = createWrapper();
+      prepareForEdit.mockReturnValue({ identifier: 1, label: 'savings' });
+
+      actions(wrapper).vm.$emit('edit-click');
+      await nextTick();
+
+      expect(prepareForEdit).toHaveBeenCalledWith(balance());
+      expect(wrapper.emitted('edit')?.at(-1)?.[0]).toEqual({ identifier: 1, label: 'savings' });
+    });
+
+    it('should confirm before deleting', async () => {
+      const wrapper = createWrapper();
+
+      actions(wrapper).vm.$emit('delete-click');
+      await nextTick();
+
+      expect(showDeleteConfirmation).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('should refresh on request', async () => {
+    const wrapper = createWrapper();
+
+    await wrapper.find('button').trigger('click');
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  /** The table is a view onto the balances, so it re-reads whenever they actually change. */
+  describe('following the balances', () => {
+    it('should fetch on arrival', () => {
+      createWrapper();
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refetch once they change', async () => {
+      createWrapper();
+      refetch.mockClear();
+
+      set(dataSource, [balance()]);
+      await nextTick();
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+
+    /** A store write that lands on the same balances is not a change worth a round trip. */
+    it('should not refetch when they are replaced by an equal set', async () => {
+      set(dataSource, [balance()]);
+      createWrapper();
+      refetch.mockClear();
+
+      set(dataSource, [balance()]);
+      await nextTick();
+
+      expect(refetch).not.toHaveBeenCalled();
+    });
+  });
+
+  /** Prices arrive after the rows, so the table re-reads once the fetching settles. */
+  describe('following the prices', () => {
+    it('should refetch once the prices have finished loading', async () => {
+      vi.useFakeTimers();
+      createWrapper();
+      set(pricesLoading, true);
+      await nextTick();
+      refetch.mockClear();
+
+      set(pricesLoading, false);
+      await vi.advanceTimersByTimeAsync(1100);
+
+      expect(refetch).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it('should not refetch when they start loading', async () => {
+      vi.useFakeTimers();
+      createWrapper();
+      refetch.mockClear();
+
+      set(pricesLoading, true);
+      await vi.advanceTimersByTimeAsync(1100);
+
+      expect(refetch).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+  });
+});


### PR DESCRIPTION
Continues the frontend coverage work, taking the `accounts` cluster. Eleven commits, one per unit,
starting with the extraction the testing guide asks for before any of it.

## The extraction, first

`AccountForm.vue` is the file CLAUDE.md names as the standing cost of testing a fat component
first: 331 script lines held in place by a spec. It is split before anything new is written.

- **`use-account-form-warnings.ts`** — which service a missing key is worth warning about per chain
  and kind of account, and the collapsing of several warnings to the first.
- **`use-account-form-state.ts`** — the transitions that replace the whole `AccountManageState`,
  since the chain implies the shape of `data`.

The component drops from 430 to 161 lines and keeps the template, the `validate` delegation and the
wiring. **The existing spec passes untouched**, which is the evidence the split changed no
behaviour.

## What is covered

| Unit | Lines before | after |
|---|---|---|
| `AccountForm.vue` + the two composables | 33/93 | 130/149 |
| `AccountDialog.vue` | 36/93 | 88/93 |
| `QueriedAddressDialog.vue` | 20/71 | 66/71 |
| `AddressBookManagement.vue` | 12/58 | 55/58 |
| `use-account-manage.ts` (xpub and group saves) | 158/198 | 194/198 |
| `ManualBalanceTable.vue` | 24/68 | 52/68 |
| `EthStakingValidators.vue` | 25/66 | 57/66 |
| `account-helpers.ts` (groups) | 129/154 | 152/154 |
| `AccountBalancesExportImport.vue` | 12/49 | 46/49 |
| `AddressBookManagementMore.vue` | 12/51 | 48/51 |

`modules/accounts` goes from 1219 uncovered lines to 895. Total line coverage 73.79% -> 74.49%.

## Source changes

All small, and each needed by the component rather than by a spec:

- **`data-testid` on buttons that were told apart only by position** (`QueriedAddressDialog`,
  `AccountBalancesExportImport`, `AddressBookManagementMore`). This is not cosmetic: `RuiButton`
  defaults `disabled` to `false`, so picking the add button by that prop silently selected the
  close button instead, and the test that "passed" was clicking the wrong thing.

## Verification

Every assertion has a negative control: the specific line was broken, the named tests confirmed to
fail and only those, then restored. Twenty-two controls in all. Four were findings rather than
confirmations:

- dropping `transformCase` from the queried-address lookup broke nothing, because every module in
  the tests was a single word. Added the multi-word case, which is the whole reason the transform
  is there.
- the "clear the picker after adding" test passed while clicking the close button. Real once the
  test ids landed.
- `AddressBookManagement`'s add-after-edit was only pinned incidentally; retargeted at the case
  that matters, an addition following an edit reopening on the edited entry.
- two `AccountDialog` premium-error assertions passed against an empty alert, because the shared
  setup stubs `I18nT = true` and renders no `<i18n-t>` content at all.

One thing deliberately not asserted: `doImport`'s `!isDefined(importFile)` guard in both import
menus is unreachable through the UI, since the button is disabled without a file. It is left as
defence rather than covered by reaching into the component.

Gates: `typecheck`, `knip`, `lint:file:check`, `lint:style`, `check:linked-keys`, `test:proxy` and
the full `test:unit` (1106 files, 12075 tests) all green.
