### PR TITLE
refactor(frontend): derive the sync rollup from the ledger

### DIFF
--- a/frontend/app/src/modules/shell/sync-progress/use-sync-progress.spec.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-progress.spec.ts
@@ -1,3 +1,5 @@
+import { neverSettles } from '@test/utils/never-settles';
+import { err, ok, type Result } from 'plainfp/result';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   type EvmUnDecodedTransactionsData,
@@ -7,19 +9,99 @@ import {
   TransactionsQueryStatus,
   type UnifiedTransactionStatusData,
 } from '@/modules/core/messaging/types';
+import { Cancelled, type TaskError, TaskFailed } from '@/modules/core/tasks/task-result';
+import { decodeActivityId } from '@/modules/history/events/tx/decode-activity';
+import { historySyncFlow } from '@/modules/history/events/tx/history-sync.flow';
+import { accountSyncActivityId, chainSyncActivityId } from '@/modules/history/events/tx/sync-activity';
 import { useDecodingStatusStore } from '@/modules/history/use-decoding-status-store';
 import { useEventsQueryStatusStore } from '@/modules/history/use-events-query-status-store';
 import { useProtocolCacheStatusStore } from '@/modules/history/use-protocol-cache-status-store';
 import { useTxQueryStatusStore } from '@/modules/history/use-tx-query-status-store';
 import { useSettingsRepo } from '@/modules/settings/settings-repo';
+import { ActivityKind } from '@/modules/task-center/core/types';
+import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
 import { LocationStatus, SyncPhase } from './types';
 import { useSyncProgress } from './use-sync-progress';
