### PR TITLE
Classify notification producers and stop unclassified ones popping

### DIFF
--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.spec.ts
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.spec.ts
@@ -1,4 +1,4 @@
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, type VNode } from 'vue';
@@ -120,6 +120,7 @@ describe('addressBookManagementMore', () => {
 
       expect(notify).toHaveBeenCalledWith({
         message: 'address_book.import.import_success.message::3',
+        priority: Priority.HIGH,
         severity: Severity.INFO,
         title: 'address_book.import.title',
       });

--- a/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookManagementMore.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ComponentExposed } from 'vue-component-type-helpers';
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import { externalLinks } from '@shared/external-links';
 import { useAddressBookImport } from '@/modules/accounts/address-book/use-address-book-import';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
@@ -36,6 +36,7 @@ async function doImport() {
       message: t('address_book.import.import_success.message', {
         length: successEntries,
       }),
+      priority: Priority.HIGH,
       severity: Severity.INFO,
       title: t('address_book.import.title'),
     });

--- a/frontend/app/src/modules/accounts/address-book/use-address-book-operations.ts
+++ b/frontend/app/src/modules/accounts/address-book/use-address-book-operations.ts
@@ -6,6 +6,7 @@ import type {
   AddressBookSimplePayload,
 } from '@/modules/accounts/address-book/eth-names';
 import type { Collection } from '@/modules/core/common/collection';
+import { Priority } from '@rotki/common';
 import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
 import { useAddressesNamesApi } from '@/modules/accounts/address-book/use-addresses-names-api';
 import { defaultCollectionState } from '@/modules/core/common/data/collection-utils';
@@ -46,6 +47,7 @@ export function useAddressBookOperations(): UseAddressBookOperationsReturn {
         t('address_book.actions.fetch.error.message', {
           message: getErrorMessage(error),
         }),
+        { priority: Priority.NORMAL },
       );
 
       return defaultCollectionState();

--- a/frontend/app/src/modules/accounts/use-account-fetching.ts
+++ b/frontend/app/src/modules/accounts/use-account-fetching.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@rotki/common';
+import { Blockchain, Priority } from '@rotki/common';
 import { convertBtcAccounts } from '@/modules/accounts/account-helpers';
 import { useBlockchainAccountsApi } from '@/modules/accounts/api/use-blockchain-accounts-api';
 import { createAccount } from '@/modules/accounts/create-account';
@@ -29,7 +29,9 @@ export function useAccountFetching(): UseAccountFetchingReturn {
    * @remarks
    * This fans out over every supported chain, so a logout mid-flight would otherwise raise one
    * "no user is currently logged in" per chain. A cancelled request is likewise the queue dropping
-   * work the user moved away from. Everything else is surfaced.
+   * work the user moved away from. Everything else is recorded in the drawer rather than popped,
+   * for the same reason: one outage is one notification per chain, and the user asked for none of
+   * them.
    */
   const notifyFetchFailure = (chain: string, error: unknown): void => {
     if (isRequestCancellation(error) || isSessionExpired(error))
@@ -42,6 +44,7 @@ export function useAccountFetching(): UseAccountFetchingReturn {
         blockchain: chain.toUpperCase(),
         message: getErrorMessage(error),
       }),
+      { priority: Priority.NORMAL },
     );
   };
 

--- a/frontend/app/src/modules/accounts/use-account-migration.ts
+++ b/frontend/app/src/modules/accounts/use-account-migration.ts
@@ -1,6 +1,6 @@
 import type { MaybeRef } from 'vue';
 import type { MigratedAddresses } from '@/modules/core/messaging/types';
-import { assert, type Notification, NotificationCategory, Severity } from '@rotki/common';
+import { assert, type Notification, NotificationCategory, Priority, Severity } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { useSessionStorage } from '@vueuse/core';
 import { useBlockchainAccountManagement } from '@/modules/accounts/use-blockchain-account-management';
@@ -85,6 +85,7 @@ export function useAccountMigration(): UseAccountMigrationReturn {
           },
           chainAddresses.length,
         ),
+        priority: Priority.HIGH,
         severity: Severity.INFO,
         title: t('notification_messages.address_migration.title', { chain: chainName }, chainAddresses.length),
       });

--- a/frontend/app/src/modules/assets/admin/missing-mappings/exchange-unknown-asset-handler.ts
+++ b/frontend/app/src/modules/assets/admin/missing-mappings/exchange-unknown-asset-handler.ts
@@ -1,6 +1,6 @@
 import type { MessageHandler } from '@/modules/core/messaging/interfaces';
 import type { ExchangeUnknownAssetData } from '@/modules/core/messaging/types/business-types';
-import { NotificationCategory, NotificationGroup, Severity } from '@rotki/common';
+import { NotificationCategory, NotificationGroup, Priority, Severity } from '@rotki/common';
 import { pick } from 'es-toolkit';
 import { useMissingMappingsDB } from '@/modules/assets/admin/missing-mappings/use-missing-mappings-db';
 import { createStateWithNotificationHandler } from '@/modules/core/messaging/utils';
@@ -30,6 +30,7 @@ export function createExchangeUnknownAssetHandler(
       group: NotificationGroup.MISSING_EXCHANGE_MAPPING,
       groupCount,
       message: t('notification_messages.unknown_asset_mapping.message', { groupCount }),
+      priority: Priority.ACTION,
       severity: Severity.WARNING,
       title: t('notification_messages.unknown_asset_mapping.title'),
     }),

--- a/frontend/app/src/modules/assets/admin/solana-token-migration/solana-tokens-migration-handler.ts
+++ b/frontend/app/src/modules/assets/admin/solana-token-migration/solana-tokens-migration-handler.ts
@@ -1,6 +1,6 @@
 import type { MessageHandler } from '@/modules/core/messaging/interfaces';
 import type { SolanaTokensMigrationData } from '@/modules/core/messaging/types';
-import { NotificationCategory, Severity } from '@rotki/common';
+import { NotificationCategory, Priority, Severity } from '@rotki/common';
 import { useSolanaTokenMigrationStore } from '@/modules/assets/admin/solana-token-migration/use-solana-token-migration-store';
 import { createStateWithNotificationHandler } from '@/modules/core/messaging/utils';
 
@@ -25,6 +25,7 @@ export function createSolanaTokensHandler(
       message: t('notification_messages.solana_tokens_migration.message', {
         tokens: data.identifiers.map(item => `- ${item}`).join('\n'),
       }),
+      priority: Priority.ACTION,
       severity: Severity.WARNING,
       title: t('notification_messages.solana_tokens_migration.title'),
     }),

--- a/frontend/app/src/modules/assets/admin/use-restore-asset-db.ts
+++ b/frontend/app/src/modules/assets/admin/use-restore-asset-db.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue';
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import { useAssets } from '@/modules/assets/use-assets';
 import { DialogType } from '@/modules/core/common/dialogs';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
@@ -84,7 +84,7 @@ export function useRestoreAssetDb(): UseRestoreAssetDbReturn {
     if (message.includes(UNDELETABLE_ASSETS))
       showDoubleConfirmation(resetType);
 
-    notify({ message, severity: Severity.ERROR, title: t('asset_update.restore.title') });
+    notify({ message, priority: Priority.HIGH, severity: Severity.ERROR, title: t('asset_update.restore.title') });
   }
 
   function showRestoreConfirmation(type: ResetType): void {

--- a/frontend/app/src/modules/assets/prices/components/oracle/OracleCacheContent.vue
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OracleCacheContent.vue
@@ -2,7 +2,7 @@
 import type { DataTableColumn } from '@rotki/ui-library';
 import type { OracleCacheMeta } from '@/modules/assets/prices/price-types';
 import type { MatchedKeywordWithBehaviour } from '@/modules/core/table/filtering';
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import OracleCacheActionsCell from '@/modules/assets/prices/components/oracle/OracleCacheActionsCell.vue';
 import OracleCacheFilter from '@/modules/assets/prices/components/oracle/OracleCacheFilter.vue';
@@ -96,7 +96,7 @@ async function loadCaches(): Promise<void> {
     set(cacheEntries, await getPriceCache(get(cacheSource)));
   }
   catch (error: unknown) {
-    notify({ message: getErrorMessage(error), severity: Severity.ERROR, title: t('oracle_prices.cache.notification.title') });
+    notify({ message: getErrorMessage(error), priority: Priority.NORMAL, severity: Severity.ERROR, title: t('oracle_prices.cache.notification.title') });
     set(cacheEntries, []);
   }
   finally {
@@ -139,7 +139,7 @@ async function populateCache(): Promise<void> {
         toAsset: to,
       });
 
-  notify({ message: message.toString(), severity: status.success ? Severity.INFO : Severity.ERROR, title: t('oracle_prices.cache.notification.title') });
+  notify({ message: message.toString(), priority: Priority.HIGH, severity: status.success ? Severity.INFO : Severity.ERROR, title: t('oracle_prices.cache.notification.title') });
 }
 
 async function clearCache(entry: OracleCacheMeta): Promise<void> {
@@ -155,6 +155,7 @@ async function clearCache(entry: OracleCacheMeta): Promise<void> {
         fromAsset: getAssetField(entry.fromAsset, 'symbol'),
         toAsset: getAssetField(entry.toAsset, 'symbol'),
       }),
