### PR TITLE
Explain a table whose fetch failed

### DIFF
--- a/frontend/app/src/locales/en.json
+++ b/frontend/app/src/locales/en.json
@@ -2832,6 +2832,7 @@
     "title": "Manage Data"
   },
   "data_table": {
+    "fetch_failed": "Could not load the data",
     "no_data": "No data available",
     "rows_per_page": "Rows per page"
   },

--- a/frontend/app/src/modules/accounts/EthStakingValidators.vue
+++ b/frontend/app/src/modules/accounts/EthStakingValidators.vue
@@ -9,6 +9,7 @@ import { SavedFilterLocations } from '@/modules/core/table/filtering';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import PillViewsMenu from '@/modules/core/table/pill/PillViewsMenu.vue';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import PercentageDisplay from '@/modules/shell/components/display/PercentageDisplay.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
@@ -26,6 +27,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const {
   cols,
+  error,
   ethStakingValidators,
   fields,
   filters,
@@ -34,6 +36,8 @@ const {
   modelSelected,
   sort,
 } = useEthValidatorData();
+
+const emptyState = useTableEmptyState({ error, fallback: () => ({ label: t('data_table.no_data') }) });
 
 const pillLabels = usePillBarLabels();
 
@@ -148,13 +152,11 @@ defineExpose({
       sticky-header
       show-select
       return-object
-      :empty="{
-        label: t('data_table.no_data'),
-      }"
+      :empty="emptyState"
     >
       <template #empty-description>
         <p class="max-w-prose mx-auto">
-          {{ t('blockchain_balances.validators.auto_detection_info') }}
+          {{ emptyState.description ?? t('blockchain_balances.validators.auto_detection_info') }}
         </p>
       </template>
       <template #item.index="{ row }">

--- a/frontend/app/src/modules/accounts/address-book/AddressBookTable.vue
+++ b/frontend/app/src/modules/accounts/address-book/AddressBookTable.vue
@@ -4,6 +4,7 @@ import type { AddressBookEntry, AddressBookLocation } from '@/modules/accounts/a
 import type { Collection } from '@/modules/core/common/collection';
 import { useAddressBookDeletion } from '@/modules/accounts/address-book/use-address-book-deletion';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import AccountDisplay from '@/modules/shell/components/display/AccountDisplay.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
 
@@ -23,6 +24,8 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
+
+const emptyState = useTableEmptyState();
 
 const cols = computed<DataTableColumn<AddressBookEntry>[]>(() => [
   {
@@ -60,6 +63,7 @@ const { showDeleteConfirmation } = useAddressBookDeletion(location, refresh);
     v-model:sort.external="sortModel"
     :rows="collection.data"
     :cols="cols"
+    :empty="emptyState"
     :loading="loading"
     row-attr="address"
     outlined

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.spec.ts
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.spec.ts
@@ -67,15 +67,18 @@ vi.mock('@/modules/core/table/use-remember-table-sorting', async importOriginal 
 
 vi.mock('@/modules/core/table/use-server-table', async () => {
   const { computed, ref } = await import('vue');
+  const { useTableEmptyState } = await import('@/modules/core/table/use-table-empty-state');
   return {
     useServerTable: (): Record<string, unknown> => ({
       collection: computed(() => ({ data: rows.value, found: rows.value.length, limit: 10, total: rows.value.length })),
+      error: ref(undefined),
       filter: ref({}),
       isLoading: ref(false),
       pagination: ref({ limit: 10, page: 1, total: 0 }),
       refetch,
       sort: ref([]),
     }),
+    useTableEmptyState,
   };
 });
 

--- a/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.vue
+++ b/frontend/app/src/modules/accounts/manual-balances/ManualBalanceTable.vue
@@ -13,7 +13,7 @@ import { useManualBalancesOrLiabilities } from '@/modules/balances/manual/use-ma
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
-import { useServerTable } from '@/modules/core/table/use-server-table';
+import { useServerTable, useTableEmptyState } from '@/modules/core/table/use-server-table';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import { useSetting } from '@/modules/settings/use-setting';
 import RefreshButton from '@/modules/shell/components/RefreshButton.vue';
@@ -45,6 +45,7 @@ const pillLabels = usePillBarLabels();
 
 const {
   collection: state,
+  error,
   filter: filters,
   isLoading: loading,
   pagination,
@@ -69,6 +70,8 @@ const {
   },
   urlState: { mode: 'route' },
 });
+
+const emptyState = useTableEmptyState({ error });
 
 function edit(balance: ManualBalanceWithPrice): void {
   emit('edit', prepareForEdit(balance));
@@ -164,6 +167,7 @@ watchDebounced(
       dense
       :loading="loading"
       :cols="cols"
+      :empty="emptyState"
       row-attr="label"
       :rows="state.data"
       data-testid="manual-balances"

--- a/frontend/app/src/modules/accounts/table/AccountBalancesTable.vue
+++ b/frontend/app/src/modules/accounts/table/AccountBalancesTable.vue
@@ -7,6 +7,7 @@ import { getAccountAddress } from '@/modules/accounts/account-utils';
 import AccountChains from '@/modules/accounts/AccountChains.vue';
 import AccountTopTokens from '@/modules/accounts/AccountTopTokens.vue';
 import { FiatDisplay } from '@/modules/assets/amount-display/components';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import LabeledAddressDisplay from '@/modules/shell/components/display/LabeledAddressDisplay.vue';
 import RowAppend from '@/modules/shell/components/RowAppend.vue';
 import TagDisplay from '@/modules/tags/TagDisplay.vue';
@@ -46,6 +47,8 @@ defineSlots<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
+
+const emptyState = useTableEmptyState();
 
 const { createColumns, initializeTableSorting } = useAccountTableConfig<T>();
 const {
@@ -88,7 +91,7 @@ defineExpose({
     :rows="rows"
     :loading="group && isInitialLoading"
     row-attr="id"
-    :empty="{ description: t('data_table.no_data') }"
+    :empty="emptyState"
     :loading-text="t('account_balances.data_table.loading')"
     data-testid="account-table"
     single-expand

--- a/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingTable.vue
+++ b/frontend/app/src/modules/assets/admin/cex-mapping/ManageCexMappingTable.vue
@@ -7,6 +7,7 @@ import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import HintMenuIcon from '@/modules/shell/components/HintMenuIcon.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
@@ -30,6 +31,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 const pillLabels = usePillBarLabels();
+const emptyState = useTableEmptyState();
 const cols = computed<DataTableColumn<CexMapping>[]>(() => [{
   align: 'center',
   cellClass: 'py-3',
@@ -71,6 +73,7 @@ const cols = computed<DataTableColumn<CexMapping>[]>(() => [{
       striped
       :loading="loading"
       :cols="cols"
+      :empty="emptyState"
       :sticky-offset="64"
       row-attr="location"
       outlined

--- a/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingTable.vue
+++ b/frontend/app/src/modules/assets/admin/counterparty-mapping/ManageCounterpartyMappingTable.vue
@@ -7,6 +7,7 @@ import type { FieldDef } from '@/modules/core/table/pill/core/types';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import CounterpartyDisplay from '@/modules/shell/components/display/CounterpartyDisplay.vue';
 import HintMenuIcon from '@/modules/shell/components/HintMenuIcon.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
@@ -30,6 +31,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 const pillLabels = usePillBarLabels();
+const emptyState = useTableEmptyState();
 const cols = computed<DataTableColumn<CounterpartyMapping>[]>(() => [{
   align: 'center',
   cellClass: 'py-3',
@@ -71,6 +73,7 @@ const cols = computed<DataTableColumn<CounterpartyMapping>[]>(() => [{
       striped
       :loading="loading"
       :cols="cols"
+      :empty="emptyState"
       :sticky-offset="64"
       row-attr="counterparty"
       outlined

--- a/frontend/app/src/modules/assets/admin/custom/CustomAssetTable.vue
+++ b/frontend/app/src/modules/assets/admin/custom/CustomAssetTable.vue
@@ -8,6 +8,7 @@ import AssetDetailsBase from '@/modules/assets/AssetDetailsBase.vue';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import CopyButton from '@/modules/shell/components/CopyButton.vue';
 import HintMenuIcon from '@/modules/shell/components/HintMenuIcon.vue';
@@ -33,6 +34,8 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
+
+const emptyState = useTableEmptyState();
 
 const pillLabels = usePillBarLabels();
 
@@ -63,6 +66,7 @@ const deleteAsset = (asset: CustomAsset): void => emit('delete-asset', asset);
       v-model:pagination.external="paginationModel"
       v-model:sort.external="sortModel"
       :rows="assets"
+      :empty="emptyState"
       :loading="loading"
       :cols="cols"
       :expanded="expanded"

--- a/frontend/app/src/modules/assets/admin/managed/ManagedAssetTable.vue
+++ b/frontend/app/src/modules/assets/admin/managed/ManagedAssetTable.vue
@@ -62,7 +62,7 @@ const {
   toggleWhitelistAsset,
 } = useManagedAssetOperations(() => emit('refresh'), () => ignoredHandling, selected);
 
-const { cols, data, expand, getAssetLocation, isExpanded, spamDisabled } = useManagedAssetTable(
+const { cols, data, emptyState, expand, getAssetLocation, isExpanded, spamDisabled } = useManagedAssetTable(
   paginationModel,
   expanded,
   () => collection,
@@ -100,6 +100,7 @@ const { fetchIgnoredAssets } = useIgnoredAssetOperations();
       dense
       :value="selected"
       :rows="data"
+      :empty="emptyState"
       :loading="loading"
       :cols="cols"
       :expanded="expanded"

--- a/frontend/app/src/modules/assets/admin/missing-mappings/AssetMissingMappings.vue
+++ b/frontend/app/src/modules/assets/admin/missing-mappings/AssetMissingMappings.vue
@@ -4,6 +4,7 @@ import { useAssetMissingMappings } from '@/modules/assets/admin/missing-mappings
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
 
@@ -11,6 +12,7 @@ const pillLabels = usePillBarLabels();
 
 const {
   cols,
+  error,
   fields,
   mappings,
   modelFilter,
@@ -21,6 +23,8 @@ const {
   refetch,
   sort,
 } = useAssetMissingMappings();
+
+const emptyState = useTableEmptyState({ error });
 
 useRememberTableSorting(TableId.ASSET_MISSING_MAPPINGS, sort, cols);
 
@@ -52,6 +56,7 @@ onMounted(async () => {
         dense
         stripped
         :cols="cols"
+        :empty="emptyState"
         row-attr="id"
         :rows="mappings.data"
       >

--- a/frontend/app/src/modules/assets/admin/missing-mappings/use-asset-missing-mappings.ts
+++ b/frontend/app/src/modules/assets/admin/missing-mappings/use-asset-missing-mappings.ts
@@ -14,6 +14,8 @@ import { useServerTable } from '@/modules/core/table/use-server-table';
 interface UseAssetMissingMappingsReturn {
   /** The table's columns. */
   cols: ComputedRef<DataTableColumn<MissingMapping>[]>;
+  /** The last fetch failure, so the table can name it in place of its empty text. */
+  error: Ref<unknown>;
   /** The declared filter fields the pill bar reads. */
   fields: ReturnType<typeof useMissingMappingsFields>;
   /** The active filters; bound with `v-model:filters`. */
@@ -84,6 +86,7 @@ export function useAssetMissingMappings(): UseAssetMissingMappingsReturn {
 
   const {
     collection: mappings,
+    error,
     filter,
     pagination,
     refetch,
@@ -117,6 +120,7 @@ export function useAssetMissingMappings(): UseAssetMissingMappingsReturn {
 
   return {
     cols,
+    error,
     fields,
     mappings,
     modelFilter: filter,

--- a/frontend/app/src/modules/assets/admin/use-managed-asset-table.ts
+++ b/frontend/app/src/modules/assets/admin/use-managed-asset-table.ts
@@ -4,11 +4,14 @@ import type { ComputedRef, MaybeRefOrGetter, Ref } from 'vue';
 import type { Collection } from '@/modules/core/common/collection';
 import { some } from 'es-toolkit/compat';
 import { EVM_TOKEN, isSpammableAssetType, SOLANA_CHAIN, SOLANA_TOKEN } from '@/modules/assets/types';
+import { type TableEmptyState, useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import { useSetting } from '@/modules/settings/use-setting';
 
 interface UseManagedAssetTableReturn {
   cols: ComputedRef<DataTableColumn<SupportedAsset>[]>;
   data: ComputedRef<SupportedAsset[]>;
+  /** The table's empty text, which names the reason when the last fetch failed. */
+  emptyState: ComputedRef<TableEmptyState>;
   expand: (item: SupportedAsset) => void;
   /**
    * The chain whose explorer can show this asset, when one can.
@@ -38,6 +41,7 @@ export function useManagedAssetTable(
 ): UseManagedAssetTableReturn {
   const { t } = useI18n({ useScope: 'global' });
   const itemsPerPage = useSetting('itemsPerPage');
+  const emptyState = useTableEmptyState();
 
   const cols = computed<DataTableColumn<SupportedAsset>[]>(() => [{
     cellClass: 'py-0',
@@ -119,6 +123,7 @@ export function useManagedAssetTable(
   return {
     cols,
     data,
+    emptyState,
     expand,
     getAssetLocation,
     isExpanded,

--- a/frontend/app/src/modules/assets/detection/NewlyDetectedAssetTable.vue
+++ b/frontend/app/src/modules/assets/detection/NewlyDetectedAssetTable.vue
@@ -10,6 +10,7 @@ import { usePriceUtils } from '@/modules/assets/prices/use-price-utils';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import { useServerTable } from '@/modules/core/table/use-server-table';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import HashLink from '@/modules/shell/components/HashLink.vue';
 import TablePageLayout from '@/modules/shell/layout/TablePageLayout.vue';
@@ -48,6 +49,7 @@ const fields = useNewlyDetectedFields();
 
 const {
   collection,
+  error,
   filter,
   isLoading,
   pagination,
@@ -63,6 +65,8 @@ const {
     },
   },
 });
+
+const emptyState = useTableEmptyState({ error });
 
 const cols = computed<DataTableColumn<Token>[]>(() => [
   {
@@ -167,6 +171,7 @@ onMounted(async () => {
         v-model:sort.external="sort"
         v-model:pagination.external="pagination"
         :cols="cols"
+        :empty="emptyState"
         :rows="rows"
         :loading="isLoading"
         outlined

--- a/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceContent.vue
+++ b/frontend/app/src/modules/assets/prices/components/oracle/OraclePriceContent.vue
@@ -12,6 +12,7 @@ import { useConfirmStore } from '@/modules/core/common/use-confirm-store';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import { useServerTable } from '@/modules/core/table/use-server-table';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import { PriceOracle } from '@/modules/settings/types/price-oracle';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
@@ -25,6 +26,7 @@ const pillLabels = usePillBarLabels();
 
 const {
   collection,
+  error,
   filter,
   isLoading: loading,
   pagination,
@@ -43,6 +45,8 @@ const {
     },
   },
 });
+
+const emptyState = useTableEmptyState({ error });
 
 const headers = computed<DataTableColumn<OraclePriceEntry>[]>(() => [
   {
@@ -161,6 +165,7 @@ onMounted(async () => {
         outlined
         dense
         :cols="headers"
+        :empty="emptyState"
         :loading="loading"
         :rows="collection.data"
         row-attr="fromAsset"

--- a/frontend/app/src/modules/balances/exchanges/BinanceSavingDetail.vue
+++ b/frontend/app/src/modules/balances/exchanges/BinanceSavingDetail.vue
@@ -7,6 +7,7 @@ import AssetDetails from '@/modules/assets/AssetDetails.vue';
 import { useBinanceSavings } from '@/modules/balances/exchanges/use-binance-savings';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import { useServerTable } from '@/modules/core/table/use-server-table';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import { useSetting } from '@/modules/settings/use-setting';
 import DateDisplay from '@/modules/shell/components/display/DateDisplay.vue';
 import RowAppend from '@/modules/shell/components/RowAppend.vue';
@@ -33,6 +34,7 @@ const defaultParams = computed<Record<string, unknown>>(() => ({
 
 const {
   collection,
+  error,
   isLoading,
   pagination,
   refetch: fetchData,
@@ -55,6 +57,8 @@ const {
   },
   urlState: { mode: 'route' },
 });
+
+const emptyState = useTableEmptyState({ error });
 
 const receivedTableSort = ref<DataTableSortData<AssetBalance>>({
   column: 'value',
@@ -167,6 +171,7 @@ watchImmediate(currencySymbol, async () => {
         outlined
         dense
         :cols="tableHeaders"
+        :empty="emptyState"
         :rows="collection.data"
         row-attr="asset"
         :loading="isLoading"

--- a/frontend/app/src/modules/balances/non-fungible/components/NonFungibleBalances.vue
+++ b/frontend/app/src/modules/balances/non-fungible/components/NonFungibleBalances.vue
@@ -5,6 +5,7 @@ import { AssetAmountDisplay, FiatDisplay } from '@/modules/assets/amount-display
 import LatestPriceFormDialog from '@/modules/assets/prices/latest/LatestPriceFormDialog.vue';
 import { useAssetsStore } from '@/modules/assets/use-assets-store';
 import NftDetails from '@/modules/balances/nft/NftDetails.vue';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import SuccessDisplay from '@/modules/shell/components/display/SuccessDisplay.vue';
 import RowActions from '@/modules/shell/components/RowActions.vue';
 import RowAppend from '@/modules/shell/components/RowAppend.vue';
@@ -24,6 +25,7 @@ const {
   currencySymbol,
   data,
   dataLoading,
+  error,
   fetchData,
   modelIgnoredAssetsHandling,
   pagination,
@@ -32,6 +34,8 @@ const {
   sort,
   totalValue,
 } = useNftData();
+
+const emptyState = useTableEmptyState({ error });
 
 const {
   customPrice,
@@ -84,6 +88,7 @@ watch(sectionLoading, async (isLoading, wasLoading) => {
         outlined
         dense
         :cols="cols"
+        :empty="emptyState"
         :rows="data"
         :loading="dataLoading"
       >

--- a/frontend/app/src/modules/balances/non-fungible/use-nft-data.ts
+++ b/frontend/app/src/modules/balances/non-fungible/use-nft-data.ts
@@ -31,6 +31,8 @@ interface UseNftDataReturn {
   currencySymbol: Readonly<Ref<string>>;
   data: ComputedRef<NonFungibleBalance[]>;
   dataLoading: Ref<boolean>;
+  /** The last fetch failure, so the table can name it in place of its empty text. */
+  error: Ref<unknown>;
   fetchData: () => Promise<void>;
   /** Entries matching the current filter, across all pages. Zero means there is nothing to show. */
   found: ComputedRef<number>;
@@ -58,6 +60,7 @@ export function useNftData(options: UseNftDataOptions = {}): UseNftDataReturn {
 
   const {
     collection: balances,
+    error,
     isLoading: dataLoading,
     pagination,
     refetch: fetchData,
@@ -197,6 +200,7 @@ export function useNftData(options: UseNftDataOptions = {}): UseNftDataReturn {
     currencySymbol,
     data,
     dataLoading,
+    error,
     fetchData,
     found,
     modelIgnoredAssetsHandling,

--- a/frontend/app/src/modules/core/table/use-server-table.ts
+++ b/frontend/app/src/modules/core/table/use-server-table.ts
@@ -11,6 +11,7 @@ import { collectSources, mergeParams, type ParamSource, transformFilters } from 
 import { behaviourKeysFromFields, routeSchemaFromFields } from '@/modules/core/table/route';
 import { type ChangeSource, useChangeIntent } from '@/modules/core/table/use-change-intent';
 import { useTableData } from '@/modules/core/table/use-table-data';
+import { provideTableFetchError, useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import { useTablePagination } from '@/modules/core/table/use-table-pagination';
 import { type PersistFilterSetting, useTablePersistence } from '@/modules/core/table/use-table-persistence';
 import { reduce, type TableEvent, type TableState } from '@/modules/core/table/use-table-reducer';
@@ -20,7 +21,7 @@ import { useItemsPerPage } from '@/modules/session/use-items-per-page';
 
 export type { ChangeSource };
 
-export { routeWhen };
+export { routeWhen, useTableEmptyState };
 
 interface TableSortOptions<TItem extends NonNullable<unknown>> {
   /** The sorting a table starts at, and returns to when the URL carries none. */
@@ -149,6 +150,8 @@ export function useServerTable<
     (): ComputedRef<TPayload> => requestPayload,
     cancelTag,
   );
+
+  provideTableFetchError(error);
 
   const { internalPagination, pagination, setPage } = useTablePagination<TItem>(
     itemsPerPage,

--- a/frontend/app/src/modules/core/table/use-table-empty-state.spec.ts
+++ b/frontend/app/src/modules/core/table/use-table-empty-state.spec.ts
@@ -1,0 +1,70 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { type Component, defineComponent, h } from 'vue';
+import { provideTableFetchError, useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
+import '@test/i18n';
+
+/** Renders the resolved empty state as text, so a mounted tree can be asserted on. */
+function leaf(options: Parameters<typeof useTableEmptyState>[0] = {}): Component {
+  return defineComponent({
+    setup() {
+      const emptyState = useTableEmptyState(options);
+      return (): ReturnType<typeof h> => h('div', `${get(emptyState).label ?? ''}|${get(emptyState).description ?? ''}`);
+    },
+  });
+}
+
+function parentProviding(error: Ref<unknown>, child: Component): Component {
+  return defineComponent({
+    setup() {
+      provideTableFetchError(error);
+      return (): ReturnType<typeof h> => h(child);
+    },
+  });
+}
+
+describe('useTableEmptyState', () => {
+  it('should fall back to the generic no-data text when nothing failed', () => {
+    const wrapper = mount(leaf());
+
+    expect(wrapper.text()).toBe('|data_table.no_data');
+  });
+
+  it('should prefer the caller\'s own empty text over the generic one', () => {
+    const wrapper = mount(leaf({ fallback: { description: 'nothing here yet' } }));
+
+    expect(wrapper.text()).toBe('|nothing here yet');
+  });
+
+  it('should name the failure instead of the empty text once a fetch fails', () => {
+    const wrapper = mount(leaf({ error: ref<unknown>(new Error('backend is down')) }));
+
+    expect(wrapper.text()).toBe('data_table.fetch_failed|backend is down');
+  });
+
+  it('should go back to the empty text once a later fetch succeeds', async () => {
+    const error = ref<unknown>(new Error('backend is down'));
+    const wrapper = mount(leaf({ error }));
+
+    set(error, undefined);
+    await nextTick();
+
+    expect(wrapper.text()).toBe('|data_table.no_data');
+  });
+
+  it('should read the failure a server table provided further up the tree', () => {
+    const error = ref<unknown>(new Error('provided failure'));
+    const wrapper = mount(parentProviding(error, leaf()));
+
+    expect(wrapper.text()).toBe('data_table.fetch_failed|provided failure');
+  });
+
+  it('should prefer an explicitly passed failure over the provided one', () => {
+    const wrapper = mount(parentProviding(
+      ref<unknown>(new Error('provided failure')),
+      leaf({ error: ref<unknown>(new Error('own failure')) }),
+    ));
+
+    expect(wrapper.text()).toBe('data_table.fetch_failed|own failure');
+  });
+});

--- a/frontend/app/src/modules/core/table/use-table-empty-state.ts
+++ b/frontend/app/src/modules/core/table/use-table-empty-state.ts
@@ -1,0 +1,63 @@
+import type { ComputedRef, InjectionKey, MaybeRef, MaybeRefOrGetter, Ref } from 'vue';
+import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
+
+const TableFetchErrorKey: InjectionKey<Ref<unknown>> = Symbol('table-fetch-error');
+
+/** The text `RuiDataTable` renders in place of rows when a table has none. */
+export interface TableEmptyState {
+  label?: string;
+  description?: string;
+}
+
+interface TableEmptyStateOptions {
+  /**
+   * The failure to report, when the table cannot inject one.
+   *
+   * @remarks
+   * Needed where the fetch is owned by a `createSharedComposable`: the provide there would bind to
+   * whichever component instantiated the singleton first, which is not the one rendering the rows.
+   */
+  error?: MaybeRef<unknown>;
+  /** The empty text to use while there is no failure. Defaults to the generic "no data". */
+  fallback?: MaybeRefOrGetter<TableEmptyState>;
+}
+
+/**
+ * Shares a server table's last fetch failure with the component that renders its rows.
+ *
+ * @remarks
+ * The fetch is owned by the view but the failure is only ever read at the leaf, often two or three
+ * components down, so it is provided rather than threaded through every wrapper in between. A table
+ * that does not want it simply never injects.
+ */
+export function provideTableFetchError(error: Ref<unknown>): void {
+  if (getCurrentInstance())
+    provide(TableFetchErrorKey, error);
+}
+
+/**
+ * A table's empty text, replaced by the reason its last fetch failed.
+ *
+ * @remarks
+ * A failed read leaves the collection empty, so a table that could not reach the backend renders
+ * exactly like one the user genuinely has no rows for. Since rotki#12942 the read's notification is
+ * `NORMAL` and no longer pops, which leaves the table itself as the only place the reason appears.
+ */
+export function useTableEmptyState(options: TableEmptyStateOptions = {}): ComputedRef<TableEmptyState> {
+  const { error, fallback } = options;
+  const provided = inject(TableFetchErrorKey, undefined);
+  const { t } = useI18n({ useScope: 'global' });
+
+  return computed<TableEmptyState>(() => {
+    const source = error ?? provided;
+    const failure = source ? get(source) : undefined;
+
+    if (!failure)
+      return toValue(fallback) ?? { description: t('data_table.no_data') };
+
+    return {
+      description: getErrorMessage(failure),
+      label: t('data_table.fetch_failed'),
+    };
+  });
+}

--- a/frontend/app/src/modules/dashboard/NftBalanceTable.vue
+++ b/frontend/app/src/modules/dashboard/NftBalanceTable.vue
@@ -3,6 +3,7 @@ import type { RouteLocationRaw } from 'vue-router';
 import { AssetAmountDisplay, FiatDisplay } from '@/modules/assets/amount-display/components';
 import NftDetails from '@/modules/balances/nft/NftDetails.vue';
 import { useNftData } from '@/modules/balances/non-fungible/use-nft-data';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import DashboardExpandableTable from '@/modules/dashboard/DashboardExpandableTable.vue';
 import VisibleColumnsSelector from '@/modules/dashboard/VisibleColumnsSelector.vue';
 import { DashboardTableType } from '@/modules/settings/types/frontend-settings';
@@ -26,6 +27,7 @@ const {
   currencySymbol,
   data,
   dataLoading,
+  error,
   fetchData,
   found,
   percentageOfCurrentGroup,
@@ -36,6 +38,8 @@ const {
   pagination,
   totalValue,
 } = useNftData({ dashboard: true });
+
+const emptyState = useTableEmptyState({ error });
 
 onMounted(async () => {
   await fetchData();
@@ -93,7 +97,7 @@ watch(sectionLoading, async (isLoading, wasLoading) => {
       :cols="cols"
       :rows="data"
       :loading="dataLoading"
-      :empty="{ description: t('data_table.no_data') }"
+      :empty="emptyState"
       row-attr="id"
       sticky-header
       outlined

--- a/frontend/app/src/modules/history/data-issues/components/DataIssuesTable.vue
+++ b/frontend/app/src/modules/history/data-issues/components/DataIssuesTable.vue
@@ -3,6 +3,7 @@ import type { DataTableColumn, TablePaginationData } from '@rotki/ui-library';
 import type { RouteLocationRaw } from 'vue-router';
 import type { DataIssue } from '@/modules/history/data-issues/schemas';
 import AssetDetails from '@/modules/assets/AssetDetails.vue';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import DataIssueCardActions from '@/modules/history/data-issues/components/DataIssueCardActions.vue';
 import DataIssueKindChip from '@/modules/history/data-issues/components/DataIssueKindChip.vue';
 import DataIssueStateChip from '@/modules/history/data-issues/components/DataIssueStateChip.vue';
@@ -32,6 +33,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n({ useScope: 'global' });
 
+const emptyState = useTableEmptyState({ fallback: () => ({ description: emptyDescription }) });
+
 /** Deep-link to the offending history event for a row's quick "go to event" action. */
 function eventRouteFor(issue: DataIssue): RouteLocationRaw | undefined {
   return relatedEventRoute(issue.kind, describeIssue(issue).eventIdentifier, issue.groupIdentifier, issue.asset);
@@ -57,7 +60,7 @@ const headers = computed<DataTableColumn<DataIssue>[]>(() => [
     :loading="loading"
     :rows="rows"
     row-attr="id"
-    :empty="{ description: emptyDescription }"
+    :empty="emptyState"
     data-testid="data-issues-table"
     @click:row="emit('open', $event)"
   >
@@ -142,7 +145,7 @@ const headers = computed<DataTableColumn<DataIssue>[]>(() => [
       #empty-description
     >
       <div class="flex flex-col items-center gap-2 py-2">
-        <span>{{ emptyDescription }}</span>
+        <span>{{ emptyState.description }}</span>
         <RuiButton
           size="sm"
           variant="text"

--- a/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/InternalTxConflictsContent.vue
@@ -4,6 +4,7 @@ import { startPromise } from '@shared/utils';
 import { usePillBarLabels } from '@/modules/core/table/pill/composables/use-pill-bar-labels';
 import PillFilterBar from '@/modules/core/table/pill/PillFilterBar.vue';
 import ScrollableDialogContent from '@/modules/core/table/ScrollableDialogContent.vue';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import InternalTxConflictRowActions from '@/modules/history/internal-tx-conflicts/InternalTxConflictRowActions.vue';
 import { useInternalTxConflictFields } from '@/modules/history/internal-tx-conflicts/use-internal-tx-conflict-fields';
 import CopyButton from '@/modules/shell/components/CopyButton.vue';
@@ -37,6 +38,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const {
   conflicts,
+  error,
   failedCount,
   fetchConflicts,
   fetchCounts,
@@ -47,6 +49,8 @@ const {
   setFilter,
   sort,
 } = useInternalTxConflicts();
+
+const emptyState = useTableEmptyState({ error });
 
 const fields = useInternalTxConflictFields();
 const pillLabels = usePillBarLabels();
@@ -258,6 +262,7 @@ defineExpose({
         v-model:sort.external="sort"
         v-model:pagination.external="pagination"
         :cols="headers"
+        :empty="emptyState"
         :rows="conflicts"
         :loading="loading"
         row-attr="txHash"

--- a/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
+++ b/frontend/app/src/modules/history/internal-tx-conflicts/use-internal-tx-conflicts.ts
@@ -26,6 +26,8 @@ function getStatusFilter(status: InternalTxConflictStatus): { failed?: boolean; 
 interface UseInternalTxConflictsReturn {
   activeFilter: Ref<InternalTxConflictStatus>;
   conflicts: ComputedRef<InternalTxConflict[]>;
+  /** The last fetch failure, so the table can name it in place of its empty text. */
+  error: Ref<unknown>;
   failedCount: Ref<number>;
   fetchConflicts: () => Promise<void>;
   fetchCounts: () => Promise<void>;
@@ -57,6 +59,7 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
 
   const {
     collection: state,
+    error,
     filter: filters,
     isLoading: loading,
     pagination,
@@ -126,6 +129,7 @@ export const useInternalTxConflicts = createSharedComposable((): UseInternalTxCo
   return {
     activeFilter,
     conflicts,
+    error,
     failedCount,
     fetchConflicts,
     fetchCounts,

--- a/frontend/app/src/modules/reports/ProfitLossEvents.vue
+++ b/frontend/app/src/modules/reports/ProfitLossEvents.vue
@@ -9,6 +9,7 @@ import { getCollectionData, setupEntryLimit } from '@/modules/core/common/data/c
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { TableId, useRememberTableSorting } from '@/modules/core/table/use-remember-table-sorting';
 import { useServerTable } from '@/modules/core/table/use-server-table';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import HistoryEventNote from '@/modules/history/events/HistoryEventNote.vue';
 import LocationDisplay from '@/modules/history/LocationDisplay.vue';
 import UpgradeRow from '@/modules/history/UpgradeRow.vue';
@@ -47,6 +48,7 @@ const { fetchReportEvents } = useReportOperations();
 
 const {
   collection: state,
+  error,
   isLoading,
   pagination,
   refetch: fetchData,
@@ -70,6 +72,8 @@ const {
   },
   urlState: { mode: 'route' },
 });
+
+const emptyState = useTableEmptyState({ error });
 
 const { getChain } = useSupportedChains();
 
@@ -198,6 +202,7 @@ onMounted(async () => {
       v-model:sort.external="sort"
       v-model:pagination.external="pagination"
       :cols="tableHeaders"
+      :empty="emptyState"
       :rows="items"
       :loading="isLoading || refreshing"
       row-attr="id"

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.spec.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.spec.ts
@@ -31,6 +31,7 @@ vi.mock('@/modules/settings/accounting/rule/use-accounting-rule-conflict-resolut
     onResolved.call = options.onResolved;
     return {
       collection,
+      error: ref(undefined),
       isLoading: ref(false),
       loading: ref(false),
       modelResolution,

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleConflictsDialog.vue
@@ -5,6 +5,7 @@ import type {
   AccountingTreatment,
 } from '@/modules/settings/types/accounting';
 import { getCollectionData } from '@/modules/core/common/data/collection-utils';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import HistoryEventTypeCombination from '@/modules/history/events/HistoryEventTypeCombination.vue';
 import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
@@ -25,6 +26,7 @@ const { t } = useI18n({ useScope: 'global' });
 
 const {
   collection,
+  error,
   isLoading,
   loading,
   modelResolution,
@@ -41,6 +43,8 @@ const {
     close();
   },
 });
+
+const emptyState = useTableEmptyState({ error });
 
 onMounted(async () => {
   await refetch();
@@ -198,6 +202,7 @@ const { total } = getCollectionData<AccountingRuleConflict>(collection);
         v-model:pagination.external="pagination"
         class="pb-4"
         :cols="tableHeaders"
+        :empty="emptyState"
         :loading="isLoading"
         :rows="collection.data"
         disable-floating-header

--- a/frontend/app/src/modules/settings/accounting/rule/AccountingRuleTable.vue
+++ b/frontend/app/src/modules/settings/accounting/rule/AccountingRuleTable.vue
@@ -2,6 +2,7 @@
 import type { DataTableColumn, TablePaginationData } from '@rotki/ui-library';
 import type { Collection } from '@/modules/core/common/collection';
 import type { AccountingRuleEntry } from '@/modules/settings/types/accounting';
+import { useTableEmptyState } from '@/modules/core/table/use-table-empty-state';
 import BadgeDisplay from '@/modules/history/BadgeDisplay.vue';
 import HistoryEventTypeCombination from '@/modules/history/events/HistoryEventTypeCombination.vue';
 import { useHistoryEventMappings } from '@/modules/history/events/mapping/use-history-event-mappings';
@@ -28,6 +29,8 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n({ useScope: 'global' });
+
+const emptyState = useTableEmptyState();
 
 const selectedEventIds = ref<number[]>([]);
 const eventsDialogOpen = ref<boolean>(false);
@@ -130,6 +133,7 @@ function openEventsDialog(eventIds: number[]) {
     outlined
     :rows="state.data"
     :cols="cols"
+    :empty="emptyState"
     :loading="isLoading"
     row-attr="identifier"
     data-testid="accounting-rule-table"

--- a/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-conflict-resolution.ts
+++ b/frontend/app/src/modules/settings/accounting/rule/use-accounting-rule-conflict-resolution.ts
@@ -21,6 +21,8 @@ interface UseAccountingRuleConflictResolutionOptions {
 interface UseAccountingRuleConflictResolutionReturn {
   /** The conflicts on the current page. */
   collection: Ref<Collection<AccountingRuleConflict>>;
+  /** The last fetch failure, so the table can name it in place of its empty text. */
+  error: Ref<unknown>;
   /** Whether the page is being read. */
   isLoading: Ref<boolean>;
   /** Whether a resolution is being submitted. */
@@ -69,7 +71,7 @@ export function useAccountingRuleConflictResolution(
   const { setMessage } = useMessageStore();
   const { getAccountingRulesConflicts, resolveAccountingRuleConflicts } = useAccountingSettings();
 
-  const { collection, isLoading, pagination, refetch } = useServerTable<
+  const { collection, error, isLoading, pagination, refetch } = useServerTable<
     AccountingRuleConflict,
     AccountingRuleConflictRequestPayload
   >({
@@ -122,6 +124,7 @@ export function useAccountingRuleConflictResolution(
 
   return {
     collection,
+    error,
     isLoading,
     loading: readonly(loading),
     modelResolution,

--- a/frontend/app/src/modules/staking/eth/use-eth-validator-data.ts
+++ b/frontend/app/src/modules/staking/eth/use-eth-validator-data.ts
@@ -15,6 +15,8 @@ import { useBlockchainValidatorsStore } from '@/modules/staking/use-blockchain-v
 
 interface UseEthValidatorDataReturn {
   cols: ComputedRef<DataTableColumn<EthereumValidator>[]>;
+  /** The last fetch failure, so the table can name it in place of its empty text. */
+  error: Ref<unknown>;
   ethStakingValidators: ComputedRef<EthereumValidator[]>;
   /** The pill-bar fields, built here because the table's url shape is read off them. */
   fields: FieldDef[];
@@ -39,6 +41,7 @@ export function useEthValidatorData(): UseEthValidatorDataReturn {
 
   const {
     collection: rows,
+    error,
     filter: filters,
     pagination,
     refetch: fetchData,
@@ -118,6 +121,7 @@ export function useEthValidatorData(): UseEthValidatorDataReturn {
 
   return {
     cols,
+    error,
     ethStakingValidators,
     fields,
     fetchData,


### PR DESCRIPTION
## Problem

A failed table read leaves the collection empty, so every server table in the app renders the same `No data available` whether the backend was unreachable or the user genuinely has no rows.

Phase 3 of #12942 reclassified the generic table-fetch notification to `NORMAL`, so it no longer pops. That was the right call for a fetch the user did not explicitly ask for, but it means a failed table now says nothing at all, anywhere.

`useTableData` already returned the failure, with a TSDoc reading *"Lets a table render inline."* None of the 28 `useServerTable` consumers rendered it.

## Change

`useTableEmptyState` turns that failure into the table's own empty text: the reason in place of `No data available`, under a `Could not load the data` label. `RuiDataTable` already takes `:empty="{ label, description }"`, so there is no new surface, only a populated one.

19 leaves now render it. The other four `useServerTable` consumers are not `RuiDataTable` and are untouched: `HistoryEventsVirtualTable`, `CalendarGrid`, `UserNotesList` (which already has its own `RuiAlert`), and `AccountingRuleEventsDialog`, which delegates to the history events table.

## How the failure reaches the leaf

`useServerTable` provides it and the leaf injects it. That follows `use-history-events-selection-context`, which is provided for the same reason and says so: owned by the view, read only at the leaves. Six of the leaves sit two or three components below the fetch, so the alternative was threading a prop through every wrapper in between.

Two cases the provide cannot serve, both handled by passing the error in explicitly:

- A leaf that calls `useServerTable` itself. Vue resolves `inject` from the parent chain, so a component cannot inject what it provided.
- `use-internal-tx-conflicts`, a `createSharedComposable`. Its `provide` would bind to whichever component instantiated the singleton first, which is not the one rendering the rows. `provideTableFetchError` is guarded on `getCurrentInstance()` so that case is inert rather than warning.

## Notes for review

- `EthStakingValidators` and `DataIssuesTable` override `#empty-description`, which would have masked the message. Both now read the description off the resolved state, so the error wins and the original text is still the fallback.
- Two files were at the 20-import ceiling. `ManualBalanceTable` folds into `use-server-table`'s existing sibling re-export (the same line that already re-exports `routeWhen`); `ManagedAssetTable` gets it from `useManagedAssetTable`, its own table view-model composable. No barrel.
- `en.json` gains one key, `data_table.fetch_failed`.

## Testing

Full unit suite 12207 passing, plus typecheck, eslint, stylelint, knip and linked-keys. All 8 pre-push gates green.

Two negative controls on the new composable, since three of its six tests turn on one branch:

- dropping the injection lookup fails exactly the "provided further up the tree" test;
- making the failure branch unreachable fails exactly the three tests that assert a reason is named, and no others.

## Scope

This is §6.0 of #12942, the inline states owed to the surfaces phase 3 quieted, after the RPC node table (#13103) and the net worth graph (#13107). The condition-shaped work (`NEW_DETECTED_TOKENS`, `MISSING_EXCHANGE_MAPPING`) belongs to #13105 and is not here; these are occurrences, so there is no overlap.