### PR TITLE
test(frontend): cover the history events composables

### DIFF
--- a/frontend/app/src/modules/history/events/tx/use-history-transactions.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transactions.spec.ts
@@ -1,12 +1,16 @@
+import type { SubmittedSpec } from '@test/utils/mocks/native-task';
 import type { EvmChainInfo } from '@/modules/core/api/types/chains';
 import type {
   EditEvmHistoryEventPayload,
   EvmHistoryEvent,
   HistoryEventRow,
 } from '@/modules/history/events/schemas';
+import type { RunBackendTask } from '@/modules/task-center/use-native-task';
 import { assert, type Blockchain } from '@rotki/common';
-import { runSpecWith } from '@test/utils/mocks/native-task';
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { err, ok, type Result } from 'plainfp/result';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiValidationError } from '@/modules/core/api/types/errors';
+import { Cancelled, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import { isOfEventType } from '@/modules/history/event-utils';
 import { useHistoryTransactionDecoding } from '@/modules/history/events/tx/use-history-transaction-decoding';
@@ -23,16 +27,54 @@ vi.mock('@/modules/core/tasks/use-task-handler', async importOriginal => ({
   }),
 }));
 
+/**
+ * The submitted specs, so a test can assert what a re-pull was scheduled as, and the outcome the
+ * task runner hands back, so a test can drive the failure branches.
+ */
+const {
+  addTransactionHash,
+  notifyError,
+  notifyInfo,
+  repullingEthStakingEvents,
+  repullingExchangeEvents,
+  repullingTransactions,
+} = vi.hoisted(() => ({
+  addTransactionHash: vi.fn(),
+  notifyError: vi.fn(),
+  notifyInfo: vi.fn(),
+  repullingEthStakingEvents: vi.fn(),
+  repullingExchangeEvents: vi.fn(),
+  repullingTransactions: vi.fn(),
+}));
+
+/**
+ * The submitted specs, so a test can assert what a re-pull was scheduled as, and the outcome the
+ * task runner hands back, so a test can drive the failure branches.
+ */
+const { outcome, submitted } = vi.hoisted((): {
+  outcome: { value: Result<unknown, TaskError> | undefined };
+  submitted: SubmittedSpec[];
+} => ({ outcome: { value: undefined }, submitted: [] }));
+
 vi.mock(import('@/modules/task-center/use-native-task'), async (importOriginal) => {
   const actual = await importOriginal();
   const { ok } = await import('plainfp/result');
+  const { runSpecWith } = await import('@test/utils/mocks/native-task');
   return {
     ...actual,
     useNativeTask: vi.fn().mockReturnValue({
       cancelByType: vi.fn(() => vi.fn()),
       reportProgress: vi.fn(),
       statusOf: vi.fn(() => ({ active: false, everCompleted: false, pending: false, running: false })),
-      submitTask: vi.fn(runSpecWith(vi.fn().mockImplementation(async (taskFn: () => Promise<unknown>) => ok(await taskFn())))),
+      submitTask: vi.fn(async (spec: SubmittedSpec) => {
+        submitted.push(spec);
+        const runTask: RunBackendTask = async <R>(taskFn: () => Promise<{ taskId: number }>): Promise<Result<R, TaskError>> => {
+          const result = await taskFn();
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the stub stands in for a runner whose result type only its caller knows
+          return (outcome.value ?? ok(result)) as Result<R, TaskError>;
+        };
+        return runSpecWith(runTask)(spec);
+      }),
     }),
   };
 });
@@ -47,12 +89,29 @@ vi.mock('@/modules/core/tasks/use-task-store', async () => {
   };
 });
 