+      priority: Priority.HIGH,
       severity: Severity.ERROR,
       title: t('oracle_prices.cache.notification.title'),
     });

--- a/frontend/app/src/modules/assets/prices/use-historic-price-manager.ts
+++ b/frontend/app/src/modules/assets/prices/use-historic-price-manager.ts
@@ -1,5 +1,6 @@
 import type { MaybeRefOrGetter, Ref } from 'vue';
 import type { HistoricalPrice, HistoricalPriceFormPayload, ManualPricePayload } from '@/modules/assets/prices/price-types';
+import { Priority } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
 import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
@@ -35,6 +36,7 @@ export function useHistoricPrices(
       notifyError(
         t('price_table.fetch.failure.title'),
         t('price_table.fetch.failure.message', { message: getErrorMessage(error) }),
+        { priority: Priority.NORMAL },
       );
     }
     finally {

--- a/frontend/app/src/modules/assets/prices/use-latest-price-manager.ts
+++ b/frontend/app/src/modules/assets/prices/use-latest-price-manager.ts
@@ -1,7 +1,7 @@
 import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { ManualPrice, ManualPriceFormPayload, ManualPriceWithUsd } from '@/modules/assets/prices/price-types';
 import type { TaskError } from '@/modules/core/tasks/task-result';
-import { type BigNumber, Zero } from '@rotki/common';
+import { type BigNumber, Priority, Zero } from '@rotki/common';
 import { isErr, ok, type Result } from 'plainfp/result';
 import { msg } from '@/message-key';
 import { CURRENCY_USD } from '@/modules/assets/amount-display/currencies';
@@ -84,6 +84,7 @@ export function useLatestPrices(
       notifyError(
         t('price_table.fetch.failure.title'),
         t('price_table.fetch.failure.message', { message: getErrorMessage(error) }),
+        { priority: Priority.NORMAL },
       );
     }
     finally {

--- a/frontend/app/src/modules/assets/prices/use-oracle-prices.ts
+++ b/frontend/app/src/modules/assets/prices/use-oracle-prices.ts
@@ -1,6 +1,7 @@
 import type { MaybeRef } from 'vue';
 import type { OraclePriceEntry, OraclePricesQuery } from '@/modules/assets/prices/price-types';
 import type { Collection } from '@/modules/core/common/collection';
+import { Priority } from '@rotki/common';
 import { useAssetPricesApi } from '@/modules/assets/api/use-asset-prices-api';
 import { useHistoricPriceCache } from '@/modules/assets/prices/use-historic-price-cache';
 import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
@@ -33,6 +34,7 @@ export function useOraclePrices(): UseOraclePricesReturn {
       notifyError(
         t('oracle_prices.fetch.failure.title'),
         t('oracle_prices.fetch.failure.message', { message: getErrorMessage(error) }),
+        { priority: Priority.NORMAL },
       );
       return defaultCollectionState<OraclePriceEntry>();
     }

--- a/frontend/app/src/modules/assets/use-asset-info-cache.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-cache.ts
@@ -1,6 +1,6 @@
 import type { ShallowRef } from 'vue';
 import type { AssetMap } from '@/modules/assets/types';
-import { type AssetCollection, type AssetInfo, transformCase } from '@rotki/common';
+import { type AssetCollection, type AssetInfo, Priority, transformCase } from '@rotki/common';
 import { useAssetInfoApi } from '@/modules/assets/api/use-asset-info-api';
 import { useAssetInfoCacheStore } from '@/modules/assets/use-asset-info-cache-store';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
@@ -40,6 +40,7 @@ export const useAssetInfoCache = createSharedComposable((): UseAssetInfoCacheRet
           identifiers: identifiers.join(', '),
           message: getErrorMessage(error),
         }),
+        { priority: Priority.NORMAL },
       );
       return undefined;
     }

--- a/frontend/app/src/modules/assets/use-asset-info-retrieval.ts
+++ b/frontend/app/src/modules/assets/use-asset-info-retrieval.ts
@@ -12,6 +12,7 @@ import {
   isHyperliquidTokenIdentifier,
   isSolanaTokenIdentifier,
   NotificationGroup,
+  Priority,
   Severity,
 } from '@rotki/common';
 import { isErr, map as mapResult, type Result } from 'plainfp/result';
@@ -274,6 +275,7 @@ export function useAssetInfoRetrieval(): UseAssetInfoRetrievalReturn {
         message: t('asset_search.error.message', {
           message: getErrorMessage(error),
         }),
+        priority: Priority.NORMAL,
         severity: Severity.ERROR,
         title: t('asset_search.error.title'),
       });

--- a/frontend/app/src/modules/assets/use-ignored-asset-operations.ts
+++ b/frontend/app/src/modules/assets/use-ignored-asset-operations.ts
@@ -1,4 +1,5 @@
 import type { ActionStatus } from '@/modules/core/common/action';
+import { Priority } from '@rotki/common';
 import { useAssetIgnoreApi } from '@/modules/assets/api/use-asset-ignore-api';
 import { useAssetInfoRetrieval } from '@/modules/assets/use-asset-info-retrieval';
 import { useAssetsStore } from '@/modules/assets/use-assets-store';
@@ -32,7 +33,7 @@ export function useIgnoredAssetOperations(): UseIgnoredAssetOperationsReturn {
       const message = t('actions.session.ignored_assets.error.message', {
         error: getErrorMessage(error),
       });
-      notifyError(title, message);
+      notifyError(title, message, { priority: Priority.NORMAL });
     }
   }
 

--- a/frontend/app/src/modules/assets/use-whitelisted-asset-operations.ts
+++ b/frontend/app/src/modules/assets/use-whitelisted-asset-operations.ts
@@ -1,4 +1,5 @@
 import type { ActionStatus } from '@/modules/core/common/action';
+import { Priority } from '@rotki/common';
 import { useAssetWhitelistApi } from '@/modules/assets/api/use-asset-whitelist-api';
 import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import { useIgnoredAssetOperations } from '@/modules/assets/use-ignored-asset-operations';
@@ -29,6 +30,7 @@ export function useWhitelistedAssetOperations(): UseWhitelistedAssetOperationsRe
         t('actions.session.whitelisted_assets.error.message', {
           error: getErrorMessage(error),
         }),
+        { priority: Priority.NORMAL },
       );
     }
   }

--- a/frontend/app/src/modules/calendar/CalendarReminder.vue
+++ b/frontend/app/src/modules/calendar/CalendarReminder.vue
@@ -2,6 +2,7 @@
 import type { ZodType } from 'zod';
 import type { CalendarReminderEntry as StoredEntry } from '@/modules/calendar/reminder';
 import type { CalendarEvent } from '@/modules/calendar/types';
+import { Priority } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { type MessageKey, msg } from '@/message-key';
 import CalendarReminderEntry from '@/modules/calendar/CalendarReminderEntry.vue';
