### PR TITLE
Decode The Graph vesting contract actions on L2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+* :bug:`-` Undelegating, withdrawing and bridging GRT back to Ethereum through a The Graph vesting contract on Arbitrum One are now decoded for the tracked beneficiary instead of showing up as gas-only transactions.
 * :bug:`-` The chain picker now lists the chains alphabetically instead of in the order the backend happens to return them, so a chain can be found by scrolling to where its name belongs. "All Supported Chains" stays at the top, and it can now be found by typing part of its name, which matched nothing before.
 * :bug:`-` A price source that stops answering is now set aside after its first timeout and checked with a quick probe before it is used again.
 * :bug:`-` Hovering the last-queried time in the dashboard sync bar no longer turns the cursor into a question mark.

--- a/rotkehlchen/chain/arbitrum_one/modules/thegraph/balances.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/thegraph/balances.py
@@ -76,8 +76,11 @@ class ThegraphBalances(ProtocolWithBalance):
         delegations_unique = set()
         queried_addresses = set(addresses)
         for event in events:
-            if event.location_label is None or event.extra_data is None:
-                log.error(f'Skipping TheGraph deposit event {event} due to one or both of location_label and extra_data missing')  # noqa: E501
+            if event.extra_data is None:  # undelegate/withdraw/bridge informational events carry no delegation  # noqa: E501
+                continue
+
+            if event.location_label is None:
+                log.error('Skipping TheGraph deposit event due to missing location_label', event=event)  # noqa: E501
                 continue
 
             verifier = event.extra_data.get('verifier', SUBGRAPH_DATA_SERVICE_ADDRESS)

--- a/rotkehlchen/chain/arbitrum_one/modules/thegraph/constants.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/thegraph/constants.py
@@ -6,6 +6,11 @@ if TYPE_CHECKING:
     from eth_typing import ABI
 
 CONTRACT_STAKING: Final = string_to_evm_address('0x00669A4CF01450B64E8A2A20E9b1FCB71E61eF03')
+# L2GraphTokenLockTransferTool. Sends GRT from an L2 vesting contract back to its L1 counterpart
+# https://github.com/graphprotocol/token-distribution/blob/main/packages/token-distribution/contracts/L2GraphTokenLockTransferTool.sol
+L2_GRAPH_TOKEN_LOCK_TRANSFER_TOOL: Final = string_to_evm_address('0x23C9c8575E6bA0349a497b6D0E8F0b9239e68028')  # noqa: E501
+# LockedFundsSentToL1(address indexed l1Wallet, address indexed l2Wallet, address indexed l2LockManager, uint256 amount)  # noqa: E501
+LOCKED_FUNDS_SENT_TO_L1: Final = b'\n7\xa2T\x0c\x9a\x8e\xaf\x902\xc5\xd1\x8b\x8d\x82\xab\xee;\xc1\xcc\x85:\xe5\xd0\xc6\xdd?\x91i\xf0\xf0\xf2'  # noqa: E501
 # Default verifier address (subgraph data service) for pre-Horizon delegations
 # https://github.com/graphprotocol/contracts/blob/b91017dc1e3492d768d0df377a27f4b15606950e/packages/horizon/contracts/staking/HorizonStakingBase.sol#L259-L268
 SUBGRAPH_DATA_SERVICE_ADDRESS: Final = string_to_evm_address('0xb2Bb92d0DE618878E438b55D5846cfecD9301105')  # noqa: E501

--- a/rotkehlchen/chain/arbitrum_one/modules/thegraph/decoder.py
+++ b/rotkehlchen/chain/arbitrum_one/modules/thegraph/decoder.py
@@ -1,13 +1,37 @@
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Any
 
