### PR TITLE
Explain an empty RPC node table instead of showing nothing

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2082,6 +2082,7 @@
       "proceed": "Proceed",
       "pull": "Pull",
       "push": "Push",
+      "retry": "Retry",
       "save": "Save",
       "search": "Search",
       "select_all": "Select All",
@@ -3075,6 +3076,7 @@
     "loading_error": {
       "title": "Loading {chain} RPC Nodes"
     },
+    "no_nodes": "No RPC nodes configured for this chain",
     "node": "Node",
     "node_weight": "Node Weight",
     "private_node": "This is a private node added by the user. It takes priority over public nodes",

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.spec.ts
@@ -138,4 +138,52 @@ describe('modules/settings/general/rpc/BlockchainRpcNodeManager.vue', () => {
 
     expect(editEvmNode).toHaveBeenCalledWith(expect.objectContaining({ active: false, identifier: 4 }));
   });
+
+  describe('when the read fails', () => {
+    async function createFailingWrapper(message = 'backend is down'): Promise<VueWrapper> {
+      fetchEvmNodes.mockRejectedValue(new Error(message));
+      const wrapper = mount(BlockchainRpcNodeManager, {
+        global: {
+          plugins: [createCustomPinia()],
+          stubs: { BlockchainRpcNodeFormDialog: true, RpcNodeStatusCell: true, RpcReconnectButton: true },
+        },
+        props: { chain: Blockchain.ETH, chains: [Blockchain.ETH] },
+      });
+      await flushPromises();
+      return wrapper;
+    }
+
+    it('should say why the table is empty instead of leaving it blank', async () => {
+      const wrapper = await createFailingWrapper();
+
+      const error = wrapper.find('[data-testid=rpc-nodes-error]');
+      expect(error.exists()).toBe(true);
+      expect(error.text()).toContain('backend is down');
+    });
+
+    it('should not read as a chain that simply has no nodes', async () => {
+      const wrapper = await createFailingWrapper();
+
+      expect(wrapper.find('[data-testid=rpc-nodes-empty]').exists()).toBe(false);
+    });
+
+    it('should offer a retry that re-reads the nodes', async () => {
+      const wrapper = await createFailingWrapper();
+      fetchEvmNodes.mockResolvedValue([node({ name: 'back up' })]);
+
+      await wrapper.find('[data-testid=rpc-nodes-retry]').trigger('click');
+      await flushPromises();
+
+      expect(fetchEvmNodes).toHaveBeenCalledTimes(2);
+      expect(wrapper.find('[data-testid=rpc-nodes-error]').exists()).toBe(false);
+      expect(wrapper.findAll('[data-testid=ethereum-node]')).toHaveLength(1);
+    });
+  });
+
+  it('should say a chain has no nodes when the read succeeds empty', async () => {
+    const wrapper = await createWrapper([]);
+
+    expect(wrapper.find('[data-testid=rpc-nodes-empty]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid=rpc-nodes-error]').exists()).toBe(false);
+  });
 });