@@ -95,7 +96,7 @@ const NOTIFY_KEYS: Record<ReminderAction, { message: MessageKey; title: MessageK
 function notifyFailure(key: ReminderAction, error: unknown): void {
   logger.error(error);
   const keys = NOTIFY_KEYS[key];
-  notify({ message: t(keys.message, { message: getErrorMessage(error) }), title: t(keys.title) });
+  notify({ message: t(keys.message, { message: getErrorMessage(error) }), priority: Priority.HIGH, title: t(keys.title) });
 }
 
 async function loadStored(): Promise<void> {
@@ -163,7 +164,7 @@ async function addReminders(eventId: number, secsBefore: number[]): Promise<void
   try {
     const result = await addCalendarReminder(secsBefore.map(seconds => ({ eventId, secsBefore: seconds })));
     if (result.failed && result.failed.length > 0) {
-      notify({ message: t('calendar.reminder.add_error.some_failed', { ids: result.failed.join(', ') }), title: t('calendar.reminder.add_error.title') });
+      notify({ message: t('calendar.reminder.add_error.some_failed', { ids: result.failed.join(', ') }), priority: Priority.HIGH, title: t('calendar.reminder.add_error.title') });
     }
   }
   catch (error: unknown) {

--- a/frontend/app/src/modules/calendar/use-google-calendar-integration.ts
+++ b/frontend/app/src/modules/calendar/use-google-calendar-integration.ts
@@ -1,6 +1,6 @@
 import type { OAuthResult } from '@shared/ipc';
 import type { Ref } from 'vue';
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
@@ -54,7 +54,7 @@ export function useGoogleCalendarIntegration(): UseGoogleCalendarIntegrationRetu
   const modelManualRefreshToken = shallowRef<string>('');
 
   function notifyMessage(message: string): void {
-    notify({ message, severity: Severity.ERROR, title: t('external_services.google_calendar.error') });
+    notify({ message, priority: Priority.HIGH, severity: Severity.ERROR, title: t('external_services.google_calendar.error') });
   }
 
   function notifyError(error: unknown, fallback: string): void {
@@ -87,7 +87,7 @@ export function useGoogleCalendarIntegration(): UseGoogleCalendarIntegrationRetu
         set(showTokenInput, true);
       }
 
-      notify({ message: t('external_services.google_calendar.opening_browser'), severity: Severity.INFO, title: t('external_services.google_calendar.authorizing') });
+      notify({ message: t('external_services.google_calendar.opening_browser'), priority: Priority.HIGH, severity: Severity.INFO, title: t('external_services.google_calendar.authorizing') });
     }
     catch (error: unknown) {
       notifyError(error, t('external_services.google_calendar.auth_failed'));
@@ -181,6 +181,7 @@ export function useGoogleCalendarIntegration(): UseGoogleCalendarIntegrationRetu
               total: result.eventsProcessed || 0,
               updated: result.eventsUpdated || 0,
             }),
+        priority: Priority.HIGH,
         severity: Severity.INFO,
         title: t('external_services.google_calendar.success'),
       });

--- a/frontend/app/src/modules/core/messaging/handlers/calendar-reminder.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/calendar-reminder.ts
@@ -1,6 +1,6 @@
 import type { NotificationHandler } from '../interfaces';
 import type { CalendarEventWithReminder } from '@/modules/calendar/types';
-import { NotificationCategory, Severity } from '@rotki/common';
+import { NotificationCategory, Priority, Severity } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import dayjs from 'dayjs';
 import { useAddressNameResolution } from '@/modules/accounts/address-book/use-address-name-resolution';
@@ -67,6 +67,7 @@ export function createCalendarReminderHandler(t: ReturnType<typeof useI18n>['t']
         eventId: identifier,
       },
       message,
+      priority: Priority.ACTION,
       severity: Severity.REMINDER,
       title,
     };

--- a/frontend/app/src/modules/core/messaging/handlers/gnosis-pay-session.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/gnosis-pay-session.ts
@@ -1,6 +1,6 @@
 import type { NotificationHandler } from '../interfaces';
 import type { GnosisPaySessionKeyExpiredData } from '@/modules/core/messaging/types';
-import { NotificationCategory, NotificationGroup, Severity } from '@rotki/common';
+import { NotificationCategory, NotificationGroup, Priority, Severity } from '@rotki/common';
 import { createNotificationHandler } from '@/modules/core/messaging/utils';
 
 export function createGnosisPaySessionHandler(
@@ -20,6 +20,7 @@ export function createGnosisPaySessionHandler(
     category: NotificationCategory.DEFAULT,
     group: NotificationGroup.GNOSIS_PAY_SESSION_EXPIRED,
     message: data.error,
+    priority: Priority.ACTION,
     severity: Severity.WARNING,
     title: t('notification_messages.gnosis_pay_session_key_expired.title'),
   }));

--- a/frontend/app/src/modules/core/messaging/handlers/monerium-session.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/monerium-session.ts
@@ -1,6 +1,6 @@
 import type { MessageHandler } from '../interfaces';
 import type { MoneriumSessionKeyExpiredData } from '@/modules/core/messaging/types';
-import { NotificationCategory, NotificationGroup, Severity } from '@rotki/common';
+import { NotificationCategory, NotificationGroup, Priority, Severity } from '@rotki/common';
 import { createNotificationHandler } from '@/modules/core/messaging/utils';
 import { useMoneriumOAuth } from '@/modules/integrations/monerium/use-monerium-auth';
 
@@ -35,6 +35,7 @@ export function createMoneriumSessionHandler(
       category: NotificationCategory.DEFAULT,
       group: NotificationGroup.MONERIUM_AUTH,
       message: data.error,
+      priority: Priority.ACTION,
       severity: Severity.WARNING,
       title: t('notification_messages.monerium_session_key_expired.title'),
     };

--- a/frontend/app/src/modules/core/messaging/handlers/premium-status.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/premium-status.ts
@@ -1,9 +1,17 @@
 import type { MessageHandler } from '../interfaces';
 import type { PremiumStatusUpdateData } from '../types/shared-types';
-import { NotificationCategory, Severity } from '@rotki/common';
+import { NotificationCategory, Priority, Severity } from '@rotki/common';
 import { createStateWithNotificationHandler } from '@/modules/core/messaging/utils';
 import { usePremium } from '@/modules/premium/use-premium';
 
+/**
+ * Reports a change in premium status.
+ *
+ * @remarks
+ * The two branches carry different priorities because they are different kinds of message. Becoming
+ * active confirms something the user just did, so it interrupts once and goes; becoming inactive is
+ * a condition that stays true until they renew, so it is sticky and reaches the "Needs action" tab.
+ */
 export function createPremiumStatusHandler(t: ReturnType<typeof useI18n>['t']): MessageHandler<PremiumStatusUpdateData> {
   const premium = usePremium();
 
@@ -19,6 +27,7 @@ export function createPremiumStatusHandler(t: ReturnType<typeof useI18n>['t']): 
         return {
           category: NotificationCategory.DEFAULT,
           message: t('notification_messages.premium.active.message'),
+          priority: Priority.HIGH,
           severity: Severity.INFO,
           title: t('notification_messages.premium.active.title'),
         };
@@ -29,6 +38,7 @@ export function createPremiumStatusHandler(t: ReturnType<typeof useI18n>['t']): 
           message: reason ?? (expired
             ? t('notification_messages.premium.inactive.expired_message')
             : t('notification_messages.premium.inactive.network_problem_message')),
+          priority: Priority.ACTION,
           severity: Severity.ERROR,
           title: t('notification_messages.premium.inactive.title'),
         };

--- a/frontend/app/src/modules/core/messaging/handlers/snapshot-error.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/snapshot-error.ts
@@ -1,12 +1,13 @@
 import type { NotificationHandler } from '../interfaces';
 import type { BalanceSnapshotError } from '@/modules/core/messaging/types';