-from rotkehlchen.chain.arbitrum_one.modules.thegraph.constants import CONTRACT_STAKING
+from rotkehlchen.assets.utils import token_normalized_value
+from rotkehlchen.chain.arbitrum_one.constants import CPT_ARBITRUM_ONE
+from rotkehlchen.chain.arbitrum_one.modules.arbitrum_one_bridge.decoder import L2_TO_L1_TX
+from rotkehlchen.chain.arbitrum_one.modules.thegraph.constants import (
+    CONTRACT_STAKING,
+    L2_GRAPH_TOKEN_LOCK_TRANSFER_TOOL,
+    LOCKED_FUNDS_SENT_TO_L1,
+)
+from rotkehlchen.chain.evm.decoding.structures import (
+    DEFAULT_EVM_DECODING_OUTPUT,
+    DecoderContext,
+    EvmDecodingOutput,
+)
+from rotkehlchen.chain.evm.decoding.thegraph.constants import CPT_THEGRAPH
 from rotkehlchen.chain.evm.decoding.thegraph.decoder import ThegraphCommonDecoder
+from rotkehlchen.chain.evm.decoding.utils import make_bridge_extra_data
 from rotkehlchen.constants.assets import A_GRT_ARB
+from rotkehlchen.constants.misc import ZERO
+from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
+from rotkehlchen.logging import RotkehlchenLogsAdapter
+from rotkehlchen.types import ChainID
+from rotkehlchen.utils.misc import bytes_to_address
 
 if TYPE_CHECKING:
     from rotkehlchen.chain.arbitrum_one.node_inquirer import ArbitrumOneInquirer
     from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
+    from rotkehlchen.types import ChecksumEvmAddress
     from rotkehlchen.user_messages import MessagesAggregator
+
+logger = logging.getLogger(__name__)
+log = RotkehlchenLogsAdapter(logger)
 
 
 class ThegraphDecoder(ThegraphCommonDecoder):
@@ -25,3 +49,74 @@ class ThegraphDecoder(ThegraphCommonDecoder):
             native_asset=A_GRT_ARB,
             staking_contract=CONTRACT_STAKING,
         )
+
+    def _decode_locked_funds_sent_to_l1(self, context: DecoderContext) -> EvmDecodingOutput:
+        """Decode GRT being sent from an L2 vesting contract back to its L1 counterpart
+        through the L2GraphTokenLockTransferTool (withdrawToL1Locked). The transfer tool pulls
+        the GRT from the vesting contract and bridges it with the arbitrum gateway to the
+        L1 vesting contract, where it has to be claimed from the outbox after 7 days."""
+        if context.tx_log.topics[0] != LOCKED_FUNDS_SENT_TO_L1:
+            return DEFAULT_EVM_DECODING_OUTPUT
+
+        l1_wallet = bytes_to_address(context.tx_log.topics[1])
+        if (resolved := self._resolve_delegator(l2_wallet := bytes_to_address(context.tx_log.topics[2]))) is None:  # noqa: E501
+            return DEFAULT_EVM_DECODING_OUTPUT
+
+        user_address, vesting_contract = resolved
+        amount = token_normalized_value(
+            token_amount=int.from_bytes(context.tx_log.data[:32]),
+            token=self.token,
+        )
+        if vesting_contract is not None:  # only the beneficiary is tracked. No transfer to edit
+            return EvmDecodingOutput(events=[self.base.make_event_from_transaction(
+                transaction=context.transaction,
+                tx_log=context.tx_log,
+                event_type=HistoryEventType.INFORMATIONAL,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=self.token,
+                amount=ZERO,
+                location_label=user_address,
+                notes=f'Bridge {amount} GRT from vesting contract {vesting_contract} on Arbitrum One to vesting contract {l1_wallet} on Ethereum',  # noqa: E501
+                counterparty=CPT_THEGRAPH,
+                address=context.tx_log.address,
+            )])
+
+        for event in context.decoded_events:
+            if (
+                event.event_type == HistoryEventType.SPEND and
+                event.event_subtype == HistoryEventSubType.NONE and
+                event.location_label == l2_wallet and
+                event.address == context.tx_log.address and
+                event.asset == self.token and
+                event.amount == amount
+            ):
+                event.event_type = HistoryEventType.DEPOSIT
+                event.event_subtype = HistoryEventSubType.BRIDGE
+                event.counterparty = CPT_ARBITRUM_ONE
+                event.notes = f'Bridge {amount} GRT from Arbitrum One to Ethereum vesting contract {l1_wallet} via Arbitrum One bridge'  # noqa: E501
+                event.extra_data = make_bridge_extra_data(
+                    from_chain=ChainID.ARBITRUM_ONE,
+                    to_chain=ChainID.ETHEREUM,
+                    from_address=l2_wallet,
+                    to_address=l1_wallet,
+                    transfer_id=next(  # position of the L2 to L1 message, matching the L1 outbox execution  # noqa: E501
+                        (str(int.from_bytes(tx_log.topics[3])) for tx_log in context.all_logs if tx_log.topics[0] == L2_TO_L1_TX),  # noqa: E501
+                        None,
+                    ),
+                )
+                break
+        else:
+            log.error(
+                'Could not find the GRT transfer of the vesting contract to the graph transfer tool',  # noqa: E501
+                vesting_contract=l2_wallet,
+                tx_hash=context.transaction.tx_hash,
+            )
+
+        return DEFAULT_EVM_DECODING_OUTPUT
+
+    # -- DecoderInterface methods
+
+    def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
+        return super().addresses_to_decoders() | {
+            L2_GRAPH_TOKEN_LOCK_TRANSFER_TOOL: (self._decode_locked_funds_sent_to_l1,),
+        }

