### PR TITLE
test(frontend): cover the assets module, crossing 75%

### DIFF
--- a/frontend/app/src/modules/assets/AssetLocations.spec.ts
+++ b/frontend/app/src/modules/assets/AssetLocations.spec.ts
@@ -1,0 +1,242 @@
+import type { AssetLocation } from '@/modules/assets/use-asset-locations-data';
+import { bigNumberify, Blockchain } from '@rotki/common';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, type Ref } from 'vue';
+import AssetLocations from '@/modules/assets/AssetLocations.vue';
+
+const { isPricePending, matchChain, visibleAssetLocations } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    isPricePending: vi.fn<(identifier: string) => boolean>(() => false),
+    matchChain: vi.fn<(location: string) => string | undefined>(() => undefined),
+    visibleAssetLocations: ref<AssetLocation[]>([]),
+  };
+});
+
+/** Captures the filters the page drives, which is where the exclusivity rule is observable. */
+const captured: { addresses?: Ref<string[]>; locationFilter?: Ref<string> } = {};
+
+vi.mock('@/modules/assets/use-asset-locations-data', async () => {
+  const { computed } = await import('vue');
+  return {
+    useAssetLocationsData: (options: {
+      addresses: Ref<string[]>;
+      locationFilter: Ref<string>;
+    }): Record<string, unknown> => {
+      captured.addresses = options.addresses;
+      captured.locationFilter = options.locationFilter;
+      return {
+        assetLocations: computed(() => visibleAssetLocations.value),
+        currencySymbol: computed(() => 'EUR'),
+        detailsLoading: computed(() => false),
+        matchChain,
+        totalValue: computed(() => visibleAssetLocations.value.reduce(
+          (sum, row) => sum.plus(row.value),
+          bigNumberify(0),
+        )),
+        visibleAssetLocations: computed(() => visibleAssetLocations.value),
+      };
+    },
+  };
+});
+
+vi.mock('@/modules/assets/prices/use-price-utils', () => ({
+  usePriceUtils: (): Record<string, unknown> => ({ isPricePending }),
+}));
+
+vi.mock('@/modules/assets/use-asset-location-fields', () => ({
+  useAssetLocationFields: (): unknown[] => [],
+}));
+
+vi.mock('@/modules/core/table/pill/composables/use-pill-bar-labels', () => ({
+  usePillBarLabels: (): Record<string, unknown> => ({}),
+}));
+
+vi.mock('@/modules/core/table/use-remember-table-sorting', async importOriginal => ({
+  ...await importOriginal<typeof import('@/modules/core/table/use-remember-table-sorting')>(),
+  useRememberTableSorting: (): void => {},
+}));
+
+/** Renders the percentage cell, which is the one the page computes rather than reads. */
+const TableStub = defineComponent({
+  emits: ['update:pagination', 'update:sort'],
+  props: ['cols', 'rows', 'loading', 'sort', 'pagination'],
+  template: `<div>
+    <template v-for="row in rows" :key="row.label">
+      <span class="percentage"><slot name="item.percentage" :row="row" /></span>
+    </template>
+  </div>`,
+});
+
+function location(overrides: Partial<AssetLocation> = {}): AssetLocation {
+  return {
+    address: '0xaaa',
+    amount: bigNumberify(1),
+    label: '0xaaa',
+    location: Blockchain.ETH,
+    value: bigNumberify(100),
+    ...overrides,
+  };
+}
+
+function createWrapper(): VueWrapper<any> {
+  return mount(AssetLocations, {
+    global: {
+      stubs: {
+        LabeledAddressDisplay: true,
+        LocationDisplay: true,
+        PercentageDisplay: { props: ['value'], template: '<span>{{ value }}</span>' },
+        PillFilterBar: true,
+        RuiCard: { template: '<div><slot name="header" /><slot /></div>' },
+        RuiDataTable: TableStub,
+        TagDisplay: true,
+      },
+    },
+    props: { identifier: 'ETH' },
+  });
+}
+
+function table(wrapper: VueWrapper<any>): VueWrapper<any> {
+  return wrapper.findComponent(TableStub);
+}
+
+function labelOf(wrapper: VueWrapper<any>): string {
+  const column = table(wrapper).props('cols').find((col: { key: string }) => col.key === 'label');
+  assert(column);
+  return column.label;
+}
+
+function percentages(wrapper: VueWrapper<any>): string[] {
+  return wrapper.findAll('.percentage').map(node => node.text());
+}
+
+describe('assetLocations', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    isPricePending.mockReturnValue(false);
+    matchChain.mockReturnValue(undefined);
+    set(visibleAssetLocations, [location()]);
+  });
+
+  /**
+   * A validator is not an account, so the column is named for what it actually holds rather than
+   * always for one of them.
+   */
+  describe('the account column', () => {
+    it('should be named for accounts when no validator is shown', () => {
+      expect(labelOf(createWrapper())).toBe('common.account');
+    });
+
+    it('should be named for validators when only validators are shown', () => {
+      set(visibleAssetLocations, [location({ location: Blockchain.ETH2 })]);
+
+      expect(labelOf(createWrapper())).toBe('asset_locations.header.validator');
+    });
+
+    it('should name both when the rows are mixed', () => {
+      set(visibleAssetLocations, [location(), location({ label: 'v1', location: Blockchain.ETH2 })]);
+
+      expect(labelOf(createWrapper())).toBe('common.account / asset_locations.header.validator');
+    });
+  });
+
+  describe('the share each location holds', () => {
+    it('should be the row value against the total', () => {
+      set(visibleAssetLocations, [
+        location({ value: bigNumberify(25) }),
+        location({ label: '0xbbb', value: bigNumberify(75) }),
+      ]);
+
+      expect(percentages(createWrapper())).toEqual(['25.00', '75.00']);
+    });
+
+    /** Nothing held is not a division to attempt, and every share of it is zero. */
+    it('should be zero when nothing is held anywhere', () => {
+      set(visibleAssetLocations, [location({ value: bigNumberify(0) })]);
+
+      expect(percentages(createWrapper())).toEqual(['0.00']);
+    });
+  });
+
+  /**
+   * An account is only ever held on a chain, so an exchange location and an account can never both
+   * match a row: leaving both set would empty the table.
+   */
+  describe('keeping the location and account filters exclusive', () => {
+    it('should clear the picked accounts when a non-chain location is picked', async () => {
+      const wrapper = createWrapper();
+      assert(captured.addresses && captured.locationFilter);
+      set(captured.addresses, ['0xaaa']);
+      await nextTick();
+
+      set(captured.locationFilter, 'kraken');
+      await nextTick();
+
+      expect(get(captured.addresses)).toEqual([]);
+      expect(wrapper.exists()).toBe(true);
+    });
+
+    /** A chain location and an account on that chain agree, so neither has to give way. */
+    it('should keep the picked accounts when the location names a chain', async () => {
+      matchChain.mockReturnValue(Blockchain.ETH);
+      createWrapper();
+      assert(captured.addresses && captured.locationFilter);
+      set(captured.addresses, ['0xaaa']);
+      await nextTick();
+
+      set(captured.locationFilter, Blockchain.ETH);
+      await nextTick();
+
+      expect(get(captured.addresses)).toEqual(['0xaaa']);
+    });
+
+    it('should clear a non-chain location when accounts are picked', async () => {
+      createWrapper();
+      assert(captured.addresses && captured.locationFilter);
+      set(captured.locationFilter, 'kraken');
+      await nextTick();
+
+      set(captured.addresses, ['0xaaa']);
+      await nextTick();
+
+      expect(get(captured.locationFilter)).toBe('');
+    });
+  });
+
+  /** A filter change re-reads the list, so the page it lands on has to start from the first. */
+  describe('paging', () => {
+    it('should go back to the first page when a filter changes', async () => {
+      const wrapper = createWrapper();
+      table(wrapper).vm.$emit('update:pagination', { limit: 10, page: 3 });
+      await nextTick();
+
+      assert(captured.locationFilter);
+      set(captured.locationFilter, 'kraken');
+      await nextTick();
+
+      expect(table(wrapper).props('pagination').page).toBe(1);
+    });
+
+    it('should follow the table changing page', async () => {
+      const wrapper = createWrapper();
+
+      table(wrapper).vm.$emit('update:pagination', { limit: 25, page: 2 });
+      await nextTick();
+
+      expect(table(wrapper).props('pagination')).toMatchObject({ limit: 25, page: 2 });
+    });
+
+    /** The table reports no pagination while it has none to report, which is not a change. */
+    it('should ignore a pagination it was not given', async () => {
+      const wrapper = createWrapper();
+      const before = table(wrapper).props('pagination');
+
+      table(wrapper).vm.$emit('update:pagination', undefined);
+      await nextTick();
+
+      expect(table(wrapper).props('pagination')).toEqual(before);
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/amount-display/CurrencyDropdown.spec.ts
+++ b/frontend/app/src/modules/assets/amount-display/CurrencyDropdown.spec.ts
@@ -1,0 +1,188 @@
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { Currency } from '@/modules/assets/amount-display/currencies';
+import CurrencyDropdown from '@/modules/assets/amount-display/CurrencyDropdown.vue';
+
+const { currency, onCurrencyUpdate, update } = await vi.hoisted(async () => {
+  const { ref } = await import('vue');
+  return {
+    currency: ref<{ tickerSymbol: string; unicodeSymbol: string }>({ tickerSymbol: 'USD', unicodeSymbol: '$' }),
+    onCurrencyUpdate: vi.fn(async () => {}),
+    update: vi.fn(async () => ({ success: true })),
+  };
+});
+
+vi.mock('@/modules/settings/use-settings-operations', () => ({
+  useSettingsOperations: (): Record<string, unknown> => ({ update }),
+}));
+
+vi.mock('@/modules/settings/use-setting', () => ({
+  useSetting: (): typeof currency => currency,
+}));
+
+vi.mock('@/modules/assets/prices/use-currency-update', () => ({
+  useCurrencyUpdate: (): Record<string, unknown> => ({ onCurrencyUpdate }),
+}));
+
+const MenuStub = defineComponent({
+  emits: ['update:modelValue'],
+  props: ['modelValue'],
+  template: '<div><slot name="activator" :attrs="{}" /><slot /></div>',
+});
+
+const TextFieldStub = defineComponent({
+  emits: ['update:modelValue'],
+  props: ['modelValue'],
+  template: '<input @keyup.enter="$emit(\'keyup\', $event)" />',
+});
+
+function createWrapper(): VueWrapper<any> {
+  return mount(CurrencyDropdown, {
+    global: {
+      stubs: {
+        /** No `@click` of its own: the parent's listener already falls through onto the root. */
+        ListItem: {
+          props: ['title', 'subtitle'],
+          template: '<div class="currency">{{ title }}<slot name="avatar" /></div>',
+        },
+        MenuTooltipButton: true,
+        RuiMenu: MenuStub,
+        RuiTextField: TextFieldStub,
+      },
+    },
+  });
+}
+
+function listed(wrapper: VueWrapper<any>): string[] {
+  return wrapper.findAll('.currency').map(node => node.text().replace(/[^\w\s()]+$/u, '').trim());
+}
+
+async function type(wrapper: VueWrapper<any>, value: string): Promise<void> {
+  wrapper.findComponent(TextFieldStub).vm.$emit('update:modelValue', value);
+  await nextTick();
+}
+
+async function pick(wrapper: VueWrapper<any>, index: number): Promise<void> {
+  await wrapper.findAll('.currency')[index].trigger('click');
+  await flushPromises();
+}
+
+describe('currencyDropdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    set(currency, new Currency('US Dollar', 'USD', '$'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('filtering', () => {
+    it('should offer every currency while nothing is typed', () => {
+      expect(listed(createWrapper()).length).toBeGreaterThan(10);
+    });
+
+    it('should match on the ticker symbol', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'gbp');
+
+      expect(listed(wrapper)).toEqual(['currencies.gbp']);
+    });
+
+    /** The names are translated, so a user typing what they read has to match on them too. */
+    it('should match on the name', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'currencies.eur');
+
+      expect(listed(wrapper)).toEqual(['currencies.eur']);
+    });
+
+    it('should match regardless of case', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'GBP');
+
+      expect(listed(wrapper)).toEqual(['currencies.gbp']);
+    });
+
+    it('should offer nothing when nothing matches', async () => {
+      const wrapper = createWrapper();
+
+      await type(wrapper, 'nonsense');
+
+      expect(listed(wrapper)).toEqual([]);
+    });
+  });
+
+  describe('picking a currency', () => {
+    it('should save it and re-read the prices', async () => {
+      const wrapper = createWrapper();
+      await type(wrapper, 'gbp');
+
+      await pick(wrapper, 0);
+
+      expect(update).toHaveBeenCalledWith({ mainCurrency: 'GBP' });
+      expect(onCurrencyUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    /** Re-picking the current currency changes nothing, so it is not worth a write or a re-read. */
+    it('should do nothing when it is already the current one', async () => {
+      const wrapper = createWrapper();
+      await type(wrapper, 'usd');
+
+      await pick(wrapper, 0);
+
+      expect(update).not.toHaveBeenCalled();
+      expect(onCurrencyUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should close the menu either way', async () => {
+      const wrapper = createWrapper();
+      await type(wrapper, 'usd');
+
+      await pick(wrapper, 0);
+
+      expect(wrapper.findComponent(MenuStub).props('modelValue')).toBe(false);
+    });
+  });
+
+  /** Reopening the menu on the last search would hide most of the list without saying why. */
+  it('should forget the filter when the menu closes', async () => {
+    const wrapper = createWrapper();
+    await type(wrapper, 'gbp');
+
+    wrapper.findComponent(MenuStub).vm.$emit('update:modelValue', true);
+    await nextTick();
+    wrapper.findComponent(MenuStub).vm.$emit('update:modelValue', false);
+    await nextTick();
+
+    expect(listed(wrapper).length).toBeGreaterThan(10);
+  });
+
+  /** A longer symbol has to shrink, or it overflows the avatar the short ones fill. */
+  describe('the symbol size', () => {
+    function fontSizeOf(wrapper: VueWrapper<any>, ticker: string): string | undefined {
+      const item = wrapper.findAll('.currency').find(node => node.text().includes(`currencies.${ticker}`));
+      assert(item);
+      return item.find('.font-bold').attributes('style');
+    }
+
+    it('should render a one-character symbol at full size', async () => {
+      const wrapper = createWrapper();
+      await type(wrapper, 'usd');
+
+      expect(fontSizeOf(wrapper, 'usd')).toBe('font-size: 2em;');
+    });
+
+    it('should shrink a three-character symbol', async () => {
+      const wrapper = createWrapper();
+      await type(wrapper, 'chf');
+
+      expect(fontSizeOf(wrapper, 'chf')).toBe('font-size: 1.2em;');
+    });
+  });
+});

--- a/frontend/app/src/modules/assets/use-collection-info.spec.ts
+++ b/frontend/app/src/modules/assets/use-collection-info.spec.ts
@@ -1,0 +1,249 @@
+import type { AssetMap } from '@/modules/assets/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { assetMapping, resolveAssetIdentifier } = vi.hoisted(() => ({
+  assetMapping: vi.fn<(identifiers: string[]) => Promise<AssetMap>>(),
+  resolveAssetIdentifier: vi.fn<(identifier: string) => string>(identifier => identifier),
+}));
+
+vi.mock('@/modules/assets/api/use-asset-info-api', () => ({
+  useAssetInfoApi: (): Record<string, unknown> => ({ assetMapping }),
+}));
+
+vi.mock('@/modules/assets/use-resolve-asset-identifier', () => ({
+  useResolveAssetIdentifier: (): typeof resolveAssetIdentifier => resolveAssetIdentifier,
+}));
+
+/** The delay the composable batches over, so a test can let one batch go out. */
+const BATCH_DELAY = 1600;
+
+function mapping(assets: Record<string, string | undefined>, collections: Record<string, string> = {}): AssetMap {
+  return {
+    assetCollections: Object.fromEntries(
+      Object.entries(collections).map(([id, mainAsset]) => [id, { mainAsset, name: id, symbol: id }]),
+    ),
+    assets: Object.fromEntries(
+      Object.entries(assets).map(([id, collectionId]) => [
+        id,
+        { collectionId, isCustomAsset: false, name: id, symbol: id },
+      ]),
+    ),
+  };
+}
+
+describe('useCollectionInfo', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    resolveAssetIdentifier.mockImplementation(identifier => identifier);
+    // `clearAllMocks` leaves a queued `...Once` implementation behind, which would leak here.
+    assetMapping.mockReset();
+    assetMapping.mockResolvedValue(mapping({}));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * `createSharedComposable` keeps its queues and its debounce for the life of the module, so each
+   * case re-imports it rather than inheriting the last one's pending batch.
+   */
+  async function importFresh(): Promise<typeof import('@/modules/assets/use-collection-info')> {
+    vi.resetModules();
+    return import('@/modules/assets/use-collection-info');
+  }
+
+  /** Asks for the asset, lets the batch go out, then asks again for the settled answer. */
+  async function collectionOf(assetId: string, ...also: string[]): Promise<string | undefined> {
+    const { useCollectionInfo } = await importFresh();
+    const { getCollectionId } = useCollectionInfo();
+
+    getCollectionId(assetId);
+    for (const other of also)
+      getCollectionId(other);
+
+    await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+    return getCollectionId(assetId);
+  }
+
+  it('should not know a collection before the batch has gone out', async () => {
+    const { useCollectionInfo } = await importFresh();
+
+    expect(useCollectionInfo().getCollectionId('ETH')).toBeUndefined();
+  });
+
+  it('should answer with the collection the backend gave', async () => {
+    assetMapping.mockResolvedValue(mapping({ ETH: 'evm-eth' }));
+
+    expect(await collectionOf('ETH')).toBe('evm-eth');
+  });
+
+  /**
+   * An asset with no collection is remembered as having none, rather than left unknown: an unknown
+   * asset is asked about again on every read, which is a request per render.
+   */
+  it('should remember that an asset has no collection', async () => {
+    assetMapping.mockResolvedValue(mapping({ ETH: undefined }));
+
+    expect(await collectionOf('ETH')).toBeNull();
+  });
+
+  /** The backend leaves out what it does not know, so the gap has to be filled in here. */
+  it('should remember an asset the backend did not answer for', async () => {
+    assetMapping.mockResolvedValue(mapping({}));
+
+    expect(await collectionOf('UNKNOWN')).toBeNull();
+  });
+
+  describe('batching the requests', () => {
+    it('should ask once for everything asked of it in the window', async () => {
+      await collectionOf('ETH', 'BTC', 'DAI');
+
+      expect(assetMapping).toHaveBeenCalledTimes(1);
+      expect(assetMapping).toHaveBeenCalledWith(['ETH', 'BTC', 'DAI']);
+    });
+
+    it('should not ask twice for the same asset in one window', async () => {
+      await collectionOf('ETH', 'ETH');
+
+      expect(assetMapping).toHaveBeenCalledWith(['ETH']);
+    });
+
+    /**
+     * A read while the batch is in flight has no answer yet, so without the in-flight guard it
+     * would queue the same asset again and every render would cost another request.
+     */
+    it('should not ask again for an asset already in flight', async () => {
+      let answer: (map: AssetMap) => void = () => {};
+      assetMapping.mockImplementation(async () => new Promise<AssetMap>((resolve) => {
+        answer = resolve;
+      }));
+      const { useCollectionInfo } = await importFresh();
+      const { getCollectionId } = useCollectionInfo();
+      getCollectionId('ETH');
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+
+      getCollectionId('ETH');
+      answer(mapping({ ETH: 'evm-eth' }));
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+
+      expect(assetMapping).toHaveBeenCalledTimes(1);
+    });
+
+    /** Once the answer is known there is nothing left to ask. */
+    it('should not ask again for an asset it already knows', async () => {
+      assetMapping.mockResolvedValue(mapping({ ETH: 'evm-eth' }));
+      const { useCollectionInfo } = await importFresh();
+      const { getCollectionId } = useCollectionInfo();
+      getCollectionId('ETH');
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+      assetMapping.mockClear();
+
+      getCollectionId('ETH');
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+
+      expect(assetMapping).not.toHaveBeenCalled();
+    });
+
+    /** The backend takes 50 at a time, so a larger batch is split rather than sent whole. */
+    it('should split a batch larger than the backend takes', async () => {
+      const { useCollectionInfo } = await importFresh();
+      const { getCollectionId } = useCollectionInfo();
+
+      for (let i = 0; i < 120; i++)
+        getCollectionId(`asset-${i}`);
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+
+      expect(assetMapping).toHaveBeenCalledTimes(3);
+      expect(assetMapping.mock.calls[0][0]).toHaveLength(50);
+      expect(assetMapping.mock.calls[2][0]).toHaveLength(20);
+    });
+
+    it('should ask nothing when nothing was queued', async () => {
+      await importFresh();
+
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+
+      expect(assetMapping).not.toHaveBeenCalled();
+    });
+  });
+
+  /** eth2 is the same asset as eth when the user has said so, so it is asked about under that id. */
+  it('should ask under the identifier the settings resolve to', async () => {
+    resolveAssetIdentifier.mockImplementation(identifier => (identifier === 'ETH2' ? 'ETH' : identifier));
+
+    await collectionOf('ETH2');
+
+    expect(assetMapping).toHaveBeenCalledWith(['ETH']);
+  });
+
+  describe('when a request fails', () => {
+    it('should leave the asset unknown rather than remembering a wrong answer', async () => {
+      assetMapping.mockRejectedValue(new Error('the backend said no'));
+
+      expect(await collectionOf('ETH')).toBeUndefined();
+    });
+
+    /** One failed chunk must not cost the others, which were separate requests. */
+    it('should keep the answers from the chunks that did work', async () => {
+      assetMapping
+        .mockRejectedValueOnce(new Error('the backend said no'))
+        .mockResolvedValueOnce(mapping({ 'asset-60': 'late-collection' }));
+      const { useCollectionInfo } = await importFresh();
+      const { getCollectionId } = useCollectionInfo();
+
+      for (let i = 0; i < 70; i++)
+        getCollectionId(`asset-${i}`);
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+
+      expect(getCollectionId('asset-60')).toBe('late-collection');
+    });
+  });
+
+  describe('the main asset of a collection', () => {
+    it('should answer with the main asset the backend gave', async () => {
+      assetMapping.mockResolvedValue(mapping({ ETH: 'evm-eth' }, { 'evm-eth': 'ETH' }));
+      const { useCollectionInfo } = await importFresh();
+      const { getCollectionId, getCollectionMainAsset } = useCollectionInfo();
+      getCollectionId('ETH');
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+
+      expect(getCollectionMainAsset('evm-eth')).toBe('ETH');
+    });
+
+    /** A collection with no main asset is stored as null, which is not an answer to hand back. */
+    it('should answer with nothing for a collection that has no main asset', async () => {
+      const { useCollectionInfo } = await importFresh();
+
+      expect(useCollectionInfo().getCollectionMainAsset('unknown-collection')).toBeUndefined();
+    });
+  });
+
+  describe('the reactive readers', () => {
+    it('should follow the collection arriving', async () => {
+      assetMapping.mockResolvedValue(mapping({ ETH: 'evm-eth' }));
+      const { useCollectionInfo } = await importFresh();
+      const collection = useCollectionInfo().useCollectionId('ETH');
+
+      expect(get(collection)).toBeUndefined();
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+
+      expect(get(collection)).toBe('evm-eth');
+    });
+
+    it('should follow the main asset arriving', async () => {
+      assetMapping.mockResolvedValue(mapping({ ETH: 'evm-eth' }, { 'evm-eth': 'ETH' }));
+      const { useCollectionInfo } = await importFresh();
+      const { useCollectionId, useCollectionMainAsset } = useCollectionInfo();
+      const collection = useCollectionId('ETH');
+      const mainAsset = useCollectionMainAsset('evm-eth');
+      get(collection);
+
+      await vi.advanceTimersByTimeAsync(BATCH_DELAY);
+
+      expect(get(mainAsset)).toBe('ETH');
+    });
+  });
+});