-import { NotificationCategory, Severity } from '@rotki/common';
+import { NotificationCategory, Priority, Severity } from '@rotki/common';
 import { createNotificationHandler } from '@/modules/core/messaging/utils';
 
 export function createSnapshotErrorHandler(t: ReturnType<typeof useI18n>['t']): NotificationHandler<BalanceSnapshotError> {
   return createNotificationHandler<BalanceSnapshotError>(data => ({
     category: NotificationCategory.DEFAULT,
     message: t('notification_messages.snapshot_failed.message', data),
+    priority: Priority.NORMAL,
     severity: Severity.ERROR,
     title: t('notification_messages.snapshot_failed.title'),
   }));

--- a/frontend/app/src/modules/core/messaging/index.ts
+++ b/frontend/app/src/modules/core/messaging/index.ts
@@ -1,3 +1,4 @@
+import { Priority } from '@rotki/common';
 import { backoff } from '@shared/utils';
 import { camelCaseTransformer } from '@/modules/core/api/transformers';
 import { uniqueStrings } from '@/modules/core/common/data/data';
@@ -109,7 +110,7 @@ export function useMessageHandling(): UseMessageHandling {
     }
     catch (error: unknown) {
       const message = handleMessageError(error, 'Message consumption failed');
-      notify({ message, title });
+      notify({ message, priority: Priority.NORMAL, title });
     }
     finally {
       isRunning = false;

--- a/frontend/app/src/modules/core/notifications/notification-display-policy.spec.ts
+++ b/frontend/app/src/modules/core/notifications/notification-display-policy.spec.ts
@@ -16,7 +16,7 @@ describe('displaysFor', () => {
     expect(displaysFor()).toBe(displaysFor(DEFAULT_PRIORITY));
   });
 
-  it('should keep popping the unclassified, so deriving display changes no existing behaviour', () => {
-    expect(displaysFor(undefined)).toBe(true);
+  it('should record the unclassified without popping it, so forgetting to classify cannot interrupt', () => {
+    expect(displaysFor(undefined)).toBe(false);
   });
 });

--- a/frontend/app/src/modules/core/notifications/notification-display-policy.ts
+++ b/frontend/app/src/modules/core/notifications/notification-display-policy.ts
@@ -4,13 +4,12 @@ import { Priority } from '@rotki/common';
  * The priority a notification lands on when its caller does not classify itself.
  *
  * @remarks
- * `HIGH` preserves the behaviour the app shipped with, where anything reaching the dispatcher
- * interrupted unless it opted out. The target model in rotki#12942 is `NORMAL`, so that an
- * unclassified notification is stored rather than popped, but flipping this constant is a sweep
- * of every call site's intent rather than a policy change, and it belongs with the classification
- * work. It is a constant so that sweep is one edit.
+ * `NORMAL` is the target model of rotki#12942: an unclassified notification is recorded in the
+ * drawer rather than popped, so forgetting to classify costs a missed toast rather than an
+ * unwanted interruption. Every producer in the tree was classified before this was flipped from
+ * `HIGH`, so nothing relies on the default to interrupt.
  */
-export const DEFAULT_PRIORITY = Priority.HIGH;
+export const DEFAULT_PRIORITY = Priority.NORMAL;
 
 /**
  * Whether a notification of this priority interrupts the user with a popup.

--- a/frontend/app/src/modules/core/notifications/strategies/beaconchain-rate-limit.spec.ts
+++ b/frontend/app/src/modules/core/notifications/strategies/beaconchain-rate-limit.spec.ts
@@ -1,4 +1,4 @@
-import { NotificationGroup, Severity } from '@rotki/common';
+import { NotificationGroup, Priority, Severity } from '@rotki/common';
 import { mockTranslate } from '@test/i18n';
 import { describe, expect, it, vi } from 'vitest';
 import { createNotification } from '@/modules/core/notifications/notification-utils';
@@ -62,25 +62,28 @@ describe('createBeaconchainRateLimitStrategy', () => {
     });
   });
 
-  it('should pop again for a new endpoint after the row was already shown', () => {
+  it('should refresh the row for a new endpoint without popping, since BULK never interrupts', () => {
     const shown = createNotification(1, {
       extras: { endpoints: ['Endpoint 1'], until: '2025-01-15T12:00:00Z' },
       group: NotificationGroup.BEACONCHAIN_RATE_LIMITED,
       groupCount: 1,
       message: 'old message',
+      priority: Priority.BULK,
       title: 'grouped',
     });
 
     const result = strategy.process(
       {
         message: 'Beaconcha.in is rate limited until 2025-01-15T12:00:00Z. Check logs',
+        priority: Priority.BULK,
         severity: Severity.WARNING,
         title: 'Endpoint 2',
       },
       { getNextId: vi.fn(), notifications: [{ ...shown, display: false }] },
     );
 
-    expect(result!.notifications[0].display).toBe(true);
+    expect(result!.notifications[0].display).toBe(false);
+    expect(result!.notifications[0].extras).toMatchObject({ endpoints: ['Endpoint 1', 'Endpoint 2'] });
   });
 
   it('should not add duplicate endpoints', () => {

--- a/frontend/app/src/modules/core/notifications/strategies/group-update.spec.ts
+++ b/frontend/app/src/modules/core/notifications/strategies/group-update.spec.ts
@@ -32,7 +32,7 @@ describe('createGroupUpdateStrategy', () => {
   });
 
   it('should show a new group notification that is not suppressed', () => {
-    const result = strategy.process({ group, message: 'no indexers', title: 'test' }, context());
+    const result = strategy.process({ group, message: 'no indexers', priority: Priority.ACTION, title: 'test' }, context());
 
     expect(result!.notifications).toHaveLength(1);
     expect(result!.notifications[0].display).toBe(true);
@@ -70,9 +70,9 @@ describe('createGroupUpdateStrategy', () => {
   });
 
   it('should store the same priority on update as it decided display from', () => {
-    const existing = [createNotification(2, { group, message: 'stale', title: 'test' })];
+    const existing = [createNotification(2, { group, message: 'stale', priority: Priority.ACTION, title: 'test' })];
 
-    const result = strategy.process({ group, message: 'fresh', title: 'test' }, context(existing));
+    const result = strategy.process({ group, message: 'fresh', priority: Priority.ACTION, title: 'test' }, context(existing));
 
     expect(result!.notifications[0].priority).toBe(existing[0].priority);
     expect(result!.notifications[0].display).toBe(true);
@@ -95,7 +95,7 @@ describe('createGroupUpdateStrategy', () => {
     ];
 
     const result = strategy.process(
-      { group, groupCount: 3, message: 'fresh', severity: Severity.WARNING, title: 'test' },
+      { group, groupCount: 3, message: 'fresh', priority: Priority.ACTION, severity: Severity.WARNING, title: 'test' },
       context(existing),
     );
 

--- a/frontend/app/src/modules/core/notifications/use-notification-dispatcher.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-notification-dispatcher.spec.ts
@@ -33,13 +33,13 @@ describe('useNotificationDispatcher', () => {
     const store = useNotificationsStore();
     const { data } = storeToRefs(store);
 
-    notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'message-1', title: 'title-1' });
+    notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'message-1', priority: Priority.ACTION, title: 'title-1' });
 
     expect(get(data)[0]).toMatchObject({ display: true, group: NotificationGroup.NEW_DETECTED_TOKENS });
     const originalDate = get(data)[0].date;
 
     // Second notification within cooldown should suppress display
-    notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, groupCount: 2, message: 'message-2', title: 'title-1' });
+    notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, groupCount: 2, message: 'message-2', priority: Priority.ACTION, title: 'title-1' });
 
     expect(get(data)).toHaveLength(1);
     expect(get(data)[0]).toMatchObject({
@@ -51,7 +51,7 @@ describe('useNotificationDispatcher', () => {
 
     vi.advanceTimersByTime(NOTIFICATION_COOLDOWN_MS);
 
-    notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, groupCount: 3, message: 'message-3', title: 'title-1' });
+    notify({ group: NotificationGroup.NEW_DETECTED_TOKENS, groupCount: 3, message: 'message-3', priority: Priority.ACTION, title: 'title-1' });
 
     expect(get(data)[0]).toMatchObject({ display: true, groupCount: 3, message: 'message-3' });
   });
@@ -252,9 +252,9 @@ describe('useNotificationDispatcher', () => {
       const { notify } = useNotificationDispatcher();
       const { queue } = storeToRefs(useNotificationsStore());
 
-      notify({ message: 'quiet', title: 'title' });
+      notify({ message: 'quiet', priority: Priority.HIGH, title: 'title' });
       unsilence();
-      notify({ message: 'loud', title: 'title' });
+      notify({ message: 'loud', priority: Priority.HIGH, title: 'title' });
 
       expect(get(queue)).toHaveLength(1);
       expect(get(queue)[0]).toMatchObject({ message: 'loud' });

--- a/frontend/app/src/modules/core/notifications/use-notifications-store.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-notifications-store.spec.ts
@@ -124,7 +124,7 @@ describe('useNotificationsStore', () => {
     const { queue } = storeToRefs(store);
 
     store.add([
-      createNotification(store.getNextId(), testPayload({ message: 'shown', title: 'shown' })),
+      createNotification(store.getNextId(), testPayload({ message: 'shown', priority: Priority.HIGH, title: 'shown' })),
       createNotification(store.getNextId(), testPayload({ message: 'hidden', priority: Priority.NORMAL, title: 'hidden' })),
     ]);
 
@@ -177,7 +177,7 @@ describe('useNotificationsStore', () => {
     const { data } = storeToRefs(store);
 
     store.add([
-      createNotification(store.getNextId(), testPayload({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'msg', title: 'title' })),
+      createNotification(store.getNextId(), testPayload({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'msg', priority: Priority.ACTION, title: 'title' })),
     ]);
     store.displayed([9999]);
 
@@ -190,7 +190,7 @@ describe('useNotificationsStore', () => {
     const { data } = storeToRefs(store);
 
     store.add([
-      createNotification(store.getNextId(), testPayload({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'msg', title: 'title' })),
+      createNotification(store.getNextId(), testPayload({ group: NotificationGroup.NEW_DETECTED_TOKENS, message: 'msg', priority: Priority.ACTION, title: 'title' })),
     ]);
     store.displayed([]);
 

--- a/frontend/app/src/modules/core/notifications/use-notifications.spec.ts
+++ b/frontend/app/src/modules/core/notifications/use-notifications.spec.ts
@@ -35,6 +35,7 @@ describe('useNotifications', () => {
 
     expect(mockNotify).toHaveBeenCalledWith({
       message: 'Error message',
+      priority: Priority.HIGH,
       severity: Severity.ERROR,
       title: 'Error Title',
     });
@@ -46,6 +47,7 @@ describe('useNotifications', () => {
 
     expect(mockNotify).toHaveBeenCalledWith({
       message: 'Warn message',
+      priority: Priority.HIGH,
       severity: Severity.WARNING,
       title: 'Warn Title',
     });
@@ -57,6 +59,7 @@ describe('useNotifications', () => {
 
     expect(mockNotify).toHaveBeenCalledWith({
       message: 'Info message',
+      priority: Priority.HIGH,
       severity: Severity.INFO,
       title: 'Info Title',
     });
@@ -77,6 +80,15 @@ describe('useNotifications', () => {
 
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ priority: Priority.NORMAL }),
+    );
+  });
+
+  it('should leave a raw notify unclassified rather than lending it the toast door default', () => {
+    const { notify } = useNotifications();
+    notify({ message: 'Message', title: 'Title' });
+
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.not.objectContaining({ priority: expect.anything() }),
     );
   });
 

--- a/frontend/app/src/modules/core/notifications/use-notifications.ts
+++ b/frontend/app/src/modules/core/notifications/use-notifications.ts
@@ -1,4 +1,4 @@
-import { type Notification, type NotificationData, type Priority, Severity } from '@rotki/common';
+import { type Notification, type NotificationData, Priority, Severity } from '@rotki/common';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
 import { useNotificationsStore } from '@/modules/core/notifications/use-notifications-store';
 import { useNotificationDispatcher } from './use-notification-dispatcher';
@@ -50,10 +50,18 @@ export function useNotifications(): UseNotificationsReturn {
   const { notify: dispatchNotify } = useNotificationDispatcher();
   const { setMessage } = useMessageStore();
 
+  /**
+   * @remarks
+   * The fallback is `HIGH` rather than `DEFAULT_PRIORITY` because the two doors into the dispatcher
+   * carry opposite assumptions. A caller reaching for `notifyError` and friends is reporting the
+   * outcome of something the user just did, so it interrupts unless it says otherwise; a raw
+   * `notify()` payload is assembled field by field, so an absent priority there means unclassified
+   * and lands on the quiet default instead.
+   */
   function toast(severity: Severity, title: string, message: string, options?: ToastOptions): void {
     dispatchNotify({
       message,
-      priority: options?.priority,
+      priority: options?.priority ?? Priority.HIGH,
       severity,
       title,
     });

--- a/frontend/app/src/modules/core/table/use-table-data.ts
+++ b/frontend/app/src/modules/core/table/use-table-data.ts
@@ -1,5 +1,6 @@
 import type { MaybeRef, Ref } from 'vue';
 import type { Collection } from '@/modules/core/common/collection';
+import { Priority } from '@rotki/common';
 import { FetchError } from 'ofetch';
 import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
 import { api } from '@/modules/core/api/rotki-api';
@@ -70,7 +71,7 @@ export function useTableData<TItem extends NonNullable<unknown>, TPayload>(
 
         logger.error(e);
         if (Number(code) >= 400) {
-          notifyError(t('error.generic.title'), t('error.generic.message', { code, message, path }));
+          notifyError(t('error.generic.title'), t('error.generic.message', { code, message, path }), { priority: Priority.NORMAL });
         }
       },
       resetOnExecute: false,

--- a/frontend/app/src/modules/history/data-issues/use-data-issues.ts
+++ b/frontend/app/src/modules/history/data-issues/use-data-issues.ts
@@ -1,6 +1,7 @@
 import type { MaybeRef } from 'vue';
 import type { Collection } from '@/modules/core/common/collection';
 import type { DataIssue, DataIssuesRequestPayload } from '@/modules/history/data-issues/schemas';
+import { Priority } from '@rotki/common';
 import { defaultCollectionState } from '@/modules/core/common/data/collection-utils';
 import { useMessageStore } from '@/modules/core/common/use-message-store';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -29,6 +30,7 @@ export function useDataIssues(): UseDataIssuesReturn {
     notifyError(
       t('data_issues.fetch.error.title'),
       t('data_issues.fetch.error.message', { message: result.error.message }),
+      { priority: Priority.NORMAL },
     );
     return defaultCollectionState<DataIssue>();
   };

--- a/frontend/app/src/modules/history/events/mapping/use-history-event-counterparty-mappings.ts
+++ b/frontend/app/src/modules/history/events/mapping/use-history-event-counterparty-mappings.ts
@@ -35,7 +35,7 @@ export const useHistoryEventCounterpartyMappings = createSharedComposable(() => 
         message: t('actions.fetch_counterparties.error.description', {
           message: getErrorMessage(error),
         }),
-        priority: Priority.NORMAL,
+        priority: Priority.HIGH,
         title: t('actions.fetch_counterparties.error.title'),
       });
     }

--- a/frontend/app/src/modules/history/events/mapping/use-history-event-counterparty-mappings.ts
+++ b/frontend/app/src/modules/history/events/mapping/use-history-event-counterparty-mappings.ts
@@ -1,6 +1,6 @@
 import type { MaybeRefOrGetter } from 'vue';
 import type { ActionDataEntry } from '@/modules/core/common/action';
-import { isValidEthAddress, toHumanReadable } from '@rotki/common';
+import { isValidEthAddress, Priority, toHumanReadable } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { getPublicProtocolImagePath } from '@/modules/core/common/file/file';
 import { getErrorMessage, useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -35,6 +35,7 @@ export const useHistoryEventCounterpartyMappings = createSharedComposable(() => 
         message: t('actions.fetch_counterparties.error.description', {
           message: getErrorMessage(error),
         }),
+        priority: Priority.NORMAL,
         title: t('actions.fetch_counterparties.error.title'),
       });
     }