--- a/rotkehlchen/chain/ethereum/modules/thegraph/constants.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/constants.py
@@ -5,7 +5,3 @@ from rotkehlchen.chain.evm.types import string_to_evm_address
 GRAPH_L1_LOCK_TRANSFER_TOOL: Final = string_to_evm_address('0xCa82c7Ce3388b0B5d307574099aC57d7a00d509F')  # noqa: E501
 CONTRACT_STAKING: Final = string_to_evm_address('0xF55041E37E12cD407ad00CE2910B8269B01263b9')
 DELEGATION_TRANSFERRED_TO_L2: Final = b'#\x1e\\\xfe\xffwY\xa4h$\x1d\x93\x9a\xb0J`\xd6\x03\xb1~5\x90W\xab\xbb\x8fR\xaf\xc3\xe4\x98k'  # noqa: E501
-TOKEN_DESTINATIONS_APPROVED: Final = b"\xb87\xfdQPk\xa3\xccb:7\xc7\x8e\xd2/\xd5!\xf2\xf6\xe9\xf6\x9a4\xd5\xc2\xa4\xa9GO'W\x93"  # noqa: E501
-
-# Method signatures on the vested contract
-APPROVE_PROTOCOL: Final = b'*bx\x14'

--- a/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
+++ b/rotkehlchen/chain/ethereum/modules/thegraph/decoder.py
@@ -14,21 +14,13 @@ from rotkehlchen.chain.evm.decoding.structures import (
 from rotkehlchen.chain.evm.decoding.thegraph.constants import CPT_THEGRAPH
 from rotkehlchen.chain.evm.decoding.thegraph.decoder import ThegraphCommonDecoder
 from rotkehlchen.constants.assets import A_GRT
-from rotkehlchen.constants.misc import ZERO
 from rotkehlchen.fval import FVal
 from rotkehlchen.history.events.structures.types import HistoryEventSubType, HistoryEventType
 from rotkehlchen.utils.misc import bytes_to_address
 
-from .constants import (
-    APPROVE_PROTOCOL,
-    DELEGATION_TRANSFERRED_TO_L2,
-    GRAPH_L1_LOCK_TRANSFER_TOOL,
-    TOKEN_DESTINATIONS_APPROVED,
-)
+from .constants import DELEGATION_TRANSFERRED_TO_L2, GRAPH_L1_LOCK_TRANSFER_TOOL
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from rotkehlchen.chain.ethereum.node_inquirer import EthereumInquirer
     from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
     from rotkehlchen.types import ChecksumEvmAddress
@@ -83,27 +75,6 @@ class ThegraphDecoder(ThegraphCommonDecoder):
         )
         return EvmDecodingOutput(events=[event])
 
