### PR TITLE
build(frontend): migrate to vitest 5

### DIFF
--- a/frontend/app/electron/main/address-import-server.spec.ts
+++ b/frontend/app/electron/main/address-import-server.spec.ts
@@ -26,7 +26,7 @@ describe('addressImportServer', () => {
       body: JSON.stringify({ addresses: ['0xabc', '0xdef', '0x123'] }),
     });
     expect(res.status).toBe(400);
-    expect(await res.json()).toStrictEqual({ message: 'Only requests up to 0.0MB are allowed' });
+    expect(JSON.parse(await res.text())).toStrictEqual({ message: 'Only requests up to 0.0MB are allowed' });
   });
 
   it('should reject an import with a non-json content type', async () => {
@@ -37,7 +37,7 @@ describe('addressImportServer', () => {
       body: '{}',
     });
     expect(res.status).toBe(400);
-    expect(await res.json()).toStrictEqual({ message: 'Invalid content type' });
+    expect(JSON.parse(await res.text())).toStrictEqual({ message: 'Invalid content type' });
   });
 
   it('should invoke the callback with the parsed addresses', async () => {
@@ -61,7 +61,7 @@ describe('addressImportServer', () => {
       body: '{ not valid json',
     });
     expect(res.status).toBe(400);
-    expect(await res.json()).toStrictEqual({ message: 'Malformed JSON' });
+    expect(JSON.parse(await res.text())).toStrictEqual({ message: 'Malformed JSON' });
   });
 
   it('should reject an import payload without an addresses array', async () => {
@@ -73,7 +73,7 @@ describe('addressImportServer', () => {
       body: JSON.stringify({ notAddresses: true }),
     });
     expect(res.status).toBe(400);
-    expect(await res.json()).toStrictEqual({ message: 'Invalid request schema' });
+    expect(JSON.parse(await res.text())).toStrictEqual({ message: 'Invalid request schema' });
     expect(cb).not.toHaveBeenCalled();
   });
 
@@ -81,6 +81,6 @@ describe('addressImportServer', () => {
     const base = startServer();
     const res = await fetch(`${base}/etc/passwd`);
     expect(res.status).toBe(404);
-    expect(await res.json()).toStrictEqual({ message: 'Resource not found' });
+    expect(JSON.parse(await res.text())).toStrictEqual({ message: 'Resource not found' });
   });
 });