--- a/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.ts
+++ b/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.ts
@@ -6,7 +6,7 @@ import type {
   HistoryEventCategoryMapping,
   HistoryEventTypeData,
 } from '@/modules/history/events/event-type';
-import { HistoryEventEntryType, toCapitalCase, toSentenceCase, toSnakeCase } from '@rotki/common';
+import { HistoryEventEntryType, Priority, toCapitalCase, toSentenceCase, toSnakeCase } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { cloneDeep } from 'es-toolkit';
 import { uniqueStrings } from '@/modules/core/common/data/data';
@@ -245,6 +245,7 @@ export const useHistoryEventMappings = createSharedComposable(() => {
         message: t('actions.history_events.fetch_mapping.error.description', {
           message: getErrorMessage(error),
         }),
+        priority: Priority.NORMAL,
         title: t('actions.history_events.fetch_mapping.error.title'),
       });
     }

--- a/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.ts
+++ b/frontend/app/src/modules/history/events/mapping/use-history-event-mappings.ts
@@ -245,7 +245,7 @@ export const useHistoryEventMappings = createSharedComposable(() => {
         message: t('actions.history_events.fetch_mapping.error.description', {
           message: getErrorMessage(error),
         }),
-        priority: Priority.NORMAL,
+        priority: Priority.HIGH,
         title: t('actions.history_events.fetch_mapping.error.title'),
       });
     }

