### PR TITLE
feat(frontend): route progress into the ledger with a typed detail channel

### DIFF
--- a/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
@@ -1,9 +1,11 @@
 import type { ProgressUpdateResultData } from '../types/status-types';
+import { Blockchain } from '@rotki/common';
 import { mockT } from '@test/i18n';
 import { createMock } from '@test/utils/create-mock';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createProgressUpdateHandler } from '@/modules/core/messaging/handlers/progress-updates';
 import { SocketMessageProgressUpdateSubType } from '@/modules/core/messaging/types/base';
+import { decodeActivityId } from '@/modules/history/events/tx/decode-activity';
 import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 
 const mockSetUndecodedTransactionsStatus = vi.fn();
@@ -13,7 +15,18 @@ const mockSetHistoricalDailyPriceStatus = vi.fn();
 const mockSetHistoricalPriceStatus = vi.fn();
 const mockSetStatsPriceQueryStatus = vi.fn();
 const mockReportProgress = vi.fn();
+const mockReportProgressByPrefix = vi.fn();
 const mockNotifyHistoricalBalanceProcessingCompleted = vi.fn();
+
+type SupportedChains = typeof import('@/modules/core/common/use-supported-chains');
+
+vi.mock('@/modules/core/common/use-supported-chains', () => ({
+  useSupportedChains: vi.fn<SupportedChains['useSupportedChains']>(() =>
+    createMock<ReturnType<SupportedChains['useSupportedChains']>>({
+      // The decoder's spelling, so a route that forgets to canonicalise composes the wrong id.
+      matchChain: (chain: string) => (chain === 'ethereum' ? Blockchain.ETH : undefined),
+    })),
+} satisfies Partial<SupportedChains>));
 
 vi.mock('@/modules/history/data-issues/use-data-issues-inbox-store', () => ({
   useDataIssuesInboxStore: vi.fn(() => ({
@@ -45,6 +58,7 @@ vi.mock('@/modules/assets/prices/use-historic-cache-price-store', () => ({
 vi.mock('@/modules/task-center/use-task-orchestrator', () => ({
   useTaskOrchestrator: vi.fn(() => ({
     reportProgress: mockReportProgress,
+    reportProgressByPrefix: mockReportProgressByPrefix,
   })),
 }));
 
@@ -64,6 +78,39 @@ describe('createProgressUpdateHandler', () => {
     expect(mockSetReceivingProtocolCacheStatus).toHaveBeenCalledWith(false);
     expect(mockSetUndecodedTransactionsStatus).toHaveBeenCalledOnce();
     expect(result).toBeNull();
+  });
+
+  it('should report decode progress onto the chain activity under its canonical chain id', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(createMock<ProgressUpdateResultData>({
+      chain: 'ethereum',
+      processed: 3,
+      subtype: SocketMessageProgressUpdateSubType.UNDECODED_TRANSACTIONS,
+      total: 10,
+    }));
+
+    // Both variants of the chain-wide decode, never a targeted one.
+    expect(mockReportProgress).toHaveBeenCalledWith(decodeActivityId('eth', false), { current: 3, total: 10 });
+    expect(mockReportProgress).toHaveBeenCalledWith(decodeActivityId('eth', true), { current: 3, total: 10 });
+    expect(mockReportProgress).not.toHaveBeenCalledWith(
+      expect.stringContaining('ethereum'),
+      expect.anything(),
+    );
+  });
+
+  it('should fall back to the lowercased chain when it matches no known chain', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(createMock<ProgressUpdateResultData>({
+      chain: 'Hyperliquid',
+      processed: 1,
+      subtype: SocketMessageProgressUpdateSubType.UNDECODED_TRANSACTIONS,
+      total: 2,
+    }));
+
+    expect(mockReportProgress).toHaveBeenCalledWith(
+      decodeActivityId('hyperliquid', false),
+      { current: 1, total: 2 },
+    );
   });
 
   it('should route protocol cache updates', async () => {
@@ -106,6 +153,23 @@ describe('createProgressUpdateHandler', () => {
     await handler.handle(data(SocketMessageProgressUpdateSubType.MULTIPLE_PRICES_QUERY_STATUS));
 
     expect(mockSetHistoricalPriceStatus).toHaveBeenCalledOnce();
+  });
+
+  it('should report multiple prices progress onto the batch activities only', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(createMock<ProgressUpdateResultData>({
+      processed: 4,
+      subtype: SocketMessageProgressUpdateSubType.MULTIPLE_PRICES_QUERY_STATUS,
+      total: 9,
+    }));
+
+    // BATCH is part of the prefix, so single-pair price activities are left alone.
+    expect(mockReportProgressByPrefix).toHaveBeenCalledWith(
+      { current: 4, total: 9 },
+      ActivityKind.PRICES,
+      ActivityPart.HISTORIC,
+      ActivityPart.BATCH,
+    );
   });
 
   it('should route historical balance processing updates', async () => {

--- a/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
@@ -2,11 +2,14 @@ import type { ProgressUpdateResultData } from '../types/status-types';
 import { Blockchain } from '@rotki/common';
 import { mockT } from '@test/i18n';
 import { createMock } from '@test/utils/create-mock';
+import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createProgressUpdateHandler } from '@/modules/core/messaging/handlers/progress-updates';
 import { SocketMessageProgressUpdateSubType } from '@/modules/core/messaging/types/base';
-import { decodeActivityId } from '@/modules/history/events/tx/decode-activity';
+import { decodeActivity, decodeActivityId } from '@/modules/history/events/tx/decode-activity';
+import { protocolCacheActivity } from '@/modules/history/protocol-cache-activity';
 import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { readActivityDetail, useActivityDetail } from '@/modules/task-center/use-activity-detail';
 
 const mockSetUndecodedTransactionsStatus = vi.fn();
 const mockSetProtocolCacheStatus = vi.fn();
@@ -16,6 +19,15 @@ const mockSetHistoricalPriceStatus = vi.fn();
 const mockSetStatsPriceQueryStatus = vi.fn();
 const mockReportProgress = vi.fn();
 const mockReportProgressByPrefix = vi.fn();
+/** What the protocol-cache store has accumulated, as the handler reads it back. */
+let protocolCacheRows: { chain: string; protocol: string; processed: number; total: number }[] = [];
+/** Which activity ids count as running, so a test can put one parent or the other in flight. */
+let runningIds: string[] = [];
+const mockStatusOf = vi.fn((kind: ActivityKind, ...parts: (string | number)[]) => ({
+  active: runningIds.includes(makeActivityId(kind, ...parts)),
+  everCompleted: false,
+  running: runningIds.includes(makeActivityId(kind, ...parts)),
+}));
 const mockNotifyHistoricalBalanceProcessingCompleted = vi.fn();
 
 type SupportedChains = typeof import('@/modules/core/common/use-supported-chains');
@@ -42,6 +54,9 @@ vi.mock('@/modules/history/use-decoding-status-store', () => ({
 
 vi.mock('@/modules/history/use-protocol-cache-status-store', () => ({
   useProtocolCacheStatusStore: vi.fn(() => ({
+    get protocolCacheStatus(): typeof protocolCacheRows {
+      return protocolCacheRows;
+    },
     setProtocolCacheStatus: mockSetProtocolCacheStatus,
     setReceivingProtocolCacheStatus: mockSetReceivingProtocolCacheStatus,
   })),
@@ -59,6 +74,7 @@ vi.mock('@/modules/task-center/use-task-orchestrator', () => ({
   useTaskOrchestrator: vi.fn(() => ({
     reportProgress: mockReportProgress,
     reportProgressByPrefix: mockReportProgressByPrefix,
+    statusOf: mockStatusOf,
   })),
 }));
 
@@ -68,7 +84,11 @@ function data(subtype: SocketMessageProgressUpdateSubType): ProgressUpdateResult
 
 describe('createProgressUpdateHandler', () => {
   beforeEach(() => {
+    setActivePinia(createPinia());
+    useActivityDetail().resetDetails();
     vi.clearAllMocks();
+    protocolCacheRows = [];
+    runningIds = [];
   });
 
   it('should route undecoded transaction updates and stop the receiving flag', async () => {
@@ -118,6 +138,59 @@ describe('createProgressUpdateHandler', () => {
     await handler.handle(data(SocketMessageProgressUpdateSubType.PROTOCOL_CACHE_UPDATES));
 
     expect(mockSetProtocolCacheStatus).toHaveBeenCalledOnce();
+  });
+
+  describe('protocol cache rows', () => {
+    const curveOnEthereum = { chain: 'ethereum', processed: 2, protocol: 'curve', total: 8 };
+    const aaveOnOptimism = { chain: 'optimism', processed: 1, protocol: 'aave', total: 4 };
+
+    async function handleProtocolCacheFrame(chain = 'ethereum'): Promise<void> {
+      await createProgressUpdateHandler(mockT).handle(createMock<ProgressUpdateResultData>({
+        chain,
+        subtype: SocketMessageProgressUpdateSubType.PROTOCOL_CACHE_UPDATES,
+      }));
+    }
+
+    it('should attach every accumulated row to a running cache refresh', async () => {
+      protocolCacheRows = [curveOnEthereum, aaveOnOptimism];
+      runningIds = [protocolCacheActivity.id()];
+
+      await handleProtocolCacheFrame();
+
+      expect(get(readActivityDetail(protocolCacheActivity, undefined))?.protocols)
+        .toStrictEqual([curveOnEthereum, aaveOnOptimism]);
+    });
+
+    it('should attach only the decoding chain\'s rows to its decode, under the canonical chain id', async () => {
+      protocolCacheRows = [curveOnEthereum, aaveOnOptimism];
+      const subject = { chain: 'eth', ignoreCache: false };
+      runningIds = [decodeActivity.id(subject)];
+
+      // The frame says 'ethereum' while the activity is keyed by 'eth'.
+      await handleProtocolCacheFrame();
+
+      expect(get(readActivityDetail(decodeActivity, subject))?.protocols).toStrictEqual([curveOnEthereum]);
+    });
+
+    it('should publish nothing when neither parent is running', async () => {
+      protocolCacheRows = [curveOnEthereum];
+
+      await handleProtocolCacheFrame();
+
+      expect(get(readActivityDetail(protocolCacheActivity, undefined))).toBeUndefined();
+      expect(get(readActivityDetail(decodeActivity, { chain: 'eth', ignoreCache: false }))).toBeUndefined();
+    });
+
+    it('should publish against the forced decode when that is the live variant', async () => {
+      protocolCacheRows = [curveOnEthereum];
+      const forced = { chain: 'eth', ignoreCache: true };
+      runningIds = [decodeActivity.id(forced)];
+
+      await handleProtocolCacheFrame();
+
+      expect(get(readActivityDetail(decodeActivity, forced))?.protocols).toStrictEqual([curveOnEthereum]);
+      expect(get(readActivityDetail(decodeActivity, { chain: 'eth', ignoreCache: false }))).toBeUndefined();
+    });
   });
 
   it('should route historical price query updates', async () => {

--- a/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/progress-updates.spec.ts
@@ -148,6 +148,34 @@ describe('createProgressUpdateHandler', () => {
     expect(mockSetStatsPriceQueryStatus).toHaveBeenCalledOnce();
   });
 
+  it('should report a stats price backfill onto the query it is a phase of', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(createMock<ProgressUpdateResultData>({
+      counterparty: 'liquity',
+      processed: 4,
+      subtype: SocketMessageProgressUpdateSubType.STATS_PRICE_QUERY,
+      total: 8,
+    }));
+
+    expect(mockReportProgress).toHaveBeenCalledWith(
+      makeActivityId(ActivityKind.LIQUITY, ActivityPart.STATISTICS),
+      { current: 4, total: 8 },
+    );
+  });
+
+  it('should report nothing for a counterparty with no activity of its own', async () => {
+    const handler = createProgressUpdateHandler(mockT);
+    await handler.handle(createMock<ProgressUpdateResultData>({
+      counterparty: 'something-new',
+      processed: 4,
+      subtype: SocketMessageProgressUpdateSubType.STATS_PRICE_QUERY,
+      total: 8,
+    }));
+
+    expect(mockSetStatsPriceQueryStatus).toHaveBeenCalledOnce();
+    expect(mockReportProgress).not.toHaveBeenCalled();
+  });
+
   it('should route multiple prices query updates', async () => {
     const handler = createProgressUpdateHandler(mockT);
     await handler.handle(data(SocketMessageProgressUpdateSubType.MULTIPLE_PRICES_QUERY_STATUS));

--- a/frontend/app/src/modules/core/messaging/handlers/progress-updates.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/progress-updates.ts
@@ -1,8 +1,10 @@
 import type { MessageHandler } from '../interfaces';
 import type { ProgressUpdateResultData } from '../types/status-types';
 import { useHistoricCachePriceStore } from '@/modules/assets/prices/use-historic-cache-price-store';
+import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { createConditionalHandler } from '@/modules/core/messaging/utils';
 import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
+import { decodeActivityId } from '@/modules/history/events/tx/decode-activity';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import { useProtocolCacheStatusStore } from '@/modules/history/use-protocol-cache-status-store';
 import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
@@ -16,6 +18,43 @@ export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']):
   const { setHistoricalDailyPriceStatus, setHistoricalPriceStatus, setStatsPriceQueryStatus } = useHistoricCachePriceStore();
   const { notifyHistoricalBalanceProcessingCompleted } = useDataIssuesInboxStore();
   const { reportProgress, reportProgressByPrefix } = useTaskOrchestrator();
+  const { matchChain } = useSupportedChains();
+
+  /**
+   * Report a chain's decode progress onto the chain-wide decode activity.
+   *
+   * Two exact ids rather than a prefix over the chain: a prefix would also match
+   * `targetedDecodeActivityId`, whose denominator is the transactions that request named, not the
+   * chain's undecoded count. Only one of the two can be running for a chain, and `reportProgress`
+   * ignores an id that is not, so the pair is a single report either way.
+   *
+   * The chain is canonicalised first. The decoder reports `ChainID.to_name()` ('ethereum') while
+   * the activity carries the chain id its flow submitted ('eth'), so the raw value matches nothing
+   * and the decode would sit at zero for the whole run.
+   */
+  function reportDecodeProgress(data: { chain: string; processed: number; total: number }): void {
+    const chain = matchChain(data.chain) ?? data.chain.toLowerCase();
+    const steps = { current: data.processed, total: data.total };
+    reportProgress(decodeActivityId(chain, false), steps);
+    reportProgress(decodeActivityId(chain, true), steps);
+  }
+
+  /**
+   * Report a multi-pair historical price query onto the batch price activities.
+   *
+   * `ActivityPart.BATCH` belongs to the prefix. The producer is the multi-pair query behind
+   * `PRICES:HISTORIC:BATCH:<n>`, so a prefix stopping at `HISTORIC` would also drive the
+   * single-pair `PRICES:HISTORIC:<from>:<to>:<ts>` activities, which this frame's counts describe
+   * nothing about.
+   */
+  function reportBatchPriceProgress(data: { processed: number; total: number }): void {
+    reportProgressByPrefix(
+      { current: data.processed, total: data.total },
+      ActivityKind.PRICES,
+      ActivityPart.HISTORIC,
+      ActivityPart.BATCH,
+    );
+  }
 
   return createConditionalHandler<ProgressUpdateResultData>(async (data) => {
     const subtype = data.subtype;
@@ -29,6 +68,7 @@ export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']):
       case SocketMessageProgressUpdateSubType.UNDECODED_TRANSACTIONS:
         setReceivingProtocolCacheStatus(false);
         setUndecodedTransactionsStatus(data);
+        reportDecodeProgress(data);
         break;
       case SocketMessageProgressUpdateSubType.PROTOCOL_CACHE_UPDATES:
         setProtocolCacheStatus(data);
@@ -52,6 +92,7 @@ export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']):
         break;
       case SocketMessageProgressUpdateSubType.MULTIPLE_PRICES_QUERY_STATUS:
         setHistoricalPriceStatus(data);
+        reportBatchPriceProgress(data);
         break;
       case SocketMessageProgressUpdateSubType.HISTORICAL_BALANCE_PROCESSING:
         reportProgress(makeActivityId(ActivityKind.HISTORICAL_BALANCES), { current: data.processed, total: data.total });

--- a/frontend/app/src/modules/core/messaging/handlers/progress-updates.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/progress-updates.ts
@@ -4,20 +4,23 @@ import { useHistoricCachePriceStore } from '@/modules/assets/prices/use-historic
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { createConditionalHandler } from '@/modules/core/messaging/utils';
 import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-issues-inbox-store';
-import { decodeActivityId } from '@/modules/history/events/tx/decode-activity';
+import { decodeActivity, decodeActivityId, type DecodeSubject } from '@/modules/history/events/tx/decode-activity';
+import { protocolCacheActivity } from '@/modules/history/protocol-cache-activity';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import { useProtocolCacheStatusStore } from '@/modules/history/use-protocol-cache-status-store';
 import { type ActivityId, ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { publishActivityDetail } from '@/modules/task-center/use-activity-detail';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
 import { SocketMessageProgressUpdateSubType } from '../types/base';
 import { createCsvImportResultHandler } from './csv-import-result';
 
 export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']): MessageHandler<ProgressUpdateResultData> {
   const { setUndecodedTransactionsStatus } = useDecodingStatusStore();
-  const { setProtocolCacheStatus, setReceivingProtocolCacheStatus } = useProtocolCacheStatusStore();
+  const protocolCacheStore = useProtocolCacheStatusStore();
+  const { setProtocolCacheStatus, setReceivingProtocolCacheStatus } = protocolCacheStore;
   const { setHistoricalDailyPriceStatus, setHistoricalPriceStatus, setStatsPriceQueryStatus } = useHistoricCachePriceStore();
   const { notifyHistoricalBalanceProcessingCompleted } = useDataIssuesInboxStore();
-  const { reportProgress, reportProgressByPrefix } = useTaskOrchestrator();
+  const { reportProgress, reportProgressByPrefix, statusOf } = useTaskOrchestrator();
   const { matchChain } = useSupportedChains();
 
   /**
@@ -51,6 +54,44 @@ export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']):
     ['kraken', makeActivityId(ActivityKind.STAKING, ActivityPart.KRAKEN)],
     ['liquity', makeActivityId(ActivityKind.LIQUITY, ActivityPart.STATISTICS)],
   ]);
+
+  /**
+   * The decode variant currently running for a chain, if either is.
+   *
+   * A chain's cached and forced decodes are separate activities, and only one of the pair can be
+   * live. Publishing to both instead would leave an entry against an id with no record, which
+   * nothing ever drops: the channel is cleaned up by the orchestrator, and it can only clean up
+   * what it has a record for.
+   */
+  function liveDecodeSubject(chain: string): DecodeSubject | undefined {
+    return [{ chain, ignoreCache: false }, { chain, ignoreCache: true }]
+      .find(subject => statusOf(ActivityKind.TX_DECODING, ...decodeActivity.partsOf(subject)).running);
+  }
+
+  /**
+   * Attach the protocol-cache rows to whatever work is filling them.
+   *
+   * Two producers send the same frames: the user's cache refresh, which has an activity of its own,
+   * and decoding, which fills a cache when a decoder reaches a log that needs one. Read back from
+   * the store so the rows are the accumulated set rather than the single pair this frame carries.
+   *
+   * Published only against a live record, and nothing at all when neither is running — which is
+   * every frame today that arrives outside both, and is what the panel already shows for them.
+   */
+  function publishProtocolCacheDetail(data: { chain: string }): void {
+    const protocols = protocolCacheStore.protocolCacheStatus;
+
+    if (statusOf(ActivityKind.PROTOCOL_CACHE).running)
+      publishActivityDetail(protocolCacheActivity, undefined, { protocols });
+
+    const chain = matchChain(data.chain) ?? data.chain.toLowerCase();
+    const decoding = liveDecodeSubject(chain);
+    if (decoding !== undefined) {
+      publishActivityDetail(decodeActivity, decoding, {
+        protocols: protocols.filter(row => (matchChain(row.chain) ?? row.chain.toLowerCase()) === chain),
+      });
+    }
+  }
 
   /**
    * Report a stats-price backfill onto the staking query it is a phase of.
@@ -98,6 +139,7 @@ export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']):
         break;
       case SocketMessageProgressUpdateSubType.PROTOCOL_CACHE_UPDATES:
         setProtocolCacheStatus(data);
+        publishProtocolCacheDetail(data);
         break;
       case SocketMessageProgressUpdateSubType.HISTORICAL_PRICE_QUERY_STATUS:
         setHistoricalDailyPriceStatus(data);

--- a/frontend/app/src/modules/core/messaging/handlers/progress-updates.ts
+++ b/frontend/app/src/modules/core/messaging/handlers/progress-updates.ts
@@ -7,7 +7,7 @@ import { useDataIssuesInboxStore } from '@/modules/history/data-issues/use-data-
 import { decodeActivityId } from '@/modules/history/events/tx/decode-activity';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import { useProtocolCacheStatusStore } from '@/modules/history/use-protocol-cache-status-store';
-import { ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { type ActivityId, ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
 import { SocketMessageProgressUpdateSubType } from '../types/base';
 import { createCsvImportResultHandler } from './csv-import-result';
@@ -37,6 +37,32 @@ export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']):
     const steps = { current: data.processed, total: data.total };
     reportProgress(decodeActivityId(chain, false), steps);
     reportProgress(decodeActivityId(chain, true), steps);
+  }
+
+  /**
+   * The activity a stats-price backfill is a phase of, by the counterparty naming it.
+   *
+   * The frames describe the historical-price lookups a staking statistics query makes on its way,
+   * and the query's own activity is the only thing running while they arrive. A counterparty with
+   * no entry reports nothing rather than guessing at an id: the backend can name one before the
+   * frontend has an activity for it, and a wrong id would caption unrelated work.
+   */
+  const statsPriceActivities = new Map<string, ActivityId>([
+    ['kraken', makeActivityId(ActivityKind.STAKING, ActivityPart.KRAKEN)],
+    ['liquity', makeActivityId(ActivityKind.LIQUITY, ActivityPart.STATISTICS)],
+  ]);
+
+  /**
+   * Report a stats-price backfill onto the staking query it is a phase of.
+   *
+   * A counterparty with no activity of its own reports nothing rather than falling back to some
+   * broader id: the frames are about that one query, and driving anything else with its counts
+   * would caption unrelated work.
+   */
+  function reportStatsPriceProgress(data: { counterparty: string; processed: number; total: number }): void {
+    const activity = statsPriceActivities.get(data.counterparty);
+    if (activity !== undefined)
+      reportProgress(activity, { current: data.processed, total: data.total });
   }
 
   /**
@@ -89,6 +115,7 @@ export function createProgressUpdateHandler(t: ReturnType<typeof useI18n>['t']):
         break;
       case SocketMessageProgressUpdateSubType.STATS_PRICE_QUERY:
         setStatsPriceQueryStatus(data);
+        reportStatsPriceProgress(data);
         break;
       case SocketMessageProgressUpdateSubType.MULTIPLE_PRICES_QUERY_STATUS:
         setHistoricalPriceStatus(data);

--- a/frontend/app/src/modules/history/events-status-handler.spec.ts
+++ b/frontend/app/src/modules/history/events-status-handler.spec.ts
@@ -1,0 +1,66 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { type HistoryEventsQueryData, HistoryEventsQueryStatus } from '@/modules/core/messaging/types';
+import { createEventsStatusHandler } from '@/modules/history/events-status-handler';
+import { exchangeEventsActivity } from '@/modules/history/events/tx/sync-activity';
+import { useEventsQueryStatusStore } from '@/modules/history/use-events-query-status-store';
+import { readActivityDetail, useActivityDetail } from '@/modules/task-center/use-activity-detail';
+
+const kraken = { location: 'kraken', name: 'my kraken' };
+
+/**
+ * A parsed frame. `period` is spread in only when present, because that is what the schema does
+ * with an absent optional — and the store merges by spreading, so an explicit `undefined` would
+ * erase the range instead of leaving it, testing a frame the backend never sends.
+ */
+function frame(status: HistoryEventsQueryStatus, period?: [number, number]): HistoryEventsQueryData {
+  return { eventType: 'history_query', ...kraken, ...(period && { period }), status };
+}
+
+describe('createEventsStatusHandler', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    useActivityDetail().resetDetails();
+    useEventsQueryStatusStore().initializeQueryStatus([kraken]);
+  });
+
+  it('should publish the queried range as detail on the exchange activity', async () => {
+    const handler = createEventsStatusHandler();
+    await handler.handle(frame(HistoryEventsQueryStatus.QUERYING_EVENTS_STATUS_UPDATE, [100, 200]));
+
+    const detail = get(readActivityDetail(exchangeEventsActivity, kraken));
+    expect(detail?.eventType).toBe('history_query');
+    expect(detail?.period).toStrictEqual([100, 200]);
+  });
+
+  it('should keep the range a later period-less frame omits', async () => {
+    const handler = createEventsStatusHandler();
+    await handler.handle(frame(HistoryEventsQueryStatus.QUERYING_EVENTS_STATUS_UPDATE, [100, 200]));
+    await handler.handle(frame(HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED));
+
+    // The store merges onto the stored entry, so reading it back survives what the frame drops.
+    expect(get(readActivityDetail(exchangeEventsActivity, kraken))?.period).toStrictEqual([100, 200]);
+  });
+
+  it('should key detail by name, so two accounts on one exchange stay apart', async () => {
+    const second = { location: 'kraken', name: 'other kraken' };
+    useEventsQueryStatusStore().initializeQueryStatus([kraken, second], { extend: true });
+    const handler = createEventsStatusHandler();
+
+    await handler.handle(frame(HistoryEventsQueryStatus.QUERYING_EVENTS_STATUS_UPDATE, [100, 200]));
+
+    expect(get(readActivityDetail(exchangeEventsActivity, kraken))?.period).toStrictEqual([100, 200]);
+    expect(get(readActivityDetail(exchangeEventsActivity, second))).toBeUndefined();
+  });
+
+  it('should freeze a cancelled exchange at the range it reached', async () => {
+    const handler = createEventsStatusHandler();
+    await handler.handle(frame(HistoryEventsQueryStatus.QUERYING_EVENTS_STATUS_UPDATE, [100, 200]));
+
+    useEventsQueryStatusStore().markLocationCancelled(kraken);
+    await handler.handle(frame(HistoryEventsQueryStatus.QUERYING_EVENTS_STATUS_UPDATE, [200, 300]));
+
+    // The store refuses the update but keeps the entry, whose seeded range would overwrite this.
+    expect(get(readActivityDetail(exchangeEventsActivity, kraken))?.period).toStrictEqual([100, 200]);
+  });
+});

--- a/frontend/app/src/modules/history/events-status-handler.ts
+++ b/frontend/app/src/modules/history/events-status-handler.ts
@@ -1,11 +1,40 @@
 import type { StateHandler } from '@/modules/core/messaging/interfaces';
+import { HistoryEventsQueryStatus } from '@/modules/core/messaging/types';
 import { createStateHandler } from '@/modules/core/messaging/utils';
+import { exchangeEventsActivity } from '@/modules/history/events/tx/sync-activity';
 import { useEventsQueryStatusStore } from '@/modules/history/use-events-query-status-store';
+import { publishActivityDetail } from '@/modules/task-center/use-activity-detail';
 
 export function createEventsStatusHandler(): StateHandler {
-  const { setQueryStatus } = useEventsQueryStatusStore();
+  const { getQueryStatus, setQueryStatus } = useEventsQueryStatusStore();
+
+  /**
+   * Mirror one exchange's stored entry onto its activity.
+   *
+   * Read back from the store rather than taken from the frame, so what is published is the merged
+   * entry: the range an earlier message established and a later one omitted, and nothing at all for
+   * a message that arrived while no sync was running.
+   *
+   * A cancelled exchange is left frozen at its last real detail. The store refuses the update but
+   * keeps the entry, so mirroring it anyway would re-publish the seeded range over what the query
+   * had actually reached — an activity that stopped would start reading as one that never began.
+   *
+   * Detail only. The activity's status is its own, and an exchange query streams no cursor to
+   * report as progress — `ExchangeEventsDetail` carries why the range it does stream is not one.
+   */
+  function mirrorToActivity(subject: { location: string; name: string }): void {
+    const entry = getQueryStatus(subject);
+    if (entry === undefined || entry.status === HistoryEventsQueryStatus.CANCELLED)
+      return;
+
+    publishActivityDetail(exchangeEventsActivity, { location: entry.location, name: entry.name }, {
+      eventType: entry.eventType,
+      period: entry.period,
+    });
+  }
 
   return createStateHandler((data) => {
     setQueryStatus(data);
+    mirrorToActivity({ location: data.location, name: data.name });
   });
 }

--- a/frontend/app/src/modules/history/events/tx/decode-activity.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/decode-activity.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blockDecodeActivity,
+  blockDecodeActivityId,
+  decodeActivity,
+  decodeActivityId,
+  targetedDecodeActivity,
+  targetedDecodeActivityId,
+} from '@/modules/history/events/tx/decode-activity';
+
+/**
+ * The ids are asserted as literals on purpose. Comparing a helper against the descriptor it
+ * delegates to holds whatever both produce, so a change to the id shape would pass while every
+ * flow that names its children ahead of the mechanism silently stopped matching them.
+ */
+describe('decode activity ids', () => {
+  it('should key a chain decode by chain and cache flag', () => {
+    expect(decodeActivity.id({ chain: 'eth', ignoreCache: false })).toBe('tx-decoding:eth:cached');
+    expect(decodeActivity.id({ chain: 'eth', ignoreCache: true })).toBe('tx-decoding:eth:pull');
+  });
+
+  it('should give a cached and a forced decode of one chain distinct ids', () => {
+    expect(decodeActivity.id({ chain: 'eth', ignoreCache: false }))
+      .not
+      .toBe(decodeActivity.id({ chain: 'eth', ignoreCache: true }));
+  });
+
+  it('should key a targeted decode by chain and the sorted tx set', () => {
+    expect(targetedDecodeActivity.id({ chain: 'eth', txRefs: ['0xb', '0xa'] })).toBe('tx-decoding:eth:pull:0xa,0xb');
+  });
+
+  it('should give two tx sets on one chain distinct ids', () => {
+    expect(targetedDecodeActivity.id({ chain: 'eth', txRefs: ['0xa'] }))
+      .not
+      .toBe(targetedDecodeActivity.id({ chain: 'eth', txRefs: ['0xb'] }));
+  });
+
+  it('should key a block decode by the sorted block set', () => {
+    expect(blockDecodeActivity.id({ blockNumbers: [21_000_001, 21_000_000] })).toBe('eth-block-decoding:21000000,21000001');
+  });
+
+  it('should leave a chain decode readable under a chain prefix', () => {
+    const within = decodeActivity.partsWithin(['eth']);
+    expect(within).toStrictEqual(['eth']);
+    expect(decodeActivity.id({ chain: 'eth', ignoreCache: true }).startsWith(`tx-decoding:${within.join(':')}:`)).toBe(true);
+  });
+
+  it('should route every named helper through its descriptor', () => {
+    expect(decodeActivityId('eth', true)).toBe(decodeActivity.id({ chain: 'eth', ignoreCache: true }));
+    expect(decodeActivityId('eth')).toBe(decodeActivity.id({ chain: 'eth', ignoreCache: false }));
+    expect(targetedDecodeActivityId('eth', ['0xa'])).toBe(targetedDecodeActivity.id({ chain: 'eth', txRefs: ['0xa'] }));
+    expect(blockDecodeActivityId([7])).toBe(blockDecodeActivity.id({ blockNumbers: [7] }));
+  });
+});

--- a/frontend/app/src/modules/history/events/tx/decode-activity.ts
+++ b/frontend/app/src/modules/history/events/tx/decode-activity.ts
@@ -1,3 +1,4 @@
+import type { ProtocolCacheDetail } from '@/modules/history/protocol-cache-activity';
 import { defineActivity } from '@/modules/task-center/core/activity-descriptor';
 import { DECODE_LANE } from '@/modules/task-center/core/orchestrator/spec';
 import { type ActivityId, ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
@@ -41,8 +42,12 @@ export interface TargetedDecodeSubject {
  *
  * No fixed part: `TX_DECODING` hosts one operation, and the cache flag that varies belongs after
  * the chain, so a coarse reader can ask about a chain without knowing which variant ran.
+ *
+ * Its detail is the protocol caches the decode is filling on the way: they are queried lazily, as a
+ * decoder reaches a log that needs one, so they belong to whatever decode is running rather than to
+ * an activity of their own.
  */
-export const decodeActivity = defineActivity<DecodeSubject, readonly [string, ActivityPart]>({
+export const decodeActivity = defineActivity<DecodeSubject, readonly [string, ActivityPart], ProtocolCacheDetail>({
   key: subject => [subject.chain, cachePart(subject.ignoreCache)],
   kind: ActivityKind.TX_DECODING,
   lane: () => DECODE_LANE,

--- a/frontend/app/src/modules/history/events/tx/decode-activity.ts
+++ b/frontend/app/src/modules/history/events/tx/decode-activity.ts
@@ -1,10 +1,12 @@
-import { type ActivityId, ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
+import { defineActivity } from '@/modules/task-center/core/activity-descriptor';
+import { DECODE_LANE } from '@/modules/task-center/core/orchestrator/spec';
+import { type ActivityId, ActivityKind, ActivityPart } from '@/modules/task-center/core/types';
 
 /**
  * Members of a targeted set, in an id.
  *
  * Sorted so the same set asked for in a different order is the same run, and comma-joined so
- * `activityParts` recovers the set as one part instead of shredding it into members — the same
+ * `activityParts` recovers the set as one part instead of shredding it into members, the same
  * treatment the chain sweep gives its chain list.
  */
 function asScope(members: readonly (string | number)[]): string {
@@ -13,41 +15,84 @@ function asScope(members: readonly (string | number)[]): string {
     .join(',');
 }
 
-/**
- * The identity of one chain's decode.
- *
- * Shared, never rebuilt at each site: a flow names its children before they exist and the
- * mechanism submits them later, and a divergence does not fail loudly — the children are simply
- * never gated by the parent claiming them.
- *
- * `ignoreCache` is part of the identity. A refresh leaves `tx_decoding:<chain>` PENDING with
- * `ignoreCache: false` for the whole sync window, so keyed by chain alone a forced "Redecode all"
- * during that window joins the pending run, never reaches the backend, and still settles COMPLETE.
- */
-export function decodeActivityId(chain: string, ignoreCache = false): ActivityId {
-  return makeActivityId(ActivityKind.TX_DECODING, chain, ignoreCache ? ActivityPart.PULL : ActivityPart.CACHED);
+/** Whether a decode bypasses the cache, as the id part that distinguishes the two runs. */
+function cachePart(ignoreCache: boolean): ActivityPart {
+  return ignoreCache ? ActivityPart.PULL : ActivityPart.CACHED;
+}
+
+/** One chain's decode, and whether it bypasses the cache. */
+export interface DecodeSubject {
+  readonly chain: string;
+  readonly ignoreCache: boolean;
+}
+
+/** One chain's decode of a named set of transactions. */
+export interface TargetedDecodeSubject {
+  readonly chain: string;
+  readonly txRefs: readonly string[];
 }
 
 /**
- * The identity of one chain's decode within a *targeted* request.
+ * One chain's decode.
  *
- * The tx refs are part of the identity, not decoration. This was
- * `TX_DECODING:<chain>:PULL` — scoped by chain alone — while the activity is `rerunnable: false`
- * and its payload is the request. Two different tx sets on one chain therefore deduped onto each
- * other and the second caller was handed the first run's promise, so its transactions were never
- * decoded.
+ * `ignoreCache` is part of the identity. A refresh leaves the cached run PENDING for the whole sync
+ * window, so keyed by chain alone a forced "Redecode all" during that window joins the pending run,
+ * never reaches the backend, and still settles COMPLETE.
+ *
+ * No fixed part: `TX_DECODING` hosts one operation, and the cache flag that varies belongs after
+ * the chain, so a coarse reader can ask about a chain without knowing which variant ran.
  */
-export function targetedDecodeActivityId(chain: string, txRefs: readonly string[]): ActivityId {
-  return makeActivityId(ActivityKind.TX_DECODING, chain, ActivityPart.PULL, asScope(txRefs));
-}
+export const decodeActivity = defineActivity<DecodeSubject, readonly [string, ActivityPart]>({
+  key: subject => [subject.chain, cachePart(subject.ignoreCache)],
+  kind: ActivityKind.TX_DECODING,
+  lane: () => DECODE_LANE,
+});
 
 /**
- * Builds the activity id identifying a block-event decode.
+ * One chain's decode within a *targeted* request.
+ *
+ * The tx refs are part of the identity, not decoration. Scoped by chain alone, while the activity
+ * is `rerunnable: false` and its payload is the request, two different tx sets on one chain deduped
+ * onto each other and the second caller was handed the first run's promise, so its transactions
+ * were never decoded.
+ */
+export const targetedDecodeActivity = defineActivity<TargetedDecodeSubject, readonly [string, ActivityPart, string]>({
+  key: subject => [subject.chain, ActivityPart.PULL, asScope(subject.txRefs)],
+  kind: ActivityKind.TX_DECODING,
+  lane: () => DECODE_LANE,
+});
+
+/**
+ * A block-event decode.
  *
  * @remarks
  * The block numbers are the request, so they belong in the id even though block events are
  * ethereum-only: one chain is not one request.
  */
+export const blockDecodeActivity = defineActivity<{ blockNumbers: readonly number[] }, readonly [string]>({
+  key: subject => [asScope(subject.blockNumbers)],
+  kind: ActivityKind.ETH_BLOCK_DECODING,
+  lane: () => DECODE_LANE,
+});
+
+/**
+ * The identity of one chain's decode.
+ *
+ * Delegates to {@link decodeActivity} rather than composing an id of its own, so there is one
+ * definition. A flow names its children before they exist and the mechanism submits them later, and
+ * a divergence between the two does not fail loudly: the children are simply never gated by the
+ * parent claiming them.
+ */
+export function decodeActivityId(chain: string, ignoreCache = false): ActivityId {
+  return decodeActivity.id({ chain, ignoreCache });
+}
+
+/** The identity of one chain's decode within a targeted request. See {@link targetedDecodeActivity}. */
+export function targetedDecodeActivityId(chain: string, txRefs: readonly string[]): ActivityId {
+  return targetedDecodeActivity.id({ chain, txRefs });
+}
+
+/** The identity of a block-event decode. See {@link blockDecodeActivity}. */
 export function blockDecodeActivityId(blockNumbers: readonly number[]): ActivityId {
-  return makeActivityId(ActivityKind.ETH_BLOCK_DECODING, asScope(blockNumbers));
+  return blockDecodeActivity.id({ blockNumbers });
 }

--- a/frontend/app/src/modules/history/events/tx/sync-activity.spec.ts
+++ b/frontend/app/src/modules/history/events/tx/sync-activity.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  accountSyncActivity,
+  accountSyncActivityId,
+  chainSyncActivity,
+  chainSyncActivityId,
+  exchangeEventsActivity,
+  exchangeEventsActivityId,
+  onlineEventsActivity,
+  onlineEventsActivityId,
+} from '@/modules/history/events/tx/sync-activity';
+
+/**
+ * Literals, not helper-against-descriptor comparisons: the flow names these children before the
+ * mechanism submits them, so a change to the id shape has to fail here rather than quietly stop the
+ * children being gated by the umbrella that claims them.
+ */
+describe('sync activity ids', () => {
+  it('should key a chain sync by chain alone', () => {
+    expect(chainSyncActivity.id({ chain: 'eth' })).toBe('tx-sync:eth');
+  });
+
+  it('should key an account sync by chain then address', () => {
+    expect(accountSyncActivity.id({ address: '0xabc', chain: 'eth' })).toBe('tx-sync:eth:0xabc');
+  });
+
+  it('should make the chain sync id the prefix its accounts sit under', () => {
+    const chain = chainSyncActivity.id({ chain: 'eth' });
+    expect(accountSyncActivity.id({ address: '0xabc', chain: 'eth' }).startsWith(`${chain}:`)).toBe(true);
+  });
+
+  it('should let a chain-wide reader ask for the accounts of one chain', () => {
+    expect(accountSyncActivity.partsWithin(['eth'])).toStrictEqual(['eth']);
+  });
+
+  it('should key an exchange by location and name', () => {
+    expect(exchangeEventsActivity.id({ location: 'kraken', name: 'main' })).toBe('exchange-events:kraken:main');
+  });
+
+  it('should give two accounts of one exchange location distinct ids', () => {
+    expect(exchangeEventsActivity.id({ location: 'kraken', name: 'main' }))
+      .not
+      .toBe(exchangeEventsActivity.id({ location: 'kraken', name: 'second' }));
+  });
+
+  it('should key an online query by its type', () => {
+    expect(onlineEventsActivity.id({ queryType: 'eth_withdrawals' })).toBe('online-events:eth_withdrawals');
+  });
+
+  it('should give a chain sync and its accounts the same lane family per chain', () => {
+    const first = accountSyncActivity.laneOf?.({ address: '0xabc', chain: 'eth' });
+    const second = accountSyncActivity.laneOf?.({ address: '0xdef', chain: 'eth' });
+    const other = accountSyncActivity.laneOf?.({ address: '0xabc', chain: 'optimism' });
+
+    expect(first).toBe(second);
+    expect(first).not.toBe(other);
+  });
+
+  it('should route every named helper through its descriptor', () => {
+    expect(chainSyncActivityId('eth')).toBe(chainSyncActivity.id({ chain: 'eth' }));
+    expect(accountSyncActivityId('eth', '0xabc')).toBe(accountSyncActivity.id({ address: '0xabc', chain: 'eth' }));
+    expect(exchangeEventsActivityId('kraken', 'main')).toBe(exchangeEventsActivity.id({ location: 'kraken', name: 'main' }));
+    expect(onlineEventsActivityId('eth_withdrawals')).toBe(onlineEventsActivity.id({ queryType: 'eth_withdrawals' }));
+  });
+});

--- a/frontend/app/src/modules/history/events/tx/sync-activity.ts
+++ b/frontend/app/src/modules/history/events/tx/sync-activity.ts
@@ -1,3 +1,4 @@
+import type { TransactionsQueryStatus } from '@/modules/core/messaging/types';
 import type { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
 import { defineActivity } from '@/modules/task-center/core/activity-descriptor';
 import {
@@ -26,6 +27,23 @@ export interface AccountSyncSubject {
   readonly address: string;
 }
 
+/**
+ * What an account's sync carries beyond its status and its progress.
+ *
+ * Deliberately small. How far the query has got is `steps` on the activity, because the record
+ * already owns progress and a second copy here would be the duplication `DetailShape` bans. What is
+ * left is what steps cannot say: the absolute range being queried, which the panel renders as
+ * "from to", and which sub-query is running.
+ */
+export interface AccountSyncDetail {
+  /** The queried range, `[from, cursor]`, in seconds. Absent for a chain that sends no period. */
+  readonly period?: readonly [number, number];
+  /** The far end of the range, so the panel can render the target rather than only the cursor. */
+  readonly windowEnd?: number;
+  /** Which sub-query is running, as the backend's own step. */
+  readonly queryStep: TransactionsQueryStatus;
+}
+
 /** One connected exchange. */
 export interface ExchangeEventsSubject {
   readonly location: string;
@@ -50,7 +68,7 @@ export const chainSyncActivity = defineActivity<{ chain: string }, readonly [str
  * The lane is the chain's own family, so the family cap gives two concurrent accounts *per chain*
  * rather than two across the run.
  */
-export const accountSyncActivity = defineActivity<AccountSyncSubject, readonly [string, string]>({
+export const accountSyncActivity = defineActivity<AccountSyncSubject, readonly [string, string], AccountSyncDetail>({
   key: subject => [subject.chain, subject.address],
   kind: ActivityKind.TX_SYNC,
   lane: subject => familyLane(ACCOUNT_SYNC_LANE_PREFIX, subject.chain),

--- a/frontend/app/src/modules/history/events/tx/sync-activity.ts
+++ b/frontend/app/src/modules/history/events/tx/sync-activity.ts
@@ -1,31 +1,94 @@
 import type { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
-import { type ActivityId, ActivityKind, makeActivityId } from '@/modules/task-center/core/types';
+import { defineActivity } from '@/modules/task-center/core/activity-descriptor';
+import {
+  ACCOUNT_SYNC_LANE_PREFIX,
+  CHAIN_SYNC_LANE,
+  EXCHANGE_EVENTS_LANE_PREFIX,
+  familyLane,
+} from '@/modules/task-center/core/orchestrator/spec';
+import { type ActivityId, ActivityKind } from '@/modules/task-center/core/types';
 
 /**
  * The identities of everything a history refresh is made of.
  *
  * Shared between the flow declaration, which names these before any of them exists, and the
  * producers that submit them. Composing the same id in both places would not fail loudly if the
- * two drifted — the children would simply stop being gated by, and counted toward, the umbrella
+ * two drifted: the children would simply stop being gated by, and counted toward, the umbrella
  * that claims them.
+ *
+ * Declared as descriptors so the lane travels with the id. A chain and its accounts are the same
+ * kind and share a key prefix, which is what lets a per-chain reader cover both.
  */
 
-/** One chain's sync: the group its accounts and its decode hang from. */
-export function chainSyncActivityId(chain: string): ActivityId {
-  return makeActivityId(ActivityKind.TX_SYNC, chain);
+/** One account's sync, within its chain. */
+export interface AccountSyncSubject {
+  readonly chain: string;
+  readonly address: string;
 }
 
-/** One account's sync within its chain. */
-export function accountSyncActivityId(chain: string, address: string): ActivityId {
-  return makeActivityId(ActivityKind.TX_SYNC, chain, address);
+/** One connected exchange. */
+export interface ExchangeEventsSubject {
+  readonly location: string;
+  readonly name: string;
 }
+
+/**
+ * One chain's sync: the group its accounts and its decode hang from.
+ *
+ * Its key is the leading slice of {@link accountSyncActivity}'s, so the chain row's id is also the
+ * prefix its accounts sit under, and a reader asking about a chain covers the whole group.
+ */
+export const chainSyncActivity = defineActivity<{ chain: string }, readonly [string]>({
+  key: subject => [subject.chain],
+  kind: ActivityKind.TX_SYNC,
+  lane: () => CHAIN_SYNC_LANE,
+});
+
+/**
+ * One account's sync within its chain.
+ *
+ * The lane is the chain's own family, so the family cap gives two concurrent accounts *per chain*
+ * rather than two across the run.
+ */
+export const accountSyncActivity = defineActivity<AccountSyncSubject, readonly [string, string]>({
+  key: subject => [subject.chain, subject.address],
+  kind: ActivityKind.TX_SYNC,
+  lane: subject => familyLane(ACCOUNT_SYNC_LANE_PREFIX, subject.chain),
+});
 
 /** One connected exchange's event query. */
-export function exchangeEventsActivityId(location: string, name: string): ActivityId {
-  return makeActivityId(ActivityKind.EXCHANGE_EVENTS, location, name);
+export const exchangeEventsActivity = defineActivity<ExchangeEventsSubject, readonly [string, string]>({
+  key: subject => [subject.location, subject.name],
+  kind: ActivityKind.EXCHANGE_EVENTS,
+  lane: subject => familyLane(EXCHANGE_EVENTS_LANE_PREFIX, subject.location),
+});
+
+/**
+ * One online-event query (withdrawals, block productions).
+ *
+ * No lane: these are few and independent, and run unthrottled today.
+ */
+export const onlineEventsActivity = defineActivity<{ queryType: OnlineHistoryEventsQueryType }, readonly [string]>({
+  key: subject => [subject.queryType],
+  kind: ActivityKind.ONLINE_EVENTS,
+});
+
+/** One chain's sync. See {@link chainSyncActivity}. */
+export function chainSyncActivityId(chain: string): ActivityId {
+  return chainSyncActivity.id({ chain });
 }
 
-/** One online-event query (withdrawals, block productions). */
+/** One account's sync within its chain. See {@link accountSyncActivity}. */
+export function accountSyncActivityId(chain: string, address: string): ActivityId {
+  return accountSyncActivity.id({ address, chain });
+}
+
+/** One connected exchange's event query. See {@link exchangeEventsActivity}. */
+export function exchangeEventsActivityId(location: string, name: string): ActivityId {
+  return exchangeEventsActivity.id({ location, name });
+}
+
+/** One online-event query. See {@link onlineEventsActivity}. */
 export function onlineEventsActivityId(queryType: OnlineHistoryEventsQueryType): ActivityId {
-  return makeActivityId(ActivityKind.ONLINE_EVENTS, queryType);
+  return onlineEventsActivity.id({ queryType });
 }

--- a/frontend/app/src/modules/history/events/tx/sync-activity.ts
+++ b/frontend/app/src/modules/history/events/tx/sync-activity.ts
@@ -51,6 +51,22 @@ export interface ExchangeEventsSubject {
 }
 
 /**
+ * What an exchange's event query carries beyond its status.
+ *
+ * All detail and no progress, unlike {@link AccountSyncDetail}. A status update names the sub-range
+ * it is *about to* query rather than how far through the whole query it has reached, and the
+ * backend walks those ranges without saying how many there are. Nothing in the stream is a cursor,
+ * so any percentage built from it would be invented; the range is worth rendering, a made-up bar is
+ * not.
+ */
+export interface ExchangeEventsDetail {
+  /** The sub-range being queried, `[from, to]`, in seconds. Absent until the first status update. */
+  readonly period?: readonly [number, number];
+  /** Which query this is, as the backend's own type. Empty while the panel is only seeded. */
+  readonly eventType: string;
+}
+
+/**
  * One chain's sync: the group its accounts and its decode hang from.
  *
  * Its key is the leading slice of {@link accountSyncActivity}'s, so the chain row's id is also the
@@ -75,7 +91,7 @@ export const accountSyncActivity = defineActivity<AccountSyncSubject, readonly [
 });
 
 /** One connected exchange's event query. */
-export const exchangeEventsActivity = defineActivity<ExchangeEventsSubject, readonly [string, string]>({
+export const exchangeEventsActivity = defineActivity<ExchangeEventsSubject, readonly [string, string], ExchangeEventsDetail>({
   key: subject => [subject.location, subject.name],
   kind: ActivityKind.EXCHANGE_EVENTS,
   lane: subject => familyLane(EXCHANGE_EVENTS_LANE_PREFIX, subject.location),

--- a/frontend/app/src/modules/history/events/tx/use-exchange-events-refresh.ts
+++ b/frontend/app/src/modules/history/events/tx/use-exchange-events-refresh.ts
@@ -1,3 +1,4 @@
+import type { ActivityId } from '@/modules/task-center/core/types';
 import { toSentenceCase } from '@rotki/common';
 import { omit } from 'es-toolkit';
 import { isErr, map as mapResult, type Result } from 'plainfp/result';
@@ -7,11 +8,9 @@ import { logger } from '@/modules/core/common/logging/logging';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { isActionable, isCancellation, type TaskError } from '@/modules/core/tasks/task-result';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
-import { exchangeEventsActivityId } from '@/modules/history/events/tx/sync-activity';
+import { exchangeEventsActivity } from '@/modules/history/events/tx/sync-activity';
 import { useEventsQueryStatusStore } from '@/modules/history/use-events-query-status-store';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
-import { EXCHANGE_EVENTS_LANE_PREFIX, familyLane } from '@/modules/task-center/core/orchestrator/spec';
-import { type ActivityId, ActivityKind } from '@/modules/task-center/core/types';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 
 interface UseExchangeEventsRefreshReturn {
@@ -39,9 +38,9 @@ export function useExchangeEventsRefresh(): UseExchangeEventsRefreshReturn {
     const exchange = omit(payload, ['gateLocation', 'krakenAccountType', 'okxLocation']);
     const parsedPayload = QueryExchangeEventsPayload.parse(exchange);
     const outcome = await submitTask({
-      id: exchangeEventsActivityId(exchange.location, exchange.name),
-      kind: ActivityKind.EXCHANGE_EVENTS,
-      lane: familyLane(EXCHANGE_EVENTS_LANE_PREFIX, exchange.location),
+      id: exchangeEventsActivity.id(exchange),
+      kind: exchangeEventsActivity.kind,
+      lane: exchangeEventsActivity.laneOf?.(exchange),
       parent,
       rerunnable: true,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(

--- a/frontend/app/src/modules/history/events/tx/use-history-refresh-policy.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-refresh-policy.ts
@@ -3,6 +3,7 @@ import type { ChainAddress } from '@/modules/history/events/event-payloads';
 import type { StaleAfterEdge } from '@/modules/task-center/core/orchestrator/spec';
 import { useExchangeData } from '@/modules/balances/exchanges/use-exchange-data';
 import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
+import { accountSyncActivity, exchangeEventsActivity } from '@/modules/history/events/tx/sync-activity';
 import { useHistoryTransactionAccounts } from '@/modules/history/events/tx/use-history-transaction-accounts';
 import { Purgeable } from '@/modules/session/purge';
 import { useDisabledChains } from '@/modules/settings/general/disabled-chain-queries/use-disabled-chains';
@@ -78,7 +79,7 @@ export function useHistoryRefreshPolicy(): UseHistoryRefreshPolicyReturn {
    * Keying this on `everCompleted` instead would leave a failed or cancelled sync novel forever,
    * and `resolveForFullRefresh` escalates any novelty into a full re-sync of every account.
    */
-  function neverAttempted(kind: ActivityKind, ...parts: string[]): boolean {
+  function neverAttempted(kind: ActivityKind, ...parts: (string | number)[]): boolean {
     return statusOf(kind, ...parts).lastOutcome === undefined;
   }
 
@@ -102,8 +103,10 @@ export function useHistoryRefreshPolicy(): UseHistoryRefreshPolicyReturn {
 
   function detectNovelty(allAccounts: ChainAddress[], usedExchanges: Exchange[]): NoveltyDetection {
     return {
-      newAccounts: allAccounts.filter(account => neverAttempted(ActivityKind.TX_SYNC, account.chain, account.address)),
-      newExchanges: usedExchanges.filter(exchange => neverAttempted(ActivityKind.EXCHANGE_EVENTS, exchange.location, exchange.name)),
+      newAccounts: allAccounts.filter(account =>
+        neverAttempted(accountSyncActivity.kind, ...accountSyncActivity.partsOf(account))),
+      newExchanges: usedExchanges.filter(exchange =>
+        neverAttempted(exchangeEventsActivity.kind, ...exchangeEventsActivity.partsOf(exchange))),
     };
   }
 

--- a/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.ts
+++ b/frontend/app/src/modules/history/events/tx/use-history-transaction-decoding.ts
@@ -9,12 +9,12 @@ import {
   TransactionChainType,
   TransactionChainTypeNeedDecoding,
 } from '@/modules/history/events/event-payloads';
-import { decodeActivityId } from '@/modules/history/events/tx/decode-activity';
+import { decodeActivity } from '@/modules/history/events/tx/decode-activity';
 import { redecodeFlow } from '@/modules/history/events/tx/redecode.flow';
 import { useUndecodedTransactionsStatus } from '@/modules/history/events/tx/use-undecoded-transactions-status';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
-import { DECODE_LANE, UMBRELLA_LANE } from '@/modules/task-center/core/orchestrator/spec';
+import { UMBRELLA_LANE } from '@/modules/task-center/core/orchestrator/spec';
 import { type ActivityId, ActivityKind } from '@/modules/task-center/core/types';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 
@@ -61,9 +61,9 @@ export const useHistoryTransactionDecoding = createSharedComposable(() => {
   ): Promise<void> => {
     const outcome = await submitTask({
       deps: placement.deps,
-      id: decodeActivityId(chain, ignoreCache),
-      kind: ActivityKind.TX_DECODING,
-      lane: DECODE_LANE,
+      id: decodeActivity.id({ chain, ignoreCache }),
+      kind: decodeActivity.kind,
+      lane: decodeActivity.laneOf?.({ chain, ignoreCache }),
       parent: placement.parent,
       rerunnable: true,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => {

--- a/frontend/app/src/modules/history/events/tx/use-refresh-handlers.ts
+++ b/frontend/app/src/modules/history/events/tx/use-refresh-handlers.ts
@@ -1,4 +1,5 @@
 import type { Exchange } from '@/modules/balances/types/exchanges';
+import type { ActivityId } from '@/modules/task-center/core/types';
 import { err, isErr, map as mapResult, type Result } from 'plainfp/result';
 import { msg } from '@/message-key';
 import { ApiKeyMissingError } from '@/modules/core/api/types/errors';
@@ -7,7 +8,7 @@ import { useNotifications } from '@/modules/core/notifications/use-notifications
 import { isActionable, Skipped, type TaskError } from '@/modules/core/tasks/task-result';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import { OnlineHistoryEventsQueryType } from '@/modules/history/events/schemas';
-import { onlineEventsActivityId } from '@/modules/history/events/tx/sync-activity';
+import { onlineEventsActivity } from '@/modules/history/events/tx/sync-activity';
 import { useExchangeEventsRefresh } from '@/modules/history/events/tx/use-exchange-events-refresh';
 import { useMoneriumOAuth } from '@/modules/integrations/monerium/use-monerium-auth';
 import { PremiumFeature, useFeatureAccess } from '@/modules/premium/use-feature-access';
@@ -15,7 +16,6 @@ import { Module, useModuleEnabled } from '@/modules/session/use-module-enabled';
 import { useExternalApiKeys } from '@/modules/settings/api-keys/external/use-external-api-keys';
 import { SyncWarningSource, useSyncWarningsStore } from '@/modules/shell/sync-progress/use-sync-warnings-store';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
-import { type ActivityId, ActivityKind } from '@/modules/task-center/core/types';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 
 interface UseRefreshHandlersReturn {
@@ -101,8 +101,9 @@ export function useRefreshHandlers(): UseRefreshHandlersReturn {
     logger.debug(`querying for ${queryType} events`);
 
     const outcome = await submitTask({
-      id: onlineEventsActivityId(queryType),
-      kind: ActivityKind.ONLINE_EVENTS,
+      id: onlineEventsActivity.id({ queryType }),
+      kind: onlineEventsActivity.kind,
+      lane: onlineEventsActivity.laneOf?.({ queryType }),
       parent,
       rerunnable: true,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(

--- a/frontend/app/src/modules/history/events/tx/use-targeted-redecode.ts
+++ b/frontend/app/src/modules/history/events/tx/use-targeted-redecode.ts
@@ -4,6 +4,7 @@ import type {
   PullLocationTransactionPayload,
   PullTransactionPayload,
 } from '@/modules/history/events/event-payloads';
+import type { ActivityId } from '@/modules/task-center/core/types';
 import { groupBy } from 'es-toolkit';
 import { isErr, map as mapResult, ok, type Result } from 'plainfp/result';
 import { msg } from '@/message-key';
@@ -13,12 +14,11 @@ import { useSupportedChains } from '@/modules/core/common/use-supported-chains';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { isActionable, type TaskError } from '@/modules/core/tasks/task-result';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
-import { blockDecodeActivityId, targetedDecodeActivityId } from '@/modules/history/events/tx/decode-activity';
+import { blockDecodeActivity, targetedDecodeActivity } from '@/modules/history/events/tx/decode-activity';
 import { targetedRedecodeFlow, type TargetedRedecodeScope } from '@/modules/history/events/tx/targeted-redecode.flow';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
-import { DECODE_LANE, UMBRELLA_LANE } from '@/modules/task-center/core/orchestrator/spec';
-import { type ActivityId, ActivityKind } from '@/modules/task-center/core/types';
+import { UMBRELLA_LANE } from '@/modules/task-center/core/orchestrator/spec';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 
 /** What a targeted re-decode is asked for: transactions, block events, or both. */
@@ -60,9 +60,9 @@ export function useTargetedRedecode(): UseTargetedRedecodeReturn {
       : activityLabelFor(msg.$t('task_center.activity.tx_decoding.batch'), { chain, count }, count);
 
     const outcome = await submitTask<boolean>({
-      id: targetedDecodeActivityId(payload.chain, payload.txRefs),
-      kind: ActivityKind.TX_DECODING,
-      lane: DECODE_LANE,
+      id: targetedDecodeActivity.id(payload),
+      kind: targetedDecodeActivity.kind,
+      lane: targetedDecodeActivity.laneOf?.(payload),
       parent,
       rerunnable: false,
       run: async ({ runTask }): Promise<Result<boolean, TaskError>> => mapResult(
@@ -111,9 +111,9 @@ export function useTargetedRedecode(): UseTargetedRedecodeReturn {
       : activityLabelFor(msg.$t('task_center.activity.eth_block_decoding.batch'), { count }, count);
 
     const outcome = await submitTask({
-      id: blockDecodeActivityId(blockNumbers),
-      kind: ActivityKind.ETH_BLOCK_DECODING,
-      lane: DECODE_LANE,
+      id: blockDecodeActivity.id({ blockNumbers }),
+      kind: blockDecodeActivity.kind,
+      lane: blockDecodeActivity.laneOf?.({ blockNumbers }),
       parent,
       rerunnable: false,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(

--- a/frontend/app/src/modules/history/events/tx/use-transaction-sync.ts
+++ b/frontend/app/src/modules/history/events/tx/use-transaction-sync.ts
@@ -1,3 +1,4 @@
+import type { ActivityId } from '@/modules/task-center/core/types';
 import { groupBy } from 'es-toolkit';
 import { isErr, map as mapResult, type Result } from 'plainfp/result';
 import { hasTag } from 'plainfp/tagged';
@@ -8,13 +9,11 @@ import { useNotifications } from '@/modules/core/notifications/use-notifications
 import { combineOutcomes, isActionable, type TaskError } from '@/modules/core/tasks/task-result';
 import { useHistoryEventsApi } from '@/modules/history/api/events/use-history-events-api';
 import { type BlockchainAddress, type ChainAddress, TransactionChainType, TransactionChainTypeNeedDecoding, type TransactionRequestPayload } from '@/modules/history/events/event-payloads';
-import { accountSyncActivityId, chainSyncActivityId } from '@/modules/history/events/tx/sync-activity';
+import { accountSyncActivity, accountSyncActivityId, chainSyncActivity, chainSyncActivityId } from '@/modules/history/events/tx/sync-activity';
 import { useHistoryTransactionAccounts } from '@/modules/history/events/tx/use-history-transaction-accounts';
 import { useHistoryTransactionDecoding } from '@/modules/history/events/tx/use-history-transaction-decoding';
 import { useTxQueryStatusStore } from '@/modules/history/use-tx-query-status-store';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
-import { ACCOUNT_SYNC_LANE_PREFIX, CHAIN_SYNC_LANE, familyLane } from '@/modules/task-center/core/orchestrator/spec';
-import { type ActivityId, ActivityKind } from '@/modules/task-center/core/types';
 import { useNativeTask } from '@/modules/task-center/use-native-task';
 
 interface TransactionSyncParams {
@@ -121,9 +120,9 @@ export function useTransactionSync(): UseTransactionSyncReturn {
 
     const chainName = getChainName(chain);
     const outcome = await submitTask({
-      id: accountSyncActivityId(chain, address),
-      kind: ActivityKind.TX_SYNC,
-      lane: familyLane(ACCOUNT_SYNC_LANE_PREFIX, chain),
+      id: accountSyncActivity.id(account),
+      kind: accountSyncActivity.kind,
+      lane: accountSyncActivity.laneOf?.(account),
       parent,
       rerunnable: true,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(
@@ -194,8 +193,8 @@ export function useTransactionSync(): UseTransactionSyncReturn {
     const chainWork = submitTask({
       container: true,
       id: chainId,
-      kind: ActivityKind.TX_SYNC,
-      lane: CHAIN_SYNC_LANE,
+      kind: chainSyncActivity.kind,
+      lane: chainSyncActivity.laneOf?.({ chain }),
       parent,
       rerunnable: false,
       run: async (): Promise<Result<void, TaskError>> => {

--- a/frontend/app/src/modules/history/protocol-cache-activity.ts
+++ b/frontend/app/src/modules/history/protocol-cache-activity.ts
@@ -1,0 +1,48 @@
+import { defineActivity } from '@/modules/task-center/core/activity-descriptor';
+import { type ActivityId, ActivityKind } from '@/modules/task-center/core/types';
+
+/**
+ * One protocol's cache query on one chain, as a row beneath the work that triggered it.
+ *
+ * @remarks
+ * A row rather than an activity because nothing declares the set. The backend mints these pairs as
+ * its decoders reach them and never says how many are coming, so children minted from arriving
+ * frames would give their parent a denominator that grows as the run proceeds — a bar that runs
+ * backwards — and a pair whose query fails sends no terminal frame at all, so its row would stay
+ * live forever. Sub-items that have no activity of their own may carry their own counts; what a
+ * detail may never restate is the *activity's* status.
+ */
+interface ProtocolCacheRow {
+  /** The backend's own spelling (`ethereum`), not the chain id an activity is keyed by (`eth`). */
+  readonly chain: string;
+  readonly protocol: string;
+  readonly processed: number;
+  readonly total: number;
+}
+
+/**
+ * The protocol caches being filled under one activity.
+ *
+ * Per-row percentages are honest, because `processed`/`total` describe that one pair. There is
+ * deliberately no aggregate: summing across rows measures only the pairs seen so far.
+ */
+export interface ProtocolCacheDetail {
+  readonly protocols: readonly ProtocolCacheRow[];
+}
+
+/**
+ * The user-initiated cache refresh, from the data-management screen.
+ *
+ * No key: one refresh runs at a time and the id has nothing to distinguish. Declared as a
+ * descriptor anyway so the producer and the readers that ask whether it is running compose the
+ * same id from one place.
+ */
+export const protocolCacheActivity = defineActivity<void, readonly [], ProtocolCacheDetail>({
+  key: () => [],
+  kind: ActivityKind.PROTOCOL_CACHE,
+});
+
+/** The identity of the user-initiated cache refresh. See {@link protocolCacheActivity}. */
+export function protocolCacheActivityId(): ActivityId {
+  return protocolCacheActivity.id();
+}

--- a/frontend/app/src/modules/history/transaction-status-handler.spec.ts
+++ b/frontend/app/src/modules/history/transaction-status-handler.spec.ts
@@ -1,0 +1,120 @@
+import { createMock } from '@test/utils/create-mock';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TransactionsQueryStatus, type UnifiedTransactionStatusData } from '@/modules/core/messaging/types';
+import { accountSyncActivity } from '@/modules/history/events/tx/sync-activity';
+import { createTransactionStatusHandler } from '@/modules/history/transaction-status-handler';
+import { useTxQueryStatusStore } from '@/modules/history/use-tx-query-status-store';
+import { readActivityDetail, useActivityDetail } from '@/modules/task-center/use-activity-detail';
+
+const mockReportProgress = vi.fn();
+
+vi.mock('@/modules/task-center/use-task-orchestrator', () => ({
+  useTaskOrchestrator: vi.fn(() => ({
+    reportProgress: mockReportProgress,
+  })),
+}));
+
+function evmFrame(status: TransactionsQueryStatus, period: [number, number]): UnifiedTransactionStatusData {
+  return createMock<UnifiedTransactionStatusData>({
+    address: '0xabc',
+    chain: 'ETH',
+    period,
+    status,
+    subtype: 'evm',
+  });
+}
+
+describe('createTransactionStatusHandler', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    useActivityDetail().resetDetails();
+    vi.clearAllMocks();
+    useTxQueryStatusStore().initializeQueryStatus([{ address: '0xabc', chain: 'eth', subtype: 'evm' }]);
+  });
+
+  it('should publish detail under the lowercased chain the activity is keyed by', async () => {
+    const handler = createTransactionStatusHandler();
+    await handler.handle(evmFrame(TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED, [100, 200]));
+
+    const detail = get(readActivityDetail(accountSyncActivity, { address: '0xabc', chain: 'eth' }));
+    expect(detail?.queryStep).toBe(TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED);
+    expect(detail?.windowEnd).toBe(200);
+  });
+
+  it('should report the started frame as none of the window rather than all of it', async () => {
+    const handler = createTransactionStatusHandler();
+    await handler.handle(evmFrame(TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED, [100, 200]));
+
+    // Taken raw, the overloaded `period[1]` would read 100% before anything was queried.
+    expect(mockReportProgress).toHaveBeenCalledWith(
+      accountSyncActivity.id({ address: '0xabc', chain: 'eth' }),
+      { current: 0, total: 100 },
+    );
+  });
+
+  it('should report the cursor against the window established by the started frame', async () => {
+    const handler = createTransactionStatusHandler();
+    await handler.handle(evmFrame(TransactionsQueryStatus.QUERYING_TRANSACTIONS_STARTED, [100, 200]));
+    await handler.handle(evmFrame(TransactionsQueryStatus.QUERYING_TRANSACTIONS, [100, 150]));
+
+    expect(mockReportProgress).toHaveBeenCalledWith(
+      accountSyncActivity.id({ address: '0xabc', chain: 'eth' }),
+      { current: 50, total: 100 },
+    );
+  });
+
+  it('should fan a batched bitcoin frame out into one publish per address', async () => {
+    useTxQueryStatusStore().initializeQueryStatus([
+      { address: 'bc1a', chain: 'btc', subtype: 'bitcoin' },
+      { address: 'bc1b', chain: 'btc', subtype: 'bitcoin' },
+    ]);
+    const handler = createTransactionStatusHandler();
+
+    await handler.handle(createMock<UnifiedTransactionStatusData>({
+      addresses: ['bc1a', 'bc1b'],
+      chain: 'BTC',
+      period: undefined,
+      status: TransactionsQueryStatus.QUERYING_TRANSACTIONS,
+      subtype: 'bitcoin',
+    }));
+
+    for (const address of ['bc1a', 'bc1b']) {
+      expect(get(readActivityDetail(accountSyncActivity, { address, chain: 'btc' }))?.queryStep)
+        .toBe(TransactionsQueryStatus.QUERYING_TRANSACTIONS);
+    }
+  });
+
+  it('should leave a period-less chain indeterminate rather than reporting a made-up total', async () => {
+    useTxQueryStatusStore().initializeQueryStatus([{ address: 'bc1a', chain: 'btc', subtype: 'bitcoin' }]);
+    const handler = createTransactionStatusHandler();
+
+    await handler.handle(createMock<UnifiedTransactionStatusData>({
+      addresses: ['bc1a'],
+      chain: 'BTC',
+      period: undefined,
+      status: TransactionsQueryStatus.QUERYING_TRANSACTIONS,
+      subtype: 'bitcoin',
+    }));
+
+    expect(mockReportProgress).not.toHaveBeenCalled();
+  });
+
+  it('should publish nothing for a frame that lands after the sync has ended', async () => {
+    const store = useTxQueryStatusStore();
+    store.stopSyncing();
+    const handler = createTransactionStatusHandler();
+
+    await handler.handle(createMock<UnifiedTransactionStatusData>({
+      address: '0xlate',
+      chain: 'ETH',
+      period: [100, 150],
+      status: TransactionsQueryStatus.QUERYING_TRANSACTIONS,
+      subtype: 'evm',
+    }));
+
+    expect(get(readActivityDetail(accountSyncActivity, { address: '0xlate', chain: 'eth' })))
+      .toBeUndefined();
+    expect(mockReportProgress).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/src/modules/history/transaction-status-handler.ts
+++ b/frontend/app/src/modules/history/transaction-status-handler.ts
@@ -1,11 +1,61 @@
 import type { StateHandler } from '@/modules/core/messaging/interfaces';
+import type { UnifiedTransactionStatusData } from '@/modules/core/messaging/types';
+import type { ChainAddress } from '@/modules/history/events/event-payloads';
 import { createStateHandler } from '@/modules/core/messaging/utils';
+import { accountSyncActivity } from '@/modules/history/events/tx/sync-activity';
+import { periodSteps } from '@/modules/history/tx-query-status-period';
 import { useTxQueryStatusStore } from '@/modules/history/use-tx-query-status-store';
+import { publishActivityDetail } from '@/modules/task-center/use-activity-detail';
+import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
+
+/**
+ * The accounts one message speaks for.
+ *
+ * Bitcoin batches every address into a single frame while the other subtypes carry one, so the
+ * fan-out has to happen before anything per-account is published.
+ */
+function accountsOf(data: UnifiedTransactionStatusData): ChainAddress[] {
+  return data.subtype === 'bitcoin'
+    ? data.addresses.map(address => ({ address, chain: data.chain }))
+    : [{ address: data.address, chain: data.chain }];
+}
 
 export function createTransactionStatusHandler(): StateHandler {
-  const { setUnifiedTxQueryStatus } = useTxQueryStatusStore();
+  const { getQueryStatus, setUnifiedTxQueryStatus } = useTxQueryStatusStore();
+  const { reportProgress } = useTaskOrchestrator();
+
+  /**
+   * Mirror one account's stored entry onto its activity.
+   *
+   * Read back from the store rather than projected from the frame, so this sees the merged result:
+   * the period boundaries an earlier message established, the cancelled entries the store refuses
+   * to overwrite, and the canonical chain spelling the id is built from.
+   *
+   * Progress and detail are split by what the record already owns. How far the query has read is
+   * `steps`, so the percentage falls out of the machinery every other activity uses; the range and
+   * the sub-query are detail, because nothing on the record can express them.
+   */
+  function mirrorToActivity(account: ChainAddress): void {
+    const entry = getQueryStatus(account);
+    if (entry === undefined)
+      return;
+
+    const subject = { address: entry.address, chain: entry.chain };
+
+    publishActivityDetail(accountSyncActivity, subject, {
+      period: entry.period,
+      queryStep: entry.status,
+      windowEnd: entry.originalPeriodEnd,
+    });
+
+    const steps = periodSteps(entry);
+    if (steps !== undefined)
+      reportProgress(accountSyncActivity.id(subject), steps);
+  }
 
   return createStateHandler((data) => {
+    const accounts = accountsOf(data);
     setUnifiedTxQueryStatus(data);
+    accounts.forEach(mirrorToActivity);
   });
 }

--- a/frontend/app/src/modules/history/tx-query-status-period.spec.ts
+++ b/frontend/app/src/modules/history/tx-query-status-period.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { periodSteps } from '@/modules/history/tx-query-status-period';
+
+describe('periodSteps', () => {
+  it('should measure the cursor against the established window', () => {
+    expect(periodSteps({ originalPeriodEnd: 200, originalPeriodStart: 100, period: [100, 150] }))
+      .toStrictEqual({ current: 50, total: 100 });
+  });
+
+  it('should fall back to the period start when no original start was captured', () => {
+    expect(periodSteps({ originalPeriodEnd: 200, period: [100, 125] }))
+      .toStrictEqual({ current: 25, total: 100 });
+  });
+
+  it('should report nothing for a query that sends no period', () => {
+    expect(periodSteps({ originalPeriodEnd: 200 })).toBeUndefined();
+  });
+
+  it('should report nothing before the target has been established', () => {
+    expect(periodSteps({ period: [100, 150] })).toBeUndefined();
+  });
+
+  it('should report nothing for an empty window rather than claiming a percentage', () => {
+    expect(periodSteps({ originalPeriodEnd: 100, originalPeriodStart: 100, period: [100, 100] }))
+      .toBeUndefined();
+  });
+
+  it('should report nothing for a window that ends before it starts', () => {
+    expect(periodSteps({ originalPeriodEnd: 50, originalPeriodStart: 100, period: [100, 100] }))
+      .toBeUndefined();
+  });
+
+  it('should clamp a cursor that has run past the window', () => {
+    expect(periodSteps({ originalPeriodEnd: 200, originalPeriodStart: 100, period: [100, 999] }))
+      .toStrictEqual({ current: 100, total: 100 });
+  });
+
+  it('should clamp a cursor that sits before the window', () => {
+    expect(periodSteps({ originalPeriodEnd: 200, originalPeriodStart: 100, period: [100, 40] }))
+      .toStrictEqual({ current: 0, total: 100 });
+  });
+});

--- a/frontend/app/src/modules/history/tx-query-status-period.ts
+++ b/frontend/app/src/modules/history/tx-query-status-period.ts
@@ -82,6 +82,33 @@ export function periodWithCursorAtStart(
 }
 
 /**
+ * The queried range as step progress: how much of the window the backend has read, over the whole
+ * window.
+ *
+ * @remarks
+ * The unit is seconds of the queried range, not transactions. That is the only quantity these
+ * messages carry, and it is what the sync panel has always drawn; naming it as steps puts it on the
+ * activity itself instead of a projection beside it.
+ *
+ * `undefined` where the range cannot be measured, which is a real state rather than an edge case:
+ * a query with no period at all (bitcoin sends none), one that has not yet established its target,
+ * and one whose window is empty because there is nothing to catch up on. Each leaves the activity
+ * indeterminate, which is honest, rather than claiming 0% or 100%.
+ */
+export function periodSteps(tracking: Partial<PeriodTracking>): { current: number; total: number } | undefined {
+  const { originalPeriodEnd, originalPeriodStart, period } = tracking;
+  if (period === undefined || originalPeriodEnd === undefined)
+    return undefined;
+
+  const start = originalPeriodStart ?? period[0];
+  const total = originalPeriodEnd - start;
+  if (total <= 0)
+    return undefined;
+
+  return { current: Math.min(Math.max(period[1] - start, 0), total), total };
+}
+
+/**
  * Period tracking for a bitcoin message, which is the one subtype whose `period` is optional.
  *
  * Carries `existing`'s values when the message has none: the entry is rebuilt from scratch per

--- a/frontend/app/src/modules/history/use-events-query-status-store.ts
+++ b/frontend/app/src/modules/history/use-events-query-status-store.ts
@@ -61,6 +61,16 @@ export const useEventsQueryStatusStore = defineStore('history/events-query-statu
     set(queryStatus, status);
   };
 
+  /**
+   * One exchange's stored entry, as the store holds it rather than as a frame described it.
+   *
+   * Reading back is what lets a caller see the merged result: the range an earlier message
+   * established and a later one omitted, the entries a cancel froze, and the updates dropped
+   * because no sync is running.
+   */
+  const getQueryStatus = (subject: Pick<HistoryEventsQueryData, 'location' | 'name'>): HistoryEventsQueryData | undefined =>
+    get(queryStatus)[createKey(subject)];
+
   const markLocationCancelled = ({ location, name }: Pick<HistoryEventsQueryData, 'location' | 'name'>): void => {
     const key = createKey({ location, name });
     const existing = get(queryStatus)[key];
@@ -70,6 +80,7 @@ export const useEventsQueryStatusStore = defineStore('history/events-query-statu
   };
 
   return {
+    getQueryStatus,
     initializeQueryStatus,
     isAllFinished,
     isStatusFinished,

--- a/frontend/app/src/modules/history/use-tx-query-status-store.ts
+++ b/frontend/app/src/modules/history/use-tx-query-status-store.ts
@@ -279,10 +279,22 @@ export const useTxQueryStatusStore = defineStore('history/transaction-query-stat
     });
   };
 
+  /**
+   * One account's merged entry, as the store holds it.
+   *
+   * For readers that need what a message *resulted in* rather than what it said: the period fields
+   * are carried across updates and the chain is canonicalised to lower case here, so projecting
+   * from the raw frame would rebuild both, and get the second one wrong wherever the backend's
+   * spelling differs from the chain id the rest of the app uses.
+   */
+  const getQueryStatus = (account: ChainAddress): TxQueryStatusData | undefined =>
+    get(queryStatus)[createKey({ address: account.address, chain: account.chain })];
+
   const isAddressCancelled = (account: ChainAddress): boolean =>
     get(queryStatus)[createKey(account)]?.status === TransactionsQueryStatus.CANCELLED;
 
   return {
+    getQueryStatus,
     initializeQueryStatus,
     isAddressCancelled,
     isAllFinished,

--- a/frontend/app/src/modules/session/use-purge.ts
+++ b/frontend/app/src/modules/session/use-purge.ts
@@ -4,6 +4,7 @@ import { msg } from '@/message-key';
 import { getErrorMessage } from '@/modules/core/common/logging/error-handling';
 import { useNotifications } from '@/modules/core/notifications/use-notifications';
 import { isActionable, isCancellation, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { protocolCacheActivityId } from '@/modules/history/protocol-cache-activity';
 import { useProtocolCacheStatusStore } from '@/modules/history/use-protocol-cache-status-store';
 import { useSessionApi } from '@/modules/session/api/use-session-api';
 import { activityLabelFor } from '@/modules/task-center/activity-labels';
@@ -50,7 +51,7 @@ export function useSessionPurge(): UseSessionPurge {
   const refreshGeneralCache = async (source: string): Promise<void> => {
     resetProtocolCacheUpdatesStatus();
     const outcome = await submitTask({
-      id: makeActivityId(ActivityKind.PROTOCOL_CACHE),
+      id: protocolCacheActivityId(),
       kind: ActivityKind.PROTOCOL_CACHE,
       rerunnable: true,
       run: async ({ runTask }): Promise<Result<void, TaskError>> => mapResult(

--- a/frontend/app/src/modules/task-center/core/activity-descriptor.spec.ts
+++ b/frontend/app/src/modules/task-center/core/activity-descriptor.spec.ts
@@ -10,7 +10,27 @@ const testActivity = defineActivity<Subject, readonly [string, string]>({
   part: ActivityPart.ADD,
 });
 
+const partlessActivity = defineActivity<Subject, readonly [string, string]>({
+  key: subject => [subject.chain, subject.address],
+  kind: ActivityKind.TX_SYNC,
+});
+
 describe('defineActivity', () => {
+  describe('without a fixed part', () => {
+    it('should build the id from the kind and the key alone', () => {
+      expect(partlessActivity.id({ address: '0xabc', chain: 'eth' })).toBe('tx-sync:eth:0xabc');
+    });
+
+    it('should contribute no segment for the absent part', () => {
+      expect(partlessActivity.partsWithin(['eth'])).toStrictEqual(['eth']);
+      expect(partlessActivity.partsWithin([])).toStrictEqual([]);
+    });
+
+    it('should keep the batch umbrella under the key prefix', () => {
+      expect(partlessActivity.batchId(['eth'])).toBe('tx-sync:eth:batch');
+    });
+  });
+
   it('should build the id from the kind, the part and the key', () => {
     expect(testActivity.id({ address: '0xabc', chain: 'eth' })).toBe('accounts:add:eth:0xabc');
   });

--- a/frontend/app/src/modules/task-center/core/activity-descriptor.ts
+++ b/frontend/app/src/modules/task-center/core/activity-descriptor.ts
@@ -29,8 +29,14 @@ type KeyParts = readonly (string | number)[];
  */
 export interface ActivityDescriptor<TSubject, TKey extends KeyParts> {
   readonly kind: ActivityKind;
-  /** The fixed part that follows the kind, before the subject's own key parts. */
-  readonly part: ActivityPart;
+  /**
+   * The fixed part that follows the kind, before the subject's own key parts.
+   *
+   * Optional, because it discriminates *operations within a kind*: `ACCOUNTS` hosts add, remove and
+   * import, so its ids must say which. A kind that hosts one operation (`TX_SYNC`) has nothing to
+   * discriminate, and a synthetic part there is a segment every reader has to remember for no gain.
+   */
+  readonly part?: ActivityPart;
   /** The subject's identity, broadest component first. */
   readonly keyOf: (subject: TSubject) => TKey;
   /** The full activity id for one subject. */
@@ -54,7 +60,7 @@ export interface ActivityDescriptor<TSubject, TKey extends KeyParts> {
 
 interface ActivityDescriptorInput<TSubject, TKey extends KeyParts> {
   readonly kind: ActivityKind;
-  readonly part: ActivityPart;
+  readonly part?: ActivityPart;
   readonly key: (subject: TSubject) => TKey;
   readonly lane?: (subject: TSubject) => Lane;
 }
@@ -66,17 +72,19 @@ interface ActivityDescriptorInput<TSubject, TKey extends KeyParts> {
 export function defineActivity<TSubject, const TKey extends KeyParts>(
   input: ActivityDescriptorInput<TSubject, TKey>,
 ): ActivityDescriptor<TSubject, TKey> {
-  const partsOf = (subject: TSubject): KeyParts => [input.part, ...input.key(subject)];
+  /** The fixed part as key parts, so an absent one contributes no segment rather than `undefined`. */
+  const lead: KeyParts = input.part === undefined ? [] : [input.part];
+  const partsOf = (subject: TSubject): KeyParts => [...lead, ...input.key(subject)];
 
   return {
     batchId: (prefix: Prefixes<TKey>): ActivityId =>
-      makeActivityId(input.kind, input.part, ...prefix, ActivityPart.BATCH),
+      makeActivityId(input.kind, ...lead, ...prefix, ActivityPart.BATCH),
     id: (subject: TSubject): ActivityId => makeActivityId(input.kind, ...partsOf(subject)),
     keyOf: input.key,
     kind: input.kind,
     laneOf: input.lane,
     part: input.part,
     partsOf,
-    partsWithin: (prefix: Prefixes<TKey>): KeyParts => [input.part, ...prefix],
+    partsWithin: (prefix: Prefixes<TKey>): KeyParts => [...lead, ...prefix],
   };
 }

--- a/frontend/app/src/modules/task-center/core/activity-descriptor.ts
+++ b/frontend/app/src/modules/task-center/core/activity-descriptor.ts
@@ -1,3 +1,4 @@
+import type { DetailShape } from '@/modules/task-center/core/activity-detail';
 import type { Lane } from '@/modules/task-center/core/orchestrator/spec';
 import { type ActivityId, type ActivityKind, ActivityPart, makeActivityId } from '@/modules/task-center/core/types';
 
@@ -27,8 +28,18 @@ type KeyParts = readonly (string | number)[];
  * promise and report it done; a key that *grows* one leaves every exact reader matching nothing, so
  * the spinner never fires.
  */
-export interface ActivityDescriptor<TSubject, TKey extends KeyParts> {
+export interface ActivityDescriptor<TSubject, TKey extends KeyParts, TDetail = never> {
   readonly kind: ActivityKind;
+  /**
+   * Phantom: the detail this activity streams, carried in the type only.
+   *
+   * It is what binds a publish and a read to the same shape without either naming it, and it
+   * defaults to `never`, which makes {@link publishActivityDetail} uncallable for an activity that
+   * declares no detail: no value inhabits `never`, so there is no argument to pass.
+   *
+   * Never read at runtime; `defineActivity` does not set it.
+   */
+  readonly detail?: TDetail;
   /**
    * The fixed part that follows the kind, before the subject's own key parts.
    *
@@ -69,9 +80,9 @@ interface ActivityDescriptorInput<TSubject, TKey extends KeyParts> {
  * Declare an activity. See {@link ActivityDescriptor} for why the id and the readers must come from
  * one place.
  */
-export function defineActivity<TSubject, const TKey extends KeyParts>(
+export function defineActivity<TSubject, const TKey extends KeyParts, TDetail = never>(
   input: ActivityDescriptorInput<TSubject, TKey>,
-): ActivityDescriptor<TSubject, TKey> {
+): ActivityDescriptor<TSubject, TKey, DetailShape<TDetail>> {
   /** The fixed part as key parts, so an absent one contributes no segment rather than `undefined`. */
   const lead: KeyParts = input.part === undefined ? [] : [input.part];
   const partsOf = (subject: TSubject): KeyParts => [...lead, ...input.key(subject)];

--- a/frontend/app/src/modules/task-center/core/activity-detail.ts
+++ b/frontend/app/src/modules/task-center/core/activity-detail.ts
@@ -1,0 +1,35 @@
+/**
+ * What an activity carries *besides* its status: the per-subject shape a producer streams and a
+ * panel renders, kept out of the record rather than folded into it.
+ *
+ * A record is the same shape for all 31 kinds, which is what lets the ledger, the tree and the
+ * eligibility rules treat any activity as any other. Detail is per kind and open-ended (a period
+ * cursor here, a protocol breakdown there), so folding it in would either widen every record with
+ * optional fields no other kind sets, or push an `unknown` through the spine that every reader
+ * would have to narrow by hand at the point it is displayed.
+ */
+
+/**
+ * Fields the {@link Activity} projection already owns.
+ *
+ * Detail restating one of them is the failure this bans: two sources for one fact, disagreeing
+ * whenever a websocket frame lands between the orchestrator settling a record and the panel
+ * reading it. Progress belongs in `steps` through `reportProgress`, and terminal state in the
+ * record's own status.
+ */
+type ReservedDetailKey = 'percentage' | 'reason' | 'startedAt' | 'status' | 'steps';
+
+/**
+ * The detail a descriptor ends up carrying: the declared type when it names none of
+ * {@link ReservedDetailKey}, and `never` when it names any.
+ *
+ * Applied to `defineActivity`'s return rather than as a bound on its type parameter, because
+ * `TDetail extends DetailShape<TDetail>` is a circular constraint and TypeScript rejects it. The
+ * consequence is where the error lands: a detail restating a reserved key collapses to `never`, so
+ * the declaration itself compiles and every publish against it fails instead.
+ */
+export type DetailShape<T> = T extends object
+  ? Extract<keyof T, ReservedDetailKey> extends never
+    ? T
+    : never
+  : never;

--- a/frontend/app/src/modules/task-center/core/orchestrator/api.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/api.ts
@@ -73,8 +73,27 @@ export interface TaskOrchestrator {
   readonly reset: () => void;
 }
 
+/**
+ * The lifecycle half of the detail side-channel: what the spine calls, never how it stores.
+ *
+ * @remarks
+ * Detail is the one piece of per-activity state the orchestrator does not own, and nothing outside
+ * the spine observes a record being replaced, re-run or pruned. A channel left to clear itself has
+ * no event to hang off, so a stale entry survives its run and captions the next one under the same
+ * id. Injected rather than imported because the orchestrator is framework-agnostic and the channel
+ * is a Pinia store.
+ */
+interface ActivityDetailSink {
+  /** Forget one activity's detail, for a record being replaced, re-run or pruned. */
+  readonly drop: (id: ActivityId) => void;
+  /** Forget every activity's detail, for a session ending. */
+  readonly clear: () => void;
+}
+
 export interface OrchestratorOptions {
   readonly caps?: LaneCaps;
+  /** Where per-activity detail lives, so the spine can forget an entry the record no longer has. */
+  readonly detail?: ActivityDetailSink;
   /** Caps for lanes minted per entity (one per chain, …) that cannot be named up front. */
   readonly laneFamilies?: LaneFamilyCaps;
   /** How many distinct lanes of a family may run at once — the nesting a pre-submitted tree loses. */

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.spec.ts
@@ -1225,4 +1225,79 @@ describe('createTaskOrchestrator', () => {
       expect(cleanup).toHaveBeenCalledOnce();
     });
   });
+
+  describe('detail side-channel', () => {
+    /**
+     * Detail is keyed by activity id and lives outside the records, so only the spine can say when
+     * an entry stopped describing anything. Left to the producer, a period and a step outlive the
+     * run they came from and caption whatever takes the id next.
+     */
+    function withDetail(): { drop: ReturnType<typeof vi.fn>; clear: ReturnType<typeof vi.fn>; orchestrator: TaskOrchestrator } {
+      const drop = vi.fn<(id: ActivityId) => void>();
+      const clear = vi.fn<() => void>();
+      return { clear, drop, orchestrator: createTaskOrchestrator({ detail: { clear, drop } }) };
+    }
+
+    it('should drop the previous run\'s detail when an id is re-submitted', async () => {
+      const { drop, orchestrator } = withDetail();
+      const first = controllable('shared');
+      orchestrator.submit(first.spec);
+      await flush();
+      drop.mockClear();
+
+      orchestrator.submit(controllable('shared').spec);
+
+      expect(drop).toHaveBeenCalledWith(first.spec.id);
+    });
+
+    it('should drop detail when a terminal activity is re-run', async () => {
+      const { drop, orchestrator } = withDetail();
+      const work = controllable('rerunnable', { rerunnable: true });
+      const id = orchestrator.submit(work.spec);
+      work.settle(ok(undefined));
+      await flush();
+      drop.mockClear();
+
+      orchestrator.rerun(id);
+
+      expect(drop).toHaveBeenCalledWith(id);
+    });
+
+    it('should drop detail for every record clearTerminal prunes, and no other', async () => {
+      const { drop, orchestrator } = withDetail();
+      const settled = controllable('settled');
+      const live = controllable('live');
+      const settledId = orchestrator.submit(settled.spec);
+      const liveId = orchestrator.submit(live.spec);
+      settled.settle(ok(undefined));
+      await flush();
+      drop.mockClear();
+
+      orchestrator.clearTerminal();
+
+      expect(drop).toHaveBeenCalledWith(settledId);
+      expect(drop).not.toHaveBeenCalledWith(liveId);
+    });
+
+    it('should clear every entry on reset', async () => {
+      const { clear, orchestrator } = withDetail();
+      orchestrator.submit(controllable('live').spec);
+      await flush();
+
+      orchestrator.reset();
+
+      expect(clear).toHaveBeenCalledOnce();
+    });
+
+    it('should run without a detail sink', () => {
+      const orchestrator = createTaskOrchestrator();
+      const id = orchestrator.submit(controllable('a').spec);
+
+      expect(() => {
+        orchestrator.clearTerminal();
+        orchestrator.rerun(id);
+        orchestrator.reset();
+      }).not.toThrow();
+    });
+  });
 });

--- a/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
+++ b/frontend/app/src/modules/task-center/core/orchestrator/orchestrator.ts
@@ -49,6 +49,9 @@ interface ActivityRecord {
 export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskOrchestrator {
   const rules = options.rules ?? DEFAULT_RULES;
   const now = options.now ?? ((): number => Date.now());
+  const detail = options.detail;
+  /** Forget one activity's detail, where a channel is wired up at all. */
+  const dropDetail = (id: ActivityId): void => detail?.drop(id);
   const records = new Map<ActivityId, ActivityRecord>();
   /** Durable per-id completion memory — survives `clearTerminal`; the freshness backbone. */
   const ledger = new Map<ActivityId, CompletionRecord>();
@@ -230,6 +233,13 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
       superseded.spec.cleanup?.();
     }
 
+    /**
+     * A record beginning a run owns no detail yet. Resubmitting an id is the common way a run is
+     * replaced — every history refresh resubmits the same `TX_SYNC:<chain>:<address>` — so without
+     * this the previous run's period and step caption the new one until its first frame lands.
+     */
+    dropDetail(spec.id);
+
     const record: ActivityRecord = { cancelRequested: false, cleanedUp: false, spec, status: Status.PENDING };
     records.set(spec.id, record);
     if (spec.staleAfter?.length)
@@ -306,6 +316,7 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
     record.reason = undefined;
     record.cancelRequested = false;
     record.cleanedUp = false;
+    dropDetail(id);
     schedule(record);
     emit();
     return ok(undefined);
@@ -320,8 +331,10 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
     cancelGroup: (group: GroupId) => cancelMatching(record => record.spec.group === group),
     clearTerminal(): void {
       for (const [id, record] of records) {
-        if (isTerminalStatus(record.status))
+        if (isTerminalStatus(record.status)) {
           records.delete(id);
+          dropDetail(id);
+        }
       }
       emit();
     },
@@ -357,6 +370,7 @@ export function createTaskOrchestrator(options: OrchestratorOptions = {}): TaskO
       ledger.clear();
       staleEdges.clear();
       scheduler.clear();
+      detail?.clear();
       emit();
     },
     snapshot,

--- a/frontend/app/src/modules/task-center/use-activity-detail.spec.ts
+++ b/frontend/app/src/modules/task-center/use-activity-detail.spec.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { defineActivity } from '@/modules/task-center/core/activity-descriptor';
+import { ActivityKind } from '@/modules/task-center/core/types';
+import { publishActivityDetail, readActivityDetail, useActivityDetail } from '@/modules/task-center/use-activity-detail';
+
+interface ChainSubject { chain: string }
+
+interface ExchangeSubject { location: string }
+
+interface SyncDetail {
+  readonly cursor: number;
+  readonly window: readonly [number, number];
+}
+
+const syncActivity = defineActivity<ChainSubject, readonly [string], SyncDetail>({
+  key: subject => [subject.chain],
+  kind: ActivityKind.TX_SYNC,
+});
+
+const detaillessActivity = defineActivity<ExchangeSubject, readonly [string]>({
+  key: subject => [subject.location],
+  kind: ActivityKind.EXCHANGE_EVENTS,
+});
+
+describe('activity detail channel', () => {
+  // The channel is a singleton, so each case has to start from an empty one.
+  beforeEach(() => {
+    useActivityDetail().resetDetails();
+  });
+
+  it('should read back what was published for a subject', () => {
+    publishActivityDetail(syncActivity, { chain: 'eth' }, { cursor: 5, window: [0, 10] });
+
+    expect(get(readActivityDetail(syncActivity, { chain: 'eth' }))).toStrictEqual({ cursor: 5, window: [0, 10] });
+  });
+
+  it('should keep subjects of one kind apart', () => {
+    publishActivityDetail(syncActivity, { chain: 'eth' }, { cursor: 5, window: [0, 10] });
+
+    expect(get(readActivityDetail(syncActivity, { chain: 'optimism' }))).toBeUndefined();
+  });
+
+  it('should answer undefined before anything is published', () => {
+    expect(get(readActivityDetail(syncActivity, { chain: 'eth' }))).toBeUndefined();
+  });
+
+  it('should track a later publish for the same subject', () => {
+    const detail = readActivityDetail(syncActivity, { chain: 'eth' });
+    publishActivityDetail(syncActivity, { chain: 'eth' }, { cursor: 1, window: [0, 10] });
+    expect(get(detail)?.cursor).toBe(1);
+
+    publishActivityDetail(syncActivity, { chain: 'eth' }, { cursor: 7, window: [0, 10] });
+    expect(get(detail)?.cursor).toBe(7);
+  });
+
+  it('should drop one subject without disturbing another', () => {
+    publishActivityDetail(syncActivity, { chain: 'eth' }, { cursor: 5, window: [0, 10] });
+    publishActivityDetail(syncActivity, { chain: 'optimism' }, { cursor: 2, window: [0, 10] });
+
+    useActivityDetail().dropDetail(syncActivity.id({ chain: 'eth' }));
+
+    expect(get(readActivityDetail(syncActivity, { chain: 'eth' }))).toBeUndefined();
+    expect(get(readActivityDetail(syncActivity, { chain: 'optimism' }))?.cursor).toBe(2);
+  });
+
+  it('should clear every entry on reset', () => {
+    publishActivityDetail(syncActivity, { chain: 'eth' }, { cursor: 5, window: [0, 10] });
+    useActivityDetail().resetDetails();
+
+    expect(get(readActivityDetail(syncActivity, { chain: 'eth' }))).toBeUndefined();
+  });
+
+  it('should reject at compile time the ways detail can be paired with the wrong activity', () => {
+    // @ts-expect-error -- an activity declaring no detail has `TDetail = never`, so publish takes no value
+    expect(() => publishActivityDetail(detaillessActivity, { location: 'kraken' }, { cursor: 1 })).toBeTypeOf('function');
+    // @ts-expect-error -- the subject must be the one this descriptor keys on
+    expect(() => publishActivityDetail(syncActivity, { location: 'kraken' }, { cursor: 1, window: [0, 1] })).toBeTypeOf('function');
+    // @ts-expect-error -- the detail must be the shape this descriptor declares
+    expect(() => publishActivityDetail(syncActivity, { chain: 'eth' }, { cursor: 'five' })).toBeTypeOf('function');
+    // @ts-expect-error -- reading one kind's detail through another's descriptor is not the same subject
+    expect(() => readActivityDetail(syncActivity, { location: 'kraken' })).toBeTypeOf('function');
+  });
+
+  it('should collapse a detail restating what the record owns, making it unpublishable', () => {
+    const reserved = defineActivity<ChainSubject, readonly [string], { status: string }>({
+      key: subject => [subject.chain],
+      kind: ActivityKind.TX_SYNC,
+    });
+
+    // @ts-expect-error -- `status` is the record's, so this activity's detail collapsed to never
+    expect(() => publishActivityDetail(reserved, { chain: 'eth' }, { status: 'running' })).toBeTypeOf('function');
+  });
+});

--- a/frontend/app/src/modules/task-center/use-activity-detail.ts
+++ b/frontend/app/src/modules/task-center/use-activity-detail.ts
@@ -1,0 +1,91 @@
+import type { ComputedRef } from 'vue';
+import type { ActivityDescriptor } from '@/modules/task-center/core/activity-descriptor';
+import type { ActivityId } from '@/modules/task-center/core/types';
+
+/**
+ * The side channel carrying per-activity detail, beside the ledger rather than inside it.
+ *
+ * Every entry is keyed by the same {@link ActivityId} the orchestrator uses, so detail and record
+ * are joined by identity and nothing has to thread a second key through the spine. The channel
+ * holds `unknown`; the only way in and out is through a descriptor, which is what makes the shape
+ * checked at both ends.
+ *
+ * @remarks
+ * A plain singleton rather than a Pinia store, because its lifetime belongs to the orchestrator: the
+ * spine drops an entry when the record it describes is replaced, re-run or pruned, and the spine is
+ * framework-agnostic. As a store that edge cost more than it bought — Pinia re-activates the
+ * instance an action was bound to before running it, so the orchestrator could not hold the actions
+ * it needs without pinning the whole process to whichever Pinia was active when it was first
+ * constructed. Logout is covered by `orchestrator.reset()`, which is stricter than the global store
+ * reset anyway: it also fires on re-run, re-submit and prune.
+ */
+export const useActivityDetail = createGlobalState(() => {
+  const details = shallowRef<Record<ActivityId, unknown>>({});
+
+  function setDetail(id: ActivityId, detail: unknown): void {
+    set(details, { ...get(details), [id]: detail });
+  }
+
+  function dropDetail(id: ActivityId): void {
+    const current = get(details);
+    if (!(id in current))
+      return;
+
+    const next = { ...current };
+    delete next[id];
+    set(details, next);
+  }
+
+  function resetDetails(): void {
+    set(details, {});
+  }
+
+  return {
+    details,
+    dropDetail,
+    resetDetails,
+    setDetail,
+  };
+});
+
+/**
+ * Publish one subject's detail.
+ *
+ * Uncallable for an activity that declares no detail: its `TDetail` is `never`, and no value
+ * inhabits `never`, so there is no third argument to pass. That is the compile-time half of "detail
+ * is opt in per kind".
+ *
+ * `NoInfer` is what makes that hold. Without it the detail argument is an inference site of equal
+ * weight to the descriptor, so passing a detail to a `never` activity simply widens `TDetail` to
+ * whatever was passed and the call compiles.
+ */
+export function publishActivityDetail<TSubject, TKey extends readonly (string | number)[], TDetail>(
+  descriptor: ActivityDescriptor<TSubject, TKey, TDetail>,
+  subject: TSubject,
+  detail: NoInfer<TDetail>,
+): void {
+  useActivityDetail().setDetail(descriptor.id(subject), detail);
+}
+
+/**
+ * Read one subject's detail, typed by the descriptor that published it.
+ *
+ * Reading kind A's detail through kind B's descriptor does not type-check, because the subject and
+ * the returned shape both come from the descriptor passed in. `undefined` is a normal answer: an
+ * activity is submitted before anything has been streamed about it, and detail is dropped when the
+ * activity is cleared.
+ *
+ * The channel holds `unknown` by design, so this is the single narrowing point for the whole
+ * channel. What makes it sound is that the id was minted by the same descriptor: nothing else can
+ * write that key, so nothing else can put another shape behind it.
+ */
+export function readActivityDetail<TSubject, TKey extends readonly (string | number)[], TDetail>(
+  descriptor: ActivityDescriptor<TSubject, TKey, TDetail>,
+  subject: TSubject,
+): ComputedRef<TDetail | undefined> {
+  const { details } = useActivityDetail();
+  const id = descriptor.id(subject);
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- the channel holds `unknown` by design; the descriptor pairs the writer and this reader
+  return computed<TDetail | undefined>(() => get(details)[id] as TDetail | undefined);
+}

--- a/frontend/app/src/modules/task-center/use-task-orchestrator.ts
+++ b/frontend/app/src/modules/task-center/use-task-orchestrator.ts
@@ -3,6 +3,7 @@ import type { TaskOrchestrator } from './core/orchestrator/api';
 import { createTaskOrchestrator } from './core/orchestrator/orchestrator';
 import { ACCOUNT_SYNC_LANE_PREFIX, ACCOUNTS_ADD_LANE_PREFIX, ACCOUNTS_REMOVE_LANE_PREFIX, BALANCES_LANE, CHAIN_SYNC_LANE, DECODE_LANE, DETECT_LANE_PREFIX, EXCHANGE_EVENTS_LANE_PREFIX, EXCHANGE_LANE, SESSION_LANE, UMBRELLA_LANE } from './core/orchestrator/spec';
 import { type Activity, type ActivityKind, makeActivityId, type WorkStatus } from './core/types';
+import { useActivityDetail } from './use-activity-detail';
 
 /**
  * An activity-id part that may itself be reactive, so a reader whose subject changes (the chain a
@@ -55,6 +56,7 @@ export interface UseTaskOrchestratorReturn extends TaskOrchestrator {
  * reruns through it.
  */
 export const useTaskOrchestrator = createSharedComposable((): UseTaskOrchestratorReturn => {
+  const { dropDetail, resetDetails } = useActivityDetail();
   const orchestrator = createTaskOrchestrator({
     caps: {
       [BALANCES_LANE]: 2,
@@ -64,6 +66,8 @@ export const useTaskOrchestrator = createSharedComposable((): UseTaskOrchestrato
       [SESSION_LANE]: 2,
       [UMBRELLA_LANE]: 16,
     },
+    /** The detail side-channel, so a record replaced, re-run or pruned takes its detail with it. */
+    detail: { clear: resetDetails, drop: dropDetail },
     /**
      * Caps how many jobs run at once inside one lane of a family, never across the family.
      *


### PR DESCRIPTION
Phases 1 and 2 of the unified task centre spec (#10308): route every progress channel that has
somewhere to go into the ledger, then give the detail that is left a typed side-channel of its own.

Nothing here is visible to users. The dock that renders it is phase 3.

## The defect this closes

Three surfaces answer "what is rotki doing" and they can disagree, because only 3 of the 8 progress
subtypes reach the orchestrator at all. The rest land in four websocket status stores read only by
the dashboard banner and the history sync panel, each with its own idea of "is something running"
and "how far along".

The orchestrator already holds the hierarchy those panels rebuild: a history refresh submits the
umbrella, a chain per group and an account per chain before any of it runs. So this is not a second
feature to integrate, it is a duplicate projection of data the ledger already has, plus a small
amount of genuine detail.

## What is in here

**Progress into the ledger.** Undecoded transactions, historical daily prices, liquity staking, the
multiple-prices batch, historical-balance processing, `TRANSACTION_STATUS`, and the stats-price
backfill now report onto the activity they belong to. Exchange event queries and protocol-cache
updates publish detail instead, for the reasons below.

**Descriptors for tx-sync and decoding.** Both composed ids by hand; only `accounts.activity.ts`
used `defineActivity`. Producers and readers are migrated together, since growing an id silently
breaks every exact reader.

**A typed detail channel.** The payload type rides on the descriptor, so `publish` and `read` cannot
drift and a cross-kind read is a compile error. A kind that declares no detail gets `TDetail = never`
and `publish` is uncallable against it. `DetailShape` rejects a payload that restates what the record
owns (`status`, `steps`, `percentage`, `reason`, `startedAt`) by collapsing it to `never`.

The invariant that makes the side-channel safe rather than merely cheap: **no component may read a
status, a percentage or an "is running" predicate out of a detail payload.** The ledger owns
identity, status, liveness, progress and cancellation; the channel may only add descriptive detail,
joined at render.

**Lifecycle.** Detail is dropped when a record is re-submitted, re-run, pruned by `clearTerminal`, or
wiped by `reset`. Without it a period and a step outlive the run they described and caption whatever
takes the id next — every history refresh resubmits the same `TX_SYNC:<chain>:<address>`. The sink is
injected so the orchestrator core stays framework-agnostic.

## Judgement calls worth reviewing

**No progress for exchange event queries.** A status update names the sub-range it is *about to*
query rather than how far through it has reached, and the backend walks those ranges without saying
how many there are. There is no cursor, so any percentage would be invented. A cancelled exchange is
frozen at its last real detail: the store refuses the update but keeps the entry, whose seeded range
would otherwise be republished over what the query actually reached.

**Protocol-cache rows are rows, not activities.** Nothing announces the set — pairs are minted as
decoders reach them, and a pair whose query fails sends no terminal frame. Children minted from
arriving frames would give their parent a denominator that grows as the run proceeds, and a failed
pair would sit RUNNING forever. They attach as detail to whichever record is already live: the user's
cache refresh, or the decode whose chain the frame names. Per-row percentages are honest;
there is deliberately no aggregate.

**The channel is a plain singleton, not a Pinia store.** Its lifetime belongs to the orchestrator,
and the orchestrator is framework-agnostic by design. As a store it also could not be consumed
cleanly: Pinia re-activates the instance an action was bound to before running it, so a spine holding
`dropDetail`/`resetDetails` would pin the whole process to whichever Pinia was active when the
singleton was first constructed — invisible in an app with one Pinia, and in a suite it stops an
unrelated store from being reset between tests. Logout is still covered, and more precisely, by
`orchestrator.reset()`, which also fires on re-run, re-submit and prune.

## Verification

Full unit suite green (1118 files, 12266 tests) and every lint/typecheck/knip gate. Each new
lifecycle behaviour has a negative control: breaking one drop point fails exactly its own test.

Driven in the running app against a real profile. A real Gearbox cache-refresh frame reached the
detail channel through the real handler (`{chain: ethereum, protocol: gearbox, processed: 11,
total: 11}`), and the tx-sync channel populated ~78 real per-address entries during a login history
refresh. The `'ethereum'` → `'eth'` canonicalisation and the lifecycle drop were both confirmed live.

One honest gap: **a warm cache emits no protocol-cache frames at all.** Every notify site sits on a
new-data path — Curve returns early when the cached pool count matches the chain's, before
`reload_all` is consulted, and its primary path is the Curve API, which contains no notify call, so
Curve reports progress only when that API is down. That is pre-existing behaviour, unchanged here,
but it means the protocol-cache rows cannot be demonstrated on an ordinary profile.

## Not in here

The dock (L0 pill, L1 panel), folding the sync panel's lists in as L2, and the idle control panel.
Also out: a declared subtree for protocol caches, which needs the backend to announce its pairs up
front and to send a terminal frame per pair on failure.
