### PR TITLE
Explain a net worth graph that failed to load

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -5137,6 +5137,7 @@
   },
   "overall_balances": {
     "loading": "LOADING",
+    "net_value_error": "The net worth graph could not be loaded",
     "premium_hint": "Get the full experience by upgrading to rotki premium",
     "total_balance": "Total Balance"
   },

--- a/frontend/app/src/modules/dashboard/OverallBalances.spec.ts
+++ b/frontend/app/src/modules/dashboard/OverallBalances.spec.ts
@@ -4,8 +4,14 @@ import { mount, type VueWrapper } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import OverallBalances from '@/modules/dashboard/OverallBalances.vue';
+import { useStatisticsStore } from '@/modules/statistics/use-statistics-store';
 
 const state = vi.hoisted(() => ({ loading: false, netWorthLoading: false }));
+const { mockFetchNetValue } = vi.hoisted(() => ({ mockFetchNetValue: vi.fn() }));
+
+vi.mock('@/modules/statistics/use-statistics-data-fetching', () => ({
+  useStatisticsDataFetching: vi.fn(() => ({ fetchNetValue: mockFetchNetValue })),
+}));
 
 vi.mock('@/modules/balances/use-balance-loading', async () => {
   const { computed: createComputed } = await import('vue');
@@ -30,8 +36,9 @@ vi.mock('@/modules/statistics/use-statistics-store', async () => {
   return {
     useStatisticsStore: defineStore('statistics', () => {
       const totalNetWorth = createRef(bigNumberify('1500.5'));
+      const netValueError = createRef<string | undefined>(undefined);
       const getNetValue = vi.fn(() => emptyNetValue);
-      return { getNetValue, totalNetWorth };
+      return { getNetValue, netValueError, totalNetWorth };
     }),
   };
 });
@@ -105,5 +112,45 @@ describe('overallBalances', () => {
     expect(wrapper.find(skeletonSelector).exists()).toBe(false);
     expect(wrapper.find(netWorthSelector).text()).toBe('1500.5');
     expect(wrapper.find(deltaSkeletonSelector).exists()).toBe(false);
+  });
+
+  describe('when the net value read failed', () => {
+    const errorSelector = '[data-testid=net-value-error]';
+
+    function failWith(message: string): VueWrapper<InstanceType<typeof OverallBalances>> {
+      const created = createWrapper();
+      set(storeToRefs(useStatisticsStore()).netValueError, message);
+      return created;
+    }
+
+    it('should say why the graph is empty rather than leaving a blank chart', async () => {
+      wrapper = failWith('backend is down');
+      await nextTick();
+
+      expect(wrapper.find(errorSelector).text()).toContain('backend is down');
+    });
+
+    it('should stay quiet while the load is still running', async () => {
+      state.netWorthLoading = true;
+      wrapper = failWith('backend is down');
+      await nextTick();
+
+      expect(wrapper.find(errorSelector).exists()).toBe(false);
+    });
+
+    it('should show nothing when the read succeeded', () => {
+      wrapper = createWrapper();
+
+      expect(wrapper.find(errorSelector).exists()).toBe(false);
+    });
+
+    it('should offer a retry that re-reads the net value', async () => {
+      wrapper = failWith('backend is down');
+      await nextTick();
+
+      await wrapper.find('[data-testid=net-value-retry]').trigger('click');
+
+      expect(mockFetchNetValue).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/frontend/app/src/modules/dashboard/OverallBalances.vue
+++ b/frontend/app/src/modules/dashboard/OverallBalances.vue
@@ -15,6 +15,7 @@ import { useSetting } from '@/modules/settings/use-setting';
 import { useSettingsOperations } from '@/modules/settings/use-settings-operations';
 import PercentageDisplay from '@/modules/shell/components/display/PercentageDisplay.vue';
 import TimeframeSelector from '@/modules/statistics/TimeframeSelector.vue';
+import { useStatisticsDataFetching } from '@/modules/statistics/use-statistics-data-fetching';
 import { useStatisticsStore } from '@/modules/statistics/use-statistics-store';
 
 const { t } = useI18n({ useScope: 'global' });
@@ -24,7 +25,7 @@ const netWorthChart = useTemplateRef<InstanceType<typeof NetWorthChart>>('netWor
 const settingsRepo = useSettingsRepo();
 const statisticsStore = useStatisticsStore();
 const timeframe = useSetting('timeframe');
-const { totalNetWorth } = storeToRefs(statisticsStore);
+const { netValueError, totalNetWorth } = storeToRefs(statisticsStore);
 const visibleTimeframes = useSetting('visibleTimeframes');
 const { getNetValue } = statisticsStore;
 
@@ -43,6 +44,8 @@ const loadingNetWorth = useNetWorthLoading();
  * latch is what carries them through the first frames, before any balance activity is submitted.
  */
 const isBusy = computed<boolean>(() => get(loadingNetWorth) || get(isLoading));
+
+const { fetchNetValue } = useStatisticsDataFetching();
 
 const zoomRange = ref<NetValueZoomRange>();
 
@@ -195,6 +198,27 @@ onMounted(() => {
             thickness="2"
           />
           {{ t('overall_balances.loading') }}
+        </div>
+        <div
+          v-else-if="netValueError"
+          class="absolute top-0 h-full w-full flex flex-col gap-3 items-center justify-center px-4 text-center bg-white/[0.8] dark:bg-dark-elevated/[0.9] z-[6]"
+          data-testid="net-value-error"
+        >
+          <div class="text-rui-text-secondary text-caption">
+            {{ t('overall_balances.net_value_error') }}
+          </div>
+          <div class="text-rui-text-secondary text-caption break-all">
+            {{ netValueError }}
+          </div>
+          <RuiButton
+            size="sm"
+            color="primary"
+            variant="outlined"
+            data-testid="net-value-retry"
+            @click="fetchNetValue()"
+          >
+            {{ t('common.actions.retry') }}
+          </RuiButton>
         </div>
       </div>
     </div>

--- a/frontend/app/src/modules/statistics/use-statistics-data-fetching.spec.ts
+++ b/frontend/app/src/modules/statistics/use-statistics-data-fetching.spec.ts
@@ -1,5 +1,7 @@
 import { Priority } from '@rotki/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequestCancelledError } from '@/modules/core/api/request-queue/errors';
+import { useStatisticsStore } from '@/modules/statistics/use-statistics-store';
 import { useStatisticsDataFetching } from './use-statistics-data-fetching';
 import '@test/i18n';
 
@@ -49,6 +51,36 @@ describe('useStatisticsDataFetching', () => {
         expect.stringContaining('Network error'),
         { priority: Priority.NORMAL },
       );
+    });
+
+    it('should record the reason on the store, since the notification never pops', async () => {
+      mockQueryNetValueData.mockRejectedValue(new Error('Network error'));
+
+      const { fetchNetValue } = useStatisticsDataFetching();
+      await fetchNetValue();
+
+      expect(get(useStatisticsStore().netValueError)).toBe('Network error');
+    });
+
+    it('should clear a previous reason once a read succeeds', async () => {
+      mockQueryNetValueData.mockRejectedValue(new Error('Network error'));
+      const { fetchNetValue } = useStatisticsDataFetching();
+      await fetchNetValue();
+
+      mockQueryNetValueData.mockResolvedValue({ data: [1], times: [100] });
+      await fetchNetValue();
+
+      expect(get(useStatisticsStore().netValueError)).toBeUndefined();
+    });
+
+    it('should leave the reason alone when the request was cancelled', async () => {
+      mockQueryNetValueData.mockRejectedValue(new RequestCancelledError('cancelled'));
+
+      const { fetchNetValue } = useStatisticsDataFetching();
+      await fetchNetValue();
+
+      expect(get(useStatisticsStore().netValueError)).toBeUndefined();
+      expect(mockNotifyError).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/app/src/modules/statistics/use-statistics-data-fetching.ts
+++ b/frontend/app/src/modules/statistics/use-statistics-data-fetching.ts
@@ -10,7 +10,9 @@ interface UseStatisticsDataFetchingReturn {
 }
 
 export function useStatisticsDataFetching(): UseStatisticsDataFetchingReturn {
-  const { netValue } = storeToRefs(useStatisticsStore());
+  const statisticsStore = useStatisticsStore();
+  const { netValue } = storeToRefs(statisticsStore);
+  const { setNetValueError } = statisticsStore;
   const api = useStatisticsApi();
   const { notifyError } = useNotifications();
   const nftsInNetValue = useSetting('nftsInNetValue');
@@ -19,13 +21,17 @@ export function useStatisticsDataFetching(): UseStatisticsDataFetchingReturn {
   async function fetchNetValue(): Promise<void> {
     try {
       set(netValue, await api.queryNetValueData(get(nftsInNetValue)));
+      setNetValueError(undefined);
     }
     catch (error: unknown) {
+      // A cancelled request is the queue dropping work, not a failure the chart should report.
       if (isRequestCancellation(error))
         return;
 
+      const message = getErrorMessage(error);
+      setNetValueError(message);
       notifyError(t('actions.statistics.net_value.error.title'), t('actions.statistics.net_value.error.message', {
-        message: getErrorMessage(error),
+        message,
       }), { priority: Priority.NORMAL });
     }
   }

--- a/frontend/app/src/modules/statistics/use-statistics-store.ts
+++ b/frontend/app/src/modules/statistics/use-statistics-store.ts
@@ -29,6 +29,15 @@ interface Overall {
 
 export const useStatisticsStore = defineStore('statistics', () => {
   const netValue = ref<NetValue>(defaultNetValue());
+  /**
+   * Why the last net value read failed, or undefined when it succeeded.
+   *
+   * @remarks
+   * It lives here rather than in the composable that does the reading because the two are not the
+   * same instance: `useStatisticsDataFetching` is called from six places, and the dashboard that
+   * has to render the failure is none of them.
+   */
+  const netValueError = ref<string>();
 
   const nftsInNetValue = useSetting('nftsInNetValue');
   const timeframe = useSetting('timeframe');
@@ -171,9 +180,16 @@ export const useStatisticsStore = defineStore('statistics', () => {
     return computed<NetValueChartData>(() => getNetValue(startingDate));
   }
 
+  /** Records why a net value read failed, or clears it with no argument once one succeeds. */
+  function setNetValueError(message?: string): void {
+    set(netValueError, message);
+  }
+
   return {
     getNetValue,
     netValue,
+    netValueError,
+    setNetValueError,
     useNetValue,
     overall,
     totalNetWorth,


### PR DESCRIPTION
The second of the three surfaces in #12942's phase 4 groundwork (§6.0), after #13103 did the RPC node table.

A failed net value read left the dashboard's net worth graph blank and said nothing. Phase 0 had already recorded this one as a long-standing silent failure (`display: false` at the time), and #13101 classified it `NORMAL`, so the notification never interrupts to explain the blank chart.

### Where the state lives, and why

Unlike the RPC table, the reader and the renderer here are **not the same composable instance**. `useStatisticsDataFetching` is called from six places — session load, balance fetching, the watchers, the NFT setting, the premium API bridge — and the dashboard is none of them. A ref inside the composable would be invisible to the surface that has to show it.

So the reason goes on the statistics store, with a synchronous `setNetValueError` the async composable calls. That is the split the frontend guidelines already prescribe (`use-data-issues-inbox-store` + `use-data-issues-summary`): stores hold state and synchronous setters, the fetching composable writes into them.

### Behaviour

- The graph overlays the reason and a **Retry**, reusing the absolute overlay the busy state already uses in that component rather than inventing a second shape.
- It defers to the busy state, so a refresh never shows an error on top of a load that is still running.
- A cancelled request records nothing. That is the request queue dropping work the user navigated away from, not a failure.
- The `NORMAL` notification is unchanged and stays as the drawer's audit trail.

### Tests

Three on the fetching composable (the reason is recorded, cleared on the next success, and left alone on cancellation) and four on the dashboard (the reason is shown, it stays quiet while loading, it shows nothing on success, and retry re-reads).

Negative controls, run separately because one assertion is an absence:
- Disabling the error branch fails exactly the two presence tests.
- Breaking the busy precedence (`v-else-if` → `v-if`) fails exactly the "stay quiet while loading" test, which is the one that could otherwise have passed for the wrong reason.

Gates: full unit suite (12201), typecheck, eslint, stylelint, knip, linked-keys.

### Remaining

`ASSET_SEARCH_ERROR` onto the search field is the last of §6.0's three. The condition-shaped work (`NEW_DETECTED_TOKENS`, `MISSING_EXCHANGE_MAPPING`) is not here — that belongs to #13105, and both are occurrences rather than conditions, so these two surfaces do not overlap with it.