--- a/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.ts
+++ b/frontend/app/src/modules/history/events/use-customized-event-duplicates-dialog.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, Ref } from 'vue';
 import type { DuplicateHandlingStatus } from '@/modules/history/events/action-types';
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -120,7 +120,7 @@ export function useCustomizedEventDuplicatesDialog(
     }
     catch (error: unknown) {
       logger.error('Failed to load duplicate event rows:', error);
-      notify({ message: t('actions.customized_event_duplicates.fetch_events_error.description', { error: getErrorMessage(error) }), severity: Severity.ERROR, title: t('actions.customized_event_duplicates.fetch_events_error.title') });
+      notify({ message: t('actions.customized_event_duplicates.fetch_events_error.description', { error: getErrorMessage(error) }), priority: Priority.HIGH, severity: Severity.ERROR, title: t('actions.customized_event_duplicates.fetch_events_error.title') });
     }
     finally {
       set(group.loading, false);

--- a/frontend/app/src/modules/history/events/use-history-events-actions.spec.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-actions.spec.ts
@@ -2,7 +2,7 @@ import type { Exchange } from '@/modules/balances/types/exchanges';
 import type { Collection } from '@/modules/core/common/collection';
 import type { HistoryEventEntry, HistoryEventRow } from '@/modules/history/events/schemas';
 import type { RepullingTransactionResult } from '@/modules/history/events/tx/use-history-transactions';
-import { type Blockchain, HistoryEventEntryType, Severity } from '@rotki/common';
+import { type Blockchain, HistoryEventEntryType, Priority, Severity } from '@rotki/common';
 import { createMock } from '@test/utils/create-mock';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
@@ -169,6 +169,7 @@ describe('useHistoryEventsActions', () => {
       expect(mockNotify).toHaveBeenCalledWith({
         action: undefined,
         message: 'actions.repulling_transaction.success.no_tx_description',
+        priority: Priority.HIGH,
         severity: Severity.INFO,
         title: 'actions.repulling_transaction.task.title',
       });

--- a/frontend/app/src/modules/history/events/use-history-events-dialog-handlers.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-dialog-handlers.ts
@@ -3,7 +3,7 @@ import type { DialogEventHandlers } from '@/modules/history/events/dialog-types'
 import type { LocationAndTxRef, PullLocationTransactionPayload } from '@/modules/history/events/event-payloads';
 import type { RefreshTransactionsParams } from '@/modules/history/events/tx/types';
 import type { RepullingTransactionResult } from '@/modules/history/events/tx/use-history-transactions';
-import { type NotificationAction, Severity } from '@rotki/common';
+import { type NotificationAction, Priority, Severity } from '@rotki/common';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 
@@ -67,6 +67,7 @@ export function useHistoryEventsDialogHandlers(deps: UseHistoryEventsDialogHandl
       notify({
         action,
         message: newTransactionsCount ? t('actions.repulling_transaction.success.description', { length: newTransactionsCount }) : t('actions.repulling_transaction.success.no_tx_description'),
+        priority: Priority.HIGH,
         severity: Severity.INFO,
         title: t('actions.repulling_transaction.task.title'),
       });

--- a/frontend/app/src/modules/history/events/use-history-events-export.ts
+++ b/frontend/app/src/modules/history/events/use-history-events-export.ts
@@ -1,6 +1,6 @@
 import type { MaybeRefOrGetter, Ref } from 'vue';
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
-import { type NotificationPayload, type SemiPartial, Severity } from '@rotki/common';
+import { type NotificationPayload, Priority, type SemiPartial, Severity } from '@rotki/common';
 import { omit } from 'es-toolkit';
 import { isErr, map as mapResult, type Result } from 'plainfp/result';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
@@ -138,7 +138,7 @@ export function useHistoryEventsExport(
     }
 
     if (message)
-      notify(message);
+      notify({ ...message, priority: Priority.HIGH });
   }
 
   function showConfirmation(): void {

--- a/frontend/app/src/modules/history/events/use-history-events.ts
+++ b/frontend/app/src/modules/history/events/use-history-events.ts
@@ -10,6 +10,7 @@ import type {
   HistoryEventsCollectionResponse,
   ModifyHistoryEventPayload,
 } from '@/modules/history/events/schemas';
+import { Priority } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { useEnsOperations } from '@/modules/accounts/address-book/use-ens-operations';
 import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
@@ -17,10 +18,9 @@ import { ApiValidationError, type ValidationErrors } from '@/modules/core/api/ty
 import { arrayify } from '@/modules/core/common/data/array';
 import { defaultCollectionState, mapCollectionResponse } from '@/modules/core/common/data/collection-utils';
 import { millisecondsToSeconds } from '@/modules/core/common/data/date';
-import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
-import { useNotifications } from '@/modules/core/notifications/use-notifications';
+import { getErrorMessage, useNotifications } from '@/modules/core/notifications/use-notifications';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import { getEthAddressesFromText } from '@/modules/history/history-utils';
 import { useHistoryStore } from '@/modules/history/use-history-store';
@@ -127,6 +127,7 @@ export function useHistoryEvents(): UseHistoryEventsReturn {
       notifyError(
         t('actions.history_events.error.title'),
         t('actions.history_events.error.description', { error }).toString(),
+        { priority: Priority.NORMAL },
       );
       return defaultCollectionState();
     }

--- a/frontend/app/src/modules/history/use-history-data-fetching.spec.ts
+++ b/frontend/app/src/modules/history/use-history-data-fetching.spec.ts
@@ -1,5 +1,6 @@
 import type { LocationLabel } from '@/modules/core/common/location';
 import type { TransactionStatus, useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
+import { Priority } from '@rotki/common';
 import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHistoryStore } from '@/modules/history/use-history-store';
@@ -77,6 +78,7 @@ describe('useHistoryDataFetching', () => {
       expect(mockNotifyError).toHaveBeenCalledWith(
         expect.any(String),
         expect.any(String),
+        { priority: Priority.NORMAL },
       );
     });
   });
@@ -112,6 +114,7 @@ describe('useHistoryDataFetching', () => {
       expect(mockNotifyError).toHaveBeenCalledWith(
         expect.any(String),
         expect.any(String),
+        { priority: Priority.NORMAL },
       );
     });
   });

--- a/frontend/app/src/modules/history/use-history-data-fetching.ts
+++ b/frontend/app/src/modules/history/use-history-data-fetching.ts
@@ -1,3 +1,4 @@
+import { Priority } from '@rotki/common';
 import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -59,6 +60,7 @@ export function useHistoryDataFetching(): UseHistoryDataFetchingReturn {
       notifyError(
         t('actions.history.fetch_associated_locations.error.title'),
         t('actions.history.fetch_associated_locations.error.message', { message: getErrorMessage(error) }),
+        { priority: Priority.NORMAL },
       );
     }
   }
@@ -75,6 +77,7 @@ export function useHistoryDataFetching(): UseHistoryDataFetchingReturn {
       notifyError(
         t('actions.history.fetch_location_labels.error.title'),
         t('actions.history.fetch_location_labels.error.message', { message: getErrorMessage(error) }),
+        { priority: Priority.NORMAL },
       );
     }
   }

--- a/frontend/app/src/modules/integrations/monerium/MoneriumAuth.vue
+++ b/frontend/app/src/modules/integrations/monerium/MoneriumAuth.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { OAuthResult } from '@shared/ipc';
-import { type Notification, NotificationGroup, Severity } from '@rotki/common';
+import { type Notification, NotificationGroup, Priority, Severity } from '@rotki/common';
 import { getPublicServiceImagePath } from '@/modules/core/common/file/file';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -57,6 +57,7 @@ function notifyAuthStep(payload: Notification): void {
   notify({
     ...payload,
     group: NotificationGroup.MONERIUM_AUTH,
+    priority: Priority.HIGH,
   });
 }
 