--- a/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
+++ b/frontend/app/src/modules/settings/general/rpc/BlockchainRpcNodeManager.vue
@@ -25,6 +25,8 @@ const {
   editRpcNode,
   getNodeStatus,
   isEtherscan,
+  loadError,
+  loading,
   loadNodes,
   modelState,
   nodes,
@@ -74,6 +76,51 @@ defineExpose({
       </tr>
     </thead>
     <tbody>
+      <tr v-if="loading">
+        <td
+          colspan="4"
+          class="py-6"
+          data-testid="rpc-nodes-loading"
+        >
+          <RuiProgress
+            color="primary"
+            variant="indeterminate"
+            circular
+            size="24"
+          />
+        </td>
+      </tr>
+      <tr v-else-if="loadError">
+        <td colspan="4">
+          <RuiAlert
+            type="error"
+            :title="t('evm_rpc_node_manager.loading_error.title', { chain })"
+            data-testid="rpc-nodes-error"
+          >
+            <div class="flex flex-col items-start gap-2">
+              <span>{{ loadError }}</span>
+              <RuiButton
+                size="sm"
+                color="error"
+                variant="outlined"
+                data-testid="rpc-nodes-retry"
+                @click="loadNodes()"
+              >
+                {{ t('common.actions.retry') }}
+              </RuiButton>
+            </div>
+          </RuiAlert>
+        </td>
+      </tr>
+      <tr v-else-if="nodes.length === 0">
+        <td
+          colspan="4"
+          class="py-6 text-center text-rui-text-secondary"
+          data-testid="rpc-nodes-empty"
+        >
+          {{ t('evm_rpc_node_manager.no_nodes') }}
+        </td>
+      </tr>
       <tr
         v-for="(item, index) in nodes"
         :key="index + item.name"

--- a/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.spec.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.spec.ts
@@ -129,6 +129,61 @@ describe('modules/settings/general/rpc/useBlockchainRpcNodeManager', () => {
       expect(setMessage).not.toHaveBeenCalled();
       expect(get(nodes)).toHaveLength(0);
     });
+
+    it('should keep the reason for the table to render, since the notification never pops', async () => {
+      fetchEvmNodes.mockRejectedValue(new Error('backend is down'));
+
+      const { loadError, loadNodes } = manager();
+      await loadNodes();
+
+      expect(get(loadError)).toBe('backend is down');
+    });
+
+    it('should clear a previous failure once a read succeeds', async () => {
+      fetchEvmNodes.mockRejectedValue(new Error('backend is down'));
+      const { loadError, loadNodes } = manager();
+      await loadNodes();
+
+      fetchEvmNodes.mockResolvedValue([node({ name: 'first' })]);
+      await loadNodes();
+
+      expect(get(loadError)).toBeUndefined();
+    });
+
+    it('should drop stale nodes on failure, so the table cannot show a list next to its error', async () => {
+      fetchEvmNodes.mockResolvedValue([node({ name: 'first' })]);
+      const { loadNodes, nodes } = manager();
+      await loadNodes();
+
+      fetchEvmNodes.mockRejectedValue(new Error('backend is down'));
+      await loadNodes();
+
+      expect(get(nodes)).toHaveLength(0);
+    });
+
+    it('should flag the read as in flight only while it runs', async () => {
+      let release: (value: BlockchainRpcNode[]) => void = () => {};
+      fetchEvmNodes.mockReturnValue(new Promise<BlockchainRpcNode[]>((resolve) => {
+        release = resolve;
+      }));
+
+      const { loading, loadNodes } = manager();
+      const pending = loadNodes();
+      expect(get(loading)).toBe(true);
+
+      release([]);
+      await pending;
+      expect(get(loading)).toBe(false);
+    });
+
+    it('should stop flagging the read as in flight when it fails', async () => {
+      fetchEvmNodes.mockRejectedValue(new Error('backend is down'));
+
+      const { loading, loadNodes } = manager();
+      await loadNodes();
+
+      expect(get(loading)).toBe(false);
+    });
   });
 
   describe('the etherscan entry', () => {

--- a/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
+++ b/frontend/app/src/modules/settings/general/rpc/use-blockchain-rpc-node-manager.ts
@@ -33,6 +33,17 @@ interface UseBlockchainRpcNodeManagerReturn {
    * disable those controls.
    */
   isEtherscan: (item: BlockchainRpcNode) => boolean;
+  /**
+   * Why the last read failed, or undefined when it succeeded.
+   *
+   * @remarks
+   * The table renders this itself. A failed read leaves the list empty, which on its own is
+   * indistinguishable from a chain that genuinely has no nodes, and the notification it also
+   * raises is classified `NORMAL` so it never interrupts to explain the difference.
+   */
+  loadError: Readonly<Ref<string | undefined>>;
+  /** Whether a read is in flight, which the table shows instead of an empty body. */
+  loading: Readonly<Ref<boolean>>;
   /** Reads the chain's nodes, reporting a failure as a notification rather than a message. */
   loadNodes: () => Promise<void>;
   /** The form's node, or undefined while the form is closed. */
@@ -65,6 +76,8 @@ export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>)
   const nodes = ref<BlockchainRpcNodeList>([]);
   const modelState = ref<BlockchainRpcNodeManageState>();
   const reconnecting = shallowRef<boolean>(false);
+  const loading = shallowRef<boolean>(false);
+  const loadError = shallowRef<string>();
 
   const { t } = useI18n({ useScope: 'global' });
   const { notify } = useNotificationDispatcher();
@@ -105,17 +118,25 @@ export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>)
   const anyDisconnected = computed<boolean>(() => get(nodes).some(node => !isNodeConnected(node) && node.active));
 
   async function loadNodes(): Promise<void> {
+    set(loading, true);
     try {
       set(nodes, await api.fetchEvmNodes());
+      set(loadError, undefined);
     }
     catch (error: unknown) {
+      const message = getErrorMessage(error);
+      set(nodes, []);
+      set(loadError, message);
       notify({
-        message: getErrorMessage(error),
+        message,
         priority: Priority.NORMAL,
         title: t('evm_rpc_node_manager.loading_error.title', {
           chain: toValue(chain),
         }),
       });
+    }
+    finally {
+      set(loading, false);
     }
   }
 
@@ -203,6 +224,8 @@ export function useBlockchainRpcNodeManager(chain: MaybeRefOrGetter<Blockchain>)
     editRpcNode,
     getNodeStatus,
     isEtherscan,
+    loadError: readonly(loadError),
+    loading: readonly(loading),
     loadNodes,
     modelState,
     nodes: shallowReadonly(nodes),


### PR DESCRIPTION
`BlockchainRpcNodeManager.vue` rendered a bare `SimpleTable` with **no loading, empty or error state at all**. A failed `loadNodes()` therefore showed an empty table and explained nothing, and the notification it raises is classified `NORMAL`, so it never interrupts to say what happened. From the user's side "the backend is down" and "this chain has no nodes" looked identical.

### What changed

The composable keeps two more pieces of state:

- `loadError` — why the last read failed, cleared on the next success.
- `loading` — whether a read is in flight.

and the table renders all three cases: a spinner while reading, the reason plus a **Retry** when it failed, and a plain line when the chain genuinely has no nodes.

A failed read also clears the node list. Without that, a retry that fails after a successful read would leave an error sitting next to rows it does not describe.

The notification is unchanged and stays as the drawer's audit trail.

### Why here first

This is the first of the three surfaces in #12942's phase 4 groundwork (§6.0), which names this one as the strongest and a live bug today. The criterion it applies: inline is earned when a persistent visible surface is wrong or missing, the user is plausibly looking at it, and a retry is reachable from it. All three hold here.

It also got more acute with #13101, which classified 21 passive fetch failures as `NORMAL`. That was the right call — those popups were noise — but it means an empty surface is now the *only* signal, so the surfaces have to speak for themselves. This is the pattern the other two candidates (`use-statistics-data-fetching.ts` → `NetWorthChart`, and `ASSET_SEARCH_ERROR` onto the search field) copy, which is why the retry label goes in `common.actions` rather than in the RPC block.

Note this renders from the failed fetch's own state, so it does not depend on any notification phase.

### Tests

Six new cases on the composable (the reason is kept, cleared on success, stale nodes dropped, and `loading` set and unset on both paths) and four on the component (the error is shown with its reason, it does not fall through to the empty state, retry re-reads and recovers, and an empty success still reads as empty).

Negative control: disabling the error branch fails exactly those three component tests and nothing else — including "should not read as a chain that simply has no nodes", which is precisely the bug being fixed.

Gates: full unit suite (12194), typecheck, eslint, stylelint, knip, linked-keys.

Based on `develop` rather than `bugfixes`: the framing above is phase-4 groundwork and it establishes a shared pattern, but the underlying empty-table bug does exist in released versions, so say the word if you would rather have it on `bugfixes`.