-    def _decode_token_destination_approved(self, context: DecoderContext) -> EvmDecodingOutput:
-        """Decode a TokenDestinationsApproved event from the L1 bridge. This event is emitted
-        when a user approves a token destination to be used for delegation in L2. We use this
-        to query the logs to find the delegation address."""
-        if context.tx_log.topics[0] != TOKEN_DESTINATIONS_APPROVED:
-            return DEFAULT_EVM_DECODING_OUTPUT
-
-        event = self.base.make_event_from_transaction(
-            transaction=context.transaction,
-            tx_log=context.tx_log,
-            event_type=HistoryEventType.INFORMATIONAL,
-            event_subtype=HistoryEventSubType.APPROVE,
-            asset=self.token,
-            amount=ZERO,
-            location_label=context.transaction.from_address,
-            notes='Approve contract transfer',
-            counterparty=CPT_THEGRAPH,
-            address=context.tx_log.address,
-        )
-        return EvmDecodingOutput(events=[event])
-
     def _decode_contract_deposit(self, context: DecoderContext) -> EvmDecodingOutput:
         """Decode a deposit of ETH to cover the arbitrum fees of delegating GRT"""
         user_address = self.get_user_address(bytes_to_address(context.tx_log.topics[1]))
@@ -133,6 +104,3 @@ class ThegraphDecoder(ThegraphCommonDecoder):
             self.staking_contract: (self._decode_delegation_transferred_to_l2,),
             GRAPH_L1_LOCK_TRANSFER_TOOL: (self._decode_contract_deposit,),
         }
-
-    def decoding_by_input_data(self) -> dict[bytes, dict[bytes, Callable]]:
-        return {APPROVE_PROTOCOL: {TOKEN_DESTINATIONS_APPROVED: self._decode_token_destination_approved}}  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/thegraph/constants.py
+++ b/rotkehlchen/chain/evm/decoding/thegraph/constants.py
@@ -13,6 +13,10 @@ THEGRAPH_CPT_DETAILS: Final = CounterpartyDetails(
     label='The Graph',
     image='thegraph.svg',
 )
+# GraphTokenLockWallet.approveProtocol() method selector and the TokenDestinationsApproved
+# event it emits after approving all the protocol token destinations
+APPROVE_PROTOCOL: Final = b'*bx\x14'
+TOKEN_DESTINATIONS_APPROVED: Final = b"\xb87\xfdQPk\xa3\xccb:7\xc7\x8e\xd2/\xd5!\xf2\xf6\xe9\xf6\x9a4\xd5\xc2\xa4\xa9GO'W\x93"  # noqa: E501
 GRAPH_TOKEN_LOCK_WALLET_ABI: Final[ABI] = [{'inputs': [], 'name': 'beneficiary', 'outputs': [{'name': '', 'type': 'address'}], 'stateMutability': 'view', 'type': 'function'}]  # noqa: E501
 GRAPH_DELEGATION_TRANSFER_ABI: Final[Sequence[ABIEvent]] = [{'anonymous': False, 'inputs': [{'indexed': True, 'name': 'delegator', 'type': 'address'}, {'indexed': True, 'name': 'l2Delegator', 'type': 'address'}, {'indexed': True, 'name': 'indexer', 'type': 'address'}, {'indexed': False, 'name': 'l2Indexer', 'type': 'address'}, {'indexed': False, 'name': 'transferredDelegationTokens', 'type': 'uint256'}], 'name': 'DelegationTransferredToL2', 'type': 'event'}]  # noqa: E501
 TOPIC_STAKE_DELEGATED: Final = b'\xcd\x03f\xdc\xe5$}\x87O\xfc`\xa7b\xaaz\xbb\xb8,\x16\x95\xbb\xb1q`\x9c\x1b\x88a\xe2y\xebs'  # noqa: E501