--- a/frontend/app/src/modules/reports/use-report-operations.ts
+++ b/frontend/app/src/modules/reports/use-report-operations.ts
@@ -2,7 +2,7 @@ import type { MaybeRef } from 'vue';
 import type { AddressBookSimplePayload } from '@/modules/accounts/address-book/eth-names';
 import type { Collection, CollectionResponse } from '@/modules/core/common/collection';
 import type { ProfitLossEvent, ProfitLossEventsPayload } from '@/modules/reports/report-types';
-import { Blockchain } from '@rotki/common';
+import { Blockchain, Priority } from '@rotki/common';
 import { startPromise } from '@shared/utils';
 import { useEnsOperations } from '@/modules/accounts/address-book/use-ens-operations';
 import { isBlockchain } from '@/modules/core/common/chains';
@@ -56,7 +56,7 @@ export function useReportOperations(): UseReportOperationsReturn {
     }
     catch (error: unknown) {
       logger.error(error);
-      notifyError(t('actions.reports.fetch.error.title'), t('actions.reports.fetch.error.description'));
+      notifyError(t('actions.reports.fetch.error.title'), t('actions.reports.fetch.error.description'), { priority: Priority.NORMAL });
     }
   }
 
@@ -102,7 +102,7 @@ export function useReportOperations(): UseReportOperationsReturn {
     }
     catch (error: unknown) {
       logger.error(error);
-      notifyError(t('actions.report_events.fetch.error.title'), t('actions.report_events.fetch.error.description', { error }));
+      notifyError(t('actions.report_events.fetch.error.title'), t('actions.report_events.fetch.error.description', { error }), { priority: Priority.NORMAL });
       return defaultReportEvents();
     }
   }

--- a/frontend/app/src/modules/session/use-periodic-data-fetcher.ts
+++ b/frontend/app/src/modules/session/use-periodic-data-fetcher.ts
@@ -1,3 +1,4 @@
+import { Priority } from '@rotki/common';
 import { backoff } from '@shared/utils';
 import { isRequestCancellation } from '@/modules/core/api/request-queue/is-request-cancellation';
 import { getErrorMessage, useNotifications } from '@/modules/core/notifications/use-notifications';
@@ -58,6 +59,7 @@ export function usePeriodicDataFetcher(): UsePeriodicDataFetcherReturn {
         t('actions.session.periodic_query.error.message', {
           message: getErrorMessage(error),
         }),
+        { priority: Priority.NORMAL },
       );
     }
     finally {

--- a/frontend/app/src/modules/settings/accounting/use-accounting-settings.ts
+++ b/frontend/app/src/modules/settings/accounting/use-accounting-settings.ts
@@ -8,6 +8,7 @@ import type {
   AccountingRuleEntry,
   AccountingRuleRequestPayload,
 } from '@/modules/settings/types/accounting';
+import { Priority } from '@rotki/common';
 import { isErr, map as mapResult, type Result } from 'plainfp/result';
 import { defaultCollectionState, mapCollectionResponse } from '@/modules/core/common/data/collection-utils';
 import { downloadFileByTextContent } from '@/modules/core/common/file/download';
@@ -62,6 +63,7 @@ export function useAccountingSettings(): UseAccountingSettingsReturn {
         t('accounting_settings.rule.fetch_error.message', {
           message,
         }),
+        { priority: Priority.NORMAL },
       );
 
       return undefined;
@@ -85,6 +87,7 @@ export function useAccountingSettings(): UseAccountingSettingsReturn {
         t('accounting_settings.rule.fetch_error.message', {
           message,
         }),
+        { priority: Priority.NORMAL },
       );
 
       return defaultCollectionState();
@@ -108,6 +111,7 @@ export function useAccountingSettings(): UseAccountingSettingsReturn {
         t('accounting_settings.rule.conflicts.fetch_error.message', {
           message,
         }),
+        { priority: Priority.NORMAL },
       );
 
       return defaultCollectionState();

--- a/frontend/app/src/modules/settings/api-keys/BinancePairsSelector.vue
+++ b/frontend/app/src/modules/settings/api-keys/BinancePairsSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import { backoff } from '@shared/utils';
 import { useExchangeApi } from '@/modules/balances/api/use-exchange-api';
 import { trimOnPaste } from '@/modules/core/common/helpers/event';
@@ -110,7 +110,7 @@ async function queryAllMarkets() {
     const description = t('binance_market_selector.query_all.error', {
       message: getErrorMessage(error),
     });
-    notify({ message: description, severity: Severity.ERROR, title });
+    notify({ message: description, priority: Priority.NORMAL, severity: Severity.ERROR, title });
   }
 }
 
@@ -126,7 +126,7 @@ async function loadUserMarkets() {
       const description = t('binance_market_selector.query_user.error', {
         message: getErrorMessage(error),
       });
-      notify({ message: description, severity: Severity.ERROR, title });
+      notify({ message: description, priority: Priority.NORMAL, severity: Severity.ERROR, title });
     }
   }
 }

--- a/frontend/app/src/modules/settings/data-security/ManageCustomAssets.vue
+++ b/frontend/app/src/modules/settings/data-security/ManageCustomAssets.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { assert, Severity } from '@rotki/common';
+import { assert, Priority, Severity } from '@rotki/common';
 import { useAssets } from '@/modules/assets/use-assets';
 import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
 import SettingsItem from '@/modules/settings/controls/SettingsItem.vue';
@@ -64,7 +64,7 @@ async function exportZip(): Promise<void> {
 
   const notification = exportNotification(await exportCustomAssets());
   if (notification)
-    notify(notification);
+    notify({ ...notification, priority: Priority.HIGH });
 }
 </script>
 

--- a/frontend/app/src/modules/settings/data-security/backups/use-database-backups.ts
+++ b/frontend/app/src/modules/settings/data-security/backups/use-database-backups.ts
@@ -1,6 +1,6 @@
 import type { ComputedRef, Ref } from 'vue';
 import type { DatabaseInfo, UserDbBackup, UserDbBackupWithId } from '@/modules/session/backup';
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import { getFilepath } from '@/modules/core/common/file/file';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -101,7 +101,7 @@ export function useDatabaseBackups(): UseDatabaseBackupsReturn {
     }
     catch (error: unknown) {
       logger.error(error);
-      notify({ message: t('database_backups.load_error.message', { message: getErrorMessage(error) }), title: t('database_backups.load_error.title') });
+      notify({ message: t('database_backups.load_error.message', { message: getErrorMessage(error) }), priority: Priority.NORMAL, title: t('database_backups.load_error.title') });
     }
     finally {
       set(loading, false);
@@ -118,7 +118,7 @@ export function useDatabaseBackups(): UseDatabaseBackupsReturn {
     }
     catch (error: unknown) {
       logger.error(error);
-      notify({ message: t('database_backups.delete_error.mass_message', { message: getErrorMessage(error) }), title: t('database_backups.delete_error.title') });
+      notify({ message: t('database_backups.delete_error.mass_message', { message: getErrorMessage(error) }), priority: Priority.HIGH, title: t('database_backups.delete_error.title') });
     }
   }
 
@@ -136,6 +136,7 @@ export function useDatabaseBackups(): UseDatabaseBackupsReturn {
           file: filepath,
           message: getErrorMessage(error),
         }),
+        priority: Priority.HIGH,
         title: t('database_backups.delete_error.title'),
       });
     }