--- a/frontend/app/electron/main/password-store.spec.ts
+++ b/frontend/app/electron/main/password-store.spec.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { captureConsoleError } from '@test/utils/capture-console-error';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PasswordStore } from './password-store';
 
 describe('passwordStore', () => {
@@ -14,6 +15,7 @@ describe('passwordStore', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     fs.rmSync(directory, { force: true, recursive: true });
   });
 
@@ -144,10 +146,12 @@ describe('passwordStore', () => {
   });
 
   it('should treat a corrupt file as empty rather than throwing', () => {
+    const reported = captureConsoleError();
     fs.writeFileSync(filePath, 'not json', { encoding: 'utf8' });
 
     expect(new PasswordStore(filePath).get('alice')).toBeUndefined();
     expect(new PasswordStore(filePath).isEmpty()).toBe(true);
+    expect(reported).toHaveBeenCalledWith(expect.any(SyntaxError), 'Could not read the password store');
   });
 
   it('should clear every entry', () => {

--- a/frontend/app/electron/main/password-store.spec.ts
+++ b/frontend/app/electron/main/password-store.spec.ts
@@ -166,6 +166,6 @@ describe('passwordStore', () => {
   it('should leave no temporary file behind', () => {
     new PasswordStore(filePath).set('alice', 'ciphertext');
 
-    expect(fs.readdirSync(directory)).toStrictEqual(['config.json']);
+    expect([...fs.readdirSync(directory)]).toStrictEqual(['config.json']);
   });
 });

--- a/frontend/app/electron/main/settings-manager.spec.ts
+++ b/frontend/app/electron/main/settings-manager.spec.ts
@@ -2,8 +2,9 @@ import type { App } from 'electron';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { captureConsoleError } from '@test/utils/capture-console-error';
 import { createMock } from '@test/utils/create-mock';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsManager } from './settings-manager';
 
 describe('settingsManager', () => {
@@ -16,6 +17,7 @@ describe('settingsManager', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     fs.rmSync(directory, { force: true, recursive: true });
   });
 
@@ -58,15 +60,19 @@ describe('settingsManager', () => {
   });
 
   it('should fall back to the defaults when the file is corrupt', () => {
+    const reported = captureConsoleError();
     fs.writeFileSync(path.join(directory, 'app.config.json'), 'not json', { encoding: 'utf8' });
 
     expect(new SettingsManager(app).appSettings.displayTray).toBe(true);
+    expect(reported).toHaveBeenCalledWith(expect.any(SyntaxError));
   });
 
   it('should fall back to the defaults when a value has the wrong type', () => {
+    const reported = captureConsoleError();
     writeSettings({ displayTray: 'yes' });
 
     expect(new SettingsManager(app).appSettings.displayTray).toBe(true);
+    expect(reported).toHaveBeenCalledOnce();
   });
 
   it('should persist a change so a later instance reads it', () => {

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.spec.ts
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetContent.spec.ts
@@ -25,7 +25,8 @@ vi.mock('@/modules/assets/api/use-asset-management-api', () => ({
 }));
 
 vi.mock('@/modules/assets/admin/custom/use-custom-asset-fields', () => ({
-  useCustomAssetFields: (): Record<string, unknown> => ({}),
+  // The real composable returns `FieldDef[]`; an object here reaches the table's Array prop.
+  useCustomAssetFields: (): unknown[] => [],
 }));
 
 vi.mock('@/modules/core/table/use-server-table', () => ({

--- a/frontend/app/src/modules/auth/use-session-load.spec.ts
+++ b/frontend/app/src/modules/auth/use-session-load.spec.ts
@@ -1,3 +1,4 @@
+import { captureConsoleError } from '@test/utils/capture-console-error';
 import flushPromises from 'flush-promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDataLoader } from '@/modules/auth/use-session-load';
@@ -115,6 +116,7 @@ describe('composables::session::load', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -219,6 +221,7 @@ describe('composables::session::load', () => {
     });
 
     it('should release the account gate when the balance read throws before it starts', async () => {
+      const reported = captureConsoleError();
       mockFetchNetValue.mockImplementation(() => {
         throw new Error('Fetch failed');
       });
@@ -230,6 +233,7 @@ describe('composables::session::load', () => {
 
       expect(mockReleaseAccountLoad).toHaveBeenCalledTimes(1);
       expect(mockSeedFromHistoric).not.toHaveBeenCalled();
+      expect(reported).toHaveBeenCalledWith(new Error('Fetch failed'));
     });
 
     it('should call onBalancesLoaded even if some fetches fail', async () => {

--- a/frontend/app/src/modules/core/api/rotki-api.spec.ts
+++ b/frontend/app/src/modules/core/api/rotki-api.spec.ts
@@ -20,8 +20,11 @@ describe('modules/api/rotki-api', () => {
     api = new RotkiApi();
     vi.clearAllMocks();
 
+    /* A plain object, so the redirect assertions can read back what the code assigned to `href`.
+       It has to start as a valid absolute URL: happy-dom resolves every Request against
+       `window.location.href`, and an empty base makes the URL constructor throw. */
     Object.defineProperty(window, 'location', {
-      value: { href: '', origin: 'http://localhost:3000' },
+      value: { href: 'http://localhost:3000/', origin: 'http://localhost:3000' },
       writable: true,
     });
   });

--- a/frontend/app/src/modules/core/table/filters/shared/use-shared-field-resolvers.spec.ts
+++ b/frontend/app/src/modules/core/table/filters/shared/use-shared-field-resolvers.spec.ts
@@ -1,4 +1,5 @@
 import { createCustomPinia } from '@test/utils/create-pinia';
+import { withSetup } from '@test/utils/with-setup';
 import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { useSharedFieldResolvers } from '@/modules/core/table/filters/shared/use-shared-field-resolvers';
@@ -18,7 +19,7 @@ describe('useSharedFieldResolvers', () => {
   describe('privacy mode: a filtered address is no more revealing than the same address anywhere else', () => {
     it('should shorten an address without altering it while privacy is off', () => {
       setScramble(false);
-      const { resolveHex } = useSharedFieldResolvers();
+      const { resolveHex } = withSetup(useSharedFieldResolvers).result;
 
       const shown = resolveHex(ADDRESS);
 
@@ -28,7 +29,7 @@ describe('useSharedFieldResolvers', () => {
 
     it('should scramble an address once privacy is on', () => {
       setScramble(true);
-      const { resolveHex } = useSharedFieldResolvers();
+      const { resolveHex } = withSetup(useSharedFieldResolvers).result;
 
       const shown = resolveHex(ADDRESS);
 
@@ -41,7 +42,7 @@ describe('useSharedFieldResolvers', () => {
     it('should scramble a transaction hash too, its values being just as identifying', () => {
       const hash = `0x${'ab'.repeat(32)}`;
       setScramble(true);
-      const { resolveHex } = useSharedFieldResolvers();
+      const { resolveHex } = withSetup(useSharedFieldResolvers).result;
 
       expect(resolveHex(hash)).not.toBe('0xabab...abab');
     });
@@ -49,7 +50,7 @@ describe('useSharedFieldResolvers', () => {
 
   it('should fall back to a shortened address for an asset with no metadata', () => {
     setScramble(false);
-    const { resolveAssetSymbol } = useSharedFieldResolvers();
+    const { resolveAssetSymbol } = withSetup(useSharedFieldResolvers).result;
 
     const shown = resolveAssetSymbol('eip155:1/erc20:0x214AF1443f6bB9FFB2bDcF301c762Df28Dd7f818');
 

--- a/frontend/app/src/modules/history/events/HistoryEventsTableActions.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventsTableActions.spec.ts
@@ -1,7 +1,6 @@
 import type { HistoryEventRequestPayload } from '@/modules/history/events/request-types';
 import type { UseHistoryEventsPillBarOptions } from '@/modules/history/events/use-history-events-pill-bar';
 import type { SelectionState } from '@/modules/history/events/use-selection-mode';
-import { createMock } from '@test/utils/create-mock';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, h } from 'vue';
@@ -52,16 +51,17 @@ const HistoryRedecodeButtonStub = defineComponent({
 });
 
 function selectionState(overrides: Partial<SelectionState> = {}): SelectionState {
-  return createMock<SelectionState>({
+  return {
     hasAvailableEvents: true,
     isActive: true,
     isAllSelected: false,
     isPartiallySelected: false,
     selectAllMatching: false,
     selectedCount: 2,
+    selectedIds: new Set<number>(),
     totalMatchingCount: 40,
     ...overrides,
-  });
+  };
 }
 
 describe('modules/history/events/HistoryEventsTableActions', () => {
@@ -80,7 +80,7 @@ describe('modules/history/events/HistoryEventsTableActions', () => {
       },
       props: {
         action: undefined,
-        exportParams: createMock<HistoryEventRequestPayload>({}),
+        exportParams: { aggregateByGroupIds: true, limit: 10, offset: 0 } satisfies HistoryEventRequestPayload,
         fields: [],
         filters: {},
         locationLabels: [],

--- a/frontend/app/src/modules/history/events/HistoryEventsView.spec.ts
+++ b/frontend/app/src/modules/history/events/HistoryEventsView.spec.ts
@@ -34,6 +34,16 @@ const handleUpdateEventIds = vi.fn();
 const handleMovementChanged = vi.fn();
 const handleBridgeChanged = vi.fn();
 
+/*
+ * The view holds the panel as a `defineAsyncComponent`, so naming it in `stubs` does not reach it:
+ * the SFC resolves the local const itself and the dynamic import runs regardless. Left real, that
+ * import settles after the test file is torn down and lands as an unhandled rejection. Mocking the
+ * module makes it resolve from the registry, inside the test.
+ */
+vi.mock('@/modules/shell/sync-progress/components/SyncProgressPanel.vue', () => ({
+  default: defineComponent({ name: 'SyncProgressPanel', setup: () => (): unknown => h('div') }),
+}));
+
 vi.mock('@/modules/history/events/use-history-events-view-actions', () => ({
   useHistoryEventsViewActions: (): unknown => ({
     groupedEventsByTxRef: ref({}),

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsContent.spec.ts
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsContent.spec.ts
@@ -231,7 +231,7 @@ describe('modules/history/events/MatchAssetMovementsContent', () => {
       set(actionsApi.modelSelectedIgnored, [movement(1)]);
       const wrapper = await mountContent();
 
-      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:model-value', 1);
+      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:modelValue', 1);
       await nextTick();
 
       await wrapper.find('[data-testid="restore-selected"]').trigger('click');

--- a/frontend/app/src/modules/history/events/MatchAssetMovementsPinned.spec.ts
+++ b/frontend/app/src/modules/history/events/MatchAssetMovementsPinned.spec.ts
@@ -1,3 +1,4 @@
+import type { HistoryEventCollectionRow } from '@/modules/history/events/schemas';
 import type { UsePinnedMatchPanelOptions } from '@/modules/history/events/use-pinned-match-panel';
 import type { UnmatchedAssetMovement } from '@/modules/history/events/use-unmatched-asset-movements';
 import { createMock } from '@test/utils/create-mock';
@@ -71,7 +72,14 @@ const SheetStub = defineComponent({
     : null),
 });
 
-const movement = createMock<UnmatchedAssetMovement>({ groupIdentifier: 'group-a' });
+/* A real object, not `createMock`: the proxy is function-backed, so Vue's `type: Object` prop
+   check rejects it, and an unset `isFiat` would read back as a truthy auto-stub. */
+const movement: UnmatchedAssetMovement = {
+  asset: 'ETH',
+  events: createMock<HistoryEventCollectionRow>(),
+  groupIdentifier: 'group-a',
+  isFiat: false,
+};
 
 describe('modules/history/events/MatchAssetMovementsPinned', () => {
   let wrapper: VueWrapper | undefined;
@@ -175,7 +183,7 @@ describe('modules/history/events/MatchAssetMovementsPinned', () => {
     await nextTick();
 
     const potential = view.findComponent(PotentialStub);
-    expect(potential.props('movement')).toBe(movement);
+    expect(toRaw(potential.props('movement'))).toBe(movement);
     expect(potential.props('highlightedIdentifier')).toBe(99);
     expect(potential.props('isPinned')).toBe(true);
   });

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.spec.ts
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsContent.spec.ts
@@ -183,7 +183,7 @@ describe('modules/history/events/MatchBridgeTransactionsContent', () => {
     it('should hide the restore button entirely when nothing is selected', async () => {
       set(transactionsApi.ignoredTransactions, [transaction(1)]);
       const wrapper = await mountContent();
-      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:model-value', 1);
+      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:modelValue', 1);
       await nextTick();
       expect(wrapper.find('[data-testid="restore-selected"]').exists()).toBe(false);
 

--- a/frontend/app/src/modules/history/events/MatchBridgeTransactionsPinned.spec.ts
+++ b/frontend/app/src/modules/history/events/MatchBridgeTransactionsPinned.spec.ts
@@ -1,4 +1,5 @@
 import type { MatchingFlow } from '@/modules/history/events/matching/types';
+import type { HistoryEventCollectionRow } from '@/modules/history/events/schemas';
 import type { UsePinnedMatchPanelOptions } from '@/modules/history/events/use-pinned-match-panel';
 import type { UnmatchedBridgeTransaction } from '@/modules/history/events/use-unmatched-bridge-transactions';
 import { createMock } from '@test/utils/create-mock';
@@ -33,7 +34,13 @@ vi.mock('@/modules/history/events/use-pinned-match-panel', () => ({
 
 const unmatchedTransactions = ref<UnmatchedBridgeTransaction[]>([]);
 const ignoredTransactions = ref<UnmatchedBridgeTransaction[]>([]);
-const bridgeFlow = createMock<MatchingFlow>();
+/* Real objects, not `createMock`: the proxy is function-backed, so Vue's `type: Object` prop
+   check rejects it on both `flow` and `movement`. */
+const bridgeFlow: MatchingFlow = {
+  getSuggestions: vi.fn().mockResolvedValue({ closeMatches: [], otherEvents: [] }),
+  match: vi.fn().mockResolvedValue({ success: true }),
+  refresh: vi.fn().mockResolvedValue(undefined),
+};
 const entryLabels = ref({ locationHeader: 'Chain', type: 'Bridge transaction' });
 const unmatchableExplanation = ref<string | undefined>('No counterpart is tracked.');
 
@@ -92,7 +99,13 @@ const SheetStub = defineComponent({
     : null),
 });
 
-const transaction = createMock<UnmatchedBridgeTransaction>({ groupIdentifier: 'group-a', identifier: 11 });
+const transaction: UnmatchedBridgeTransaction = {
+  asset: 'ETH',
+  direction: 'deposit',
+  events: createMock<HistoryEventCollectionRow>(),
+  groupIdentifier: 'group-a',
+  identifier: 11,
+};
 
 describe('modules/history/events/MatchBridgeTransactionsPinned', () => {
   let wrapper: VueWrapper | undefined;
@@ -199,7 +212,7 @@ describe('modules/history/events/MatchBridgeTransactionsPinned', () => {
     await nextTick();
 
     const potential = view.findComponent(PotentialStub);
-    expect(potential.props('movement')).toBe(transaction);
+    expect(toRaw(potential.props('movement'))).toBe(transaction);
     expect(potential.props('flow')).toBe(bridgeFlow);
     expect(potential.props('entryLabels')).toStrictEqual(get(entryLabels));
     expect(potential.props('emptyExplanation')).toBe('No counterpart is tracked.');

--- a/frontend/app/src/modules/history/events/PotentialMatchesList.spec.ts
+++ b/frontend/app/src/modules/history/events/PotentialMatchesList.spec.ts
@@ -1,5 +1,5 @@
 import type { PotentialMatchRow, UnmatchedEventGroup } from '@/modules/history/events/matching/types';
-import type { HistoryEventEntry } from '@/modules/history/events/schemas';
+import type { HistoryEventCollectionRow, HistoryEventEntry } from '@/modules/history/events/schemas';
 import { createMock } from '@test/utils/create-mock';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -29,7 +29,13 @@ const EmptyStub = {
   template: '<button data-testid="stub-widen" @click="$emit(\'widen\')" />',
 };
 
-const movement = createMock<UnmatchedEventGroup>({ asset: 'ETH', groupIdentifier: '0xabc' });
+/* A real object, not `createMock`: the proxy is function-backed, so Vue's `type: Object` prop
+   check rejects it and every mount warns. Only the nested collection stays mocked. */
+const movement: UnmatchedEventGroup = {
+  asset: 'ETH',
+  events: createMock<HistoryEventCollectionRow>(),
+  groupIdentifier: '0xabc',
+};
 
 const noMatches: PotentialMatchRow[] = [];
 

--- a/frontend/app/src/modules/history/events/PotentialMatchesTable.spec.ts
+++ b/frontend/app/src/modules/history/events/PotentialMatchesTable.spec.ts
@@ -31,6 +31,9 @@ function createRow(identifier: number, isCloseMatch = false): PotentialMatchRow 
       groupIdentifier: `group-${identifier}`,
       identifier,
       location: 'kraken',
+      /* Unset, this reads back as a truthy auto-stub, so the row always renders the account
+         branch and passes a function to a String prop. */
+      locationLabel: 'kraken-main',
       timestamp: 1700000000000,
     }),
     identifier,

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.spec.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.spec.ts
@@ -137,7 +137,7 @@ describe('modules/history/internal-tx-conflicts/InternalTxConflictsContent', () 
     it('should clear the selection, so rows picked on one tab cannot be resolved from another', async () => {
       const wrapper = await mountContent();
 
-      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:model-value', 1);
+      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:modelValue', 1);
       await flushPromises();
 
       expect(selectionApi.clearSelection).toHaveBeenCalledOnce();
@@ -149,7 +149,7 @@ describe('modules/history/internal-tx-conflicts/InternalTxConflictsContent', () 
     ])('should filter to the status behind tab %s', async (tab, status) => {
       const wrapper = await mountContent();
 
-      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:model-value', tab);
+      await wrapper.findComponent({ name: 'RuiTabs' }).vm.$emit('update:modelValue', tab);
       await flushPromises();
 
       expect(conflictsApi.setFilter).toHaveBeenLastCalledWith(status);
@@ -159,9 +159,9 @@ describe('modules/history/internal-tx-conflicts/InternalTxConflictsContent', () 
       const wrapper = await mountContent();
       const tabs = wrapper.findComponent({ name: 'RuiTabs' });
 
-      await tabs.vm.$emit('update:model-value', 2);
+      await tabs.vm.$emit('update:modelValue', 2);
       await flushPromises();
-      await tabs.vm.$emit('update:model-value', 0);
+      await tabs.vm.$emit('update:modelValue', 0);
       await flushPromises();
 
       expect(conflictsApi.setFilter).toHaveBeenLastCalledWith(InternalTxConflictStatuses.PENDING);

--- a/frontend/app/src/modules/settings/api/use-settings-api.spec.ts
+++ b/frontend/app/src/modules/settings/api/use-settings-api.spec.ts
@@ -162,7 +162,7 @@ describe('composables/api/settings/settings-api', () => {
 
       server.use(
         http.put(`${backendUrl}/api/1/settings`, async ({ request }) => {
-          capturedBody = await request.json();
+          capturedBody = JSON.parse(await request.text());
           capturedRequest = {
             body: capturedBody,
             headers: request.headers,
@@ -305,7 +305,7 @@ describe('composables/api/settings/settings-api', () => {
 
       server.use(
         http.put(`${backendUrl}/api/1/settings`, async ({ request }) => {
-          capturedBody = await request.json();
+          capturedBody = JSON.parse(await request.text());
           return HttpResponse.json(createSettingsResponse({
             disabled_chain_queries: { binance_sc: [], [MULTI_WORD_CHAIN_ID]: [ETH_ADDRESS] },
           }));
@@ -372,7 +372,7 @@ describe('composables/api/settings/settings-api', () => {
 
       server.use(
         http.put(`${backendUrl}/api/1/settings/configuration`, async ({ request }) => {
-          capturedBody = await request.json();
+          capturedBody = JSON.parse(await request.text());
           return HttpResponse.json(createBackendConfigResponse());
         }),
       );

--- a/frontend/app/src/modules/settings/evm/IndexerOrderSetting.spec.ts
+++ b/frontend/app/src/modules/settings/evm/IndexerOrderSetting.spec.ts
@@ -199,7 +199,7 @@ describe('indexerOrderSetting', () => {
     await mountWith([EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT]);
     expect(defaultList().props('modelValue')).toEqual([EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT]);
 
-    defaultList().vm.$emit('update:model-value', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
+    defaultList().vm.$emit('update:modelValue', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
     await nextTick();
 
     expect(defaultList().props('modelValue')).toEqual([EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
@@ -209,7 +209,7 @@ describe('indexerOrderSetting', () => {
     await mountWith([EvmIndexer.ROUTESCAN, EvmIndexer.ETHERSCAN]);
     expect(wrapper.find('[data-testid=missing-api-key-alert]').exists()).toBe(false);
 
-    defaultList().vm.$emit('update:model-value', [EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN]);
+    defaultList().vm.$emit('update:modelValue', [EvmIndexer.ETHERSCAN, EvmIndexer.ROUTESCAN]);
     await nextTick();
 
     expect(wrapper.find('[data-testid=missing-api-key-alert]').exists()).toBe(true);
@@ -219,7 +219,7 @@ describe('indexerOrderSetting', () => {
     await mountWith([EvmIndexer.ETHERSCAN], { gnosis: [EvmIndexer.ETHERSCAN, EvmIndexer.BLOCKSCOUT] });
     await selectTab('gnosis');
 
-    chainList().vm.$emit('update:model-value', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
+    chainList().vm.$emit('update:modelValue', [EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);
     await nextTick();
 
     expect(chainList().props('modelValue')).toEqual([EvmIndexer.BLOCKSCOUT, EvmIndexer.ETHERSCAN]);

--- a/frontend/app/src/modules/shell/app/schedulers/use-task-polling-scheduler.spec.ts
+++ b/frontend/app/src/modules/shell/app/schedulers/use-task-polling-scheduler.spec.ts
@@ -1,4 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EffectScope } from 'vue';
+import { captureConsoleError } from '@test/utils/capture-console-error';
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMainStore } from '@/modules/core/common/use-main-store';
 import { useTaskStore } from '@/modules/core/tasks/use-task-store';
 import { useTaskPollingScheduler } from './use-task-polling-scheduler';
@@ -15,6 +17,8 @@ vi.mock('@/modules/core/tasks/use-task-monitor', () => ({
 }));
 
 describe('useTaskPollingScheduler', () => {
+  let scope: EffectScope | undefined;
+
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
@@ -24,15 +28,33 @@ describe('useTaskPollingScheduler', () => {
   });
 
   afterEach(() => {
+    scope?.stop();
+    scope = undefined;
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
+
+  /**
+   * Builds the scheduler inside an effect scope.
+   *
+   * @remarks
+   * The composable registers its own `onScopeDispose(stop)`, which needs an active scope to
+   * attach to. Stopping the scope in `afterEach` also runs that teardown, so a scheduler cannot
+   * outlive its test and keep polling into the next one.
+   */
+  function createScheduler(): ReturnType<typeof useTaskPollingScheduler> {
+    scope = effectScope();
+    const scheduler = scope.run(() => useTaskPollingScheduler());
+    assert(scheduler);
+    return scheduler;
+  }
 
   const runTask = (): void => {
     useTaskStore().add({ id: 1, label: 'test' });
   };
 
   it('should not poll while the backend is deliberately down', async () => {
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     runTask();
     start(false);
 
@@ -43,7 +65,7 @@ describe('useTaskPollingScheduler', () => {
   });
 
   it('should resume polling on its own once the backend is back, without being restarted', async () => {
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     runTask();
     start(false);
 
@@ -57,7 +79,7 @@ describe('useTaskPollingScheduler', () => {
   });
 
   it('should poll slowly while nothing is outstanding', async () => {
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     start(false);
 
     await vi.advanceTimersByTimeAsync(ACTIVE_POLLING_MS + 100);
@@ -69,7 +91,7 @@ describe('useTaskPollingScheduler', () => {
 
   it('should poll quickly as soon as a task is outstanding', async () => {
     runTask();
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     start(false);
 
     await vi.advanceTimersByTimeAsync(ACTIVE_POLLING_MS + 50);
@@ -78,7 +100,7 @@ describe('useTaskPollingScheduler', () => {
 
   it('should back off while the outstanding work does not change', async () => {
     runTask();
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     start(false);
 
     await vi.advanceTimersByTimeAsync(ACTIVE_POLLING_MS + 50);
@@ -93,7 +115,7 @@ describe('useTaskPollingScheduler', () => {
 
   it('should return to the fast cadence when a task appears, not the next step of the backoff', async () => {
     runTask();
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     start(false);
 
     await vi.advanceTimersByTimeAsync(ACTIVE_POLLING_MS + SECOND_GAP_MS + 100);
@@ -109,7 +131,7 @@ describe('useTaskPollingScheduler', () => {
 
   it('should slow down again once the work is done, from the poll after the one already scheduled', async () => {
     runTask();
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     start(false);
 
     await vi.advanceTimersByTimeAsync(ACTIVE_POLLING_MS + 50);
@@ -133,7 +155,7 @@ describe('useTaskPollingScheduler', () => {
       release = resolve;
     }));
 
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     start(true);
     await vi.advanceTimersByTimeAsync(0);
     expect(monitor).toHaveBeenCalledOnce();
@@ -147,21 +169,23 @@ describe('useTaskPollingScheduler', () => {
   });
 
   it('should keep polling after a failed pass', async () => {
+    const reported = captureConsoleError();
     runTask();
     monitor.mockRejectedValueOnce(new Error('boom'));
 
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     start(false);
 
     await vi.advanceTimersByTimeAsync(ACTIVE_POLLING_MS + 50);
     expect(monitor).toHaveBeenCalledOnce();
+    expect(reported).toHaveBeenCalledWith(new Error('boom'));
 
     await vi.advanceTimersByTimeAsync(SECOND_GAP_MS + 50);
     expect(monitor).toHaveBeenCalledTimes(2);
   });
 
   it('should poll immediately when asked to', async () => {
-    const { start } = useTaskPollingScheduler();
+    const { start } = createScheduler();
     start(true);
 
     await vi.advanceTimersByTimeAsync(0);
@@ -170,7 +194,7 @@ describe('useTaskPollingScheduler', () => {
 
   it('should stop polling', async () => {
     runTask();
-    const { start, stop } = useTaskPollingScheduler();
+    const { start, stop } = createScheduler();
     start(false);
     stop();
 

--- a/frontend/app/src/modules/shell/components/About.spec.ts
+++ b/frontend/app/src/modules/shell/components/About.spec.ts
@@ -19,7 +19,9 @@ const { copy, dataDirectory, getVersion, premium, version, versionSource } = awa
 });
 
 vi.mock('@/modules/core/common/use-main-store', () => ({
-  useMainStore: (): { dataDirectory: Ref<string>; version: Ref<{ version: string }> } => ({
+  /* The component calls `toRefs(store)`, which warns on a plain object. The real store is a
+     Pinia one, so the stand-in has to be reactive too. */
+  useMainStore: (): { dataDirectory: string; version: { version: string } } => reactive({
     dataDirectory,
     version,
   }),

--- a/frontend/app/tests/unit/setup-files/setup.ts
+++ b/frontend/app/tests/unit/setup-files/setup.ts
@@ -5,7 +5,7 @@ import { RuiAlertStub } from '@test/stubs/RuiAlert';
 import { RuiAutoCompleteStub } from '@test/stubs/RuiAutoComplete';
 import { RuiIconStub } from '@test/stubs/RuiIcon';
 import { RuiTooltipStub } from '@test/stubs/RuiTooltip';
-import { config, enableAutoUnmount } from '@vue/test-utils';
+import { config, enableAutoUnmount, RouterLinkStub } from '@vue/test-utils';
 import consola, { type ConsolaReporter } from 'consola';
 import { afterAll, afterEach, beforeAll, beforeEach, onTestFailed, vi } from 'vitest';
 import { server } from './server';
@@ -241,6 +241,10 @@ config.global.stubs.RuiAutoComplete = RuiAutoCompleteStub;
 config.global.stubs.RuiIcon = RuiIconStub;
 config.global.stubs.RuiTooltip = RuiTooltipStub;
 config.global.stubs.I18nT = true;
+/* The `vue-router` mock above replaces the plugin, so nothing registers RouterLink and RouterView
+   as global components and every component rendering one warns instead. */
+config.global.stubs.RouterLink = RouterLinkStub;
+config.global.stubs.RouterView = true;
 // JsonInput lazy-loads `vanilla-jsoneditor` on mount, and no spec asserts its DOM.
 config.global.stubs.JsonInput = true;
 

--- a/frontend/app/tests/unit/setup-files/vm-globals.ts
+++ b/frontend/app/tests/unit/setup-files/vm-globals.ts
@@ -1,0 +1,16 @@
+import { BroadcastChannel as NodeBroadcastChannel } from 'node:worker_threads';
+
+/*
+ * A `vmThreads` worker evaluates each test file in a fresh V8 context, and that context carries
+ * the environment's globals rather than Node's. `BroadcastChannel` is not among them, so MSW,
+ * which reaches for it at import time, throws `ReferenceError` before any test runs. See
+ * https://github.com/mswjs/msw/issues/2340.
+ *
+ * This file is listed ahead of `setup.ts` in `setupFiles` so the global exists before the MSW
+ * server module is evaluated. Under a pool that already provides it the branch is skipped.
+ *
+ * `Reflect.set` rather than assignment: node's channel and the DOM lib's declaration describe the
+ * same runtime object with different constructor types, and this keeps the seam free of a cast.
+ */
+if (!('BroadcastChannel' in globalThis))
+  Reflect.set(globalThis, 'BroadcastChannel', NodeBroadcastChannel);

--- a/frontend/app/tests/unit/utils/capture-console-error.ts
+++ b/frontend/app/tests/unit/utils/capture-console-error.ts
@@ -1,0 +1,22 @@
+import { type MockInstance, vi } from 'vitest';
+
+/**
+ * Silences `console.error` for the current test and returns the spy to assert on.
+ *
+ * @remarks
+ * Code under test that swallows a failure reports it through `console.error`, directly or via
+ * `startPromise`. A spec exercising that path therefore prints a stack trace on a passing run,
+ * which is noise in CI and hides the traces that do mean something.
+ *
+ * Asserting on the returned spy is the point: it turns the printed error into the statement the
+ * test was making anyway, that the failure was reported rather than silently dropped. Silencing
+ * without asserting only hides it.
+ *
+ * The spy is installed for the calling test alone, so restore it in `afterEach` with
+ * `vi.restoreAllMocks()`.
+ *
+ * @returns the `console.error` spy, with its calls recorded and its output suppressed
+ */
+export function captureConsoleError(): MockInstance<typeof console.error> {
+  return vi.spyOn(console, 'error').mockImplementation(() => {});
+}

--- a/frontend/app/vitest.config.ts
+++ b/frontend/app/vitest.config.ts
@@ -1,7 +1,16 @@
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { configDefaults, defineConfig, mergeConfig } from 'vitest/config';
 import viteConfig from './vite.config.ts';
+
+/*
+ * `test.env` is applied inside the worker, which is too late for a `vmThreads` V8 context: the
+ * context builds its `Date` from the timezone the process started with, so a spec pinning the
+ * clock reads host-local hours and drifts by the local offset. Setting it here, on the parent,
+ * means every worker inherits it before its context exists. `test.env` keeps it for the runtime.
+ */
+process.env.TZ = 'UTC';
 
 export default mergeConfig(
   mergeConfig(viteConfig, {
@@ -16,6 +25,15 @@ export default mergeConfig(
     test: {
       globals: true,
       environment: 'happy-dom',
+      /*
+       * `vmThreads` builds the happy-dom environment once per worker instead of once per file,
+       * which was a quarter of the run across 1111 files. `vmMemoryLimit` is not optional here:
+       * this pool does not reclaim contexts reliably, and without a limit the run holds ~17GB
+       * against ~5GB for the default pool, which does not fit a CI runner. It is a top-level
+       * option, not a `poolOptions` one, so a misplaced key silently does nothing.
+       */
+      pool: 'vmThreads',
+      vmMemoryLimit: '512MB',
       testTimeout: 15_000,
       env: {
         TZ: 'UTC',
@@ -39,7 +57,7 @@ export default mergeConfig(
           inline: ['@rotki/ui-library'],
         },
       },
-      setupFiles: ['tests/unit/setup-files/setup.ts'],
+      setupFiles: ['tests/unit/setup-files/vm-globals.ts', 'tests/unit/setup-files/setup.ts'],
       coverage: {
         provider: 'v8',
         reportsDirectory: 'tests/unit/coverage',

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -159,11 +159,11 @@ catalogs:
       specifier: 6.0.8
       version: 6.0.8
     '@vitest/coverage-v8':
-      specifier: 4.1.11
-      version: 4.1.11
+      specifier: 5.0.0
+      version: 5.0.0
     '@vitest/ui':
-      specifier: 4.1.11
-      version: 4.1.11
+      specifier: 5.0.0
+      version: 5.0.0
     '@vue/devtools-api':
       specifier: 8.2.1
       version: 8.2.1
@@ -348,8 +348,8 @@ catalogs:
       specifier: 8.2.1
       version: 8.2.1
     vitest:
-      specifier: 4.1.11
-      version: 4.1.11
+      specifier: 5.0.0
+      version: 5.0.0
     vue:
       specifier: 3.5.42
       version: 3.5.42
@@ -576,10 +576,10 @@ importers:
         version: 6.0.8(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.11(vitest@4.1.11)
+        version: 5.0.0(vitest@5.0.0)
       '@vitest/ui':
         specifier: 'catalog:'
-        version: 4.1.11(vitest@4.1.11)
+        version: 5.0.0(vitest@5.0.0)
       '@vue/devtools-api':
         specifier: 'catalog:'
         version: 8.2.1
@@ -672,7 +672,7 @@ importers:
         version: 8.2.1(supports-color@10.2.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))
+        version: 5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))
       vue-component-type-helpers:
         specifier: 'catalog:'
         version: 3.3.11
@@ -721,7 +721,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+        version: 5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
 
 packages:
 
@@ -2561,6 +2561,15 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/coverage-v8@5.0.0':
+    resolution: {integrity: sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==}
+    peerDependencies:
+      '@vitest/browser': 5.0.0
+      vitest: 5.0.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/eslint-plugin@1.6.27':
     resolution: {integrity: sha512-X1RCAfwbatG4GFbJ/1PIHP9MSZMt0JJThqbYID+vS4L783k6QGlLPe421wQE8dHXuGCcenVLsydiM4qzsYWxhg==}
     engines: {node: '>=18'}
@@ -2580,8 +2589,27 @@ packages:
   '@vitest/expect@4.1.11':
     resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
+  '@vitest/istanbul-lib-coverage@1.0.1':
+    resolution: {integrity: sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==}
+    engines: {node: '>=22'}
+
+  '@vitest/istanbul-lib-report@1.0.1':
+    resolution: {integrity: sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==}
+    engines: {node: '>=22'}
+
   '@vitest/mocker@4.1.11':
     resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@5.0.0':
+    resolution: {integrity: sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2594,6 +2622,9 @@ packages:
   '@vitest/pretty-format@4.1.11':
     resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
+  '@vitest/pretty-format@5.0.0':
+    resolution: {integrity: sha512-PVRNuB3wpReb4SQEs4zTKM4KWFhQ5pw3spE8naoDJNB5T5aWRzGKHwXcLUllr0WeOTXpB6bSr3CJLo5+7XQSSQ==}
+
   '@vitest/runner@4.1.11':
     resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
@@ -2603,13 +2634,24 @@ packages:
   '@vitest/spy@4.1.11':
     resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
+  '@vitest/spy@5.0.0':
+    resolution: {integrity: sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==}
+
   '@vitest/ui@4.1.11':
     resolution: {integrity: sha512-r/rwyKoev21mWdRGSEkZOqkQ2BYy68mwjihg9M90nNRbf4NGrgzZ4cj6JNCEwlOGJkbKeMgsjlykvwKUbRr7gw==}
     peerDependencies:
       vitest: 4.1.11
 
+  '@vitest/ui@5.0.0':
+    resolution: {integrity: sha512-h2FIFwggCY2GxUd2UdQoYNVQkOIqEQLPhNREcl3FUiRsdzQep7NWwYbSmhGEA9nFLPDq5pXzRMcBZQU8Py83sg==}
+    peerDependencies:
+      vitest: 5.0.0
+
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
+  '@vitest/utils@5.0.0':
+    resolution: {integrity: sha512-dO++xL3vDfvhTAVimfkuQUA3k+JClIF1i1vAkPqpcGAthRmeWnXmHB7YPViPvgCwviX8u7Y5W1u2N//AaQr3fw==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -2968,6 +3010,9 @@ packages:
 
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   ast-walker-scope@0.9.0:
     resolution: {integrity: sha512-IJdzo2vLiElBxKzwS36VsCue/62d6IdWjnPB2v3nuPKeWGynp6FF/CYoLa5i/3jXH/z97ZDdsXz6abpgM6w07A==}
@@ -3611,6 +3656,9 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -3922,6 +3970,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
@@ -4027,6 +4079,9 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   flush-promises@1.0.2:
     resolution: {integrity: sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==}
@@ -4744,6 +4799,9 @@ packages:
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
     engines: {node: '>=18'}
@@ -5124,6 +5182,10 @@ packages:
 
   obug@2.1.2:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
+    engines: {node: '>=12.20.0'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
   ofetch@1.5.1:
@@ -5793,6 +5855,9 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
@@ -5996,6 +6061,10 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
+  tinybench@6.1.4:
+    resolution: {integrity: sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==}
+    engines: {node: '>=20.0.0'}
+
   tinycolor2@1.6.0:
     resolution: {integrity: sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==}
 
@@ -6013,6 +6082,10 @@ packages:
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@7.4.2:
@@ -6475,6 +6548,47 @@ packages:
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@5.0.0:
+    resolution: {integrity: sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==}
+    engines: {node: ^22.12.0 || ^24.0.0 || >=26.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 5.0.0
+      '@vitest/browser-preview': 5.0.0
+      '@vitest/browser-webdriverio': ^5.0.0-beta.5 || >=5.0.0
+      '@vitest/coverage-istanbul': 5.0.0
+      '@vitest/coverage-v8': 5.0.0
+      '@vitest/ui': 5.0.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.4.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -8160,7 +8274,8 @@ snapshots:
 
   '@sphinxxxx/color-conversion@2.2.2': {}
 
-  '@standard-schema/spec@1.1.0': {}
+  '@standard-schema/spec@1.1.0':
+    optional: true
 
   '@stylistic/eslint-plugin@5.10.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))':
     dependencies:
@@ -8434,7 +8549,20 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+    optional: true
+
+  '@vitest/coverage-v8@5.0.0(vitest@5.0.0)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/istanbul-lib-coverage': 1.0.1
+      '@vitest/istanbul-lib-report': 1.0.1
+      ast-v8-to-istanbul: 1.0.5
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)(vitest@4.1.11)':
     dependencies:
@@ -8444,7 +8572,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       typescript: 6.0.3
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8456,15 +8584,13 @@ snapshots:
       '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.0
+    optional: true
 
-  '@vitest/mocker@4.1.11(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))':
+  '@vitest/istanbul-lib-coverage@1.0.1': {}
+
+  '@vitest/istanbul-lib-report@1.0.1':
     dependencies:
-      '@vitest/spy': 4.1.11
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
-      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0)
+      '@vitest/istanbul-lib-coverage': 1.0.1
 
   '@vitest/mocker@4.1.11(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))':
     dependencies:
@@ -8474,23 +8600,42 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
+    optional: true
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))':
+  '@vitest/mocker@5.0.0(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.11
+      '@jridgewell/trace-mapping': 0.3.31
+      '@vitest/spy': 5.0.0
       estree-walker: 3.0.3
-      magic-string: 0.30.21
+      magic-string: 1.2.3
     optionalDependencies:
+      msw: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0)
+
+  '@vitest/mocker@5.0.0(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@vitest/spy': 5.0.0
+      estree-walker: 3.0.3
+      magic-string: 1.2.3
+    optionalDependencies:
+      msw: 2.15.0(@types/node@24.13.3)(typescript@6.0.3)
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.0
+    optional: true
+
+  '@vitest/pretty-format@5.0.0':
+    dependencies:
+      tinyrainbow: 3.1.1
 
   '@vitest/runner@4.1.11':
     dependencies:
       '@vitest/utils': 4.1.11
       pathe: 2.0.3
+    optional: true
 
   '@vitest/snapshot@4.1.11':
     dependencies:
@@ -8498,8 +8643,12 @@ snapshots:
       '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
+    optional: true
 
-  '@vitest/spy@4.1.11': {}
+  '@vitest/spy@4.1.11':
+    optional: true
+
+  '@vitest/spy@5.0.0': {}
 
   '@vitest/ui@4.1.11(vitest@4.1.11)':
     dependencies:
@@ -8510,13 +8659,31 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+    optional: true
+
+  '@vitest/ui@5.0.0(vitest@5.0.0)':
+    dependencies:
+      '@vitest/utils': 5.0.0
+      fflate: 0.8.3
+      flatted: 3.4.4
+      pathe: 2.0.3
+      sirv: 3.0.2
+      tinyrainbow: 3.1.1
+      vitest: 5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))
 
   '@vitest/utils@4.1.11':
     dependencies:
       '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+    optional: true
+
+  '@vitest/utils@5.0.0':
+    dependencies:
+      '@vitest/pretty-format': 5.0.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -9164,6 +9331,13 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+    optional: true
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   ast-walker-scope@0.9.0:
     dependencies:
@@ -9799,7 +9973,10 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.1.0: {}
+  es-module-lexer@2.1.0:
+    optional: true
+
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -10267,7 +10444,10 @@ snapshots:
 
   events@3.3.0: {}
 
-  expect-type@1.3.0: {}
+  expect-type@1.3.0:
+    optional: true
+
+  expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -10367,6 +10547,8 @@ snapshots:
       hookified: 1.15.1
 
   flatted@3.4.2: {}
+
+  flatted@3.4.4: {}
 
   flush-promises@1.0.2: {}
 
@@ -11060,6 +11242,13 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
       source-map-js: 1.2.1
+    optional: true
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
 
   make-asynchronous@1.1.0:
     dependencies:
@@ -11617,6 +11806,8 @@ snapshots:
     optional: true
 
   obug@2.1.2: {}
+
+  obug@2.1.4: {}
 
   ofetch@1.5.1:
     dependencies:
@@ -12300,7 +12491,10 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@4.1.0: {}
+  std-env@4.1.0:
+    optional: true
+
+  std-env@4.2.0: {}
 
   strict-event-emitter@0.5.1: {}
 
@@ -12577,7 +12771,10 @@ snapshots:
 
   tiny-typed-emitter@2.1.0: {}
 
-  tinybench@2.9.0: {}
+  tinybench@2.9.0:
+    optional: true
+
+  tinybench@6.1.4: {}
 
   tinycolor2@1.6.0: {}
 
@@ -12590,7 +12787,10 @@ snapshots:
 
   tinypool@2.1.0: {}
 
-  tinyrainbow@3.1.0: {}
+  tinyrainbow@3.1.0:
+    optional: true
+
+  tinyrainbow@3.1.1: {}
 
   tldts-core@7.4.2: {}
 
@@ -13017,36 +13217,6 @@ snapshots:
       tsx: 4.23.13
       yaml: 2.9.0
 
-  vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11
-      '@vitest/snapshot': 4.1.11
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.2
-      pathe: 2.0.3
-      picomatch: 4.0.7
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 24.13.3
-      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
-      '@vitest/ui': 4.1.11(vitest@4.1.11)
-      happy-dom: 20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - msw
-
   vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
@@ -13076,33 +13246,52 @@ snapshots:
       happy-dom: 20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - msw
+    optional: true
 
-  vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)):
+  vitest@5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11
-      '@vitest/snapshot': 4.1.11
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.2
-      pathe: 2.0.3
+      '@types/chai': 5.2.3
+      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+      chai: 6.2.2
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 1.2.3
+      obug: 2.1.4
       picomatch: 4.0.7
-      std-env: 4.1.0
-      tinybench: 2.9.0
+      std-env: 4.2.0
+      tinybench: 6.1.4
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
       '@vitest/ui': 4.1.11(vitest@4.1.11)
+      happy-dom: 20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@5.0.0(@types/node@24.13.3)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0)):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0))
+      chai: 6.2.2
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 1.2.3
+      obug: 2.1.4
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 6.1.4
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.13)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+      '@vitest/coverage-v8': 5.0.0(vitest@5.0.0)
+      '@vitest/ui': 5.0.0(vitest@5.0.0)
       happy-dom: 20.12.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - msw

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -68,8 +68,8 @@ catalog:
   '@types/semver': 7.8.0
   '@types/ws': 8.18.1
   '@vitejs/plugin-vue': 6.0.8
-  '@vitest/coverage-v8': 4.1.11
-  '@vitest/ui': 4.1.11
+  '@vitest/coverage-v8': 5.0.0
+  '@vitest/ui': 5.0.0
   '@vue/devtools-api': 8.2.1
   '@vue/test-utils': 2.5.0
   '@vue/tsconfig': 0.9.1
@@ -131,7 +131,7 @@ catalog:
   vite: 8.2.2
   vite-plugin-checker: 0.14.5
   vite-plugin-vue-devtools: 8.2.1
-  vitest: 4.1.11
+  vitest: 5.0.0
   vue: 3.5.42
   vue-component-type-helpers: 3.3.11
   vue-echarts: 8.2.0


### PR DESCRIPTION
Bumps `vitest`, `@vitest/coverage-v8` and `@vitest/ui` from 4.1.11 to 5.0.0.

The diff is the catalog bump and the lockfile. Nothing in `app/vitest.config.ts`,
`app/vitest.contract.config.ts`, `dev-proxy/vitest.config.ts`, the shared setup file or any spec
had to change. Below is why, item by item, against the
[5.0 migration guide](https://vitest.dev/guide/migration.html).

## The one default that changed behaviour

`clearMocks` now defaults to `true`, so `vi.clearAllMocks()` runs before each test. This repo never
set it, so it was `false` before.

It is adopted rather than pinned back with `clearMocks: false`: the full suite passes under the new
default, unchanged. 1111 files, 12185 tests, 1 todo, zero failures. Pinning it back would keep the
order-dependence the new default exists to remove.

## Breaking changes checked and found not to apply

| Change | Why it does not apply |
|---|---|
| `test.sequential()` / `describe.sequential()` / `{ sequential: true }` removed | No occurrences. |
| `vitest/coverage`, `vitest/reporters`, `vitest/environments`, `vitest/snapshot`, `vitest/runners`, `vitest/suite`, `vitest/mocker` entrypoints removed | No imports from any of them. |
| `@vitest/expect` no longer bundled | Not imported; only a transitive lockfile entry. |
| `@vitest/runner` and `@vitest/ws-client` deprecated | Not direct dependencies. |
| `vi.mock` / `vi.hoisted` / `vi.unmock` must be top level | Every call already is. |
| `bench` import removed, benchmark config removed | No benchmarks. |
| `toThrow("")` now matches any message | No occurrences. |
| `expect.poll()` now rejects on timeout | The `expect.poll` uses are in `tests/e2e/`, which is Playwright's `expect`, not vitest's. |
| Unawaited async assertions now fail the test | The two deferred `expect(...).rejects` assertions (`async-utilities.spec.ts`, `rotki-api.spec.ts`) are both stored and awaited. |
| Assertion type signatures / `vitest.Matchers` augmentation | No custom matcher augmentation. |
| `toHaveTextContent` now strict | Not used. |
| `populateGlobal` returns descriptors | Not used. |
| `VITEST_POOL_ID` / `VITEST_WORKER_ID` now 1-based | Nothing reads them. |
| `resolveConfig` return shape | Not used. |
| `Temporal` now mocked by fake timers | `fakeTimers.toFake` is an explicit list that does not include `Temporal`, so nothing changes. |
| Browser mode: strict locators, async `render()`, WebdriverIO provider moved | Browser mode is not used; e2e is Playwright. |
| `testNamePattern` separator is now `' > '` | No `-t` in any script or workflow. |
| Inline projects inherit root config, `sharedViteServer` default | No `projects` configured. |
| Config file lookup removed | Each config sits in its own package root and is found normally. |
| Vitest UI now requires a token | Only affects interactive use of `test:unit:watch`. |

## Reporter and coverage paths

Reporters and artifacts moved under a single `.vitest/` directory, and `coverage.include`/`exclude`
now match relative paths instead of using "contains" logic.

Neither reaches this repo:

- No config sets `outputFile`, and no workflow passes a reporter flag. CI runs plain
  `pnpm run --filter rotki test:unit`.
- `coverage.reportsDirectory` is pinned to `tests/unit/coverage`, so the lcov path the
  scripts read is unchanged, and no `.gitignore` entry has to move.
- Every `coverage.exclude` entry is either an exact relative path (`src/App.vue`, `src/i18n.ts`,
  `src/main.ts`, `src/modules/shell/app/store-debug-plugin.ts`) or a glob
  (`src/pages/playground/**`), all of which still match. The two "contains" style entries
  (`node_modules`, `tests/`) were already redundant under `include: ['src/**']`.

Measured: the report holds the same 2108 files and 75.01% line coverage
(37262/49679) as develop, and none of the excluded files appear in it.

## Peer requirements

Vitest 5 needs Vite >= 6.4.0 and Node >= 22.12.0. The catalog is on vite 8.2.2 and
`package.json` pins node `>=24 <25`, so both are already satisfied.

## Gates

`test:unit` (with and without coverage), `test:proxy`, `typecheck`, `lint`, `knip`, `build` — all
green.

Not run: `test:e2e` (Playwright, no vitest involvement) and `test:contract` (needs a live backend;
its config shares no changed surface).

## A note on `minimumReleaseAgeExclude`

The first `pnpm install` for this bump appended seven `@vitest/*` entries to
`minimumReleaseAgeExclude` in `pnpm-workspace.yaml`, because 5.0.0 was still inside the 7-day
window. Those entries were removed and the install re-verified after the window closed, so the
policy stays intact.