+vi.mock('@/modules/core/notifications/use-notifications', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useNotifications: vi.fn().mockReturnValue({
+      notifyError,
+      notifyInfo,
+      removeMatching: vi.fn(),
+      showErrorMessage: vi.fn(),
+      showSuccessMessage: vi.fn(),
+    }),
+  };
+});
+
 vi.mock('@/modules/history/api/events/use-history-events-api', async () => {
   const { camelCaseTransformer } = await import('@/modules/core/api/transformers');
   const historyEvents = await import('@test/fixtures/history-events.json');
   return {
     useHistoryEventsApi: vi.fn().mockReturnValue({
-      addTransactionHash: vi.fn(),
+      addTransactionHash,
+      repullingEthStakingEvents,
+      repullingExchangeEvents,
+      repullingTransactions,
       fetchTransactionsTask: vi.fn().mockResolvedValue({}),
       deleteHistoryEvent: vi.fn(),
       decodeTransactions: vi.fn().mockResolvedValue({}),
@@ -90,6 +149,13 @@ vi.mock('@/modules/core/common/use-supported-chains', async () => {
     }),
   };
 });
+
+/** Clears what the last re-pull left behind, so an id or a notification is this test's alone. */
+function reset(): void {
+  vi.clearAllMocks();
+  submitted.length = 0;
+  outcome.value = undefined;
+}
 
 describe('useHistoryTransactions', () => {
   let events: HistoryEventRow[];
@@ -170,5 +236,221 @@ describe('useHistoryTransactions', () => {
     await redecodeTransactions();
 
     expect(decodeTxSpy).toHaveBeenCalledTimes(2);
+  });
+
+  describe('addTransactionHash', () => {
+    beforeEach(() => {
+      addTransactionHash.mockReset();
+    });
+
+    it('should report a hash that was accepted', async () => {
+      const result = await useHistoryTransactions().addTransactionHash({
+        associatedAddress: '0x0',
+        blockchain: 'eth',
+        txRef: '0x9',
+      });
+
+      expect(result).toEqual({ message: '', success: true });
+    });
+
+    it('should report the message a rejection carried', async () => {
+      addTransactionHash.mockRejectedValue(new Error('already tracked'));
+
+      const result = await useHistoryTransactions().addTransactionHash({
+        associatedAddress: '0x0',
+        blockchain: 'eth',
+        txRef: '0x9',
+      });
+
+      expect(result).toEqual({ message: 'already tracked', success: false });
+    });
+
+    /** A form needs the failure per field, not one message covering the whole submission. */
+    it('should report a validation failure against the fields it names', async () => {
+      addTransactionHash.mockRejectedValue(new ApiValidationError('{"txRef":["not a transaction hash"]}'));
+
+      const result = await useHistoryTransactions().addTransactionHash({
+        associatedAddress: '0x0',
+        blockchain: 'eth',
+        txRef: 'nonsense',
+      });
+
+      assert(!result.success);
+      expect(result.message).toEqual({ txRef: ['not a transaction hash'] });
+    });
+  });
+
+  /**
+   * A re-pull is scheduled as one activity, and its identity is what stops two different requests
+   * being taken for the same one. An absent bound is part of that identity: "everything before X"
+   * is a different request from "X to Y".
+   */
+  describe('repullingTransactions', () => {
+    beforeEach(() => {
+      reset();
+      repullingTransactions.mockResolvedValue({});
+    });
+
+    it('should hand back what the re-pull found', async () => {
+      const found = { newTransactions: { eth: ['0x1'] }, newTransactionsCount: 1 };
+      outcome.value = ok(found);
+
+      expect(await useHistoryTransactions().repullingTransactions({})).toEqual(found);
+    });
+
+    it('should tell two bounded ranges apart', async () => {
+      const { repullingTransactions: repull } = useHistoryTransactions();
+
+      await repull({ fromTimestamp: 1, toTimestamp: 2 });
+      await repull({ fromTimestamp: 3, toTimestamp: 4 });
+
+      expect(submitted[0].id).not.toBe(submitted[1].id);
+    });
+
+    it('should tell an open-ended range from a bounded one', async () => {
+      const { repullingTransactions: repull } = useHistoryTransactions();
+
+      await repull({ toTimestamp: 2 });
+      await repull({ fromTimestamp: 1, toTimestamp: 2 });
+
+      expect(submitted[0].id).not.toBe(submitted[1].id);
+    });
+
+    it('should treat the same request as the same activity', async () => {
+      const { repullingTransactions: repull } = useHistoryTransactions();
+
+      await repull({ address: '0x0', chain: 'eth' });
+      await repull({ address: '0x0', chain: 'eth' });
+
+      expect(submitted[0].id).toBe(submitted[1].id);
+    });
+
+    /** Without an address and chain there is no account to name, so the wording differs. */
+    it('should name the account it is re-pulling for', async () => {
+      await useHistoryTransactions().repullingTransactions({ address: '0x0', chain: 'eth' });
+
+      expect(submitted[0].subtitle).toContain('actions.repulling_transaction.task.description');
+    });
+
+    it('should say when there is no account to name', async () => {
+      await useHistoryTransactions().repullingTransactions({});
+
+      expect(submitted[0].subtitle)
+        .toContain('actions.repulling_transaction.task.no_address_or_chain_transaction');
+    });
+
+    it('should report a failure and hand back nothing', async () => {
+      outcome.value = err(TaskFailed({ message: 'the backend gave up' }));
+
+      expect(await useHistoryTransactions().repullingTransactions({})).toBeUndefined();
+      expect(notifyError).toHaveBeenCalledWith(
+        'actions.repulling_transaction.task.title',
+        expect.stringContaining('actions.repulling_transaction.error.no_address_or_chain_transaction'),
+      );
+    });
+
+    /** The user asked for the cancellation, so there is nothing to report back to them. */
+    it('should stay quiet about a cancellation', async () => {
+      outcome.value = err(Cancelled({ message: 'cancelled' }));
+
+      expect(await useHistoryTransactions().repullingTransactions({})).toBeUndefined();
+      expect(notifyError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('repullingExchangeEvents', () => {
+    const payload = { location: 'kraken', name: 'my kraken' };
+
+    beforeEach(() => {
+      reset();
+      repullingExchangeEvents.mockResolvedValue({});
+    });
+
+    it('should report events were stored', async () => {
+      outcome.value = ok({ storedEvents: 4 });
+
+      expect(await useHistoryTransactions().repullingExchangeEvents(payload)).toBe(true);
+      expect(notifyInfo).toHaveBeenCalledWith(
+        'actions.repulling_exchange_events.task.title',
+        expect.stringContaining('actions.repulling_exchange_events.success.description'),
+      );
+    });
+
+    /** A re-pull that found nothing still succeeded, so it is reported rather than left silent. */
+    it('should say so when it found nothing', async () => {
+      outcome.value = ok({ storedEvents: 0 });
+
+      expect(await useHistoryTransactions().repullingExchangeEvents(payload)).toBe(false);
+      expect(notifyInfo).toHaveBeenCalledWith(
+        'actions.repulling_exchange_events.task.title',
+        'actions.repulling_exchange_events.success.no_events_description',
+      );
+    });
+
+    it('should report a failure', async () => {
+      outcome.value = err(TaskFailed({ message: 'the backend gave up' }));
+
+      expect(await useHistoryTransactions().repullingExchangeEvents(payload)).toBe(false);
+      expect(notifyError).toHaveBeenCalled();
+      expect(notifyInfo).not.toHaveBeenCalled();
+    });
+
+    it('should stay quiet about a cancellation', async () => {
+      outcome.value = err(Cancelled({ message: 'cancelled' }));
+
+      expect(await useHistoryTransactions().repullingExchangeEvents(payload)).toBe(false);
+      expect(notifyError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('repullingEthStakingEvents', () => {
+    const payload = { entryType: 'eth withdrawal event' };
+
+    beforeEach(() => {
+      reset();
+      repullingEthStakingEvents.mockResolvedValue({});
+    });
+
+    /** The counts are what the user came for, so they are broken down rather than totalled away. */
+    it('should break the total down per validator and per address', async () => {
+      outcome.value = ok({ perAddress: { '0xabc': 2 }, perValidator: { 12: 3 }, total: 5 });
+
+      expect(await useHistoryTransactions().repullingEthStakingEvents(payload)).toBe(true);
+
+      const [, message] = notifyInfo.mock.calls[0];
+      expect(message).toContain('actions.repulling_eth_staking.success.per_validator');
+      expect(message).toContain('actions.repulling_eth_staking.success.validator_entry');
+      expect(message).toContain('actions.repulling_eth_staking.success.per_address');
+      expect(message).toContain('actions.repulling_eth_staking.success.address_entry');
+    });
+
+    /** A breakdown with nothing in it is dropped rather than left as a blank block at the end. */
+    it('should leave out a breakdown it has nothing for', async () => {
+      outcome.value = ok({ perAddress: {}, perValidator: { 12: 3 }, total: 3 });
+
+      await useHistoryTransactions().repullingEthStakingEvents(payload);
+
+      const [, message] = notifyInfo.mock.calls[0];
+      expect(message).toContain('actions.repulling_eth_staking.success.per_validator');
+      expect(message).not.toContain('actions.repulling_eth_staking.success.per_address');
+      expect(message.endsWith('\n')).toBe(false);
+    });
+
+    it('should say so when it found nothing', async () => {
+      outcome.value = ok({ perAddress: {}, perValidator: {}, total: 0 });
+
+      expect(await useHistoryTransactions().repullingEthStakingEvents(payload)).toBe(false);
+      expect(notifyInfo).toHaveBeenCalledWith(
+        'actions.repulling_eth_staking.task.title',
+        expect.stringContaining('actions.repulling_eth_staking.success.no_events_description'),
+      );
+    });
+
+    it('should report a failure', async () => {
+      outcome.value = err(TaskFailed({ message: 'the backend gave up' }));
+
+      expect(await useHistoryTransactions().repullingEthStakingEvents(payload)).toBe(false);
+      expect(notifyError).toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/app/src/modules/history/events/use-history-event-fields.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-event-fields.spec.ts
@@ -1,0 +1,309 @@
+import type { FieldDef } from '@/modules/core/table/pill/core/types';
+import type { HistoryEventsRestrictions } from '@/modules/history/events/history-events-restrictions';
+import type { Filters } from '@/modules/history/events/use-events-filter';
+import { HistoryEventEntryType } from '@rotki/common';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+import { useHistoryEventFields } from '@/modules/history/events/use-history-event-fields';
+
+const {
+  accountOptions,
+  actionRows,
+  assetSearch,
+  assetSuggestions,
+  associatedLocations,
+  counterparties,
+  typeMapping,
+} = await vi.hoisted(
+  async () => {
+    const { ref } = await import('vue');
+    return {
+      accountOptions: ref<{ keywords?: string; loading?: boolean; value: string }[]>([]),
+      actionRows: ref<{ direction: string; icon: string; label: string; verbKey: string }[]>([]),
+      assetSearch: vi.fn(async () => []),
+      assetSuggestions: vi.fn(() => async (): Promise<unknown[]> => []),
+      associatedLocations: ref<string[]>([]),
+      counterparties: ref<string[]>([]),
+      typeMapping: ref<Record<string, Record<string, string>>>({}),
+    };
+  },
+);
+
+vi.mock('@/modules/history/events/mapping/use-history-event-mappings', async () => {
+  const { computed } = await import('vue');
+  return {
+    useHistoryEventMappings: (): Record<string, unknown> => ({
+      getHistoryEventSubTypeName: (value: string): string => value,
+      getHistoryEventTypeName: (value: string): string => value,
+      historyEventTypeGlobalMapping: computed(() => typeMapping.value),
+      historyEventTypes: computed(() => Object.keys(typeMapping.value)),
+    }),
+  };
+});
+
+vi.mock('@/modules/history/events/mapping/use-history-event-counterparty-mappings', async () => {
+  const { computed } = await import('vue');
+  return {
+    useHistoryEventCounterpartyMappings: (): Record<string, unknown> => ({
+      counterparties: computed(() => counterparties.value),
+    }),
+  };
+});
+
+vi.mock('@/modules/history/use-account-filter-options', async () => {
+  const { computed } = await import('vue');
+  return {
+    useAccountFilterOptions: (): Record<string, unknown> => ({
+      options: computed(() => accountOptions.value),
+      resolveCaption: (value: string): string => `caption:${value}`,
+      resolveLabel: (value: string): string => `label:${value}`,
+    }),
+  };
+});
+
+vi.mock('@/modules/history/events/action-picker/use-event-action-picker', async () => {
+  const { computed } = await import('vue');
+  return {
+    useEventActionPicker: (): Record<string, unknown> => ({
+      rows: computed(() => actionRows.value),
+    }),
+  };
+});
+
+vi.mock('@/modules/assets/use-asset-info-retrieval', () => ({
+  useAssetInfoRetrieval: (): Record<string, unknown> => ({ assetSearch }),
+}));
+
+/**
+ * Replaced rather than driven: the real one returns a debounced search, so the scope it was built
+ * with is only observable at build time.
+ */
+vi.mock('@/modules/core/common/display/assets', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, assetSuggestions };
+});
+
+vi.mock('@/modules/history/use-history-store', async () => {
+  const { computed, ref } = await import('vue');
+  return {
+    useHistoryStore: (): Record<string, unknown> => ({
+      associatedLocations: computed(() => associatedLocations.value),
+      undecodedTransactionsStatus: ref({}),
+    }),
+  };
+});
+
+/** `storeToRefs` would double-wrap the plain refs the store mock hands back. */
+vi.mock('pinia', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    storeToRefs: (store: Record<string, unknown>): Record<string, unknown> => store,
+  };
+});
+
+function fields(
+  restrictions: HistoryEventsRestrictions = {},
+  modelFilters: Ref<Filters> = ref({}),
+): FieldDef[] {
+  return get(useHistoryEventFields({ modelFilters, restrictions }));
+}
+
+function keys(defs: FieldDef[]): string[] {
+  return defs.map(def => def.key);
+}
+
+function field(defs: FieldDef[], key: string): FieldDef {
+  const found = defs.find(def => def.key === key);
+  assert(found);
+  return found;
+}
+
+describe('useHistoryEventFields', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    set(accountOptions, []);
+    set(actionRows, []);
+    set(associatedLocations, []);
+    set(counterparties, []);
+    set(typeMapping, {});
+  });
+
+  /**
+   * A page pinned to one protocol, location, period, validator set or event type has already made
+   * that choice for the user, so the bar has nothing left to offer a pill for.
+   */
+  describe('what the view has already fixed', () => {
+    it('should offer every pill when nothing is pinned', () => {
+      expect(keys(fields())).toContain('location');
+      expect(keys(fields())).toContain('counterparties');
+    });
+
+    it('should drop the location pill on a page pinned to one location', () => {
+      expect(keys(fields({ location: 'kraken' }))).not.toContain('location');
+    });
+
+    it('should drop the protocol pill on a page pinned to a protocol', () => {
+      expect(keys(fields({ protocols: ['uniswap-v3'] }))).not.toContain('counterparties');
+    });
+
+    it('should drop the event type pill on a page pinned to event types', () => {
+      expect(keys(fields({ eventTypes: ['deposit'] }))).not.toContain('eventTypes');
+    });
+
+    it('should drop the validator pill on a page pinned to validators', () => {
+      expect(keys(fields({ validators: [12] }))).not.toContain('validatorIndices');
+    });
+
+    /** An empty restriction is not a restriction, so the pill stays. */
+    it('should keep the protocol pill when the list is empty', () => {
+      expect(keys(fields({ protocols: [] }))).toContain('counterparties');
+    });
+  });
+
+  /** The view picks the accounts itself, so there is no account pill to offer. */
+  describe('the account pill', () => {
+    it('should be offered when the view leaves accounts to the user', () => {
+      expect(keys(fields())).toContain('account');
+    });
+
+    it('should be dropped when the view pins the accounts', () => {
+      const pinned = fields({ externalAccounts: [{ address: '0x0', chain: 'eth' }] });
+
+      expect(keys(pinned)).not.toContain('account');
+    });
+
+    it('should keep the param pills either way', () => {
+      const pinned = fields({ externalAccounts: [{ address: '0x0', chain: 'eth' }] });
+
+      expect(keys(pinned)).toEqual(expect.arrayContaining(['action', 'state', 'ignored']));
+    });
+  });
+
+  /**
+   * The subtypes on offer follow the event types that are picked, so a narrowing prunes the ones it
+   * stops admitting rather than leaving a subtype no event can have.
+   */
+  describe('the event subtypes on offer', () => {
+    beforeEach(() => {
+      set(typeMapping, {
+        deposit: { 'deposit asset': 'in' },
+        withdrawal: { 'remove asset': 'out' },
+      });
+    });
+
+    it('should offer every subtype while no event type is picked', () => {
+      const suggestions = field(fields(), 'eventSubtypes').suggest?.();
+
+      expect(suggestions).toEqual(expect.arrayContaining(['deposit asset', 'remove asset']));
+    });
+
+    it('should offer only the subtypes of the picked event type', () => {
+      const picked = ref<Filters>({ eventTypes: ['deposit'] });
+
+      const suggestions = field(fields({}, picked), 'eventSubtypes').suggest?.();
+
+      expect(suggestions).toEqual(['deposit asset']);
+    });
+
+    /** The bag types the picked types as one-or-many, so a lone pick is not a character array. */
+    it('should read a single picked type as one type', () => {
+      const picked = ref<Filters>({ eventTypes: 'deposit' });
+
+      const suggestions = field(fields({}, picked), 'eventSubtypes').suggest?.();
+
+      expect(suggestions).toEqual(['deposit asset']);
+    });
+  });
+
+  /**
+   * The asset search is scoped to the picked location, so a location that names a chain searches
+   * that chain's assets rather than everything.
+   */
+  describe('the asset search', () => {
+    async function search(picked: Filters): Promise<void> {
+      await field(fields({}, ref<Filters>(picked)), 'asset').searchAsset?.('eth');
+    }
+
+    it('should search unscoped while no location is picked', async () => {
+      await search({});
+
+      expect(assetSuggestions).toHaveBeenCalledWith(assetSearch, undefined);
+    });
+
+    it('should scope the search to the picked location', async () => {
+      await search({ location: 'optimism' });
+
+      expect(assetSuggestions).toHaveBeenCalledWith(assetSearch, 'optimism');
+    });
+
+    /** The bag types the picked location as one-or-many, so a lone pick is not an array. */
+    it('should read a single picked location as one location', async () => {
+      await search({ location: ['optimism'] });
+
+      expect(assetSuggestions).toHaveBeenCalledWith(assetSearch, 'optimism');
+    });
+  });
+
+  describe('the account pill options', () => {
+    beforeEach(() => {
+      set(accountOptions, [
+        { keywords: 'my wallet', loading: false, value: '0xaaa' },
+        { loading: true, value: '0xbbb' },
+      ]);
+    });
+
+    it('should offer every account it was given', () => {
+      expect(field(fields(), 'account').suggest?.()).toEqual(['0xaaa', '0xbbb']);
+    });
+
+    it('should resolve the keywords of an account that has them', () => {
+      expect(field(fields(), 'account').resolveKeywords?.('0xaaa')).toBe('my wallet');
+    });
+
+    it('should resolve no keywords for an account without them', () => {
+      expect(field(fields(), 'account').resolveKeywords?.('0xbbb')).toBeUndefined();
+    });
+
+    /** An account whose name is still being resolved is marked, so its row can say so. */
+    it('should report which accounts are still loading', () => {
+      const account = field(fields(), 'account');
+
+      expect(account.resolveLoading?.('0xbbb')).toBe(true);
+      expect(account.resolveLoading?.('0xaaa')).toBe(false);
+    });
+  });
+
+  it('should offer the locations the account has actually used', () => {
+    set(associatedLocations, ['kraken', 'ethereum']);
+
+    expect(field(fields(), 'location').suggest?.()).toEqual(['kraken', 'ethereum']);
+  });
+
+  it('should offer the known counterparties', () => {
+    set(counterparties, ['uniswap-v3']);
+
+    expect(field(fields(), 'counterparties').suggest?.()).toEqual(['uniswap-v3']);
+  });
+
+  /** A page admitting one entry type has nothing to choose between, so it gets no pill at all. */
+  describe('the entry type pill', () => {
+    it('should offer only the entry types the page admits', () => {
+      const defs = fields({
+        entryTypes: [HistoryEventEntryType.EVM_EVENT, HistoryEventEntryType.ETH_WITHDRAWAL_EVENT],
+      });
+
+      expect(field(defs, 'entryTypes').suggest?.())
+        .toEqual([HistoryEventEntryType.EVM_EVENT, HistoryEventEntryType.ETH_WITHDRAWAL_EVENT]);
+    });
+
+    it('should offer every entry type when the page admits any', () => {
+      expect(field(fields(), 'entryTypes').suggest?.()).toEqual(Object.values(HistoryEventEntryType));
+    });
+
+    it('should be dropped when the page admits a single entry type', () => {
+      expect(keys(fields({ entryTypes: [HistoryEventEntryType.EVM_EVENT] }))).not.toContain('entryTypes');
+    });
+  });
+});

--- a/frontend/app/src/modules/history/events/use-unmatched-asset-movements.spec.ts
+++ b/frontend/app/src/modules/history/events/use-unmatched-asset-movements.spec.ts
@@ -140,5 +140,114 @@ describe('use-unmatched-asset-movements', () => {
 
       expect(spies.removeMatching).not.toHaveBeenCalled();
     });
+
+    /** A failed fetch leaves no movements behind, and must not leave the list loading forever. */
+    it('should report a failed fetch and stop loading', async () => {
+      spies.getUnmatchedAssetMovements.mockRejectedValueOnce(new Error('the backend said no'));
+      const { useUnmatchedAssetMovements } = await importFresh();
+      const { fetchUnmatchedAssetMovements, loading } = useUnmatchedAssetMovements();
+
+      await fetchUnmatchedAssetMovements(false);
+
+      expect(spies.showErrorMessage).toHaveBeenCalledWith(
+        'actions.asset_movement_matching.fetch_error.title',
+        expect.stringContaining('the backend said no'),
+      );
+      expect(get(loading)).toBe(false);
+    });
+  });
+
+  /** The two lists are separate queries, and the ignored one is only worth re-reading sometimes. */
+  describe('refreshUnmatchedAssetMovements', () => {
+    it('should re-read both lists', async () => {
+      spies.getUnmatchedAssetMovements.mockResolvedValue([]);
+      const { useUnmatchedAssetMovements } = await importFresh();
+
+      await useUnmatchedAssetMovements().refreshUnmatchedAssetMovements();
+
+      expect(spies.getUnmatchedAssetMovements).toHaveBeenCalledTimes(2);
+      expect(spies.getUnmatchedAssetMovements).toHaveBeenNthCalledWith(2, true);
+    });
+
+    it('should re-read only the unmatched list when asked to skip the ignored one', async () => {
+      spies.getUnmatchedAssetMovements.mockResolvedValue([]);
+      const { useUnmatchedAssetMovements } = await importFresh();
+
+      await useUnmatchedAssetMovements().refreshUnmatchedAssetMovements(true);
+
+      expect(spies.getUnmatchedAssetMovements).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('matchAssetMovement', () => {
+    it('should report a match and tell the rest of the app the events changed', async () => {
+      spies.matchAssetMovements.mockResolvedValueOnce(true);
+      const { useUnmatchedAssetMovements } = await importFresh();
+
+      const result = await useUnmatchedAssetMovements().matchAssetMovement(1, [2, 3]);
+
+      expect(spies.matchAssetMovements).toHaveBeenCalledWith(1, [2, 3]);
+      expect(result).toEqual({ message: '', success: true });
+      expect(spies.showSuccessMessage).toHaveBeenCalled();
+      expect(spies.signalEventsModified).toHaveBeenCalledTimes(1);
+    });
+
+    /** A refused match changed nothing, so nothing is announced and nothing is invalidated. */
+    it('should stay quiet when the match was refused', async () => {
+      spies.matchAssetMovements.mockResolvedValueOnce(false);
+      const { useUnmatchedAssetMovements } = await importFresh();
+
+      const result = await useUnmatchedAssetMovements().matchAssetMovement(1, [2]);
+
+      expect(result).toEqual({ message: '', success: false });
+      expect(spies.showSuccessMessage).not.toHaveBeenCalled();
+      expect(spies.signalEventsModified).not.toHaveBeenCalled();
+    });
+
+    it('should report a failure and hand the message back', async () => {
+      spies.matchAssetMovements.mockRejectedValueOnce(new Error('the backend said no'));
+      const { useUnmatchedAssetMovements } = await importFresh();
+
+      const result = await useUnmatchedAssetMovements().matchAssetMovement(1, [2]);
+
+      expect(result).toEqual({ message: 'the backend said no', success: false });
+      expect(spies.showErrorMessage).toHaveBeenCalled();
+      expect(spies.signalEventsModified).not.toHaveBeenCalled();
+    });
+  });
+
+  /** Resolving as external is the same call with no matches, flagged as deliberate. */
+  describe('resolveExternal', () => {
+    it('should resolve the movement without naming any matches', async () => {
+      spies.matchAssetMovements.mockResolvedValueOnce(true);
+      const { useUnmatchedAssetMovements } = await importFresh();
+
+      const result = await useUnmatchedAssetMovements().resolveExternal(1);
+
+      expect(spies.matchAssetMovements).toHaveBeenCalledWith(1, undefined, true);
+      expect(result).toEqual({ message: '', success: true });
+      expect(spies.signalEventsModified).toHaveBeenCalledTimes(1);
+    });
+
+    /** The caller surfaces this one itself, with an undo, so a toast would be a second report. */
+    it('should say nothing on success, since the caller reports it with an undo', async () => {
+      spies.matchAssetMovements.mockResolvedValueOnce(true);
+      const { useUnmatchedAssetMovements } = await importFresh();
+
+      await useUnmatchedAssetMovements().resolveExternal(1);
+
+      expect(spies.showSuccessMessage).not.toHaveBeenCalled();
+    });
+
+    it('should report a failure and hand the message back', async () => {
+      spies.matchAssetMovements.mockRejectedValueOnce(new Error('the backend said no'));
+      const { useUnmatchedAssetMovements } = await importFresh();
+
+      const result = await useUnmatchedAssetMovements().resolveExternal(1);
+
+      expect(result).toEqual({ message: 'the backend said no', success: false });
+      expect(spies.showErrorMessage).toHaveBeenCalled();
+      expect(spies.signalEventsModified).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/app/tests/unit/i18n.ts
+++ b/frontend/app/tests/unit/i18n.ts
@@ -1,8 +1,13 @@
 import type { useI18n } from 'vue-i18n';
 
+/**
+ * @remarks
+ * `String` rather than `value.toString()`: an optional interpolation value is legitimately absent,
+ * and vue-i18n renders that as empty rather than throwing, so echoing it must not throw either.
+ */
 function stringify(value: Record<string, any>): string {
   return Object.values(value)
-    .map(value => value.toString())
+    .map(value => String(value))
     .join(', ');
 }
 

--- a/frontend/app/tests/unit/utils/mocks/native-task.ts
+++ b/frontend/app/tests/unit/utils/mocks/native-task.ts
@@ -11,6 +11,8 @@ export interface SubmittedSpec {
   /** Declared so a spec can assert scheduling intent (an umbrella's lane, a child's parent). */
   lane?: string;
   parent?: string;
+  /** What the activity says it is doing, which a producer spec asserts the wording of. */
+  subtitle?: string;
   /** Whether this activity claims freshness for its kind — an umbrella must not. */
   container?: boolean;
 }


### PR DESCRIPTION
Takes the three biggest uncovered files left in the repo, all of them `history/events` composables.
Pure logic, so the specs assert directly rather than through a mounted table.

| Unit | Lines before | after |
|---|---|---|
| `tx/use-history-transactions.ts` | 20/84 | **84/84** |
| `use-history-event-fields.ts` | 0/48 | 45/48 |
| `use-unmatched-asset-movements.ts` | 51/95 | 75/95 |

Total line coverage 74.49% -> 74.76%.

## What is covered

**The three transaction re-pulls** had no coverage at all. Each submits one activity and reports its
outcome, so the tests pin what identifies that activity, what it says it is doing, and what the user
is told afterwards. The identity is the part that matters: an absent bound is part of it, since
"everything before X" is a different request from "X to Y", and two requests taken for one would
drop the second silently.

**The filter fields**: which pills a page's restrictions take away, and that an empty restriction is
not one; the account pill dropped when the view picks the accounts itself; the subtypes following
the picked event types; the asset search scoped to the picked location. Two of those read a filter
the bag types as one-or-many, where treating a lone pick as a list spreads it into characters.

**Matching an asset movement**: matching against picked events, and resolving as external (the same
call with no matches and a flag). Both leave the events invalidated only when something actually
changed, so a refused match announces nothing.

## One harness change

`tests/unit/i18n.ts` called `toString()` on every interpolation value, so an **absent** one threw.
Since vue-i18n renders that as empty rather than throwing, any branch passing an optional value
through `t()` was unreachable from a spec — which is exactly what hid the no-address re-pull
wording. Now `String(value)`. It changes nothing across the other 1107 test files.

`SubmittedSpec` also gains `subtitle`, so a producer spec can assert what its activity says it is
doing.

## Verification

Every assertion has a negative control: the specific line was broken, the named tests confirmed to
fail and only those, then restored. Ten in all. One was a finding: dropping `.filter(Boolean)` from
the eth-staking breakdown broke nothing, because my `not.toContain` could not see a section that is
empty either way. Re-aimed at what the filter actually does, which is keep a blank block off the
end of the message.

Not covered, and deliberately: `triggerAssetMovementAutoMatching` goes through the real task
orchestrator, which this spec does not stub. It is the remaining gap in
`use-unmatched-asset-movements.ts`.

Gates: `typecheck`, `knip`, `lint:file:check`, `lint:style`, `check:linked-keys`, `test:proxy` and
the full `test:unit` (1108 files, 12145 tests) all green.