@@ -145,13 +146,13 @@ export function useDatabaseBackups(): UseDatabaseBackupsReturn {
     try {
       set(saving, true);
       const filepath = await createBackup();
-      notify({ message: t('database_backups.backup.message', { filepath }), severity: Severity.INFO, title: t('database_backups.backup.title') });
+      notify({ message: t('database_backups.backup.message', { filepath }), priority: Priority.HIGH, severity: Severity.INFO, title: t('database_backups.backup.title') });
 
       await loadInfo();
     }
     catch (error: unknown) {
       logger.error(error);
-      notify({ message: t('database_backups.backup_error.message', { message: getErrorMessage(error) }), title: t('database_backups.backup_error.title') });
+      notify({ message: t('database_backups.backup_error.message', { message: getErrorMessage(error) }), priority: Priority.HIGH, title: t('database_backups.backup_error.title') });
     }
     finally {
       set(saving, false);

--- a/frontend/app/src/modules/settings/database/DatabaseInformation.vue
+++ b/frontend/app/src/modules/settings/database/DatabaseInformation.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { DatabaseInfo } from '@/modules/session/backup';
+import { Priority } from '@rotki/common';
 import { size } from '@/modules/core/common/data/data';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { logger } from '@/modules/core/common/logging/logging';
@@ -92,7 +93,7 @@ async function loadInfo() {
     logger.error(error);
     notify({ message: t('database_backups.load_error.message', {
       message: getErrorMessage(error),
-    }), title: t('database_backups.load_error.title') });
+    }), priority: Priority.NORMAL, title: t('database_backups.load_error.title') });
   }
   finally {
     set(loading, false);

--- a/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
@@ -175,6 +175,7 @@ export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>)
   function notifyConnectFailures(messages: string[]): void {
     notify({
       message: messages.join('\n'),
+      priority: Priority.HIGH,
       title: t('evm_rpc_node_manager.connect_error.title', { chain: get(chainName) }),
     });
   }

--- a/frontend/app/src/modules/shell/app/use-backend-reload.ts
+++ b/frontend/app/src/modules/shell/app/use-backend-reload.ts
@@ -1,4 +1,4 @@
-import { Severity } from '@rotki/common';
+import { Priority, Severity } from '@rotki/common';
 import { useLogout } from '@/modules/auth/use-logout';
 import { useSessionAuthStore } from '@/modules/auth/use-session-auth-store';
 import { useMainStore } from '@/modules/core/common/use-main-store';
@@ -43,7 +43,7 @@ export function useBackendReload(): UseBackendReloadReturn {
     const result = await restartBackend();
 
     if (result.status === BackendRestartStatus.failed) {
-      notify({ message: t('backend_reload.failed.message', { message: result.message ?? '' }), severity: Severity.ERROR, title: t('backend_reload.failed.title') });
+      notify({ message: t('backend_reload.failed.message', { message: result.message ?? '' }), priority: Priority.HIGH, severity: Severity.ERROR, title: t('backend_reload.failed.title') });
       connect();
       return result;
     }

--- a/frontend/app/src/modules/shell/components/HelpSidebar.vue
+++ b/frontend/app/src/modules/shell/components/HelpSidebar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { RuiIcons } from '@rotki/ui-library';
+import { Priority } from '@rotki/common';
 import { externalLinks, TWITTER_URL } from '@shared/external-links';
 import { downloadFileByTextContent } from '@/modules/core/common/file/download';
 import { IndexedDb } from '@/modules/core/common/helpers/indexed-db';
@@ -70,7 +71,7 @@ async function downloadBrowserLog(): Promise<void> {
 
   await loggerDb.getAll((data: any) => {
     if (data?.length === 0) {
-      notify({ message: t('help_sidebar.browser_log.error.empty.message'), title: t('help_sidebar.browser_log.error.empty.title') });
+      notify({ message: t('help_sidebar.browser_log.error.empty.message'), priority: Priority.HIGH, title: t('help_sidebar.browser_log.error.empty.title') });
       return;
     }
     const messages = data.map((item: any) => item.message).join('\n');

--- a/frontend/app/src/pages/api-keys/exchanges/index.vue
+++ b/frontend/app/src/pages/api-keys/exchanges/index.vue
@@ -8,7 +8,7 @@ import { useExchanges } from '@/modules/balances/exchanges/use-exchanges';
 import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { useLocationStore } from '@/modules/core/common/use-location-store';
 import { useLocations } from '@/modules/core/common/use-locations';
-import { useNotificationDispatcher } from '@/modules/core/notifications/use-notification-dispatcher';
+import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import { useRowHighlight } from '@/modules/core/table/use-row-highlight';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
@@ -44,7 +44,7 @@ const { t } = useI18n({ useScope: 'global' });
 const router = useRouter();
 const route = useRoute('/api-keys/exchanges/');
 const { getExchangeName } = useLocations();
-const { notify } = useNotificationDispatcher();
+const { notifyInfo } = useNotifications();
 
 const cols = computed<DataTableColumn<Exchange>[]>(() => [{
   align: 'center',
@@ -122,15 +122,15 @@ async function toggleSync(exchange: Exchange) {
   });
 
   if (!status.success) {
-    notify({
-      message: t('exchange_settings.sync.messages.description', {
+    notifyInfo(
+      t('exchange_settings.sync.messages.title'),
+      t('exchange_settings.sync.messages.description', {
         action: enable ? t('exchange_settings.sync.messages.enable') : t('exchange_settings.sync.messages.disable'),
         location: exchange.location,
         message: status.message,
         name: exchange.name,
       }),
-      title: t('exchange_settings.sync.messages.title'),
-    });
+    );
   }
 
   resetNonSyncingExchanges();


### PR DESCRIPTION
Phase 3 of #12942, the part that needs no backend: every notification producer is classified, and the display default flips from `HIGH` to `NORMAL`.

`DEFAULT_PRIORITY` was a placeholder. Its own TSDoc said so: `HIGH` preserved the pre-phase-1 behaviour where anything reaching the dispatcher interrupted, and flipping it was "a sweep of every call site's intent". This is that sweep, then the flip.

### The rule

From the plan's target model (§4.1, §4.3), driven by the phase 0 classification in the first comment of #12942:

- **`ACTION`** — a condition only the user can resolve. Sticky toast, reaches the "Needs action" tab.
- **`HIGH`** — the outcome of something the user just did. Timed toast.
- **`NORMAL`** — a background failure that rotki retries or the user can retry later. Recorded in the drawer, no popup.

### Two doors, two defaults

`DEFAULT_PRIORITY` governed both entry points, so flipping it alone would have silenced 101 `notifyError`/`notifyWarning`/`notifyInfo` sites at once. PR B's design had them differ, so `toast()` now pins `HIGH` explicitly:

- `notifyError`/`notifyWarning`/`notifyInfo` — the caller is reporting an outcome, so it interrupts unless it says otherwise.
- a raw `notify()` payload — assembled field by field, so an absent priority means unclassified and lands on the quiet default.

### What was classified

**Websocket handlers**, per phase 0: gnosis-pay and monerium expired sessions, the premium-inactive branch, the calendar reminder, the solana token migration and the missing exchange mapping become `ACTION`; the balance snapshot error and the asset search error become `NORMAL`; premium-active stays interrupting as the confirmation of a user action.

**48 raw `notify()` sites** by the rule above.

**97 toast-door sites**, read individually. 21 are now `NORMAL` — collection and table loads that return an empty default, the periodic poller, the per-chain account fan-out, the asset-mapping cache, and the login-time ignored/whitelisted asset lists. The rest stay `HIGH`: user-driven operations, or core-data refreshes already gated on `isActionable`, where a silent failure means the portfolio is wrong without saying so.

### Deliberately unchanged

- **The missing exchange rate stays `HIGH`.** It does not empty one surface; it makes every amount in the app render against a zero rate.
- **`MISSING_EXCHANGE_MAPPING` and `NEW_DETECTED_TOKENS` still toast.** Phase 0's verdict for both is "action-center row, no toast", which the current policy cannot express — `ACTION` always interrupts. They are consistent with each other, and the "no toast" half waits on the action-center move.
- **The quiet tables still explain nothing.** That is the inline error state §6.0 owes them; it renders from the failed fetch's own state and does not depend on this PR.

### Notes for review

- Two files sat on the 20-import cap. `pages/api-keys/exchanges/index.vue` moves to `notifyInfo` (same severity, no new import); `use-history-events.ts` takes `getErrorMessage` through the notifications module's existing re-export, as `use-periodic-data-fetcher.ts` already does.
- Specs that encoded the old default now classify their payloads. Two changed meaning rather than shape: an unclassified notification no longer displays, and the beaconchain rate limit arrives from the legacy lane as `BULK`, so a new endpoint refreshes the row without popping it.
- Negative control: reverting the constant to `HIGH` fails exactly one test, the one named for that behaviour.

Gates: full unit suite (12185), typecheck, eslint, stylelint, knip, linked-keys, dev-proxy.