--- a/rotkehlchen/chain/evm/decoding/thegraph/decoder.py
+++ b/rotkehlchen/chain/evm/decoding/thegraph/decoder.py
@@ -21,9 +21,11 @@ from rotkehlchen.utils.misc import bytes_to_address
 from rotkehlchen.utils.mixins.customizable_date import CustomizableDateMixin
 
 from .constants import (
+    APPROVE_PROTOCOL,
     CPT_THEGRAPH,
     GRAPH_TOKEN_LOCK_WALLET_ABI,
     THEGRAPH_CPT_DETAILS,
+    TOKEN_DESTINATIONS_APPROVED,
     TOPIC_STAKE_DELEGATED,
     TOPIC_STAKE_DELEGATED_HORIZON,
     TOPIC_STAKE_DELEGATED_LOCKED,
@@ -34,6 +36,8 @@ from .constants import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from rotkehlchen.assets.asset import Asset
     from rotkehlchen.chain.decoding.types import CounterpartyDetails
     from rotkehlchen.chain.evm.decoding.base import BaseEvmDecoderTools
@@ -126,6 +130,49 @@ class ThegraphCommonDecoder(EvmDecoderInterface, CustomizableDateMixin):
                 return None
         return address_l2 or address
 
+    def _resolve_delegator(
+            self,
+            delegator: ChecksumEvmAddress,
+    ) -> tuple[ChecksumEvmAddress, ChecksumEvmAddress | None] | None:
+        """Find the tracked address an action of the given delegator belongs to.
+
+        The delegator is either a tracked address, or a vesting contract (GraphTokenLockWallet)
+        whose beneficiary is tracked. Returns (tracked address, vesting contract or None),
+        or None if nothing related to the delegator is tracked.
+        """
+        if self.base.is_tracked(delegator):
+            return delegator, None
+
+        if (
+            (beneficiary := self.get_user_address(delegator)) is None or
+            beneficiary == delegator or
+            not self.base.is_tracked(beneficiary)
+        ):
+            return None
+
+        return beneficiary, delegator
+
+    def _decode_token_destination_approved(self, context: DecoderContext) -> EvmDecodingOutput:
+        """Decode the TokenDestinationsApproved event emitted by a vesting contract
+        (GraphTokenLockWallet) when its beneficiary calls approveProtocol(), which approves
+        all the protocol contracts (staking, transfer tools etc.) to spend the vested GRT."""
+        if context.tx_log.topics[0] != TOKEN_DESTINATIONS_APPROVED:
+            return DEFAULT_EVM_DECODING_OUTPUT
+
+        event = self.base.make_event_from_transaction(
+            transaction=context.transaction,
+            tx_log=context.tx_log,
+            event_type=HistoryEventType.INFORMATIONAL,
+            event_subtype=HistoryEventSubType.APPROVE,
+            asset=self.token,
+            amount=ZERO,
+            location_label=context.transaction.from_address,
+            notes=f'Approve The Graph protocol contracts to spend GRT of vesting contract {context.tx_log.address}',  # noqa: E501
+            counterparty=CPT_THEGRAPH,
+            address=context.tx_log.address,
+        )
+        return EvmDecodingOutput(events=[event])
+
     def _decode_stake_delegated(
             self,
             context: DecoderContext,
@@ -197,14 +244,16 @@ class ThegraphCommonDecoder(EvmDecoderInterface, CustomizableDateMixin):
             delegator: ChecksumEvmAddress,
             lock_duration_msg: str,
     ) -> EvmDecodingOutput:
-        if not self.base.is_tracked(delegator):
+        if (resolved := self._resolve_delegator(delegator)) is None:
             return DEFAULT_EVM_DECODING_OUTPUT
 
+        user_address, vesting_contract = resolved
         indexer = bytes_to_address(context.tx_log.topics[1])
         tokens_amount = token_normalized_value(
             token_amount=int.from_bytes(context.tx_log.data[:32]),
             token=self.token,
         )
+        vesting_msg = '' if vesting_contract is None else f' of vesting contract {vesting_contract}'  # noqa: E501
         event = self.base.make_event_from_transaction(
             transaction=context.transaction,
             tx_log=context.tx_log,
@@ -212,8 +261,8 @@ class ThegraphCommonDecoder(EvmDecoderInterface, CustomizableDateMixin):
             event_subtype=HistoryEventSubType.NONE,
             asset=self.token,
             amount=ZERO,
-            location_label=delegator,
-            notes=f'Undelegate {tokens_amount} GRT from indexer {indexer}.{lock_duration_msg}',
+            location_label=user_address,
+            notes=f'Undelegate {tokens_amount} GRT{vesting_msg} from indexer {indexer}.{lock_duration_msg}',  # noqa: E501
             counterparty=CPT_THEGRAPH,
             address=context.tx_log.address,
         )
@@ -224,13 +273,30 @@ class ThegraphCommonDecoder(EvmDecoderInterface, CustomizableDateMixin):
             context: DecoderContext,
             delegator: ChecksumEvmAddress,
     ) -> EvmDecodingOutput:
-        if not self.base.is_tracked(delegator):
+        if (resolved := self._resolve_delegator(delegator)) is None:
             return DEFAULT_EVM_DECODING_OUTPUT
 
+        user_address, vesting_contract = resolved
         action_items, indexer, token_amount = [], bytes_to_address(context.tx_log.topics[1]), token_normalized_value(  # noqa: E501
             token_amount=int.from_bytes(context.tx_log.data[:32]),
             token=self.token,
         )
+        if vesting_contract is not None:
+            # The GRT goes back to the untracked vesting contract, not to the user, so
+            # there is no transfer to transform. Only note it for the beneficiary.
+            return EvmDecodingOutput(events=[self.base.make_event_from_transaction(
+                transaction=context.transaction,
+                tx_log=context.tx_log,
+                event_type=HistoryEventType.INFORMATIONAL,
+                event_subtype=HistoryEventSubType.NONE,
+                asset=self.token,
+                amount=ZERO,
+                location_label=user_address,
+                notes=f'Withdraw {token_amount} GRT from indexer {indexer} to vesting contract {vesting_contract}',  # noqa: E501
+                counterparty=CPT_THEGRAPH,
+                address=context.tx_log.address,
+            )])
+
         for event in context.decoded_events:
             if (
                     event.event_type == HistoryEventType.RECEIVE and
@@ -268,3 +334,6 @@ class ThegraphCommonDecoder(EvmDecoderInterface, CustomizableDateMixin):
 
     def addresses_to_decoders(self) -> dict[ChecksumEvmAddress, tuple[Any, ...]]:
         return {self.staking_contract: (self._decode_delegator_staking,)}
+
+    def decoding_by_input_data(self) -> dict[bytes, dict[bytes, Callable]]:
+        return {APPROVE_PROTOCOL: {TOKEN_DESTINATIONS_APPROVED: self._decode_token_destination_approved}}  # noqa: E501

--- a/rotkehlchen/tests/unit/decoders/test_thegraph.py
+++ b/rotkehlchen/tests/unit/decoders/test_thegraph.py
@@ -2,8 +2,10 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from rotkehlchen.chain.arbitrum_one.constants import CPT_ARBITRUM_ONE
 from rotkehlchen.chain.arbitrum_one.modules.thegraph.constants import (
     CONTRACT_STAKING as CONTRACT_STAKING_ARB,
+    L2_GRAPH_TOKEN_LOCK_TRANSFER_TOOL,
 )
 from rotkehlchen.chain.decoding.constants import CPT_GAS
 from rotkehlchen.chain.ethereum.modules.thegraph.constants import (
@@ -35,6 +37,9 @@ ADDY_ROTKI = string_to_evm_address('0x9531C059098e3d194fF87FebB587aB07B30B1306')
 ADDY_USER_1_ARB = string_to_evm_address('0xA9728D95567410555557a54EcA320e5E8bEa36a5')
 ADDY_USER_2_ARB = string_to_evm_address('0xec9342111098f8b4A293cD8033746d6f8E9e9e7F')
 ADDY_USER_3_ARB = string_to_evm_address('0xBe79986821637afD1406BF9278DA55cf9085cF8f')
+ROTKI_VESTING_L1 = string_to_evm_address('0x7D91717579885BfCFec3Cb4B4C4fe71c1EedD4dE')
+ROTKI_VESTING_L2 = string_to_evm_address('0x9F219c3D048967990f675F49C1117B0598331408')
+ROTKI_INDEXER_L2 = string_to_evm_address('0x2f09092aacd80196FC984908c5A9a7aB3ee4f1CE')
 
 
 @pytest.mark.vcr
@@ -168,9 +173,9 @@ def test_thegraph_contract_transfer_approval(ethereum_inquirer):
             asset=A_GRT,
             amount=ZERO,
             location_label=ADDY_ROTKI,
-            notes='Approve contract transfer',
+            notes=f'Approve The Graph protocol contracts to spend GRT of vesting contract {ROTKI_VESTING_L1}',  # noqa: E501
             counterparty=CPT_THEGRAPH,
-            address=string_to_evm_address('0x7D91717579885BfCFec3Cb4B4C4fe71c1EedD4dE'),
+            address=ROTKI_VESTING_L1,
         ),
     ]
 