+import { SyncWarningSource, useSyncWarningsStore } from './use-sync-warnings-store';
+
+/** How a declared leaf ends, or that it has not. */
+type LeafOutcome = 'running' | 'complete' | 'failed' | 'cancelled';
+
+const flush = async (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0));
+
+function runFor(outcome: LeafOutcome): () => Promise<Result<unknown, TaskError>> {
+  if (outcome === 'running')
+    return async () => neverSettles();
+  if (outcome === 'complete')
+    return async () => ok(undefined);
+  if (outcome === 'cancelled')
+    return async () => err(Cancelled({ message: 'stopped' }));
+  return async () => err(TaskFailed({ message: 'the backend said no' }));
+}
 
 describe('useSyncProgress', () => {
   beforeEach(() => {
     const pinia = createPinia();
     setActivePinia(pinia);
+    // The orchestrator is a shared singleton, so its records outlive a test without this.
+    useTaskOrchestrator().reset();
   });
+
+  /**
+   * Submit a history refresh the way `history-sync.flow.ts` declares one: the umbrella, a chain per
+   * entry, and an account beneath each chain.
+   *
+   * The accounts are the leaves the rollup counts, so each names its own outcome. Keep fixtures to
+   * two chains: `CHAIN_SYNC_LANE` caps concurrency at two, and a third chain would sit PENDING with
+   * its accounts ineligible, which is realistic but not what these cases are about.
+   */
+  async function submitRefresh(
+    chains: Record<string, Record<string, LeafOutcome>>,
+    decodes: Record<string, LeafOutcome> = {},
+  ): Promise<void> {
+    const orchestrator = useTaskOrchestrator();
+    const umbrella = historySyncFlow.id();
+
+    orchestrator.submit({
+      container: true,
+      id: umbrella,
+      kind: ActivityKind.HISTORY_SYNC,
+      run: async () => ok(undefined),
+      title: 'refresh',
+    });
+
+    for (const [chain, accounts] of Object.entries(chains)) {
+      orchestrator.submit({
+        id: chainSyncActivityId(chain),
+        kind: ActivityKind.TX_SYNC,
+        parent: umbrella,
+        run: async () => ok(undefined),
+        title: chain,
+      });
+
+      for (const [address, outcome] of Object.entries(accounts)) {
+        orchestrator.submit({
+          id: accountSyncActivityId(chain, address),
+          kind: ActivityKind.TX_SYNC,
+          parent: chainSyncActivityId(chain),
+          run: runFor(outcome),
+          title: address,
+        });
+      }
+    }
+
+    for (const [chain, outcome] of Object.entries(decodes)) {
+      orchestrator.submit({
+        id: decodeActivityId(chain),
+        kind: ActivityKind.TX_DECODING,
+        parent: chainSyncActivityId(chain),
+        run: runFor(outcome),
+        title: `decode ${chain}`,
+      });
+    }
+
+    await flush();
+  }
 
   const createEvmTxStatus = (
     address: string,
@@ -92,42 +174,26 @@ describe('useSyncProgress', () => {
       expect(get(phase)).toBe(SyncPhase.IDLE);
     });
 
-    it('should return SYNCING when there is activity', () => {
-      setupTxStore([
-        createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
-      ]);
+    it('should return SYNCING while any part of the refresh is still in flight', async () => {
+      await submitRefresh({ eth: { '0x123': 'running' } });
 
       const { phase } = useSyncProgress();
       expect(get(phase)).toBe(SyncPhase.SYNCING);
     });
 
-    it('should return COMPLETE when all activities are finished', () => {
-      setupTxStore([
-        createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-      ]);
-
-      setupEventsStore([
-        createEventsStatus('kraken', 'Kraken', HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED),
-      ]);
+    it('should return COMPLETE once every activity has settled', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete' } });
 
       const { phase } = useSyncProgress();
       expect(get(phase)).toBe(SyncPhase.COMPLETE);
     });
 
-    it('should complete when a chain failed rather than sitting short of the end', () => {
-      setupTxStore([
-        createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-        createEvmTxStatus('0x456', 'gnosis', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
-      ]);
-      useTxQueryStatusStore().markAddressFailed({ address: '0x456', chain: 'gnosis' });
+    /** A failure is a settled outcome, so it must not leave the panel reading as still working. */
+    it('should complete when an account failed rather than sitting short of the end', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete', '0x456': 'failed' } });
 
-      setupEventsStore([
-        createEventsStatus('kraken', 'Kraken', HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED),
-      ]);
-
-      const { completedChains, overallProgress, phase } = useSyncProgress();
+      const { overallProgress, phase } = useSyncProgress();
       expect(get(phase)).toBe(SyncPhase.COMPLETE);
-      expect(get(completedChains)).toBe(2);
       expect(get(overallProgress)).toBe(100);
     });
 
@@ -160,31 +226,34 @@ describe('useSyncProgress', () => {
       expect(get(isActive)).toBe(false);
     });
 
-    it('should be true when there are transaction queries', () => {
-      setupTxStore([
-        createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
-      ]);
+    it('should be true while the refresh has work in flight', async () => {
+      await submitRefresh({ eth: { '0x123': 'running' } });
 
       const { isActive } = useSyncProgress();
       expect(get(isActive)).toBe(true);
     });
 
-    it('should be true when there are events queries', () => {
-      setupEventsStore([
-        createEventsStatus('kraken', 'Kraken', HistoryEventsQueryStatus.QUERYING_EVENTS_STATUS_UPDATE),
-      ]);
+    /**
+     * The ledger has no notion of a warning, so this clause is deliberately not derived from it:
+     * without it the panel would vanish as the run ends, taking the failures it exists to report.
+     */
+    it('should stay true after the work stops when there are warnings to show', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete' } });
+      useSyncWarningsStore().addWarning({
+        key: 'eth:0x123',
+        message: 'the query failed',
+        source: SyncWarningSource.TRANSACTIONS,
+      });
 
       const { isActive } = useSyncProgress();
       expect(get(isActive)).toBe(true);
     });
 
-    it('should be true when there is decoding activity', () => {
-      const decodingStatusStore = useDecodingStatusStore();
-      decodingStatusStore.resetDecodingSyncProgress();
-      decodingStatusStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
+    it('should be false once the work has settled and nothing warned', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete' } });
 
       const { isActive } = useSyncProgress();
-      expect(get(isActive)).toBe(true);
+      expect(get(isActive)).toBe(false);
     });
   });
 
@@ -304,28 +373,37 @@ describe('useSyncProgress', () => {
       expect(get(overallProgress)).toBe(0);
     });
 
-    it('should calculate weighted progress with transactions only', () => {
-      setupTxStore([
-        createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-        createEvmTxStatus('0x456', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
-      ]);
+    it('should count settled leaves over declared leaves', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete', '0x456': 'running' } });
 
       const { overallProgress } = useSyncProgress();
       expect(get(overallProgress)).toBe(50);
     });
 
-    it('should calculate weighted progress with multiple activity types', () => {
-      setupTxStore([
-        createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-      ]);
+    /**
+     * The unit is the leaf, not the chain. Weighting whole chains equally would make one settled
+     * account worth more on a two-account chain than on a ten-account one.
+     */
+    it('should weight every account equally, whichever chain it sits on', async () => {
+      await submitRefresh({
+        eth: { '0x1': 'complete', '0x2': 'running', '0x3': 'running' },
+        gnosis: { '0xa': 'complete' },
+      });
 
-      setupEventsStore([
-        createEventsStatus('kraken', 'Kraken', HistoryEventsQueryStatus.QUERYING_EVENTS_FINISHED),
-      ]);
+      const { overallProgress } = useSyncProgress();
+      expect(get(overallProgress)).toBe(50);
+    });
 
-      const decodingStatusStore = useDecodingStatusStore();
-      decodingStatusStore.resetDecodingSyncProgress();
-      decodingStatusStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 100));
+    /** A chain settles when its accounts do, so counting it too would double-count that work. */
+    it('should not count the chain and umbrella rows as units of work', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete' } });
+
+      const { overallProgress } = useSyncProgress();
+      expect(get(overallProgress)).toBe(100);
+    });
+
+    it('should treat a cancelled leaf as settled, since nothing more will happen to it', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete', '0x456': 'cancelled' } });
 
       const { overallProgress } = useSyncProgress();
       expect(get(overallProgress)).toBe(100);
@@ -345,16 +423,19 @@ describe('useSyncProgress', () => {
       store.updateGeneral({ ...store.general, disabledChainQueries: value });
     }
 
-    it('should exclude a disabled chain from the transaction progress', () => {
-      setupTxStore([
-        createEvmTxStatus('0x111', WIRE_ETH, TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-        createEvmTxStatus('0x222', WIRE_POLYGON, TransactionsQueryStatus.QUERYING_TRANSACTIONS),
-      ]);
-
+    /**
+     * The bar counts what the flow declared, and a disabled chain is never declared:
+     * `getAccountsByChainType` filters at the source funnel every account getter reads through, so
+     * the exclusion happens while the refresh scope resolves, before anything is submitted.
+     * Re-filtering here would be a second implementation of the same rule, free to disagree.
+     */
+    it('should not re-filter disabled chains, which never reach the ledger to begin with', async () => {
+      await submitRefresh({ eth: { '0x111': 'complete', '0x222': 'running' } });
       expect(get(useSyncProgress().overallProgress)).toBe(50);
 
       disableChains({ [SETTING_POLYGON]: [] });
-      expect(get(useSyncProgress().overallProgress)).toBe(100);
+
+      expect(get(useSyncProgress().overallProgress)).toBe(50);
     });
 
     it('should exclude a disabled chain from the chain and account counts', () => {
@@ -387,18 +468,15 @@ describe('useSyncProgress', () => {
       expect(get(chains)[0].addresses.map(a => a.address)).toEqual(['0x111']);
     });
 
-    it('should exclude a disabled chain from decoding, which owns the whole bar when nothing else runs', () => {
+    it('should exclude a disabled chain from the decoding list', () => {
       const decodingStatusStore = useDecodingStatusStore();
       decodingStatusStore.resetDecodingSyncProgress();
       decodingStatusStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 100));
       decodingStatusStore.setUndecodedTransactionsStatus(createDecodingStatus('polygon_pos', 100, 0));
 
-      expect(get(useSyncProgress().overallProgress)).toBe(50);
-
       disableChains({ polygon_pos: [] });
-      const { decoding, overallProgress } = useSyncProgress();
-      expect(get(decoding).map(item => item.chain)).toEqual(['eth']);
-      expect(get(overallProgress)).toBe(100);
+
+      expect(get(useSyncProgress().decoding).map(item => item.chain)).toEqual(['eth']);
     });
 
     it('should exclude a disabled chain from the protocol cache list', () => {
@@ -473,20 +551,8 @@ describe('useSyncProgress', () => {
   });
 
   describe('cancellation handling', () => {
-    it('should become COMPLETE when all items are cancelled', () => {
-      setupTxStore([
-        createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
-      ]);
-
-      const txStore = useTxQueryStatusStore();
-      txStore.markAddressCancelled({ address: '0x123', chain: 'eth' });
-
-      setupEventsStore([
-        createEventsStatus('kraken', 'Kraken', HistoryEventsQueryStatus.QUERYING_EVENTS_STATUS_UPDATE),
-      ]);
-
-      const eventsStore = useEventsQueryStatusStore();
-      eventsStore.markLocationCancelled({ location: 'kraken', name: 'Kraken' });
+    it('should become COMPLETE when every item was cancelled', async () => {
+      await submitRefresh({ eth: { '0x123': 'cancelled', '0x456': 'cancelled' } });
 
       const { phase } = useSyncProgress();
       expect(get(phase)).toBe(SyncPhase.COMPLETE);
@@ -553,15 +619,8 @@ describe('useSyncProgress', () => {
       expect(decodingValue[0].cancelled).toBe(true);
     });
 
-    it('should treat cancelled decoding as done for phase calculation', () => {
-      setupTxStore([
-        createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-      ]);
-
-      const decodingStatusStore = useDecodingStatusStore();
-      decodingStatusStore.resetDecodingSyncProgress();
-      decodingStatusStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
-      decodingStatusStore.markDecodingCancelled('eth');
+    it('should treat a cancelled decode as done for phase calculation', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete' } }, { eth: 'cancelled' });
 
       const { phase } = useSyncProgress();
       expect(get(phase)).toBe(SyncPhase.COMPLETE);
@@ -578,14 +637,16 @@ describe('useSyncProgress', () => {
       expect(get(hasCancelled)).toBe(true);
     });
 
-    it('should treat cancelled decoding as 100% for overall progress', () => {
-      const decodingStatusStore = useDecodingStatusStore();
-      decodingStatusStore.resetDecodingSyncProgress();
-      decodingStatusStore.setUndecodedTransactionsStatus(createDecodingStatus('eth', 100, 50));
-      decodingStatusStore.markDecodingCancelled('eth');
+    /**
+     * A decode is one leaf among the accounts, not a weighted third of the bar. Under the old
+     * split it carried 20% whatever the shape of the run, so one cancelled decode moved the bar
+     * as much as every account on a ten-account chain.
+     */
+    it('should count a decode as one leaf rather than a weighted share', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete', '0x456': 'running' } }, { eth: 'cancelled' });
 
       const { overallProgress } = useSyncProgress();
-      expect(get(overallProgress)).toBe(100);
+      expect(get(overallProgress)).toBe(67);
     });
   });
 
@@ -623,10 +684,8 @@ describe('useSyncProgress', () => {
       expect(get(canDismiss)).toBe(false);
     });
 
-    it('should be true when complete', () => {
-      setupTxStore([
-        createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS_FINISHED),
-      ]);
+    it('should be true when complete', async () => {
+      await submitRefresh({ eth: { '0x123': 'complete' } });
 
       const { canDismiss } = useSyncProgress();
       expect(get(canDismiss)).toBe(true);
@@ -634,10 +693,15 @@ describe('useSyncProgress', () => {
   });
 
   describe('state object', () => {
-    it('should aggregate all computed values', () => {
+    /**
+     * The two halves still have separate sources: the lists and counts come from the websocket
+     * status stores, the rollup from the ledger. Seed both, or the object is half populated.
+     */
+    it('should aggregate all computed values', async () => {
       setupTxStore([
         createEvmTxStatus('0x123', 'eth', TransactionsQueryStatus.QUERYING_TRANSACTIONS),
       ]);
+      await submitRefresh({ eth: { '0x123': 'running' } });
 
       const { state } = useSyncProgress();
       const stateValue = get(state);

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-progress.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-progress.ts
@@ -16,6 +16,7 @@ import {
   type SyncProgressState,
 } from './types';
 import { isChainSettled, settledAddresses, useChainProgress } from './use-chain-progress';
+import { useSyncRollup } from './use-sync-rollup';
 import { type SyncWarning, SyncWarningSource, useSyncWarningsStore } from './use-sync-warnings-store';
 
 interface UseSyncProgressReturn {
@@ -88,26 +89,6 @@ function byStatusPriority(a: LocationProgress, b: LocationProgress): number {
   return STATUS_PRIORITY[a.status] - STATUS_PRIORITY[b.status];
 }
 
-const PROGRESS_WEIGHTS = {
-  decoding: 0.2,
-  events: 0.3,
-  transactions: 0.5,
-} as const;
-
-/** Zero rather than NaN before the total is known. */
-function completionRatio(completed: number, total: number): number {
-  return total > 0 ? completed / total : 0;
-}
-
-/** A cancelled decode counts as finished, since nothing more will happen to it. */
-function decodingRatio(items: { cancelled: boolean; progress: number }[]): number {
-  if (items.length === 0)
-    return 0;
-
-  const total = items.reduce((sum, item) => sum + (item.cancelled ? 100 : item.progress), 0);
-  return total / items.length / 100;
-}
-
 export function useSyncProgress(): UseSyncProgressReturn {
   const { t } = useI18n({ useScope: 'global' });
   const { getChainName } = useSupportedChains();
@@ -117,6 +98,7 @@ export function useSyncProgress(): UseSyncProgressReturn {
   const decodingStatusStore = useDecodingStatusStore();
   const protocolCacheStatusStore = useProtocolCacheStatusStore();
   const warningsStore = useSyncWarningsStore();
+  const rollup = useSyncRollup();
 
   const { warnings: rawWarnings } = storeToRefs(warningsStore);
 
@@ -212,61 +194,23 @@ export function useSyncProgress(): UseSyncProgressReturn {
     get(chains).reduce((sum, chain) => sum + settledAddresses(chain), 0),
   );
 
-  const hasTxActivity = computed<boolean>(() => get(totalAccounts) > 0);
-  const hasEventsActivity = computed<boolean>(() => get(totalLocations) > 0);
-  const hasDecodingActivity = computed<boolean>(() => get(decoding).length > 0);
+  const overallProgress = rollup.progress;
 
-  /** Only the running phases count, so the bar reflects the work actually in flight. */
-  const overallProgress = computed<number>(() => {
-    const running = [
-      {
-        active: get(hasTxActivity),
-        progress: completionRatio(get(completedAccounts), get(totalAccounts)),
-        weight: PROGRESS_WEIGHTS.transactions,
-      },
-      {
-        active: get(hasEventsActivity),
-        progress: completionRatio(get(completedLocations), get(totalLocations)),
-        weight: PROGRESS_WEIGHTS.events,
-      },
-      {
-        active: get(hasDecodingActivity),
-        progress: decodingRatio(get(decoding)),
-        weight: PROGRESS_WEIGHTS.decoding,
-      },
-    ].filter(phase => phase.active);
-
-    const totalWeight = running.reduce((sum, phase) => sum + phase.weight, 0);
-    if (totalWeight === 0)
-      return 0;
-
-    const weighted = running.reduce((sum, phase) => sum + phase.progress * phase.weight, 0);
-    return Math.round((weighted / totalWeight) * 100);
-  });
-
-  const isActive = computed<boolean>(() =>
-    get(hasTxActivity) || get(hasEventsActivity) || get(hasDecodingActivity) || get(hasWarnings),
-  );
+  /**
+   * Warnings keep the panel up after the work stops.
+   *
+   * The ledger has no notion of them — a failed address is a terminal activity like any other — so
+   * this clause is the one part of "is something happening" that is deliberately not derived from
+   * it. Without it the panel vanishes at the moment the run ends, taking the failures it exists to
+   * report with it.
+   */
+  const isActive = computed<boolean>(() => get(rollup.isWorking) || get(hasWarnings));
 
   const phase = computed<SyncPhase>(() => {
-    if (!get(isActive))
-      return SyncPhase.IDLE;
+    if (get(rollup.isWorking))
+      return SyncPhase.SYNCING;
 
-    // Use count-based completion checks (same as header display)
-    const chainsTotal = get(totalChains);
-    const chainsCompleted = get(completedChains);
-    const locationsTotal = get(totalLocations);
-    const locationsCompleted = get(completedLocations);
-    const decodingItems = get(decoding);
-
-    const allChainsDone = chainsTotal === 0 || chainsCompleted === chainsTotal;
-    const allLocationsDone = locationsTotal === 0 || locationsCompleted === locationsTotal;
-    const allDecodingDone = decodingItems.every(d => d.processed >= d.total || d.cancelled);
-
-    if (allChainsDone && allLocationsDone && allDecodingDone)
-      return SyncPhase.COMPLETE;
-
-    return SyncPhase.SYNCING;
+    return get(rollup.isSettled) ? SyncPhase.COMPLETE : SyncPhase.IDLE;
   });
 
   const canDismiss = computed<boolean>(() => get(phase) === SyncPhase.COMPLETE);

--- a/frontend/app/src/modules/shell/sync-progress/use-sync-rollup.ts
+++ b/frontend/app/src/modules/shell/sync-progress/use-sync-rollup.ts
@@ -1,0 +1,90 @@
+import type { ComputedRef } from 'vue';
+import type { Activity, ActivityId } from '@/modules/task-center/core/types';
+import { historySyncFlow } from '@/modules/history/events/tx/history-sync.flow';
+import { isTerminalStatus } from '@/modules/task-center/core/status';
+import { useTaskOrchestrator } from '@/modules/task-center/use-task-orchestrator';
+
+interface UseSyncRollupReturn {
+  /** Whether the refresh has work in flight right now. */
+  readonly isWorking: ComputedRef<boolean>;
+  /** Whether a refresh ran and every part of it has settled. */
+  readonly isSettled: ComputedRef<boolean>;
+  /** Units of work done, 0-100; `0` when no refresh has been submitted. */
+  readonly progress: ComputedRef<number>;
+}
+
+/**
+ * Is this activity a leaf — the unit the aggregate counts?
+ *
+ * A parent settles when its children do, so counting both would weight a chain once for itself and
+ * once per account, and a chain with ten accounts would move the bar differently from one with two.
+ */
+function isLeaf(activity: Activity, parents: ReadonlySet<ActivityId>): boolean {
+  return !parents.has(activity.id);
+}
+
+/**
+ * The refresh's own progress, read off the ledger rather than rebuilt from websocket frames.
+ *
+ * @remarks
+ * The unit is **settled leaves over declared leaves**. `history-sync.flow.ts` names every chain,
+ * exchange and online query before any of them runs, and each chain in turn declares its accounts
+ * and its decode, so the denominator is known at submit time rather than growing as work is
+ * discovered. That is what makes the number honest: the three alternatives — a mean of per-activity
+ * percentages, completed activities over total, or weighting whole phases against each other — all
+ * move the bar when the shape of the work changes rather than when work is done.
+ *
+ * 🔴🔴 Liveness is `status !== terminal`, never "the model is non-empty". Settled activities stay in
+ * the model so the panel can list them, so any predicate shaped like "is anything there" reads true
+ * forever after the first completion.
+ */
+export function useSyncRollup(): UseSyncRollupReturn {
+  const { activities } = useTaskOrchestrator();
+  const umbrellaId = historySyncFlow.id();
+
+  /** The umbrella and everything beneath it, however deep the producer nested it. */
+  const subtree = computed<Activity[]>(() => {
+    const all = get(activities);
+    const claimed = new Set<ActivityId>([umbrellaId]);
+    let growing = true;
+
+    // A single pass would drop any child the snapshot happens to list before its parent.
+    while (growing) {
+      growing = false;
+      for (const activity of all) {
+        if (activity.parent !== undefined && claimed.has(activity.parent) && !claimed.has(activity.id)) {
+          claimed.add(activity.id);
+          growing = true;
+        }
+      }
+    }
+
+    return all.filter(activity => claimed.has(activity.id));
+  });
+
+  const leaves = computed<Activity[]>(() => {
+    const nodes = get(subtree);
+    const parents = new Set<ActivityId>(nodes.map(node => node.parent).filter(id => id !== undefined));
+    return nodes.filter(node => isLeaf(node, parents));
+  });
+
+  const isWorking = computed<boolean>(() =>
+    get(subtree).some(activity => !isTerminalStatus(activity.status)),
+  );
+
+  const isSettled = computed<boolean>(() => {
+    const nodes = get(subtree);
+    return nodes.length > 0 && nodes.every(activity => isTerminalStatus(activity.status));
+  });
+
+  const progress = computed<number>(() => {
+    const declared = get(leaves);
+    if (declared.length === 0)
+      return 0;
+
+    const settled = declared.filter(activity => isTerminalStatus(activity.status)).length;
+    return Math.round((settled / declared.length) * 100);
+  });
+
+  return { isSettled, isWorking, progress };
+}


### PR DESCRIPTION
Follow-up to #13117. That PR routed progress into the ledger but removed nothing, leaving two
answers to the same question. This deletes one of them.

`use-sync-progress`'s `phase`, `overallProgress` and `isActive` were a second implementation of what
the ledger already knows, rebuilt from the four websocket status stores. They are not a symptom of
the three-definitions defect in #10308, they *are* it: three surfaces could disagree about whether
anything was running and how far along it was, because each derived it separately.

## ⚠️ The numbers on screen change

No component is edited — the four consumers (`SyncProgressHeader`, `SyncProgressPanel`,
`use-sync-completed`, `ReportGenerator`) read the same fields with the same signatures — but they
render different values. Please review this as a behaviour change, not a refactor.

## What replaces the bar

**Settled leaves over declared leaves.** `history-sync.flow.ts` names every chain, exchange and
online query before any of them runs, and each chain declares its accounts and its decode, so the
denominator is known at submit time rather than growing as work is discovered.

The three alternatives all move the bar when the *shape* of the work changes rather than when work
is done: a mean of per-activity percentages, completed-over-total activities, and the 50/30/20 phase
weighting this replaces.

**Leaves only.** A parent settles when its children do, so counting parents as well would weight a
chain once for itself and once per account — a chain with ten accounts would move the bar
differently from one with two.

## Two things kept deliberately

**`isActive` keeps its warnings clause.** The ledger has no notion of a warning — a failed address is
a terminal activity like any other — so without `|| hasWarnings` the panel would vanish the moment
the run ends, taking the failures it exists to report with it.

**Disabled chains are not re-filtered.** They never reach the ledger: `getAccountsByChainType`
filters at the funnel every account getter reads through, so the exclusion happens while the refresh
scope resolves, before anything is submitted. Filtering again here would be a second implementation
of one rule, free to disagree with the first. (Filtering lives at the source because a disabled
account reaching the novelty question would read as "never attempted", hence novel forever.)

## Verification

Full unit suite green. The 15 cases that pinned the old semantics are rewritten against orchestrator
fixtures rather than the four status stores, which let them state things the old ones structurally
could not — that a decode is one leaf rather than a weighted third of the bar, and that every account
weighs the same whichever chain it sits on.

Two negative controls, both restored: counting parents alongside leaves fails the four cases pinning
the unit of work, and reading liveness as "the model is non-empty" fails the six pinning settlement —
the trap that regressed `NotificationIndicator`, since settled activities stay in the model.

**Driven in the running app against a real profile.** A login-triggered refresh declared 90 leaves
and the bar tracked `settled/declared` through 50 monotonic transitions, 16% to 100%
(14/90→16, 45/90→50, 66/90→73, 89/90→99). It never decreased, which the old bar could, since its
denominator shifted as phases became active and inactive. It also sat at 99% for six minutes while
one bitcoin account was genuinely still querying — backend task confirmed pending — rather than
rounding up to complete.

Not exercised in the app: the warnings clause, since that run produced no failures. It is covered by
a unit test.

## Still dual-written

`chains`, `locations`, `decoding`, `protocolCache` and `warnings` are untouched and still come from
the websocket status stores, which remain the only source for the panel's lists and for
`DashboardProgressIndicator`. This removes the rival rollup, not the duplication beneath it;
`use-history-query-progress.ts` is the same shape for the dashboard and is still to do.