### PR DESCRIPTION
Takes the top of the `assets` cluster. Three units, one commit each.

**Line coverage crosses 75%: 74.76% -> 75.01%.**

| Unit | Lines before | after |
|---|---|---|
| `use-collection-info.ts` | 8/54 | 51/54 |
| `AssetLocations.vue` | 1/53 | 46/53 |
| `amount-display/CurrencyDropdown.vue` | 0/49 | 39/49 |

## What is covered

**The collection batching** exists to turn one request per rendered asset into one batched request,
so the tests pin the parts that do that: the window that collects the reads, the split into what the
backend takes, and the three ways an asset is already accounted for. An asset with no collection,
and one the backend did not answer for, are both remembered as having none: left unknown they would
be asked about again on every render.

**The asset locations table**: the account column named for what the rows actually hold (a validator
is not an account, and a mixed list is neither), the share each location holds including the division
the page must not attempt when nothing is held, and the rule keeping the location and account filters
exclusive, which clears the older pill only when the location is not a chain.

**The profit currency dropdown**: filtering on either the ticker or the translated name, saving the
pick and re-reading the prices it changes, and doing neither when the pick is already current.

## Verification

Every assertion has a negative control: the specific line was broken, the named tests confirmed to
fail and only those, then restored. Nine in all. Two were findings:

- the queued/pending dedupe in `use-collection-info` was not pinned by "should not ask twice in one
  window", because `queuedAssets` is a `Set` and adding twice is idempotent regardless. The check
  that actually matters is a read arriving **while the batch is in flight**, which is now its own
  test.
- that same control exposed order-coupling in my own spec: `vi.clearAllMocks()` leaves a queued
  `...Once` implementation behind, so an unconsumed one leaked into the next test. Fixed with an
  explicit `mockReset()`.

One stub bug worth noting, since it inflated a call count rather than failing outright: a `ListItem`
stub that re-emitted `click` made the handler run twice, because the parent's listener already falls
through onto the stub's root.

Gates: `typecheck`, `knip`, `lint:file:check`, `lint:style`, `check:linked-keys`, `test:proxy` and
the full `test:unit` (1111 files, 12184 tests) all green.