@@ -634,4 +639,209 @@ def test_thegraph_delegated_withdrawn_horizon(
         notes=f'Withdraw {withdraw_amount} GRT from indexer 0x920FDEB00EE04dd72f62d8A8f80F13c82ef76C1e',  # noqa: E501
         counterparty=CPT_THEGRAPH,
         address=CONTRACT_STAKING_ARB,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_ROTKI]])
+def test_thegraph_undelegate_vesting_arbitrum_one(
+        arbitrum_one_inquirer: ArbitrumOneInquirer,
+        arbitrum_one_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Undelegation done through an (untracked) vesting contract by its tracked beneficiary"""
+    events, decoder = get_decoded_events_of_transaction(
+        evm_inquirer=arbitrum_one_inquirer,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xa59786af3f2d8ca1e50855167e8c545ed374300dcf5f0f7945f3b8070851458d')),  # noqa: E501
+    )
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1786538383000)),
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount := '0.000004849081406'),
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=3,
+        timestamp=timestamp,
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_GRT_ARB,
+        amount=ZERO,
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Undelegate 266596.860507359918405274 GRT of vesting contract {ROTKI_VESTING_L2} from indexer {ROTKI_INDEXER_L2}. Lock expires at {decoder.decoders["Thegraph"].timestamp_to_date(Timestamp(1788957583))}',  # type: ignore  # noqa: E501
+        counterparty=CPT_THEGRAPH,
+        address=CONTRACT_STAKING_ARB,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_ROTKI]])
+def test_thegraph_delegated_withdrawn_vesting_arbitrum_one(
+        arbitrum_one_inquirer: ArbitrumOneInquirer,
+        arbitrum_one_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Withdrawal of undelegated GRT back into an (untracked) vesting contract
+    by its tracked beneficiary"""
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=arbitrum_one_inquirer,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x59554c4b53e42bd52a8e8284676cbfb4d9d07de4f401d4bf96244be58daed435')),  # noqa: E501
+    )
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1789069330000)),
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount := '0.00000234985951'),
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=4,
+        timestamp=timestamp,
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_GRT_ARB,
+        amount=ZERO,
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Withdraw 266596.860507359918405274 GRT from indexer {ROTKI_INDEXER_L2} to vesting contract {ROTKI_VESTING_L2}',  # noqa: E501
+        counterparty=CPT_THEGRAPH,
+        address=CONTRACT_STAKING_ARB,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_ROTKI]])
+def test_thegraph_approve_protocol_arbitrum_one(
+        arbitrum_one_inquirer: ArbitrumOneInquirer,
+        arbitrum_one_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """approveProtocol() on an L2 vesting contract, approving the protocol token destinations"""
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=arbitrum_one_inquirer,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0xc514f8915f1d1ada021707ac630deb6f5306ae727a4aeb5f6f31ab9e8a5f67bf')),  # noqa: E501
+    )
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1789069447000)),
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount := '0.000002967461876'),
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=14,
+        timestamp=timestamp,
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.APPROVE,
+        asset=A_GRT_ARB,
+        amount=ZERO,
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Approve The Graph protocol contracts to spend GRT of vesting contract {ROTKI_VESTING_L2}',  # noqa: E501
+        counterparty=CPT_THEGRAPH,
+        address=ROTKI_VESTING_L2,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('arbitrum_one_accounts', [[ADDY_ROTKI]])
+def test_thegraph_vesting_bridge_to_l1_arbitrum_one(
+        arbitrum_one_inquirer: ArbitrumOneInquirer,
+        arbitrum_one_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """withdrawToL1Locked() sending the GRT of an (untracked) L2 vesting contract back to
+    its L1 counterpart, seen from the tracked beneficiary"""
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=arbitrum_one_inquirer,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x63415a5309604754513afbfd41d999c8762fb6919b5adafcdb8b989983c8869d')),  # noqa: E501
+    )
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=0,
+        timestamp=(timestamp := TimestampMS(1789069473000)),
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.SPEND,
+        event_subtype=HistoryEventSubType.FEE,
+        asset=A_ETH,
+        amount=FVal(gas_amount := '0.00000423804744'),
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Burn {gas_amount} ETH for gas',
+        counterparty=CPT_GAS,
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=23,
+        timestamp=timestamp,
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.NONE,
+        asset=A_GRT_ARB,
+        amount=ZERO,
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Bridge 266597.860507359918405274 GRT from vesting contract {ROTKI_VESTING_L2} on Arbitrum One to vesting contract {ROTKI_VESTING_L1} on Ethereum',  # noqa: E501
+        counterparty=CPT_THEGRAPH,
+        address=L2_GRAPH_TOKEN_LOCK_TRANSFER_TOOL,
+    )]
+
+
+@pytest.mark.vcr(filter_query_parameters=['apikey'])
+@pytest.mark.parametrize('arbitrum_one_accounts', [[ROTKI_VESTING_L2]])
+def test_thegraph_vesting_bridge_to_l1_tracked_vesting(
+        arbitrum_one_inquirer: ArbitrumOneInquirer,
+        arbitrum_one_accounts: list[ChecksumEvmAddress],
+) -> None:
+    """Same as above but with the L2 vesting contract itself tracked, so the GRT
+    transfer out of it becomes a bridge deposit"""
+    events, _ = get_decoded_events_of_transaction(
+        evm_inquirer=arbitrum_one_inquirer,
+        tx_hash=(tx_hash := deserialize_evm_tx_hash('0x63415a5309604754513afbfd41d999c8762fb6919b5adafcdb8b989983c8869d')),  # noqa: E501
+    )
+    assert events == [EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=11,
+        timestamp=(timestamp := TimestampMS(1789069473000)),
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.DEPOSIT,
+        event_subtype=HistoryEventSubType.BRIDGE,
+        asset=A_GRT_ARB,
+        amount=FVal(amount := '266597.860507359918405274'),
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Bridge {amount} GRT from Arbitrum One to Ethereum vesting contract {ROTKI_VESTING_L1} via Arbitrum One bridge',  # noqa: E501
+        counterparty=CPT_ARBITRUM_ONE,
+        address=L2_GRAPH_TOKEN_LOCK_TRANSFER_TOOL,
+        extra_data={'bridge': {
+            'from_chain': 42161,
+            'to_chain': 1,
+            'from_address': ROTKI_VESTING_L2,
+            'to_address': ROTKI_VESTING_L1,
+            'transfer_id': '165835',
+        }},
+    ), EvmEvent(
+        tx_ref=tx_hash,
+        sequence_index=12,
+        timestamp=timestamp,
+        location=Location.ARBITRUM_ONE,
+        event_type=HistoryEventType.INFORMATIONAL,
+        event_subtype=HistoryEventSubType.APPROVE,
+        asset=A_GRT_ARB,
+        amount=FVal('115792089237316195423570985008687907853269984665640563772859.723500553211234661'),
+        location_label=arbitrum_one_accounts[0],
+        notes=f'Set GRT spending approval of {ROTKI_VESTING_L2} by {L2_GRAPH_TOKEN_LOCK_TRANSFER_TOOL} to 115792089237316195423570985008687907853269984665640563772859.723500553211234661',  # noqa: E501
+        address=L2_GRAPH_TOKEN_LOCK_TRANSFER_TOOL,
     )]


### PR DESCRIPTION
Undelegating, withdrawing and bridging GRT back to Ethereum through an L2 GraphTokenLockWallet were only showing as gas burned, since the delegator in the logs is the vesting contract and not the tracked beneficiary. Resolve the beneficiary of a vesting contract delegator and create events for it, decode approveProtocol() on Arbitrum too and add a decoder for the L2GraphTokenLockTransferTool LockedFundsSentToL1 event.
